### PR TITLE
[#PLAT-542]Update Identifier creation to no longer create ARKs

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -398,7 +398,7 @@ def root(request, format=None, **kwargs):
     The OSF serves as a repository and archive for study designs, materials, data, manuscripts, or anything else
     associated with your research during the research process. Every project and file on the OSF has a permanent unique
     identifier, and every registration (a permanent, time-stamped version of your projects and files) can be assigned a
-    DOI/ARK. You can use the OSF to measure your impact by monitoring the traffic to projects and files you make
+    DOI. You can use the OSF to measure your impact by monitoring the traffic to projects and files you make
     public. With the OSF you have full control of what parts of your research are public and what remains private.
 
     Beta notice: This API is currently a beta service.  You are encouraged to use the API and will receive support

--- a/api/logs/views.py
+++ b/api/logs/views.py
@@ -51,7 +51,7 @@ class NodeLogDetail(JSONAPIBaseView, generics.RetrieveAPIView, LogMixin):
     * 'edit_title': A Node's title is changed
     * 'edit_description': A Node's description is changed
     * 'updated_fields': One or more of a Node's fields are changed
-    * 'external_ids_added': An external identifier is added to a Node (e.g. DOI, ARK)
+    * 'external_ids_added': An external identifier is added to a Node (e.g. DOI)
     ---
     * 'contributor_added': A Contributor is added to a Node
     * 'contributor_removed': A Contributor is removed from a Node

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2421,7 +2421,7 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMi
     * 'edit_title': A Node's title is changed
     * 'edit_description': A Node's description is changed
     * 'updated_fields': One or more of a Node's fields are changed
-    * 'external_ids_added': An external identifier is added to a Node (e.g. DOI, ARK)
+    * 'external_ids_added': An external identifier is added to a Node (e.g. DOI)
     ===
     * 'contributor_added': A Contributor is added to a Node
     * 'contributor_removed': A Contributor is removed from a Node

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -119,7 +119,7 @@ class TestPreprintDetail:
 
     def test_published_preprint_doi_link_returned_after_datacite_request(self, app, user, preprint, url):
         expected_doi = EZID_FORMAT.format(namespace=DOI_NAMESPACE, guid=preprint._id).replace('doi:', '')
-        preprint.set_identifier_values(doi=expected_doi, ark='testark')
+        preprint.set_identifier_values(doi=expected_doi)
         res = app.get(url, auth=user.auth)
         assert res.json['data']['id'] == preprint._id
         assert res.json['data']['attributes']['is_published'] is True

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -228,10 +228,8 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMi
         if save:
             self.save()
 
-    def set_identifier_values(self, doi, ark=None, save=False):
+    def set_identifier_values(self, doi, save=False):
         self.set_identifier_value('doi', doi)
-        if ark:
-            self.set_identifier_value('ark', ark)
         self.preprint_doi_created = timezone.now()
 
         if save:

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -228,9 +228,10 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMi
         if save:
             self.save()
 
-    def set_identifier_values(self, doi, ark, save=False):
+    def set_identifier_values(self, doi, ark=None, save=False):
         self.set_identifier_value('doi', doi)
-        self.set_identifier_value('ark', ark)
+        if ark:
+            self.set_identifier_value('ark', ark)
         self.preprint_doi_created = timezone.now()
 
         if save:

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -548,7 +548,7 @@ def sync_set_identifiers(preprint):
         'already_exists': False
     }
     id_dict = parse_identifiers(ezid_return_value)
-    preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict.get('ark', None))
+    preprint.set_identifier_values(doi=id_dict['doi'])
 
 
 class PreprintFactory(DjangoModelFactory):

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -548,9 +548,10 @@ def sync_set_identifiers(preprint):
         'already_exists': False
     }
     id_dict = parse_identifiers(ezid_return_value)
-    try:
-        preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'])
-    except KeyError:
+    ark = id_dict.get('ark', None)
+    if ark:
+        preprint.set_identifier_values(doi=id_dict['doi'], ark=ark)
+    else:
         preprint.set_identifier_values(doi=id_dict['doi'])
 
 

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -548,11 +548,7 @@ def sync_set_identifiers(preprint):
         'already_exists': False
     }
     id_dict = parse_identifiers(ezid_return_value)
-    ark = id_dict.get('ark', None)
-    if ark:
-        preprint.set_identifier_values(doi=id_dict['doi'], ark=ark)
-    else:
-        preprint.set_identifier_values(doi=id_dict['doi'])
+    preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict.get('ark', None))
 
 
 class PreprintFactory(DjangoModelFactory):

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -548,7 +548,10 @@ def sync_set_identifiers(preprint):
         'already_exists': False
     }
     id_dict = parse_identifiers(ezid_return_value)
