### PR TITLE
[WIP]Feature/Add file download endpoint [OSF-8982]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -34,7 +34,8 @@ from addons.base import exceptions
 from addons.base import signals as file_signals
 from osf.models import (BaseFileNode, TrashedFileNode,
                         OSFUser, AbstractNode,
-                        NodeLog, DraftRegistration, MetaSchema)
+                        NodeLog, DraftRegistration, MetaSchema,
+                        Guid)
 from website.profile.utils import get_profile_image_url
 from website.project import decorators
 from website.project.decorators import must_be_contributor_or_public, must_be_valid_project
@@ -691,6 +692,32 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         guid = file_node.get_guid(create=True)
         return redirect(furl.furl('/{}/'.format(guid._id)).set(args=extras).url)
     return addon_view_file(auth, node, file_node, version)
+
+
+@must_be_valid_project(quickfiles_valid=True)
+@must_be_contributor_or_public
+def persistent_file_download(**kwargs):
+    id_or_guid = kwargs.get('fid_or_guid')
+    file = BaseFileNode.active.filter(_id=id_or_guid).first()
+    if not file:
+        guid = Guid.load(id_or_guid)
+        if guid:
+            file = guid.referent
+        else:
+            raise HTTPError(httplib.NOT_FOUND, data={
+                'message_short': 'File Not Found',
+                'message_long': 'The requested file could not be found.'
+            })
+
+    return redirect(
+        file.generate_waterbutler_url(
+            version=request.args.get(
+                file.version_identifier,
+                file.versions.first().identifier
+            )
+        ),
+        code=httplib.FOUND
+    )
 
 
 def addon_view_or_download_quickfile(**kwargs):

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -709,13 +709,11 @@ def persistent_file_download(**kwargs):
                 'message_long': 'The requested file could not be found.'
             })
 
+    query_params = request.args.to_dict()
+    query_params.setdefault('version', file.versions.first().identifier)
+
     return redirect(
-        file.generate_waterbutler_url(
-            version=request.args.get(
-                file.version_identifier,
-                file.versions.first().identifier
-            )
-        ),
+        file.generate_waterbutler_url(**query_params),
         code=httplib.FOUND
     )
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -186,9 +186,12 @@ class BaseFileSerializer(JSONAPISerializer):
         'move': WaterbutlerLink(),
         'upload': WaterbutlerLink(),
         'delete': WaterbutlerLink(),
-        'download': WaterbutlerLink(must_be_file=True),
+        'download': 'get_download_link',
         'new_folder': WaterbutlerLink(must_be_folder=True, kind='folder'),
     })
+
+    def get_download_link(self, obj):
+        return get_file_download_link(obj)
 
     class Meta:
         type_ = 'files'
@@ -358,7 +361,8 @@ class FileVersionSerializer(JSONAPISerializer):
     date_created = DateByVersion(source='created', read_only=True, help_text='The date that this version was created')
     links = LinksField({
         'self': 'self_url',
-        'html': 'absolute_url'
+        'html': 'absolute_url',
+        'download': 'get_download_link',
     })
 
     class Meta:
@@ -380,3 +384,20 @@ class FileVersionSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return self.self_url(obj)
+
+    def get_download_link(self, obj):
+        return get_file_download_link(
+            self.context['view'].get_file(), version=obj.identifier
+        )
+
+
+def get_file_download_link(obj, version=None):
+    guid = obj.get_guid()
+    url = furl.furl(settings.DOMAIN).set(
+        path=(obj.node._id, 'download', guid._id if guid else obj._id),
+    )
+
+    if version:
+        url.set(query={obj.version_identifier: version})
+
+    return url.url

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -191,7 +191,7 @@ class BaseFileSerializer(JSONAPISerializer):
     })
 
     def get_download_link(self, obj):
-        return get_file_download_link(obj)
+        return get_file_download_link(obj, view_only=self.context['request'].get('view_only'))
 
     class Meta:
         type_ = 'files'
