### PR TITLE
[hotfix] Process command line single quotes for custom taxonomy [no ticket]

### DIFF
--- a/osf/management/commands/populate_custom_taxonomies.py
+++ b/osf/management/commands/populate_custom_taxonomies.py
@@ -178,6 +178,11 @@ def migrate(provider=None, share_title=None, data=None, dry_run=False, copy=Fals
     do_custom_mapping(custom_provider, data.get('custom', {}))
     map_preprints_to_custom_subjects(custom_provider, data.get('merge', {}), dry_run=dry_run)
 
+def process_shell_escaped_quotes(data):
+    # Translate shell-style escaped quotes for apostrophes - "Children\''s" to "Children\'s"
+    return data.replace("\\\'", "\'")
+
+
 class Command(BaseCommand):
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -216,6 +221,13 @@ class Command(BaseCommand):
             help='Adds "used-but-not-included" subjects.'
         )
         parser.add_argument(
+            '--escape-quotes',
+            action='store_true',
+            dest='escape_quotes',
+            help='Properly handles escaped quotes in data entered from the command line,'
+            '\nTo specify a subject with text containing an apostrophe, as in Women\'s Studies, include two quotes after the escape backslash.'
+        )
+        parser.add_argument(
             '--share-title',
             action='store',
             type=str,
@@ -228,7 +240,10 @@ class Command(BaseCommand):
         BEPRESS_PROVIDER = PreprintProvider.objects.filter(_id='osf').first()
         dry_run = options.get('dry_run')
         provider = options['provider']
-        data = json.loads(options['data'] or '{}')
+        data_given = options['data'] or '{}'
+        if options.get('escape_quotes'):
+            data_given = process_shell_escaped_quotes(data_given)
+        data = json.loads(data_given)
         share_title = options.get('share_title')
         copy = options.get('from_subjects_acceptable')
         add_missing = options.get('add_missing')


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Since this is essentially a command line tool, in order to use subject text whose name includes a ' (such as Children's and Young Adult Literature or Women's Studies), we need a way to translate between bash/zsh escaped quotes (`\''`) and JSON loads escaped quotes (`\'`).

As far as I can tell, this is the only way I could get the quotes all the way through the pipeline:
in command line : `\''` (two single quotes) ` ("Women\''s Studies")`
in python, as a string, pre-json loads: `\\\'`  `("Women\\\'s Studies")`

## Changes

- add the `--escape-quotes` argument that let's you enter subjects with ' in their name if you escape it with a backslash and two single quotes

## QA Notes
no qa needed

## Side Effects
none

## Ticket
no direct ticket, but related to https://openscience.atlassian.net/browse/PLAT-521