### PR TITLE
[Feature] Optimize search migration [#OSF-9037]

### DIFF
--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -834,29 +834,29 @@ class TestSearchMigration(OsfTestCase):
             is_public=True
         )
 
-    def test_first_migration_no_delete(self):
-        migrate(delete=False, index=settings.ELASTIC_INDEX, app=self.app.app)
+    def test_first_migration_no_remove(self):
+        migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
         assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
-    def test_multiple_migrations_no_delete(self):
+    def test_multiple_migrations_no_remove(self):
         for n in xrange(1, 21):
-            migrate(delete=False, index=settings.ELASTIC_INDEX, app=self.app.app)
+            migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
             assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
-    def test_first_migration_with_delete(self):
-        migrate(delete=True, index=settings.ELASTIC_INDEX, app=self.app.app)
+    def test_first_migration_with_remove(self):
+        migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
         assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
-    def test_multiple_migrations_with_delete(self):
+    def test_multiple_migrations_with_remove(self):
         for n in xrange(1, 21, 2):
-            migrate(delete=True, index=settings.ELASTIC_INDEX, app=self.app.app)
+            migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
             assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
-            migrate(delete=True, index=settings.ELASTIC_INDEX, app=self.app.app)
+            migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
             assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n + 1)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
             assert not var.get(settings.ELASTIC_INDEX + '_v{}'.format(n))

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -279,7 +279,7 @@ def elasticsearch(ctx):
         print('Your system is not recognized, you will have to start elasticsearch manually')
 
 @task
-def migrate_search(ctx, delete=False, index=settings.ELASTIC_INDEX):
+def migrate_search(ctx, delete=True, remove=False, index=settings.ELASTIC_INDEX):
     """Migrate the search-enabled models."""
     from website.app import init_app
     init_app(routes=False, set_backends=False)
@@ -291,7 +291,7 @@ def migrate_search(ctx, delete=False, index=settings.ELASTIC_INDEX):
     for logger in SILENT_LOGGERS:
         logging.getLogger(logger).setLevel(logging.ERROR)
 
-    migrate(delete, index=index)
+    migrate(delete, remove=remove, index=index)
 
 
 @task
@@ -317,7 +317,7 @@ def rebuild_search(ctx):
     print('Creating index {}'.format(settings.ELASTIC_INDEX))
     print('----- PUT {}'.format(url))
     requests.put(url)
-    migrate_search(ctx)
+    migrate_search(ctx, delete=False)
 
 
 @task

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -273,7 +273,7 @@ def format_result(result, parent_id=None):
         'category': result.get('category'),
         'date_created': result.get('date_created'),
         'date_registered': result.get('registered_date'),
-        'n_wikis': len(result['wikis']),
+        'n_wikis': len(result['wikis'] or []),
         'license': result.get('license'),
         'affiliated_institutions': result.get('affiliated_institutions'),
         'preprint_url': result.get('preprint_url'),

