### PR TITLE
[PLAT-471] Preprint provider export should include _id

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -21,7 +21,7 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable', '_id']
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -239,6 +239,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         res = self.view.get(self.request)
         content_dict = json.loads(res.content)
 
+        content_dict['fields']['_id'] = 'new_id'
         content_dict['fields']['name'] = 'Awesome New Name'
         data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
         self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})
@@ -249,6 +250,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         new_provider = PreprintProvider.objects.get(id=provider_id)
 
         nt.assert_equal(res.status_code, 302)
+        nt.assert_equal(new_provider._id, 'new_id')
         nt.assert_equal(new_provider.name, 'Awesome New Name')
         nt.assert_equal(new_provider.subjects.all().count(), 1)
         nt.assert_equal(new_provider.licenses_acceptable.all().count(), 1)
@@ -261,6 +263,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         res = self.view.get(self.request)
         content_dict = json.loads(res.content)
 
+        content_dict['fields']['_id'] = 'new_id'
         content_dict['fields']['name'] = 'Awesome New Name'
         content_dict['fields']['new_field'] = 'this is a new field, not in the model'
         del content_dict['fields']['description']  # this is a old field, removed from the model JSON
@@ -274,6 +277,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         new_provider = PreprintProvider.objects.get(id=provider_id)
 
         nt.assert_equal(res.status_code, 302)
+        nt.assert_equal(new_provider._id, 'new_id')
         nt.assert_equal(new_provider.name, 'Awesome New Name')
 
     def test_update_provider_existing_subjects(self):


### PR DESCRIPTION
## Purpose

When you export a preprint providers settings JSON as it doesn't include the _id attribute, this is less then desirable so we're putting the _id in the JSON.

## Changes

Changes config to stop blocking the _id and reinstates old test statement to test for it.

## QA Notes

In the Admin app export any preprint provider as JSON, do a quick ctrl-f to ensure "_id" is in the text of the file.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-471