### PR TITLE
feature/make prereg csvs send to prereg email [PLAT-633]

### DIFF
--- a/scripts/generate_prereg_csv.py
+++ b/scripts/generate_prereg_csv.py
@@ -51,7 +51,7 @@ def main():
 
     mails.send_mail(
         mail=mails.PREREG_CSV,
-        to_addr=settings.OSF_SUPPORT_EMAIL,
+        to_addr=settings.PREREG_EMAIL,
         attachment_name=filename,
         attachment_content=output.getvalue(),
         celery=False  # attachment is not JSON-serializable, so don't pass it to celery

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -133,6 +133,8 @@ FROM_EMAIL = 'openscienceframework-noreply@osf.io'
 # support email
 OSF_SUPPORT_EMAIL = 'support@osf.io'
 
+# prereg email
+PREREG_EMAIL = 'prereg@cos.io'
 
 # Default settings for fake email address generation
 FAKE_EMAIL_NAME = 'freddiemercury'


### PR DESCRIPTION
## Purpose

Mistakenly was sending prereg csv emails to 'support@osf.io' - should have been sending them to 'prereg@cos.io'.

## Changes
Change them to send to 'prereg@cos.io'

## QA Notes
None


## Side Effects
None


## Ticket
https://openscience.atlassian.net/browse/PLAT-633