--- a/website/search_migration/__init__.py
+++ b/website/search_migration/__init__.py
@@ -1,0 +1,732 @@
+JSON_UPDATE_NODES_SQL = """
+SELECT json_agg(
+    json_build_object(
+        '_type', CASE
+                 WHEN N.type = 'osf.registration'
+                   THEN 'registration'
+                 WHEN PREPRINT.URL IS NOT NULL
+                   THEN 'preprint'
+                 WHEN PARENT_GUID._id IS NULL
+                   THEN 'project'
+                 ELSE 'component'
+                 END
+        , '_index', '{index}'
+        , 'doc_as_upsert', TRUE
+        , '_id', NODE_GUID._id
+        , '_op_type', 'update'
+        , 'doc', json_build_object(
+            'contributors', (SELECT json_agg(json_build_object(
+                                                 'url', CASE
+                                                        WHEN U.is_active
+                                                          THEN '/' || USER_GUID._id || '/'
+                                                        ELSE NULL
+                                                        END
+                                                 , 'fullname', U.fullname
+                                             ))
+                             FROM osf_osfuser AS U
+                               INNER JOIN osf_contributor AS CONTRIB
+                                 ON (U.id = CONTRIB.user_id)
+                               LEFT OUTER JOIN osf_guid AS USER_GUID
+                                 ON (U.id = USER_GUID.object_id AND (USER_GUID.content_type_id = (SELECT id FROM django_content_type WHERE model = 'osfuser')))
+                             WHERE (CONTRIB.node_id = N.id AND CONTRIB.visible = TRUE))
+            , 'extra_search_terms', CASE
+                                    WHEN strpos(N.title, '-') + strpos(N.title, '_') + strpos(N.title, '.') > 0
+                                      THEN translate(N.title, '-_.', '   ')
+                                    ELSE ''
+                                    END
+            , 'normalized_title', N.title
+            , 'registered_date', N.registered_date
+            , 'id', NODE_GUID._id
+            , 'category', CASE
+                          WHEN PARENT_GUID._id IS NULL
+                            THEN 'project'
+                          ELSE 'component'
+                          END
+            , 'title', N.title
+            , 'parent_id', PARENT_GUID._id
+            , 'embargo_end_date', EMBARGO.DATA ->> 'end_date'
+            , 'is_pending_registration', CASE
+                                         WHEN N.type = 'osf.registration'
+                                           THEN REGISTRATION_APPROVAL.PENDING
+                                         ELSE FALSE
+                                         END
+            , 'is_pending_embargo', EMBARGO.DATA ->> 'pending'
+            , 'is_registration', N.type = 'osf.registration'
+            , 'is_pending_retraction', RETRACTION.state = 'pending'
+            , 'is_retracted', RETRACTION.state = 'approved'
+            , 'preprint_url', PREPRINT.URL
+            , 'boost', CASE
+                       WHEN N.type = 'osf.node'
+                         THEN 2
+                       ELSE 1
+                       END
+            , 'public', N.is_public
+            , 'description', N.description
+            , 'tags', (CASE
+                       WHEN TAGS.names IS NOT NULL
+                       THEN TAGS.names
+                       ELSE
+                         '{{}}'::TEXT[]
+                       END)
+                , 'affiliated_institutions', (SELECT array_agg(INST.name)
+                                          FROM osf_institution AS INST
+                                            INNER JOIN osf_abstractnode_affiliated_institutions
+                                              ON (INST.id = osf_abstractnode_affiliated_institutions.institution_id)
+                                          WHERE osf_abstractnode_affiliated_institutions.abstractnode_id = N.id)
+            , 'license', json_build_object(
+                'text', LICENSE.text
+                , 'name', LICENSE.name
+                , 'id', LICENSE.license_id
+                , 'copyright_holders', LICENSE.copyright_holders
+                , 'year', LICENSE.year
+            )
+            , 'url', '/' || NODE_GUID._id || '/'
+            , 'date_created', N.created
+            , 'wikis', CASE
+                       WHEN RETRACTION.state != 'approved'
+                         THEN
+                           (SELECT json_agg(json_build_object(
+                                                translate(page_name, '.', ' '), content
+                                            ))
+                            FROM addons_wiki_nodewikipage
+                              INNER JOIN osf_guid
+                                ON (addons_wiki_nodewikipage.id = osf_guid.object_id AND
+                                    (osf_guid.content_type_id = (SELECT id FROM django_content_type WHERE model = 'nodewikipage')))
+                            WHERE osf_guid._id = ANY (SELECT p.value
+                                                      FROM osf_abstractnode
+                                                        INNER JOIN
+                                                            jsonb_each_text(osf_abstractnode.wiki_pages_current) P
+                                                          ON TRUE
+                                                      WHERE id = N.id))
+                       ELSE
+                         '{{}}'::JSON
+                       END
+        )
+    )
+)
+FROM osf_abstractnode AS N
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = N.id
+                  AND content_type_id = (SELECT id FROM django_content_type WHERE model = 'abstractnode')
+            LIMIT 1
+            ) NODE_GUID ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = (
+              SELECT parent_id
+              FROM osf_noderelation
+              WHERE child_id = N.id
+                    AND is_node_link = FALSE
+              LIMIT 1)
+                  AND content_type_id = (SELECT id FROM django_content_type WHERE model = 'abstractnode')
+            LIMIT 1
+            ) PARENT_GUID ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT array_agg(TAG.name) as names
+            FROM osf_tag AS TAG
+            INNER JOIN osf_abstractnode_tags ON (TAG.id = osf_abstractnode_tags.tag_id)
+            WHERE (TAG.system = FALSE AND osf_abstractnode_tags.abstractnode_id = N.id)
+            LIMIT 1
+            ) TAGS ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT
+              osf_nodelicense.license_id,
+              osf_nodelicense.name,
+              osf_nodelicense.text,
+              osf_nodelicenserecord.year,
+              osf_nodelicenserecord.copyright_holders
+            FROM osf_nodelicenserecord
+              INNER JOIN osf_abstractnode ON (osf_nodelicenserecord.id = osf_abstractnode.node_license_id)
+              LEFT OUTER JOIN osf_nodelicense ON (osf_nodelicenserecord.node_license_id = osf_nodelicense.id)
+            WHERE osf_abstractnode.id = N.id
+            ) LICENSE ON TRUE
+  LEFT JOIN LATERAL (SELECT (
+    CASE WHEN N.type = 'osf.registration'
+      THEN
+        (CASE WHEN N.retraction_id IS NOT NULL
+          THEN
+            (SELECT state
+             FROM osf_retraction
+             WHERE id = N.retraction_id)
+         ELSE
+           (WITH RECURSIVE ascendants AS (
+             SELECT
+               parent_id,
+               child_id,
+               1                AS LEVEL,
+               ARRAY [child_id] AS cids,
+               '' :: VARCHAR    AS state
+             FROM osf_noderelation
+             WHERE is_node_link IS FALSE AND child_id = N.id
+             UNION ALL
+             SELECT
+               S.parent_id,
+               D.child_id,
+               D.level + 1,
+               D.cids || S.child_id,
+               R.state
+             FROM ascendants AS D
+               INNER JOIN osf_noderelation AS S
+                 ON D.parent_id = S.child_id
+               INNER JOIN osf_abstractnode AS A
+                 ON D.child_id = A.id
+               INNER JOIN osf_retraction AS R
+                 ON A.retraction_id = R.id
+             WHERE S.is_node_link IS FALSE
+                   AND N.id = ANY (cids)
+           ) SELECT state
+             FROM ascendants
+             WHERE child_id = N.id
+                   AND state IS NOT NULL
+             ORDER BY LEVEL ASC
+             LIMIT 1)
+         END)
+    ELSE
+      (SELECT '' :: VARCHAR AS state)
+    END
+  )) RETRACTION ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT (
+              CASE WHEN N.type = 'osf.registration'
+                THEN (
+                  CASE WHEN N.embargo_id IS NOT NULL
+                    THEN (
+                      SELECT json_build_object(
+                                 'pending', state = 'unapproved',
+                                 'end_date',
+                                 CASE WHEN state = 'approved'
+                                   THEN
+                                     TO_CHAR(end_date, 'Day, Mon DD, YYYY')
+                                 ELSE
+                                   NULL
+                                 END
+                             ) AS DATA
+                      FROM osf_retraction
+                      WHERE id = N.retraction_id
+                    )
+                  ELSE (
+                    WITH RECURSIVE ascendants AS (
+                      SELECT
+                        parent_id,
+                        child_id,
+                        1                                AS LEVEL,
+                        ARRAY [child_id]                 AS cids,
+                        '' :: VARCHAR                    AS state,
+                        NULL :: TIMESTAMP WITH TIME ZONE AS end_date
+                      FROM osf_noderelation
+                      WHERE is_node_link IS FALSE AND child_id = N.id
+                      UNION ALL
+                      SELECT
+                        S.parent_id,
+                        D.child_id,
+                        D.level + 1,
+                        D.cids || S.child_id,
+                        E.state,
+                        E.end_date
+                      FROM ascendants AS D
+                        JOIN osf_noderelation AS S
+                          ON D.parent_id = S.child_id
+                        JOIN osf_abstractnode AS A
+                          ON D.child_id = A.id
+                        JOIN osf_embargo AS E
+                          ON A.retraction_id = E.id
+                      WHERE S.is_node_link IS FALSE
+                            AND N.id = ANY (cids)
+                    ) SELECT json_build_object(
+                                 'pending', state = 'unapproved',
+                                 'end_date',
+                                 CASE WHEN state = 'approved'
+                                   THEN
+                                     TO_CHAR(end_date, 'Day, Mon DD, YYYY')
+                                 ELSE
+                                   NULL
+                                 END
+                             ) AS DATA
+                      FROM ascendants
+                      WHERE child_id = N.id
+                            AND state IS NOT NULL
+                      ORDER BY LEVEL ASC
+                      LIMIT 1
+                  ) END
+                )
+              ELSE (
+                SELECT json_build_object(
+                           'pending', FALSE,
+                           'end_date', NULL
+                       ) AS DATA
+              ) END
+            )
+            ) EMBARGO ON TRUE
+  LEFT JOIN LATERAL ( SELECT (
+    CASE WHEN N.type = 'osf.registration' AND N.registration_approval_id IS NOT NULL
+      THEN (
+        SELECT state = 'unapproved' AS PENDING
+        FROM osf_registrationapproval
+        WHERE id = N.retraction_id
+      )
+    ELSE (
+      SELECT FALSE AS PENDING
+    ) END)
+            ) REGISTRATION_APPROVAL ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT
+              CASE WHEN ((osf_preprintprovider.domain_redirect_enabled AND osf_preprintprovider.domain IS NOT NULL) OR
+                         osf_preprintprovider._id = 'osf')
+                THEN
+                  '/' || (SELECT G._id
+                          FROM osf_guid G
+                          WHERE (G.object_id = P.id)
+                                AND (G.content_type_id = (SELECT id FROM django_content_type WHERE model = 'preprintservice'))
+                          ORDER BY created ASC, id ASC
+                          LIMIT 1) || '/'
+              ELSE
+                '/preprints/' || osf_preprintprovider._id || '/' || (SELECT G._id
+                                                                     FROM osf_guid G
+                                                                     WHERE (G.object_id = P.id)
+                                                                           AND (G.content_type_id = (SELECT id FROM django_content_type WHERE model = 'preprintservice'))
+                                                                     ORDER BY created ASC, id ASC
+                                                                     LIMIT 1) || '/'
+              END AS URL
+            FROM osf_preprintservice P
+              INNER JOIN osf_preprintprovider ON P.provider_id = osf_preprintprovider.id
+            WHERE P.node_id = N.id
+              AND P.machine_state != 'initial'  -- is_preprint
+              AND N.preprint_file_id IS NOT NULL
+              AND N.is_public = TRUE
+              AND N._is_preprint_orphan != TRUE
+            ORDER BY P.is_published DESC, P.created DESC
+            LIMIT 1
+            ) PREPRINT ON TRUE
+WHERE (TYPE = 'osf.node' OR TYPE = 'osf.registration')
+  AND is_public IS TRUE
+  AND is_deleted IS FALSE
+  AND (spam_status IS NULL OR NOT ((spam_status = 2 or spam_status = 3) AND {spam_flagged_removed_from_search}))
+  AND NOT (UPPER(N.title :: TEXT) LIKE UPPER(
+'%[''Bulk stress 201'', ''Bulk stress 202'', ''OSF API Registration test'']%') -- is_qa_node
+           OR N.id IN  -- Comes from website.settings.DO_NOT_INDEX_LIST
+              (SELECT THRUTAGS.abstractnode_id
+               FROM osf_abstractnode_tags THRUTAGS
+                 INNER JOIN osf_tag TAGS ON (THRUTAGS.tag_id = TAGS.id)
+               WHERE TAGS.name = '[''qatest'', ''qa test'']'))
+  AND NOT (N.id IN  -- node.archiving
+           (SELECT AJ.dst_node_id  -- May need to be made recursive as AJ table grows
+            FROM osf_archivejob AJ
+            WHERE (AJ.status != 'FAILURE' AND AJ.status != 'SUCCESS'
+                   AND AJ.dst_node_id IS NOT NULL)))
+  AND id > {page_start}
+  AND id <= {page_end}
+LIMIT 1;
+"""
+
+JSON_UPDATE_FILES_SQL = """
+SELECT json_agg(
+    json_build_object(
+        '_type', 'file'
+        , '_index', '{index}'
+        , 'doc_as_upsert', TRUE
+        , '_id', F._id
+        , '_op_type', 'update'
+        , 'doc', json_build_object(
+            'id', F._id
+            , 'deep_url', CASE WHEN F.provider = 'osfstorage'
+                          THEN '/' || (NODE.DATA ->> 'guid') || '/files/' || F.provider || '/' || F._id
+                          ELSE '/' || (NODE.DATA ->> 'guid') || '/files/' || F.provider || F._path
+                          END
+            , 'guid_url', CASE WHEN FILE_GUID._id IS NOT NULL
+                          THEN '/' || FILE_GUID._id || '/'
+                          ELSE NULL
+                          END
+            , 'tags', (CASE
+              WHEN TAGS.names IS NOT NULL
+              THEN TAGS.names
+              ELSE
+                '{{}}'::TEXT[]
+              END)
+            , 'name', F.name
+            , 'category', 'file'
+            , 'node_url', '/' || (NODE.DATA ->> 'guid') || '/'
+            , 'node_title', NODE.DATA ->> 'title'
+            , 'parent_id', NODE.DATA ->> 'parent_guid'
+            , 'is_registration', NODE.DATA ->> 'is_registration' = 'true' -- Weirdness from the lateral join causes this to be a string
+            , 'is_retracted', NODE.DATA ->> 'is_retracted' = 'true' -- Weirdness from the lateral join causes this to be a string
+            , 'extra_search_terms', CASE WHEN strpos(F.name, '-') + strpos(F.name, '_') + strpos(F.name, '.') > 0
+                                    THEN translate(F.name, '-_.', '   ')
+                                    ELSE ''
+                                    END
+        )
+    )
+)
+FROM osf_basefilenode AS F
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = F.id
+                  AND content_type_id = (SELECT id FROM django_content_type WHERE model = 'basefilenode')
+            LIMIT 1
+            ) FILE_GUID ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT array_agg(TAG.name) AS names
+            FROM osf_tag AS TAG
+              INNER JOIN osf_basefilenode_tags ON (TAG.id = osf_basefilenode_tags.tag_id)
+            WHERE (TAG.system = FALSE AND osf_basefilenode_tags.basefilenode_id = F.id)
+      ) TAGS ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT json_build_object(
+                       'is_registration', (CASE WHEN N.type = 'osf.registration'
+                                           THEN TRUE
+                                           ELSE FALSE
+                                           END)
+                       , 'title', N.title
+                       , 'guid', (SELECT _id
+                                  FROM osf_guid
+                                  WHERE object_id = N.id
+                                        AND content_type_id = (SELECT id
+                                                               FROM django_content_type
+                                                               WHERE model = 'abstractnode')
+                                  LIMIT 1)
+                       , 'parent_guid', (SELECT _id
+                                         FROM osf_guid
+                                         WHERE object_id = (
+                                           SELECT parent_id
+                                           FROM osf_noderelation
+                                           WHERE child_id = N.id
+                                                 AND is_node_link = FALSE
+                                           LIMIT 1)
+                                               AND content_type_id = (SELECT id
+                                                                      FROM django_content_type
+                                                                      WHERE model = 'abstractnode')
+                                         LIMIT 1)
+                       , 'is_retracted', (CASE WHEN N.type = 'osf.registration'
+                         THEN
+                           (CASE WHEN N.retraction_id IS NOT NULL
+                             THEN
+                               (SELECT state = 'approved'
+                                FROM osf_retraction
+                                WHERE id = N.retraction_id)
+                             ELSE
+                              (WITH RECURSIVE ascendants AS (
+                                SELECT
+                                  parent_id,
+                                  child_id,
+                                  1                AS LEVEL,
+                                  ARRAY [child_id] AS cids,
+                                  FALSE            AS is_retracted
+                                FROM osf_noderelation
+                                WHERE is_node_link IS FALSE AND child_id = N.id
+                                UNION ALL
+                                SELECT
+                                  S.parent_id,
+                                  D.child_id,
+                                  D.level + 1,
+                                  D.cids || S.child_id,
+                                  R.state = 'approved' AS is_retracted
+                                FROM ascendants AS D
+                                  INNER JOIN osf_noderelation AS S
+                                    ON D.parent_id = S.child_id
+                                  INNER JOIN osf_abstractnode AS A
+                                    ON D.child_id = A.id
+                                  INNER JOIN osf_retraction AS R
+                                    ON A.retraction_id = R.id
+                                WHERE S.is_node_link IS FALSE
+                                      AND N.id = ANY (cids)
+                              ) SELECT is_retracted
+                                FROM ascendants
+                                WHERE child_id = N.id
+                                ORDER BY is_retracted DESC -- Put TRUE at the top
+                                LIMIT 1)
+                            END)
+                         ELSE
+                           FALSE
+                         END)
+                   ) AS DATA
+            FROM osf_abstractnode N
+            WHERE N.id = F.node_id
+            LIMIT 1
+            ) NODE ON TRUE
+WHERE name IS NOT NULL
+      AND name != ''
+      AND node_id = ANY (SELECT id
+                         FROM osf_abstractnode
+                         WHERE (TYPE = 'osf.node' OR TYPE = 'osf.registration' OR TYPE = 'osf.quickfilesnode')
+                               AND is_public IS TRUE
+                               AND is_deleted IS FALSE
+                               AND (spam_status IS NULL OR NOT ((spam_status = 2 or spam_status = 3) AND {spam_flagged_removed_from_search}))
+                               AND NOT (UPPER(osf_abstractnode.title :: TEXT) LIKE UPPER(
+                             '%[''Bulk stress 201'', ''Bulk stress 202'', ''OSF API Registration test'']%')
+                                        OR "osf_abstractnode"."id" IN
+                                           (SELECT THRUTAGS.abstractnode_id
+                                            FROM osf_abstractnode_tags THRUTAGS
+                                              INNER JOIN osf_tag TAGS ON (THRUTAGS.tag_id = TAGS.id)
+                                            WHERE TAGS.name = '[''qatest'', ''qa test'']'))
+                               AND NOT (osf_abstractnode.id IN
+                                        (SELECT AJ.dst_node_id
+                                         FROM osf_archivejob AJ
+                                             WHERE (AJ.status != 'FAILURE' AND AJ.status != 'SUCCESS'
+                                                AND AJ.dst_node_id IS NOT NULL)))
+                        )
+      AND id > {page_start}
+      AND id <= {page_end}
+LIMIT 1;
+"""
+
+JSON_UPDATE_USERS_SQL = """
+SELECT json_agg(
+    json_build_object(
+        '_type', 'user'
+        , '_index', '{index}'
+        , 'doc_as_upsert', TRUE
+        , '_id', USER_GUID._id
+        , '_op_type', 'update'
+        , 'doc', json_build_object(
+            'id', USER_GUID._id
+            , 'user', U.fullname
+            , 'normalized_user', U.fullname
+            , 'normalized_names', json_build_object(
+                'fullname', U.fullname
+                , 'given_name', U.given_name
+                , 'family_name', U.family_name
+                , 'middle_names', U.middle_names
+                , 'suffix', U.suffix
+            )
+            , 'names', json_build_object(
+                'fullname', U.fullname
+                , 'given_name', U.given_name
+                , 'family_name', U.family_name
+                , 'middle_names', U.middle_names
+                , 'suffix', U.suffix
+            )
+            , 'job', CASE
+                     WHEN U.jobs :: JSON -> 0 -> 'institution' IS NOT NULL
+                       THEN
+                         (U.jobs :: JSON -> 0 -> 'institution') :: TEXT
+                     ELSE
+                       ''
+                     END
+            , 'job_title', (CASE
+                            WHEN U.jobs :: JSON -> 0 -> 'title' IS NOT NULL
+                              THEN
+                                (U.jobs :: JSON -> 0 -> 'title') :: TEXT
+                            ELSE
+                              ''
+                            END)
+            , 'all_jobs', (SELECT array_agg(DISTINCT (JOB :: JSON -> 'institution') :: TEXT)
+                           FROM
+                             (SELECT json_array_elements(jobs :: JSON) AS JOB
+                              FROM osf_osfuser
+                              WHERE id = U.id
+                             ) AS JOBS)
+            , 'school', (CASE
+                         WHEN U.schools :: JSON -> 0 -> 'institution' IS NOT NULL
+                           THEN
+                             (U.schools :: JSON -> 0 -> 'institution') :: TEXT
+                         ELSE
+                           ''
+                         END)
+            , 'all_schools', (SELECT array_agg(DISTINCT (SCHOOL :: JSON -> 'institution') :: TEXT)
+                              FROM
+                                (SELECT json_array_elements(schools :: JSON) AS SCHOOL
+                                 FROM osf_osfuser
+                                 WHERE id = U.id
+                                ) AS SCHOOLS)
+            , 'category', 'user'
+            , 'degree', (CASE
+                         WHEN U.schools :: JSON -> 0 -> 'degree' IS NOT NULL
+                           THEN
+                             (U.schools :: JSON -> 0 -> 'degree') :: TEXT
+                         ELSE
+                           ''
+                         END)
+            , 'social', (SELECT json_object_agg(
+                key,
+                (
+                  CASE
+                  WHEN key = 'orcid'
+                    THEN 'http://orcid.org/' || value
+                  WHEN key = 'github'
+                    THEN 'http://github.com/' || value
+                  WHEN key = 'scholar'
+                    THEN 'http://scholar.google.com/citations?user=' || value
+                  WHEN key = 'twitter'
+                    THEN 'http://twitter.com/' || value
+                  WHEN key = 'profileWebsites'
+                    THEN value
+                  WHEN key = 'linkedIn'
+                    THEN 'https://www.linkedin.com/' || value
+                  WHEN key = 'impactStory'
+                    THEN 'https://impactstory.org/u/' || value
+                  WHEN key = 'researcherId'
+                    THEN 'http://researcherid.com/rid/' || value
+                  WHEN key = 'researchGate'
+                    THEN 'https://researchgate.net/profile/' || value
+                  WHEN key = 'academiaInstitution'
+                    THEN 'https://' || value
+                  WHEN key = 'academiaProfileID'
+                    THEN '.academia.edu/' || value
+                  WHEN key = 'baiduScholar'
+                    THEN 'http://xueshu.baidu.com/scholarID/' || value
+                  WHEN key = 'ssrn'
+                    THEN 'http://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id=' || value
+                  END
+                ))
+                         FROM jsonb_each_text(
+                             (SELECT social
+                              FROM osf_osfuser
+                              WHERE id = U.id)
+                         )
+                         WHERE value IS NOT NULL
+                               AND value != ''
+                               AND value != '[]'
+            )
+            , 'boost', 2
+        )
+    )
+)
+FROM osf_osfuser AS U
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = U.id
+                  AND content_type_id = ANY (SELECT id
+                                             FROM django_content_type
+                                             WHERE model = 'osfuser')
+            LIMIT 1
+            ) USER_GUID ON TRUE
+WHERE is_active = TRUE
+      AND id > {page_start}
+      AND id <= {page_end}
+LIMIT 1;
+"""
+
+JSON_DELETE_NODES_SQL = """
+SELECT json_agg(
+    json_build_object(
+        '_type', CASE
+                 WHEN N.type = 'osf.registration'
+                   THEN 'registration'
+                 WHEN PREPRINT.is_preprint > 0
+                   THEN 'preprint'
+                 WHEN PARENT_GUID._id IS NULL
+                   THEN 'project'
+                 ELSE 'component'
+                 END
+        , '_index', '{index}'
+        , '_id', NODE_GUID._id
+        , '_op_type', 'delete'
+    )
+)
+FROM osf_abstractnode AS N
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = N.id
+                  AND content_type_id = (SELECT id FROM django_content_type WHERE model = 'abstractnode')
+            LIMIT 1
+            ) NODE_GUID ON TRUE
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = (
+              SELECT parent_id
+              FROM osf_noderelation
+              WHERE child_id = N.id
+                    AND is_node_link = FALSE
+              LIMIT 1)
+                  AND content_type_id = (SELECT id FROM django_content_type WHERE model = 'abstractnode')
+            LIMIT 1
+            ) PARENT_GUID ON TRUE
+  LEFT JOIN LATERAL (
+          SELECT COUNT(P.id) as is_preprint
+          FROM osf_preprintservice P
+          WHERE P.node_id = N.id
+            AND P.machine_state != 'initial'
+            AND N.preprint_file_id IS NOT NULL
+            AND N.is_public = TRUE
+            AND N._is_preprint_orphan != TRUE
+          LIMIT 1
+          ) PREPRINT ON TRUE
+WHERE NOT ((TYPE = 'osf.node' OR TYPE = 'osf.registration')
+  AND N.is_public IS TRUE
+  AND N.is_deleted IS FALSE
+  AND (spam_status IS NULL OR NOT ((spam_status = 2 or spam_status = 3) AND {spam_flagged_removed_from_search}))
+  AND NOT (UPPER(N.title :: TEXT) LIKE UPPER(
+'%[''Bulk stress 201'', ''Bulk stress 202'', ''OSF API Registration test'']%') -- is_qa_node
+           OR N.id IN  -- Comes from website.settings.DO_NOT_INDEX_LIST
+              (SELECT THRUTAGS.abstractnode_id
+               FROM osf_abstractnode_tags THRUTAGS
+                 INNER JOIN osf_tag TAGS ON (THRUTAGS.tag_id = TAGS.id)
+               WHERE TAGS.name = '[''qatest'', ''qa test'']'))
+  AND NOT (N.id IN  -- node.archiving
+           (SELECT AJ.dst_node_id  -- May need to be made recursive as AJ table grows
+            FROM osf_archivejob AJ
+               WHERE (AJ.status != 'FAILURE' AND AJ.status != 'SUCCESS'
+                   AND AJ.dst_node_id IS NOT NULL)))
+  )
+  AND id > {page_start}
+  AND id <= {page_end}
+LIMIT 1;
+"""
+
+JSON_DELETE_FILES_SQL = """
+SELECT json_agg(json_build_object(
+    '_type', 'file'
+    , '_index', '{index}'
+    , '_id', F._id
+    , '_op_type', 'delete'
+))
+FROM osf_basefilenode AS F
+WHERE NOT (name IS NOT NULL
+      AND name != ''
+      AND node_id = ANY (SELECT id
+                         FROM osf_abstractnode
+                         WHERE (TYPE = 'osf.node' OR TYPE = 'osf.registration' OR TYPE = 'osf.quickfilesnode')
+                               AND is_public IS TRUE
+                               AND is_deleted IS FALSE
+                               AND NOT ((spam_status = 1 OR spam_status = 2) AND {spam_flagged_removed_from_search})
+                               -- settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH
+                               -- node.archiving or is_qa_node
+                               AND NOT (UPPER(osf_abstractnode.title :: TEXT) LIKE UPPER(
+                             '%[''Bulk stress 201'', ''Bulk stress 202'', ''OSF API Registration test'']%')
+                                        OR "osf_abstractnode"."id" IN
+                                           (SELECT THRUTAGS.abstractnode_id
+                                            FROM osf_abstractnode_tags THRUTAGS
+                                              INNER JOIN osf_tag TAGS ON (THRUTAGS.tag_id = TAGS.id)
+                                            WHERE TAGS.name = '[''qatest'', ''qa test'']'))
+                               AND NOT (osf_abstractnode.id IN
+                                        (SELECT AJ.dst_node_id
+                                         FROM osf_archivejob AJ
+                                             WHERE (AJ.status != 'FAILURE' AND AJ.status != 'SUCCESS'
+                                                AND AJ.dst_node_id IS NOT NULL)))
+                        )
+      )
+      AND id > {page_start}
+      AND id <= {page_end}
+LIMIT 1;
+"""
+
+JSON_DELETE_USERS_SQL = """
+SELECT json_agg(
+    json_build_object(
+        '_type', 'user'
+        , '_index', '{index}'
+        , '_id', USER_GUID._id
+        , '_op_type', 'delete'
+    )
+)
+FROM osf_osfuser AS U
+  LEFT JOIN LATERAL (
+            SELECT _id
+            FROM osf_guid
+            WHERE object_id = U.id
+                  AND content_type_id = ANY (SELECT id
+                                             FROM django_content_type
+                                             WHERE model = 'osfuser')
+            LIMIT 1
+            ) USER_GUID ON TRUE
+WHERE is_active != TRUE
+  AND id > {page_start}
+  AND id <= {page_end}
+LIMIT 1;
+"""

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -2,17 +2,18 @@
 # -*- coding: utf-8 -*-
 '''Migration script for Search-enabled Models.'''
 from __future__ import absolute_import
