### PR TITLE
[feature] Allow updates of all auto_now fields on all models to be disabled [OSF-9081]

### DIFF
--- a/osf/migrations/0044_ever_mentioned_array_to_m2m.py
+++ b/osf/migrations/0044_ever_mentioned_array_to_m2m.py
@@ -17,7 +17,7 @@ def migrate_user_guid_array_to_m2m(state, schema):
 
 def unmigrate_user_guid_array_from_m2m(state, schema):
     Comment = state.get_model('osf', 'comment')
-    with disable_auto_now_fields(Comment):
+    with disable_auto_now_fields(models=[Comment]):
         for comment in Comment.objects.exclude(ever_mentioned__isnull=False).all():
             comment._ever_mentioned = list(comment.ever_mentioned.values_list('guids___id', flat=True))
             comment.save()

--- a/osf/migrations/0069_auto_20171127_1119.py
+++ b/osf/migrations/0069_auto_20171127_1119.py
@@ -18,7 +18,7 @@ def add_preprint_doi_created(state, schema):
     current_preprint = 0
     logger.info('{} published preprints found with preprint_doi_created is null.'.format(preprints_count))
 
-    with disable_auto_now_fields(PreprintService):
+    with disable_auto_now_fields(models=[PreprintService]):
         for preprint in null_preprint_doi_created:
             current_preprint += 1
             if preprint.get_identifier('doi'):

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -13,15 +13,26 @@ from website.project.metadata.schemas import OSF_META_SCHEMAS
 logger = logging.getLogger(__file__)
 
 
-@contextmanager
-def disable_auto_now_fields(model=None):
+def get_osf_models():
     """
-    Context manager to disable updates of all auto_now fields for a given model.
-    If model=None, updates for all auto_now fields on all models will be disabled.
+    Helper function to retrieve all osf related models.
 
+    Example usage:
+        with disable_auto_now_fields(models=get_osf_models()):
+            ...
     """
-    all_app_models = list(itertools.chain(*[app.get_models() for app in apps.get_app_configs() if 'addons' in app.label or 'osf' in app.label]))
-    models = [model] if model else all_app_models
+    return list(itertools.chain(*[app.get_models() for app in apps.get_app_configs() if app.label.startswith('addons_') or app.label.startswith('osf')]))
+
+@contextmanager
+def disable_auto_now_fields(models=None):
+    """
+    Context manager to disable auto_now field updates.
+    If models=None, updates for all auto_now fields on *all* models will be disabled.
+
+    :param list models: Optional list of models for which auto_now field updates should be disabled.
+    """
+    if not models:
+        models = apps.get_models()
 
     changed = []
     for model in models:

--- a/osf_tests/test_utils.py
+++ b/osf_tests/test_utils.py
@@ -22,7 +22,7 @@ class TestDisableAutoNowContextManager:
 
         # update and save within context manager, confirm date doesn't change (i.e. auto_now was set to False)
         new_date_modified = node.modified
-        with disable_auto_now_fields(Node):
+        with disable_auto_now_fields(models=[Node]):
             node.title = 'AB'
             node.save()
         assert node.modified == new_date_modified
@@ -55,7 +55,7 @@ class TestDisableAutoNowContextManager:
         old_created = node.created
         assert Node._meta.get_field('created').auto_now is False
 
-        with disable_auto_now_fields(Node):
+        with disable_auto_now_fields(models=[Node]):
             node.description = 'new cool description!!'
         node.save()
 

--- a/osf_tests/test_utils.py
+++ b/osf_tests/test_utils.py
@@ -32,6 +32,25 @@ class TestDisableAutoNowContextManager:
         node.save()
         assert node.modified != new_date_modified
 
+    def test_auto_now_all_models_not_updated(self, node):
+        # update, save, confirm date changes
+        original_date_modified = node.modified
+        node.title = 'A'
+        node.save()
+        assert node.modified != original_date_modified
+
+        # update and save within context manager, confirm date doesn't change (i.e. auto_now was set to False)
+        new_date_modified = node.modified
+        with disable_auto_now_fields():
+            node.title = 'AB'
+            node.save()
+        assert node.modified == new_date_modified
+
+        # update, save, confirm date changes (i.e. that auto_now was set back to True)
+        node.title = 'ABC'
+        node.save()
+        assert node.modified != new_date_modified
+
     def test_auto_now_does_not_modify_non_auto_now_fields(self, node):
         old_created = node.created
         assert Node._meta.get_field('created').auto_now is False


### PR DESCRIPTION
#### Purpose
- Adds a precaution to ensure auto_now fields aren't updated in migrations. A dev may forget to pass all models that would get automatically updated by auto_now.

#### Changes
- Allows `disable_auto_now_fields` to take no arguments. If no arguments are passed, **all** auto_now fields on **all** models in the `osf` and `addons` apps will be disabled.

#### QA Notes
- None required/possible.

#### Side Effects
- None expected.

#### Ticket
- [OSF-9081](https://openscience.atlassian.net/browse/OSF-9081)