### PR TITLE
[hotfix] Increase max page size for preprint provider taxonomies [OSF-9158]

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -168,6 +168,9 @@ class MaxSizePagination(JSONAPIPagination):
 class NoMaxPageSizePagination(JSONAPIPagination):
     max_page_size = None
 
+class IncreasedPageSizePagination(JSONAPIPagination):
+    max_page_size = 1000
+
 class CommentPagination(JSONAPIPagination):
 
     def get_paginated_response(self, data):

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -15,7 +15,7 @@ from api.base import permissions as base_permissions
 from api.base.exceptions import InvalidFilterValue, InvalidFilterOperator, Conflict
 from api.base.filters import PreprintFilterMixin, ListFilterMixin
 from api.base.views import JSONAPIBaseView
-from api.base.pagination import MaxSizePagination
+from api.base.pagination import MaxSizePagination, IncreasedPageSizePagination
 from api.base.utils import get_object_or_error, get_user_auth, is_truthy
 from api.licenses.views import LicenseList
 from api.taxonomies.serializers import TaxonomySerializer
@@ -301,6 +301,7 @@ class PreprintProviderTaxonomies(JSONAPIBaseView, generics.ListAPIView):
     required_write_scopes = [CoreScopes.NULL]
 
     serializer_class = TaxonomySerializer
+    pagination_class = IncreasedPageSizePagination
 
     ordering = ('-id',)
 

--- a/api_tests/preprint_providers/views/test_preprint_provider_subjects_list.py
+++ b/api_tests/preprint_providers/views/test_preprint_provider_subjects_list.py
@@ -64,6 +64,21 @@ class TestPreprintProviderSubjects(ApiTestCase):
         self.lawless_url = '/{}preprint_providers/{}/taxonomies/?page[size]=15&'.format(API_BASE, self.lawless_preprint_provider._id)
         self.ruled_url = '/{}preprint_providers/{}/taxonomies/?page[size]=15&'.format(API_BASE, self.ruled_preprint_provider._id)
 
+    def test_max_page_size(self):
+        base_url = '/{}preprint_providers/{}/taxonomies/'.format(API_BASE, self.lawless_preprint_provider._id)
+
+        res = self.app.get(base_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['links']['meta']['per_page'], 10)
+
+        res = self.app.get(base_url + '?page[size]=150')
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['links']['meta']['per_page'], 150)
+
+        res = self.app.get(base_url + '?page[size]=2018')
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['links']['meta']['per_page'], 1000)
+
     def test_no_rules_grabs_all(self):
         res = self.app.get(self.lawless_url)
 


### PR DESCRIPTION
#### Purpose
- Increases the max page size for `/v2/preprint_providers/<provider_id>/taxonomies/` endpoint to 1000. 
- The preprints app used to make requests to the `/v2/taxonomies/` endpoint which has the `NoMaxSizePagination` class (see #6245), but a similar pagination class was never added to the preprint providers taxonomies endpoint.

#### Changes
- Add an `IncreasedPageSizePagination` class that sets `max_page_size` for a given view to 1000.
- Adds the `IncreasedPageSizePagination` class to the `PreprintProviderTaxonomies` list view.

#### QA Notes
- Noted on ticket.

#### Ticket
- [OSF-9158](https://openscience.atlassian.net/browse/OSF-9158)