+from math import ceil
 
 import logging
 
-from django.db.models import Q
-from django.utils import timezone
+from django.db import connection
 from elasticsearch import helpers
 
 import website.search.search as search
-from framework.database import paginated
+from website.search.elastic_search import client
+from website.search_migration import JSON_UPDATE_NODES_SQL, JSON_UPDATE_FILES_SQL, JSON_UPDATE_USERS_SQL
 from scripts import utils as script_utils
-from osf.models import OSFUser, Institution, AbstractNode
+from osf.models import OSFUser, Institution, AbstractNode, BaseFileNode
 from website import settings
 from website.app import init_app
 from website.search.elastic_search import client as es_client
@@ -20,35 +21,78 @@ from website.search.search import update_institution
 
 logger = logging.getLogger(__name__)
 
-def migrate_nodes(index, query=None):
+def sql_migrate(index, sql, max_id, increment, **kwargs):
+    """ Run provided SQL and send output to elastic.
+
+    :param str index: Elastic index to update (formatted into `sql`)
+    :param str sql: SQL to format and run. See __init__.py in this module
+    :param int max_id: Last known object id. Indicates when to stop paging
+    :param int increment: Page size
+    :kwargs: Additional format arguments for `sql` arg
+
+    :return int: Number of migrated objects
+    """
+    total_pages = int(ceil(max_id / float(increment)))
+    total_objs = 0
+    page_start = 0
+    page_end = 0
+    page = 0
+    while page_end <= (max_id + increment):
+        page += 1
+        page_end += increment
+        if page <= total_pages:
+            logger.info('Updating page {} / {}'.format(page_end / increment, total_pages))
+        else:
+            # An extra page is included to cover the edge case where:
+            #       max_id == (total_pages * increment) - 1
+            # and two additional objects are created during runtime.
+            logger.info('Cleaning up...')
+        with connection.cursor() as cursor:
+            cursor.execute(sql.format(
+                index=index,
+                page_start=page_start,
+                page_end=page_end,
+                **kwargs))
+            ser_objs = cursor.fetchone()[0]
+            if ser_objs:
+                total_objs += len(ser_objs)
+                helpers.bulk(client(), ser_objs)
+        page_start = page_end
+    return total_objs
+
+def migrate_nodes(index, increment=10000):
     logger.info('Migrating nodes to index: {}'.format(index))
