### PR TITLE
[Fix][MOD-203] Preprint banner should not show on project for non-contributors

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -273,7 +273,7 @@
     <%include file="include/comment_pane_template.mako"/>
 % endif
 
-% if node['is_preprint']:
+% if node['is_preprint'] and (user['is_contributor'] or node['has_published_preprint']):
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice m-b-md p-md clearfix">
@@ -299,9 +299,9 @@
                 This project represents a ${node['preprint_word']}.
             % endif
             <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with ${node['preprint_word']} files.
-            <a href="${node['preprint_url']}" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
+            <a href="${node['preprint_url']}" class="btn btn-default btn-sm m-r-xs pull-right">View ${node['preprint_word']}</a>
             % if user['is_admin']:
-                <a href="${node['preprint_url']}edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint</a>
+                <a href="${node['preprint_url']}edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit ${node['preprint_word']}</a>
             % endif
         </div>
     </div>


### PR DESCRIPTION
## Purpose
Non-contributors should not see the banner with "View Preprint" and then be taken to a "Page not found" since they don't have permissions. Preprint banner should not show on project for non-contributors.
<!-- Describe the purpose of your changes -->

## Changes
- Update project template
<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/MOD-203
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
