### PR TITLE
[#PLAT-92]OSF landing page for logged out users is missing footer

### DIFF
--- a/website/static/css/pages/landing-page.css
+++ b/website/static/css/pages/landing-page.css
@@ -154,6 +154,10 @@ font-weight: bold;
   border-top: 1px solid #D9E8F4;
 }
 
+.footer {
+    margin-top: -25px; /* Override footer margin for this page only */
+}
+
 /* Knockout Validation Styles */
 
 .customMessage { color: #ed9c28; }

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -339,9 +339,7 @@
 </%def>
 
 <%def name="footer()">
-    <div style="margin-top:-25px">
-        <%include file="footer.mako"/>
-    </div>
+    <%include file="footer.mako"/>
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -311,7 +311,7 @@
 
       </div>
     </div>
-    <div class  ="space-top space-bottom feature-6">
+    <div class="space-top space-bottom feature-6">
       <div class="container">
         <div class="row">
           <div class="col-md-8">

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -339,7 +339,9 @@
 </%def>
 
 <%def name="footer()">
-    <div style="margin-top:-25px"><%include file="footer.mako"/></div>
+    <div style="margin-top:-25px">
+        <%include file="footer.mako"/>
+    </div>
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -311,7 +311,7 @@
 
       </div>
     </div>
-    <div class="space-top space-bottom feature-6">
+    <div class  ="space-top space-bottom feature-6">
       <div class="container">
         <div class="row">
           <div class="col-md-8">
@@ -336,11 +336,12 @@
 
     </div>
 
-
 </%def>
 
 <%def name="footer()">
-
+    <div style="margin-top:-25px">
+        <%include file="footer.mako"/>
+    </div>
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -339,9 +339,7 @@
 </%def>
 
 <%def name="footer()">
-    <div style="margin-top:-25px">
-        <%include file="footer.mako"/>
-    </div>
+    <div style="margin-top:-25px"><%include file="footer.mako"/></div>
 </%def>
 
 <%def name="stylesheets()">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add footer to landing page.
<!-- Describe the purpose of your changes -->

## Changes
Now when you go to osf.io as a non login user, you can see the footer at the very bottom.
<!-- Briefly describe or list your changes  -->

## QA Notes
1. go to staging.osf.io as a non login user and go to the very bottom of the page. You should see the footer there now.
before change:
<img width="1345" alt="screen shot 2018-01-23 at 4 10 17 pm" src="https://user-images.githubusercontent.com/4974056/35300991-4c5aebee-0058-11e8-9e5e-e712e8853a87.png">
after change:
<img width="1375" alt="screen shot 2018-01-23 at 4 09 58 pm" src="https://user-images.githubusercontent.com/4974056/35300998-525833a8-0058-11e8-9235-aa1a2c8e4b4b.png">

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-92
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
