### PR TITLE
Hotfix/get ARK users [OSF-9117]

### DIFF
--- a/scripts/get_users_with_ARKs.py
+++ b/scripts/get_users_with_ARKs.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import io
+import csv
+import logging
+
+from website.app import setup_django
+setup_django()
+
+from website import mails
+from website import settings
+
+from osf.models import AbstractNode
+
+logger = logging.getLogger(__name__)
+
+
+def find_users_with_arks():
+    return list(
+        AbstractNode.objects.filter(
+        is_deleted=False,
+        is_public=True,
+        identifiers__category='ark',
+        ).values_list(
+            'contributor__user__username', flat=True
+        ).distinct()
+    )
+
+def main():
+    users_with_arks = find_users_with_arks()
+    if users_with_arks:
+        filename = 'users_with_arks.csv'
+
+        output = io.BytesIO()
+        writer = csv.writer(output)
+        for user in users_with_arks:
+            writer.writerow([user])
+
+        mails.send_mail(
+            mail=mails.EMPTY,
+            subject='Users with fake ARKs',
+            to_addr=settings.OSF_SUPPORT_EMAIL,
+            body='List of users with ARKs attached.',
+            attachment_name=filename,
+            attachment_content=output.getvalue(),
+        )
+
+    logger.info('{n} users with ARKs found.'.format(n=len(users_with_arks)))
+    logger.info('Users with ARKs email sent.')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/get_users_with_ARKs.py
+++ b/scripts/get_users_with_ARKs.py
@@ -9,43 +9,57 @@ setup_django()
 from website import mails
 from website import settings
 
-from osf.models import AbstractNode
+from osf.models import OSFUser
 
 logger = logging.getLogger(__name__)
 
 
-def find_users_with_arks():
-    return list(
-        AbstractNode.objects.filter(
-        is_deleted=False,
-        is_public=True,
-        identifiers__category='ark',
-        ).values_list(
-            'contributor__user__username', flat=True
-        ).distinct()
-    )
+def find_ark_dict():
+    users = OSFUser.objects.filter(nodes__identifiers__category='ark')
+
+    users_and_guids = {}
+
+    for user in users:
+        if user.is_registered:
+            users_and_guids[user.username] = list(
+                user.nodes.filter(
+                    is_deleted=False,
+                    is_public=True,
+                    identifiers__category='ark',
+                )
+            )
+
+    return users_and_guids
+
+def get_node_urls(node_list):
+    urls = ''
+    for node in node_list:
+        urls += node.absolute_url + ', '
+    return urls[0:-2]
+
 
 def main():
-    users_with_arks = find_users_with_arks()
-    if users_with_arks:
-        filename = 'users_with_arks.csv'
+    ark_dict = find_ark_dict()
+    if ark_dict:
+        filename = 'users_ark_nodes.csv'
 
         output = io.BytesIO()
         writer = csv.writer(output)
-        for user in users_with_arks:
-            writer.writerow([user])
+        for user in ark_dict:
+            urls = get_node_urls(ark_dict[user])
+            writer.writerow([user, urls])
 
         mails.send_mail(
             mail=mails.EMPTY,
-            subject='Users with fake ARKs',
+            subject='Users/Projects with ARKs',
             to_addr=settings.OSF_SUPPORT_EMAIL,
-            body='List of users with ARKs attached.',
+            body='CSV with users/nodes with ARKs attached.',
             attachment_name=filename,
             attachment_content=output.getvalue(),
         )
 
-    logger.info('{n} users with ARKs found.'.format(n=len(users_with_arks)))
-    logger.info('Users with ARKs email sent.')
+    logger.info('{n} users with ARKs found.'.format(n=len(ark_dict)))
+    logger.info('ARK csv email sent.')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Purpose

We are getting rid of ARKs because they aren't working correctly. Because of this,
 we need to email the users that currently have them.

## Changes

This script grabs the names of the users that have projects with ARKs so we can email them. It creates a CSV containing the users and their projects with ARKs.

Requirements:
- Grab projects/registrations that have ARKs (must be public/not deleted)
- List all registered users who are contributors on those projects
- Do not include any preprints (ARKs are generated for preprints but not surfaced


## Tests
No tests needed - one off script.

## QA Notes
None

## Side Effects
IMPORTANT: In OSF-9118, I remove ARKs from the UI, but do not stop their creation/addition to the database.  This script will not know whether or not ARKs were surfaced to users. It should be run once right after we merge #8088 (merging that PR will hide ARK creation from users - meaning they don't need to be notified about their disappearance).

## Ticket

https://openscience.atlassian.net/browse/OSF-9117

<img width="416" alt="screen shot 2018-01-04 at 6 02 30 pm" src="https://user-images.githubusercontent.com/7839433/34588187-a7063a0a-f179-11e7-8d8f-af5cc530b14b.png">

  