@@ -387,11 +387,12 @@ class FileVersionSerializer(JSONAPISerializer):
 
     def get_download_link(self, obj):
         return get_file_download_link(
-            self.context['view'].get_file(), version=obj.identifier
+            self.context['view'].get_file(), version=obj.identifier,
+            view_only=self.context['request'].get('view_only')
         )
 
 
-def get_file_download_link(obj, version=None):
+def get_file_download_link(obj, version=None, view_only=None):
     guid = obj.get_guid()
     url = furl.furl(settings.DOMAIN).set(
         path=(obj.node._id, 'download', guid._id if guid else obj._id),
@@ -399,5 +400,8 @@ def get_file_download_link(obj, version=None):
 
     if version:
         url.set(query={obj.version_identifier: version})
+
+    if view_only:
+        url.add(query=view_only)
 
     return url.url

--- a/api_tests/files/serializers/test_file_serializer.py
+++ b/api_tests/files/serializers/test_file_serializer.py
@@ -24,7 +24,7 @@ class TestFileSerializer:
 
     @pytest.fixture()
     def file_one(self, node, user):
-        return utils.create_test_file(node, user)
+        return utils.create_test_file(node, user, create_guid=False)
 
     def test_file_serializer(self, file_one):
         created = file_one.versions.last().created
@@ -32,6 +32,10 @@ class TestFileSerializer:
         created_tz_aware = created.replace(tzinfo=utc)
         modified_tz_aware = modified.replace(tzinfo=utc)
         new_format = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+        download_base = '/{}/download/{}'
+        path = file_one._id
+        pid = file_one.node._id
 
         # test_date_modified_formats_to_old_format
         req = make_drf_request_with_version(version='2.0')
@@ -52,3 +56,12 @@ class TestFileSerializer:
         req = make_drf_request_with_version(version='2.2')
         data = FileSerializer(file_one, context={'request': req}).data['data']
         assert datetime.strftime(created, new_format) == data['attributes']['date_created']
+
+        # check download file link with path
+        assert download_base.format(pid, path) in data['links']['download']
+
+        # check download file link with guid
+        guid = file_one.get_guid(create=True)._id
+        req = make_drf_request_with_version()
+        data = FileSerializer(file_one, context={'request': req}).data['data']
+        assert download_base.format(pid, guid) in data['links']['download']

--- a/website/routes.py
+++ b/website/routes.py
@@ -1169,6 +1169,12 @@ def make_url_map(app):
             OsfWebRenderer('project/view_file.mako', trust=False)
         ),
         Rule(
+            '/<pid>/download/<fid_or_guid>/',
+            'get',
+            addon_views.persistent_file_download,
+            json_renderer,
+        ),
+        Rule(
             [
                 '/api/v1/project/<pid>/files/<provider>/<path:path>/',
                 '/api/v1/project/<pid>/node/<nid>/files/<provider>/<path:path>/',


### PR DESCRIPTION
## Purpose

Currently the API surfaces waterbutler links for file downloads, we want to add persistent download links.

## Changes

- File download link `www.osf.io/<node_id>/download/<file_path_or_guid>/` added. 
(It currently redirects to the waterbutler link)
- Replaced the waterbutler links in the file serializer with the above url.
- Added the above link with a query parameter for version to the `/v2/files/<file_path_or_guid>/versions/` endpoint.

## QA Notes

- Add files to both public/private projects in order to check if the download links maintain permissions.
- Have files that have both have a guid and some that do not.
- Create multiple versions of a file and check the version links and default link work as expected. (The plain download link should download the latest version).

## Side Effects

None expected

## Ticket

https://openscience.atlassian.net/browse/OSF-8982
<img width="709" alt="screen shot 2018-01-16 at 11 25 35 pm" src="https://user-images.githubusercontent.com/7839433/35025847-d9209a94-fb15-11e7-91a8-e01b05e72956.png">
<img width="764" alt="screen shot 2018-01-16 at 11 25 03 pm" src="https://user-images.githubusercontent.com/7839433/35025899-fdd75c06-fb15-11e7-890e-e8e5cf40411c.png">