-    preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'])
+    try:
+        preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'])
+    except KeyError:
+        preprint.set_identifier_values(doi=id_dict['doi'])
 
 
 class PreprintFactory(DjangoModelFactory):

--- a/scripts/add_missing_identifiers_to_preprints.py
+++ b/scripts/add_missing_identifiers_to_preprints.py
@@ -26,7 +26,7 @@ def add_identifiers_to_preprints(dry_run=True):
         if not dry_run:
             ezid_response = request_identifiers_from_ezid(preprint)
             id_dict = parse_identifiers(ezid_response)
-            preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'])
+            preprint.set_identifier_values(doi=id_dict['doi'])
             preprint.save()
 
             doi = preprint.get_identifier('doi')

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -234,10 +234,7 @@ class TestIdentifierViews(OsfTestCase):
             res.json['doi'],
             self.node.get_identifier_value('doi')
         )
-
-        with assert_raises(KeyError):
-            ark = res.json['ark']
-
+        assert_not_in(res.json.keys(), 'ark')
         assert_equal(res.status_code, 201)
 
     @httpretty.activate

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -234,12 +234,11 @@ class TestIdentifierViews(OsfTestCase):
             res.json['doi'],
             self.node.get_identifier_value('doi')
         )
-        assert_equal(
-            res.json['ark'],
-            self.node.get_identifier_value('ark')
-        )
-        assert_equal(res.status_code, 201)
 
+        with assert_raises(KeyError):
+            ark = res.json['ark']
+
+        assert_equal(res.status_code, 201)
 
     @httpretty.activate
     def test_create_identifiers_exists(self):

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -130,7 +130,11 @@ def parse_identifiers(ezid_response):
             'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
         }
     else:
-        return {'doi': resp['success'].strip().split(':')[1]}
+        identifiers = dict(
+            [each.strip('/') for each in pair.strip().split(':')]
+            for pair in resp['success'].split('|')
+        )
+        return identifiers['doi']
 
 
 def get_or_create_identifiers(target_object):

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -103,7 +103,8 @@ def request_identifiers_from_ezid(target_object):
                 raise
             resp = client.get_identifier(doi)
             new = False
-
+        if new:
+            resp = {'success': resp['success'].split('|')[0]}
         return {
             'response': resp,
             'already_exists': already_exists,
@@ -129,10 +130,7 @@ def parse_identifiers(ezid_response):
             'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
         }
     else:
-        return dict(
-            [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]
-            for pair in resp['success'].split('|')
-        )
+        return {'doi': resp['success'].strip().split(':')[1]}
 
 
 def get_or_create_identifiers(target_object):
@@ -148,7 +146,6 @@ def get_or_create_identifiers(target_object):
         resp = response_dict['response']
         exists = response_dict['already_exists']
         new = response_dict['new']
-
         if exists:
             doi = resp['success']
             suffix = doi.strip(settings.DOI_NAMESPACE)
@@ -160,7 +157,4 @@ def get_or_create_identifiers(target_object):
             else:
                 return {'doi': doi.replace('doi:', '')}
         else:
-            return dict(
-                [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]
-                for pair in resp['success'].split('|')
-            )
+            return {'doi': resp['success'].strip().split(':')[1]}

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -146,6 +146,7 @@ def get_or_create_identifiers(target_object):
         resp = response_dict['response']
         exists = response_dict['already_exists']
         new = response_dict['new']
+        
         if exists:
             doi = resp['success']
             suffix = doi.strip(settings.DOI_NAMESPACE)

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -130,11 +130,7 @@ def parse_identifiers(ezid_response):
             'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
         }
     else:
-        identifiers = dict(
-            [each.strip('/') for each in pair.strip().split(':')]
-            for pair in resp['success'].split('|')
-        )
-        return identifiers['doi']
+        return {'doi': resp['success'].strip().split(':')[1]}
 
 
 def get_or_create_identifiers(target_object):

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -94,7 +94,7 @@ def request_identifiers_from_ezid(target_object):
 
         client = get_ezid_client()
         already_exists = False
-        new = True
+        only_doi = True
         try:
             resp = client.create_identifier(doi, metadata)
         except HTTPError as error:
@@ -102,13 +102,13 @@ def request_identifiers_from_ezid(target_object):
             if 'identifier already exists' not in error.message.lower():
                 raise
             resp = client.get_identifier(doi)
-            new = False
-        if new:
+            only_doi = False
+        if only_doi:
             resp = {'success': resp['success'].split('|')[0]}
         return {
             'response': resp,
             'already_exists': already_exists,
-            'new': new
+            'only_doi': only_doi
         }
 
 
