### PR TITLE
[#PLAT-67]Add an unregister contributor to a not top-level component send wrong email

### DIFF
--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -520,9 +520,8 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
     throttle = throttle or settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE
 
     # Email users for projects, or for components where they are not contributors on the parent node.
-    if (contributor.is_registered
-            and not node.parent_node
-            or node.parent_node and not node.parent_node.is_contributor(contributor)):
+    if contributor.is_registered and \
+            (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor))):
 
         preprint_provider = None
         if email_template == 'preprint':

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -520,8 +520,8 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
     throttle = throttle or settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE
 
     # Email users for projects, or for components where they are not contributors on the parent node.
-    if contributor.is_registered and (not node.parent_node or (
-                node.parent_node and not node.parent_node.is_contributor(contributor))):
+    if contributor.is_registered and \
+            (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor))):
 
         preprint_provider = None
         if email_template == 'preprint':

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -520,8 +520,8 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
     throttle = throttle or settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE
 
     # Email users for projects, or for components where they are not contributors on the parent node.
-    if contributor.is_registered and \
-            (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor))):
+    if contributor.is_registered and (not node.parent_node or (
+                node.parent_node and not node.parent_node.is_contributor(contributor))):
 
         preprint_provider = None
         if email_template == 'preprint':


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that add an unregistered contributor to non top level project sending the wrong email.
<!-- Describe the purpose of your changes -->

## Changes
Fix the logic to check contributor.is_registered as a priority
<!-- Briefly describe or list your changes  -->

## QA Notes
1. create a project A
2. create a project B which is a component of A
3. Add an unregistered contributor with email to project B and check the email you get
before change:
You get an email with no way to set your password.
<img width="1162" alt="screen shot 2018-01-19 at 12 34 32 pm" src="https://user-images.githubusercontent.com/4974056/35163549-24d6596e-fd15-11e7-9c2e-c5bfae886e79.png">
after change:
You get an email with a link to set your password.
<img width="1010" alt="screen shot 2018-01-19 at 12 35 20 pm" src="https://user-images.githubusercontent.com/4974056/35163595-46a3fc2c-fd15-11e7-8ca9-cdbdd60acc55.png">

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-67
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
