### PR TITLE
Hotfix/fix copyright date[OSF-9024]

### DIFF
--- a/website/templates/copyright.mako
+++ b/website/templates/copyright.mako
@@ -1,7 +1,9 @@
+<% from datetime import datetime %>
+
 <div class="container copyright">
     <div class="row">
         <div class="col-md-12">
-            <p>Copyright &copy; 2011-2017 <a href="https://cos.io/">Center for Open Science</a> |
+            <p>Copyright &copy; 2011-${datetime.utcnow().year} <a href="https://cos.io/">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
             </p>


### PR DESCRIPTION
## Purpose

It's 2018 - let's have our copyright date show that. While we're at it let's make copyright dates change automatically with the years (like we do on the ember side).

## Changes
Generate the copyright date based on the actual time for the footer.

## QA Notes
Does the copyright date on the bottom of the OSF say 2018?

## Tests
Because this is a change in the mako it doesn't need a test.

## Side Effects

None expected

## Ticket

https://openscience.atlassian.net/browse/OSF-9024

  
<img width="539" alt="screen shot 2018-01-03 at 1 37 20 pm" src="https://user-images.githubusercontent.com/7839433/34534245-73fe0b54-f08b-11e7-9cb3-588874a91dcb.png">