@@ -149,11 +149,11 @@ def get_or_create_identifiers(target_object):
 
         resp = response_dict['response']
         exists = response_dict['already_exists']
-        new = response_dict['new']
+        only_doi = response_dict['only_doi']
         if exists:
             doi = resp['success']
             suffix = doi.strip(settings.DOI_NAMESPACE)
-            if not new:
+            if not only_doi:
                 return {
                     'doi': doi.replace('doi:', ''),
                     'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -120,23 +120,20 @@ def parse_identifiers(ezid_response):
     """
     resp = ezid_response['response']
     exists = ezid_response['already_exists']
-    new = ezid_response['new']
 
     if exists:
         doi = resp['success']
         suffix = doi.strip(settings.DOI_NAMESPACE)
-        if not new:
-            return {
-                'doi': doi.replace('doi:', ''),
-                'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
-            }
-        else:
-            return {'doi': doi.replace('doi:', '')}
+        return {
+            'doi': doi.replace('doi:', ''),
+            'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
+        }
     else:
         return dict(
             [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]
             for pair in resp['success'].split('|')
         )
+
 
 def get_or_create_identifiers(target_object):
     """

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -131,7 +131,7 @@ def parse_identifiers(ezid_response):
                 'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
             }
         else:
-            return {'doi': doi.replace('doi:', ''), }
+            return {'doi': doi.replace('doi:', '')}
     else:
         return dict(
             [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]
@@ -161,7 +161,7 @@ def get_or_create_identifiers(target_object):
                     'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
                 }
             else:
