### PR TITLE
Feature/Ignore download_file and download_zip log actions [OSF-8785]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -314,6 +314,9 @@ def create_waterbutler_log(payload, **kwargs):
     with transaction.atomic():
         try:
             auth = payload['auth']
+            # Don't log download actions
+            if payload['action'] in ('download_file', 'download_zip'):
+                return {'status': 'success'}
             action = LOG_ACTION_MAP[payload['action']]
         except KeyError:
             raise HTTPError(httplib.BAD_REQUEST)

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -298,6 +298,23 @@ class TestAddonLogs(OsfTestCase):
             'github_addon_file_renamed',
         )
 
+    def test_action_downloads(self):
+        url = self.node.api_url_for('create_waterbutler_log')
+        download_actions=('download_file', 'download_zip')
+        for action in download_actions:
+            payload = self.build_payload(metadata={'path': 'foo'}, action=action)
+            nlogs = self.node.logs.count()
+            res = self.app.put_json(
+                url,
+                payload,
+                headers={'Content-Type': 'application/json'},
+                expect_errors=False,
+            )
+            assert_equal(res.status_code, 200)
+
+        self.node.reload()
+        assert_equal(self.node.logs.count(), nlogs)
+
     def test_add_file_osfstorage_log(self):
         self.configure_osf_addon()
         path = 'pizza'


### PR DESCRIPTION
## Purpose
We want Waterbutler to be able to send download information to `create_waterbutler_log` without raising an error or actually creating log data.

## Changes
This allows `create_waterbutler_log` to accept `download_file` and `download_zip` actions. Currently it just ignores them (This allows waterbutler to send us the data without returning 400s. We will use this data in OSF-8786 to tally downloads).

## QA Notes
When a preprint is downloaded, nothing should be added to its node log.

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/OSF-8785
