### PR TITLE
[#OSF-8990]Top level project have an 'Admins on Parent Projects' section

### DIFF
--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -46,9 +46,11 @@ class TestContributorUtils(OsfTestCase):
         user = AuthUserFactory()
         self.project.add_contributor(user, auth=Auth(self.project.creator), visible=False)
         self.project.save()
+        self.project.reload()
         serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True, admin_contributor=True)
         assert_equal(len(serialized), 1)
         assert_false(serialized[0]['visible'])
+
 
 class TestContributorViews(OsfTestCase):
 

--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -41,6 +41,14 @@ class TestContributorUtils(OsfTestCase):
         assert_false(serialized['visible'])
         assert_equal(serialized['permission'], 'read')
 
+    def test_serialize_contributor(self):
+        node = NodeFactory(parent=self.project, creator=self.project.creator)
+        user = AuthUserFactory()
+        self.project.add_contributor(user, auth=Auth(self.project.creator), visible=False)
+        self.project.save()
+        serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True, admin_contributor=True)
+        assert_equal(len(serialized), 1)
+        assert_false(serialized[0]['visible'])
 
 class TestContributorViews(OsfTestCase):
 

--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -48,7 +48,7 @@ class TestContributorUtils(OsfTestCase):
             user, auth=Auth(self.project.creator), permissions=['admin', 'read', 'wrtie'], visible=False
         )
         self.project.save()
-        serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True, admin_contributor=True)
+        serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True)
         assert_equal(len(serialized), 1)
         assert_false(serialized[0]['visible'])
 

--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -44,9 +44,10 @@ class TestContributorUtils(OsfTestCase):
     def test_serialize_contributor(self):
         node = NodeFactory(parent=self.project, creator=self.project.creator)
         user = AuthUserFactory()
-        self.project.add_contributor(user, auth=Auth(self.project.creator), visible=False)
+        self.project.add_contributor(
+            user, auth=Auth(self.project.creator), permissions=['admin', 'read', 'wrtie'], visible=False
+        )
         self.project.save()
-        self.project.reload()
         serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True, admin_contributor=True)
         assert_equal(len(serialized), 1)
         assert_false(serialized[0]['visible'])

--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -45,10 +45,10 @@ class TestContributorUtils(OsfTestCase):
         node = NodeFactory(parent=self.project, creator=self.project.creator)
         user = AuthUserFactory()
         self.project.add_contributor(
-            user, auth=Auth(self.project.creator), permissions=['admin', 'read', 'wrtie'], visible=False
+            user, auth=Auth(self.project.creator), permissions=['admin', 'read', 'write'], visible=False
         )
         self.project.save()
-        serialized = utils.serialize_contributors(node.admin_contributors, node, admin=True)
+        serialized = utils.serialize_contributors(node.parent_admin_contributors, node, admin=True)
         assert_equal(len(serialized), 1)
         assert_false(serialized[0]['visible'])
 

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -14,7 +14,8 @@ def get_profile_image_url(user, size=settings.PROFILE_IMAGE_MEDIUM):
                              use_ssl=True,
                              size=size)
 
-def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False, admin_contributor=False):
+
+def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False):
     """
     Return a dictionary representation of a registered user.
 
@@ -37,7 +38,7 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
         'active': user.is_active,
     }
     if node is not None:
-        if admin_contributor:
+        if admin:
             visible = False
             for x in node.parents:
                 if x.contributor_set.filter(user=user, admin=True, visible=True).exists():
@@ -45,11 +46,6 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
                     pass
             flags = {
                 'visible': visible,
-                'permission': 'read',
-            }
-        elif admin:
-            flags = {
-                'visible': False,
                 'permission': 'read',
             }
         else:
@@ -112,17 +108,10 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
 
 
 def serialize_contributors(contribs, node, **kwargs):
-    admin_contributor = kwargs.get('admin_contributor', False)
-    if not admin_contributor:
-        return [
-            serialize_user(contrib, node, **kwargs)
-            for contrib in contribs
-        ]
-    else:
-        return [
-            serialize_user(contrib, node, **kwargs)
-            for contrib in contribs if not node.contributor_set.filter(user=contrib).exists()
-        ]
+    return [
+        serialize_user(contrib, node, **kwargs)
+        for contrib in contribs
+    ]
 
 
 def serialize_visible_contributors(node):

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -37,8 +37,8 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
         'active': user.is_active,
     }
     if node is not None:
-        visible = False
         if admin_contributor:
+            visible = False
             for x in node.parents:
                 if x.contributor_set.filter(user=user, admin=True, visible=True).exists():
                     visible = True

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -374,7 +374,7 @@ def node_contributors(auth, node, **kwargs):
     ret = _view_project(node, auth, primary=True)
     ret['contributors'] = utils.serialize_contributors(node.contributors, node)
     ret['adminContributors'] = utils.serialize_contributors(
-        node.admin_contributors, node, admin=True, admin_contributor=True
+        node.parent_admin_contributors, node, admin=True
     )
     return ret
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -373,7 +373,9 @@ def node_choose_addons(auth, node, **kwargs):
 def node_contributors(auth, node, **kwargs):
     ret = _view_project(node, auth, primary=True)
     ret['contributors'] = utils.serialize_contributors(node.contributors, node)
-    ret['adminContributors'] = utils.serialize_contributors(node.admin_contributors, node, admin=True)
+    ret['adminContributors'] = utils.serialize_contributors(
+        node.admin_contributors, node, admin=True, admin_contributor=True
+    )
     return ret
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the 'admin on parents' table on contributor tab of projects
<!-- Describe the purpose of your changes -->

## Changes
1. Change the serialize_contributor function to handle the case when it is serialized for admin_contributor. Remove the return of the contributor on both the current project and its parent. 2. Improve the way to calculate the visibility of contributor on parent project in serialize_user function.
Before the change:
<img width="1245" alt="screen shot 2018-01-09 at 3 48 11 pm" src="https://user-images.githubusercontent.com/4974056/34742557-88872362-f554-11e7-8206-e00d83af1bf9.png">
After the change:
<img width="1256" alt="screen shot 2018-01-09 at 3 48 36 pm" src="https://user-images.githubusercontent.com/4974056/34742571-94f6e560-f554-11e7-9b3d-465a59bb7beb.png">

<!-- Briefly describe or list your changes  -->

## QA Notes
Test setup:
1. Create a project A with one child node B and one grandchild node C
2. add a new admin permission visible contributor X to node A
3. add a new admin permission invisible contributor Y to node B
Check:
1. go to the contributor tab of project A
expected: no 'admin on parents' table show up in that page
2. go to the contributor tab of project B
expected: 'Admin on parents' table shows up in that page with only one contributor X in it and X's 'Bibliographic Contributor' checkbox is checked
3. go to the contributor tab of project C
expected:  'Admin on parents' table shows up in that page with two contributors in it. Contributor X's 'Bibliographic Contributor' checkbox is checked and contributor Y's 'Bibliographic Contributor' checkbox is  NOT checked.

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-8990
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
