### PR TITLE
[PLAT-106] Embed nodes on user detail causes 502s.

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -68,7 +68,7 @@ class UserMixin(object):
 
         if self.kwargs.get('is_embedded') is True:
             if key in self.request.parents[OSFUser]:
-                return self.request.parents[key]
+                return self.request.parents[OSFUser].get(key)
 
         current_user = self.request.user
 

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -260,6 +260,14 @@ class TestUserRoutesNodeRoutes:
         assert folder_deleted._id not in ids
         assert project_deleted_user_one._id not in ids
 
+    def test_embed_nodes(self, app, user_one, project_public_user_one):
+
+        url = '/{}users/{}/?embed=nodes'.format(API_BASE, user_one._id)
+        res = app.get(url, auth=user_one.auth)
+        assert res.status_code == 200
+        embedded_data = res.json['data']['embeds']['nodes']['data'][0]['attributes']
+        assert embedded_data['title'] == project_public_user_one.title
+
     def test_get_400_responses(self, app, user_one, user_two):
 
     #   test_get_403_path_users_me_nodes_no_user


### PR DESCRIPTION
## Purpose

Currently using the embed query parameter with value 'nodes' causes and KeyError and unsightly 502. This fix restores the intended behavior and add a test.

## Changes

- fixes key error in user detail
- adds test for  /?embed=nodes

## QA Notes

From a user detail endpoint uses the query parameter /?embed=nodes, this the response should include the embedded information about that user's nodes.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-106