### PR TITLE
Don't enable n+1 logging on travis [no ticket]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -267,9 +267,5 @@ SELECT_FOR_UPDATE_ENABLED = True
 # Disable anonymous user permissions in django-guardian
 ANONYMOUS_USER_NAME = None
 
-if DEBUG:
-    INSTALLED_APPS += ('nplusone.ext.django',)
-    MIDDLEWARE_CLASSES += ('nplusone.ext.django.NPlusOneMiddleware',)
-
 # If set to True, automated tests with extra queries will fail.
 NPLUSONE_RAISE = False

--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -12,8 +12,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 # DEBUG_PROPAGATE_EXCEPTIONS = True
 
 if DEBUG:
-    INSTALLED_APPS += ('debug_toolbar', )
-    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', )
+    INSTALLED_APPS += ('debug_toolbar', 'nplusone.ext.django',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', 'nplusone.ext.django.NPlusOneMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda(_): True
     }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Every once in awhile, a too-long n+1 log prevents travis from showing what tests have failed - so let's only enable it locally when on debug, not on travis (like django debug toolbar!)

## Changes

- move settings for adding N+1 to local-dist

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
None needed!

## Side Effects
None anticipated

## Ticket
no ticket