-                return {'doi': doi.replace('doi:', ''),}
+                return {'doi': doi.replace('doi:', '')}
         else:
             return dict(
                 [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -107,6 +107,7 @@ def request_identifiers_from_ezid(target_object):
             'already_exists': already_exists
         }
 
+
 def parse_identifiers(ezid_response):
     """
     Note: ARKs include a leading slash. This is stripped here to avoid multiple
@@ -152,6 +153,6 @@ def get_or_create_identifiers(target_object):
             }
         else:
             return dict(
-                [each.strip('/') for each in pair.strip().split(':')]
+                [each.strip('/') for each in pair.strip().split(':') if 'doi' in each]
                 for pair in resp['success'].split('|')
             )

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -130,7 +130,11 @@ def parse_identifiers(ezid_response):
             'ark': '{0}{1}'.format(settings.ARK_NAMESPACE.replace('ark:', ''), suffix),
         }
     else:
-        return {'doi': resp['success'].strip().split(':')[1]}
+        identifiers = dict(
+            [each.strip('/') for each in pair.strip().split(':')]
+            for pair in resp['success'].split('|')
+        )
+        return {'doi': identifiers['doi']}
 
 
 def get_or_create_identifiers(target_object):
@@ -157,4 +161,8 @@ def get_or_create_identifiers(target_object):
             else:
                 return {'doi': doi.replace('doi:', '')}
         else:
-            return {'doi': resp['success'].strip().split(':')[1]}
+            identifiers = dict(
+                [each.strip('/') for each in pair.strip().split(':')]
+                for pair in resp['success'].split('|')
+            )
+            return {'doi': identifiers['doi']}

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -103,8 +103,6 @@ def request_identifiers_from_ezid(target_object):
                 raise
             resp = client.get_identifier(doi)
             only_doi = False
-        if only_doi:
-            resp = {'success': resp['success'].split('|')[0]}
         return {
             'response': resp,
             'already_exists': already_exists,

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -146,7 +146,6 @@ def get_or_create_identifiers(target_object):
         resp = response_dict['response']
         exists = response_dict['already_exists']
         new = response_dict['new']
-        
         if exists:
             doi = resp['success']
             suffix = doi.strip(settings.DOI_NAMESPACE)

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -185,7 +185,7 @@ def get_and_set_preprint_identifiers(preprint_id):
     if ezid_response is None:
         return
     id_dict = parse_identifiers(ezid_response)
-    preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'], save=True)
+    preprint.set_identifier_values(doi=id_dict['doi'], save=True)
 
 
 @celery_app.task(ignore_results=True)

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -201,7 +201,7 @@ var ProjectViewModel = function(data, options) {
             title: 'Create identifiers',
             message: '<p class="overflow">' +
                 'Are you sure you want to create a DOI for this ' +
-                $osf.htmlEscape(self.nodeType) + '? A DOI identifier' +
+                $osf.htmlEscape(self.nodeType) + '? A DOI' +
                 ' is persistent and will always resolve to this page.',
             callback: function(confirmed) {
                 if (confirmed) {

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -196,9 +196,9 @@ var ProjectViewModel = function(data, options) {
         bootbox.confirm({
             title: 'Create identifiers',
             message: '<p class="overflow">' +
-                'Are you sure you want to create a DOI and ARK for this ' +
-                $osf.htmlEscape(self.nodeType) + '? DOI and ARK identifiers' +
-                ' are persistent and will always resolve to this page.',
+                'Are you sure you want to create a DOI for this ' +
+                $osf.htmlEscape(self.nodeType) + '? DOI  identifier' +
+                ' is persistent and will always resolve to this page.',
             callback: function(confirmed) {
                 if (confirmed) {
                     self.createIdentifiers();
@@ -225,7 +225,7 @@ var ProjectViewModel = function(data, options) {
             self.ark(resp.ark);
         }).fail(function(xhr) {
             var message = 'We could not create the identifier at this time. ' +
-                'The DOI/ARK acquisition service may be down right now. ' +
+                'The DOI acquisition service may be down right now. ' +
                 'Please try again soon and/or contact ' + $osf.osfSupportLink();
             $osf.growl('Error', message, 'danger');
             Raven.captureMessage('Could not create identifiers', {extra: {url: url, status: xhr.status}});

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -201,7 +201,7 @@ var ProjectViewModel = function(data, options) {
             title: 'Create identifiers',
             message: '<p class="overflow">' +
                 'Are you sure you want to create a DOI for this ' +
-                $osf.htmlEscape(self.nodeType) + '? DOI  identifier' +
+                $osf.htmlEscape(self.nodeType) + '? A DOI identifier' +
                 ' is persistent and will always resolve to this page.',
             callback: function(confirmed) {
                 if (confirmed) {

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -174,7 +174,11 @@ var ProjectViewModel = function(data, options) {
     };
 
     self.hasIdentifiers = ko.pureComputed(function() {
-        return !!(self.doi() && self.ark());
+        return !!(self.doi());
+    });
+
+    self.hasArk = ko.pureComputed(function() {
+        return !!(self.ark());
     });
 
     self.canCreateIdentifiers = ko.pureComputed(function() {

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -23,7 +23,7 @@ Keep your research materials and data private, make it accessible to specific ot
 Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report.<br>
 <br>
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI/ARK.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
 <br>
 <h4>Measure your impact</h4>
 You can monitor traffic to your public projects and downloads of your public files.<br>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -25,7 +25,7 @@ Keep your research materials and data private, make it accessible to specific ot
 Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report.<br>
 <br>
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI/ARK.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research.<br>
 <br>
 <h4>Measure your impact</h4>
 You can monitor traffic to your public projects and downloads of your public files.<br>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -197,13 +197,13 @@
                   <!-- ko if: idCreationInProgress() -->
                     <p>
                       <i class="fa fa-spinner fa-lg fa-spin"></i>
-                        <span class="text-info">Creating DOI and ARK. Please wait...</span>
+                        <span class="text-info">Creating DOI. Please wait...</span>
                     </p>
                   <!-- /ko -->
 
                   <!-- ko ifnot: idCreationInProgress() -->
                   <p>
-                  <a data-bind="click: askCreateIdentifiers, visible: !idCreationInProgress()">Create DOI / ARK</a>
+                  <a data-bind="click: askCreateIdentifiers, visible: !idCreationInProgress()">Create DOI</a>
                   </p>
                   <!-- /ko -->
                 </span>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -189,8 +189,8 @@
                 <span data-bind="if: hasIdentifiers()" class="scripted">
                   <p>
                     Identifiers:
-                  DOI <span data-bind="text: doi"></span> |
-                  ARK <span data-bind="text: ark"></span>
+                  DOI <span data-bind="text: doi"></span>
+                      <span data-bind="if: hasArk()" class="scripted">| ARK <span data-bind="text: ark"></span></span>
                   </p>
                 </span>
                 <span data-bind="if: canCreateIdentifiers()" class="scripted">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Update the identifier process, where we allow users to click 'Create DOI/ARK' to only create DOIs going forward.
Continue to display ARKs that were previously created
Update the UI so that users no longer see the option to Create ARKs, and only have the option to get a DOI for their content.
<!-- Describe the purpose of your changes -->

## Changes
Now you should only see 'Create DOI' for public projects we are admin on. For all new created DOI, it will only have DOI. For all existing identifier, it will show DOI and ARK.
<!-- Briefly describe or list your changes  -->

## QA Notes
1. go to a public project you have already created DOI/ ARK, everything should be the same.
2. create a new public project
3. You should see ' Create DOI' instead of 'Create DOI/ ARK'
4. After clicking that link and DOI is created, you should only see 'DOI: ........' without any 'ARK:.......'
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-542
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
