### PR TITLE
Hotfix/remove ARKs from user-facing locations[OSF-9118]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -398,7 +398,7 @@ def root(request, format=None, **kwargs):
     The OSF serves as a repository and archive for study designs, materials, data, manuscripts, or anything else
     associated with your research during the research process. Every project and file on the OSF has a permanent unique
     identifier, and every registration (a permanent, time-stamped version of your projects and files) can be assigned a
-    DOI/ARK. You can use the OSF to measure your impact by monitoring the traffic to projects and files you make
+    DOI. You can use the OSF to measure your impact by monitoring the traffic to projects and files you make
     public. With the OSF you have full control of what parts of your research are public and what remains private.
 
     Beta notice: This API is currently a beta service.  You are encouraged to use the API and will receive support

--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -26,7 +26,7 @@ class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
         name           type                   description
         ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
+        category       string                 e.g. 'doi'
         value          string                 the identifier value itself
 
     ##Links
@@ -71,7 +71,7 @@ class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     def get_default_queryset(self):
         obj = self.get_object()
-        return obj.identifiers.all()
+        return obj.identifiers.exclude(category='ark')
 
     # overrides ListCreateAPIView
     def get_queryset(self):
@@ -88,7 +88,7 @@ class IdentifierDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
         name           type                   description
         ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
+        category       string                 e.g. 'doi'
         value          string                 the identifier value itself
 
     ##Links

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -3343,7 +3343,7 @@ class NodeIdentifierList(NodeMixin, IdentifierList):
 
         name           type                   description
         ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
+        category       string                 e.g. 'doi'
         value          string                 the identifier value itself
 
     ##Links

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -358,7 +358,7 @@ class PreprintIdentifierList(IdentifierList, PreprintMixin):
 
         name           type                   description
         ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
+        category       string                 e.g. 'doi'
         value          string                 the identifier value itself
 
     ##Links

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -1036,7 +1036,7 @@ class RegistrationIdentifierList(RegistrationMixin, NodeIdentifierList):
 
         name           type                   description
         ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
+        category       string                 e.g. 'doi'
         value          string                 the identifier value itself
 
     ##Links

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -18,7 +18,8 @@ def user():
 
 @pytest.fixture()
 def all_identifiers():
-    return Identifier.objects.all()
+    # ark identifiers should not show up in identifier responses
+    return Identifier.objects.all().exclude(category='ark')
 
 @pytest.mark.django_db
 class TestRegistrationIdentifierList:
@@ -139,11 +140,15 @@ class TestNodeIdentifierList:
     def identifier_registration(self, registration):
         return IdentifierFactory(referent=registration)
 
+    @pytest.fixture()
+    def ark_identifier(self, node):
+        return IdentifierFactory(referent=node, category='ark')
+
     def test_identifier_list_success(self, res_node_identifiers):
         assert res_node_identifiers.status_code == 200
         assert res_node_identifiers.content_type == 'application/vnd.api+json'
 
-    def test_identifier_list_returns_correct_number_and_referent(self, node, identifier_node, res_node_identifiers, data_node_identifiers, all_identifiers):
+    def test_identifier_list_returns_correct_number_and_referent(self, node, identifier_node, ark_identifier, res_node_identifiers, data_node_identifiers, all_identifiers):
         # test_identifier_list_returns_correct_number
         total = res_node_identifiers.json['links']['meta']['total']
         assert total == all_identifiers.count()
@@ -226,7 +231,7 @@ class TestPreprintIdentifierList:
 
         # test_identifier_list_returns_correct_number
         total = res_preprint_identifier.json['links']['meta']['total']
