### PR TITLE
[#PLAT-75]Top level project have an 'Admins on Parent Projects' section

### DIFF
--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -41,6 +41,17 @@ class TestContributorUtils(OsfTestCase):
         assert_false(serialized['visible'])
         assert_equal(serialized['permission'], 'read')
 
+    def test_serialize_contributor(self):
+        node = NodeFactory(parent=self.project, creator=self.project.creator)
+        user = AuthUserFactory()
+        self.project.add_contributor(
+            user, auth=Auth(self.project.creator), permissions=['admin', 'read', 'write'], visible=False
+        )
+        self.project.save()
+        serialized = utils.serialize_contributors(node.parent_admin_contributors, node, admin=True)
+        assert_equal(len(serialized), 1)
+        assert_false(serialized[0]['visible'])
+
 
 class TestContributorViews(OsfTestCase):
 

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -14,6 +14,7 @@ def get_profile_image_url(user, size=settings.PROFILE_IMAGE_MEDIUM):
                              use_ssl=True,
                              size=size)
 
+
 def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False):
     """
     Return a dictionary representation of a registered user.
@@ -38,8 +39,13 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
     }
     if node is not None:
         if admin:
+            visible = False
+            for x in node.parents:
+                if x.contributor_set.filter(user=user, admin=True, visible=True).exists():
+                    visible = True
+            pass
             flags = {
-                'visible': False,
+                'visible': visible,
                 'permission': 'read',
             }
         else:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
A follow up fix for this ticket. This pr mainly address the problem that when you have a visible admin contributor on parent project. The admin on parent in the child component of that project show this contributor as invisible which is incorrect.
<!-- Describe the purpose of your changes -->

## Changes
Now all the admin on parent project should show up their visibility correctly on child component
<!-- Briefly describe or list your changes  -->

## QA Notes
1. Create a project with a visible admin contributor and create a component of the project without that admin contributor.
2. visit the contributor tab of the component. In the 'Admin on parent' table, that checkbox for visibility for this admin contributor should be checked.

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-75
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