-    node_query = Q(is_public=True, is_deleted=False)
-    if query:
-        node_query = query & node_query
-    total = AbstractNode.objects.filter(node_query).count()
-    increment = 100
-    total_pages = (total // increment) + 1
-    pages = paginated(AbstractNode, query=node_query, increment=increment, each=False, include=['contributor__user__guids'])
+    max_nid = AbstractNode.objects.last().id
+    total_nodes = sql_migrate(
+        index,
+        JSON_UPDATE_NODES_SQL,
+        max_nid,
+        increment,
+        spam_flagged_removed_from_search=settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH)
+    logger.info('{} nodes migrated'.format(total_nodes))
 
-    for page_number, page in enumerate(pages):
-        logger.info('Updating page {} / {}'.format(page_number + 1, total_pages))
-        AbstractNode.bulk_update_search(page, index=index)
+def migrate_files(index, increment=10000):
+    logger.info('Migrating files to index: {}'.format(index))
+    max_fid = BaseFileNode.objects.last().id
+    total_files = sql_migrate(
+        index,
+        JSON_UPDATE_FILES_SQL,
+        max_fid,
+        increment,
+        spam_flagged_removed_from_search=settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH)
+    logger.info('{} files migrated'.format(total_files))
 
-    logger.info('Nodes migrated: {}'.format(total))
 
-
-def migrate_users(index):
+def migrate_users(index, increment=10000):
     logger.info('Migrating users to index: {}'.format(index))
-    n_migr = 0
-    n_iter = 0
-    users = paginated(OSFUser, query=None, each=True)
-    for user in users:
-        if user.is_active:
-            search.update_user(user, index=index)
-            n_migr += 1
-        n_iter += 1
+    max_uid = OSFUser.objects.last().id
+    total_users = sql_migrate(
+        index,
+        JSON_UPDATE_USERS_SQL,
+        max_uid,
+        increment)
+    logger.info('{} users migrated'.format(total_users))
 
-    logger.info('Users iterated: {0}\nUsers migrated: {1}'.format(n_iter, n_migr))
 
 def migrate_institutions(index):
     for inst in Institution.objects.filter(is_deleted=False):
@@ -66,17 +110,14 @@ def migrate(delete, index=None, app=None):
     ctx.push()
 
     new_index = set_up_index(index)
-    start_time = timezone.now()
 
     if settings.ENABLE_INSTITUTIONS:
         migrate_institutions(new_index)
     migrate_nodes(new_index)
+    migrate_files(new_index)
     migrate_users(new_index)
 
     set_up_alias(index, new_index)
-
-    # migrate nodes modified since start
-    migrate_nodes(new_index, query=Q(modified__gte=start_time))
 
     if delete:
         delete_old(new_index)


### PR DESCRIPTION
## Purpose
Optimize `migrate_search` and `rebuild_search`

## Changes

* Use SQL to construct ES updates / deletes

Before: took some indeterminately large amount of time (10+ hours)
After: `rebuild` takes ~15 minutes
```
[website.search_migration.migrate]  INFO: 53188 nodes migrated
[website.search_migration.migrate]  INFO: 1170014 files migrated
[website.search_migration.migrate]  INFO: 74833 users migrated
inv rebuild_search  119.07s user 4.71s system 13% cpu 15:11.86 total
```
And `migrate` takes ~23
```
[website.search_migration.migrate]  INFO: 53188 nodes migrated
[website.search_migration.migrate]  INFO: 434963 nodes marked deleted
[website.search_migration.migrate]  INFO: 1170014 files migrated
[website.search_migration.migrate]  INFO: 2577084 files marked deleted
[website.search_migration.migrate]  INFO: 74833 users migrated
[website.search_migration.migrate]  INFO: 27706 users marked deleted
inv migrate_search  221.63s user 6.73s system 16% cpu 23:01.41 total
```

## QA Notes
Things to check:
* Non-ASCII characters on 'Search' and 'Add Contributor' pages
* Things that should be indexed are
* Things that shouldn't be indexed aren't (e.g. nodes tagged with `qatest`)
* Links work on search page
* Data is present and accurate (retractions behave normally, etc)

## Side Effects
None expected

## Ticket
[[OSF-9037]](https://openscience.atlassian.net/browse/OSF-9037)

  
  