### PR TITLE
Hotfix/change SUPPORT_EMAIL to OSF_SUPPORT_EMAIL due to #7828 [OSF-8926]

### DIFF
--- a/scripts/generate_prereg_csv.py
+++ b/scripts/generate_prereg_csv.py
@@ -51,7 +51,7 @@ def main():
 
     mails.send_mail(
         mail=mails.PREREG_CSV,
-        to_addr=settings.SUPPORT_EMAIL,
+        to_addr=settings.OSF_SUPPORT_EMAIL,
         attachment_name=filename,
         attachment_content=output.getvalue(),
     )


### PR DESCRIPTION
## Purpose

Emails of the prereg challenge csv have not been sending. This is due to the change in the variable for support emails from SUPPORT_EMAIL to OSF_SUPPORT_EMAIL made in [OSF-8700](https://openscience.atlassian.net/browse/OSF-8700).

## Changes

Change the obsolete 'SUPPORT_EMAIL' to OSF_SUPPORT_EMAIL.

## QA Notes

The help desk should get an email every sunday with a csv of the preregistration data attached.

## Side Effects
None

## Ticket
https://openscience.atlassian.net/browse/OSF-8926