-        assert total == Identifier.objects.filter(object_id=preprint.id).count()
+        assert total == Identifier.objects.filter(object_id=preprint.id).exclude(category='ark').count()
 
         # test_identifier_list_returns_correct_referent
         paths = [

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -11,7 +11,7 @@ class Identifier(ObjectIDMixin, BaseModel):
     object_id = models.PositiveIntegerField(null=True, blank=True)
     content_type = models.ForeignKey(ContentType, null=True, blank=True, on_delete=models.CASCADE)
     referent = GenericForeignKey()
-    # category: e.g. 'ark', 'doi'
+    # category: e.g. 'doi'
     category = models.CharField(max_length=10)  # longest was 3, 8/19/2016
     # value: e.g. 'FK424601'
     value = models.CharField(max_length=50)  # longest was 21, 8/19/2016

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -194,11 +194,11 @@ var ProjectViewModel = function(data, options) {
     self.askCreateIdentifiers = function() {
         var self = this;
         bootbox.confirm({
-            title: 'Create identifiers',
+            title: 'Create DOI',
             message: '<p class="overflow">' +
-                'Are you sure you want to create a DOI and ARK for this ' +
-                $osf.htmlEscape(self.nodeType) + '? DOI and ARK identifiers' +
-                ' are persistent and will always resolve to this page.',
+                'Are you sure you want to create a DOI for this ' +
+                $osf.htmlEscape(self.nodeType) + '? The DOI will be' +
+                ' persistent and will always resolve to this page.',
             callback: function(confirmed) {
                 if (confirmed) {
                     self.createIdentifiers();
@@ -225,10 +225,10 @@ var ProjectViewModel = function(data, options) {
             self.ark(resp.ark);
         }).fail(function(xhr) {
             var message = 'We could not create the identifier at this time. ' +
-                'The DOI/ARK acquisition service may be down right now. ' +
+                'The DOI acquisition service may be down right now. ' +
                 'Please try again soon and/or contact ' + $osf.osfSupportLink();
             $osf.growl('Error', message, 'danger');
-            Raven.captureMessage('Could not create identifiers', {extra: {url: url, status: xhr.status}});
+            Raven.captureMessage('Could not create identifier', {extra: {url: url, status: xhr.status}});
         }).always(function() {
             clearTimeout(timeout);
             self.idCreationInProgress(false); // hide loading indicator

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -23,7 +23,7 @@ Keep your research materials and data private, make it accessible to specific ot
 Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report.<br>
 <br>
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI/ARK.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
 <br>
 <h4>Measure your impact</h4>
 You can monitor traffic to your public projects and downloads of your public files.<br>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -25,7 +25,7 @@ Keep your research materials and data private, make it accessible to specific ot
 Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report.<br>
 <br>
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI/ARK.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
 <br>
 <h4>Measure your impact</h4>
 You can monitor traffic to your public projects and downloads of your public files.<br>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -187,23 +187,19 @@
                     % endif
                     </p>
                 <span data-bind="if: hasIdentifiers()" class="scripted">
-                  <p>
-                    Identifiers:
-                  DOI <span data-bind="text: doi"></span> |
-                  ARK <span data-bind="text: ark"></span>
-                  </p>
+                  <p>DOI: <span data-bind="text: doi"></span></p>
                 </span>
                 <span data-bind="if: canCreateIdentifiers()" class="scripted">
                   <!-- ko if: idCreationInProgress() -->
                     <p>
                       <i class="fa fa-spinner fa-lg fa-spin"></i>
-                        <span class="text-info">Creating DOI and ARK. Please wait...</span>
+                        <span class="text-info">Creating DOI. Please wait...</span>
                     </p>
                   <!-- /ko -->
 
                   <!-- ko ifnot: idCreationInProgress() -->
                   <p>
-                  <a data-bind="click: askCreateIdentifiers, visible: !idCreationInProgress()">Create DOI / ARK</a>
+                  <a data-bind="click: askCreateIdentifiers, visible: !idCreationInProgress()">Create DOI</a>
                   </p>
                   <!-- /ko -->
                 </span>


### PR DESCRIPTION
## Purpose

The things we say are ARKs are not really ARKs and we should no longer show them to users. 

## Changes

This removes showing ARKs and references to ARKs in user-facing locations. References to ARKs were removed from the project detail page and the `/identifiers/`, `/node/<node-id>/identifiers/`, `/registrations/<registration-id>/identifiers/` and `/preprints/<preprint-id/identifiers/` api endpoints.

## QA Notes
ARKs should no longer show up on the project detail pages or at the `nodes/<nid>/identifiers/` endpoint. References that used to be "DOI/ARK" in these locations should just say DOI now. Mentions of 'identifiers' in these cases should be singular now.


## Side Effects

Note: This only changes the front end visibility of ARKs the fake ones we have are still being stored and used to check if identifiers exist (which is not ideal). This should be removed when we change how we get DOIs. 

## Ticket

https://openscience.atlassian.net/browse/OSF-9118

<img width="526" alt="screen shot 2018-01-03 at 3 32 49 pm" src="https://user-images.githubusercontent.com/7839433/34540164-8454f146-f0a1-11e7-9c22-30d027cf10ff.png">
<img width="614" alt="screen shot 2018-01-03 at 3 47 33 pm" src="https://user-images.githubusercontent.com/7839433/34540161-8053e0fc-f0a1-11e7-9f7e-c393abb1f0ed.png">
<img width="487" alt="screen shot 2018-01-03 at 3 47 50 pm" src="https://user-images.githubusercontent.com/7839433/34540153-779645f4-f0a1-11e7-8219-9511009e47ff.png">
<img width="592" alt="screen shot 2018-01-03 at 4 01 31 pm" src="https://user-images.githubusercontent.com/7839433/34540170-87fb6cda-f0a1-11e7-8073-fa4577e01b27.png">



  
  