### PR TITLE
[PLAT-247] Don't exclude osf_tests from flake8

### DIFF
--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -539,7 +539,7 @@ class PreprintProviderFactory(DjangoModelFactory):
 
 
 def sync_set_identifiers(preprint):
-    ezid_return_value ={
+    ezid_return_value = {
         'response': {
             'success': '{doi}osf.io/{guid} | {ark}osf.io/{guid}'.format(
                 doi=settings.DOI_NAMESPACE, ark=settings.ARK_NAMESPACE, guid=preprint._id
@@ -717,15 +717,15 @@ class ExternalAccountFactory(DjangoModelFactory):
 
 
 class MockOAuth2Provider(models.ExternalProvider):
-    name = "Mock OAuth 2.0 Provider"
-    short_name = "mock2"
+    name = 'Mock OAuth 2.0 Provider'
+    short_name = 'mock2'
 
-    client_id = "mock2_client_id"
-    client_secret = "mock2_client_secret"
+    client_id = 'mock2_client_id'
+    client_secret = 'mock2_client_secret'
 
-    auth_url_base = "https://mock2.com/auth"
-    callback_url = "https://mock2.com/callback"
-    auto_refresh_url = "https://mock2.com/callback"
+    auth_url_base = 'https://mock2.com/auth'
+    callback_url = 'https://mock2.com/callback'
+    auto_refresh_url = 'https://mock2.com/callback'
     refresh_time = 300
     expiry_time = 9001
 

--- a/osf_tests/test_analytics.py
+++ b/osf_tests/test_analytics.py
@@ -23,6 +23,8 @@ pytestmark = pytest.mark.django_db
 
 class TestAnalytics(OsfTestCase):
 
+
+
     def test_get_total_activity_count(self):
         user = UserFactory()
         date = timezone.now()

--- a/osf_tests/test_comment.py
+++ b/osf_tests/test_comment.py
@@ -391,7 +391,7 @@ class FileCommentMoveRenameTestMixin(object):
 
     @pytest.fixture()
     def project(self, user):
-        p =  ProjectFactory(creator=user)
+        p = ProjectFactory(creator=user)
         p_settings = p.get_or_add_addon(self.provider, Auth(user))
         p_settings.folder = '/Folder1'
         p_settings.save()
@@ -824,7 +824,7 @@ class FileCommentMoveRenameTestMixin(object):
 
     @pytest.mark.parametrize(
         ['destination_provider', 'destination_path'],
-        [('box', '/1234567890'), ('dropbox', '/subfolder/file.txt'), ('github', '/subfolder/file.txt'), ('googledrive', '/subfolder/file.txt'), ('s3', '/subfolder/file.txt'),]
+        [('box', '/1234567890'), ('dropbox', '/subfolder/file.txt'), ('github', '/subfolder/file.txt'), ('googledrive', '/subfolder/file.txt'), ('s3', '/subfolder/file.txt'), ]
     )
     def test_comments_move_when_folder_moved_to_different_provider(self, destination_provider, destination_path, project, user):
         if self.provider == destination_provider:

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -44,7 +44,7 @@ def create_test_file(fake):
 
 
 def test_active_manager_does_not_return_trashed_file_nodes(project, create_test_file):
-    file = create_test_file(node=project)
+    create_test_file(node=project)
     deleted_file = create_test_file(node=project)
     deleted_file.delete(user=project.creator, save=True)
     # root folder + file + deleted_file = 3 BaseFileNodes

--- a/osf_tests/test_guid_auto_include.py
+++ b/osf_tests/test_guid_auto_include.py
@@ -3,8 +3,7 @@ from django.utils import timezone
 import pytest
 from django_bulk_update.helper import bulk_update
 
-from osf.models import OSFUser
-from django.db.models import Max, DateTimeField
+from django.db.models import DateTimeField
 
 from osf_tests.factories import UserFactory, PreprintFactory, NodeFactory
 
@@ -25,8 +24,7 @@ class TestGuidAutoInclude:
     @pytest.mark.parametrize('Factory', guid_factories)
     @pytest.mark.django_assert_num_queries
     def test_all(self, Factory, django_assert_num_queries):
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             UserFactory()
         with django_assert_num_queries(1):
             wut = Factory._meta.model.objects.all()
@@ -37,8 +35,7 @@ class TestGuidAutoInclude:
     @pytest.mark.django_assert_num_queries
     def test_filter(self, Factory, django_assert_num_queries):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
         new_ids = [o.id for o in objects]
         with django_assert_num_queries(1):
@@ -51,8 +48,7 @@ class TestGuidAutoInclude:
     @pytest.mark.django_assert_num_queries
     def test_filter_order_by(self, Factory, django_assert_num_queries):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
         new_ids = [o.id for o in objects]
         with django_assert_num_queries(1):
@@ -65,10 +61,8 @@ class TestGuidAutoInclude:
     @pytest.mark.django_assert_num_queries
     def test_values(self, Factory, django_assert_num_queries):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
-        new_ids = [o.id for o in objects]
         with django_assert_num_queries(1):
             wut = Factory._meta.model.objects.values('id')
             for x in wut:
@@ -78,10 +72,8 @@ class TestGuidAutoInclude:
     @pytest.mark.django_assert_num_queries
     def test_exclude(self, Factory, django_assert_num_queries):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
-        new_ids = [o.id for o in objects]
         try:
             dtfield = [x.name for x in objects[0]._meta.get_fields() if isinstance(x, DateTimeField)][0]
         except IndexError:
@@ -95,8 +87,7 @@ class TestGuidAutoInclude:
     @pytest.mark.parametrize('Factory', guid_factories)
     def test_update_objects(self, Factory):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
         new_ids = [o.id for o in objects]
         try:
@@ -106,15 +97,14 @@ class TestGuidAutoInclude:
         qs = objects[0]._meta.model.objects.filter(id__in=new_ids)
         assert len(qs) > 0, 'No results returned'
         try:
-            count = qs.update(**{dtfield: timezone.now()})
+            qs.update(**{dtfield: timezone.now()})
         except Exception as ex:
             pytest.fail('Queryset update failed for {} with exception {}'.format(Factory._meta.model.__name__, ex))
 
     @pytest.mark.parametrize('Factory', guid_factories)
     def test_update_on_objects_filtered_by_guids(self, Factory):
         objects = []
-        ids = range(0, 5)
-        for id in ids:
+        for _ in range(0, 5):
             objects.append(Factory())
         new__ids = [o._id for o in objects]
         try:
@@ -124,7 +114,7 @@ class TestGuidAutoInclude:
         qs = objects[0]._meta.model.objects.filter(guids___id__in=new__ids)
         assert len(qs) > 0, 'No results returned'
         try:
-            count = qs.update(**{dtfield: timezone.now()})
+            qs.update(**{dtfield: timezone.now()})
         except Exception as ex:
             pytest.fail('Queryset update failed for {} with exception {}'.format(Factory._meta.model.__name__, ex))
 
@@ -136,7 +126,7 @@ class TestGuidAutoInclude:
             pytest.skip('Thing must have contributors')
         try:
             with django_assert_num_queries(1):
-                wut = [x._id for x in thing_with_contributors.contributors.all()]
+                [x._id for x in thing_with_contributors.contributors.all()]
         except Exception as ex:
             pytest.fail('Related manager failed for {} with exception {}'.format(Factory._meta.model.__name__, ex))
 
@@ -144,8 +134,7 @@ class TestGuidAutoInclude:
     @pytest.mark.django_assert_num_queries
     def test_count_objects(self, Factory, django_assert_num_queries):
         objects = []
-        things = range(0, 5)
-        for thing in things:
+        for _ in range(0, 5):
             objects.append(Factory())
         new_ids = [o.id for o in objects]
         with django_assert_num_queries(1):
@@ -162,7 +151,7 @@ class TestGuidAutoInclude:
         if Factory == PreprintFactory:
             # Don't try to save preprints on build when neither the subject nor provider have been saved
             kwargs['finish'] = False
-        for _ in range(0,5):
+        for _ in range(0, 5):
             objects.append(Factory.build(**kwargs))
         with django_assert_num_queries(1):
             things = Model.objects.bulk_create(objects)

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -22,7 +22,7 @@ def test_querying_on_domains():
 @pytest.mark.django_db
 def test_institution_banner_path_none():
     inst = InstitutionFactory(banner_name='kittens.png')
-    assert not inst.banner_path is None
+    assert inst.banner_path is not None
     inst.banner_name = None
     assert inst.banner_path is None
 
@@ -30,7 +30,7 @@ def test_institution_banner_path_none():
 @pytest.mark.django_db
 def test_institution_logo_path_none():
     inst = InstitutionFactory(logo_name='kittens.png')
-    assert not inst.logo_path is None
+    assert inst.logo_path is not None
     inst.logo_name = None
     assert inst.logo_path is None
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -4,7 +4,8 @@ from django.utils import timezone
 import mock
 import pytest
 import pytz
-import random, string
+import random
+import string
 from framework.celery_tasks import handlers
 from framework.exceptions import PermissionsError
 from framework.sessions import set_session
@@ -182,17 +183,15 @@ class TestParentNode:
         grandchild2 = NodeFactory(parent=child)
         grandchild3 = NodeFactory(parent=child)
         grandchild_1 = NodeFactory(parent=child1)
-        grandchild1_1 = NodeFactory(parent=child1)
-        grandchild2_1 = NodeFactory(parent=child1)
-        grandchild3_1 = NodeFactory(parent=child1)
-        grandchild_2 = NodeFactory(parent=child2)
-        grandchild1_2 = NodeFactory(parent=child2)
-        grandchild2_2 = NodeFactory(parent=child2)
-        grandchild3_2 = NodeFactory(parent=child2)
-        greatgrandchild = NodeFactory(parent=grandchild)
-        greatgrandchild1 = NodeFactory(parent=grandchild1)
-        greatgrandchild2 = NodeFactory(parent=grandchild2)
-        greatgrandchild3 = NodeFactory(parent=grandchild3)
+        for _ in range(0, 3):
+            NodeFactory(parent=child1)
+        for _ in range(0, 4):
+            NodeFactory(parent=child2)
+
+        NodeFactory(parent=grandchild)
+        NodeFactory(parent=grandchild1)
+        NodeFactory(parent=grandchild2)
+        NodeFactory(parent=grandchild3)
         greatgrandchild_1 = NodeFactory(parent=grandchild_1, is_deleted=True)
 
         assert 20 == Node.objects.get_children(root).count()
@@ -234,17 +233,15 @@ class TestParentNode:
         grandchild2 = NodeFactory(parent=child)
         grandchild3 = NodeFactory(parent=child)
         grandchild_1 = NodeFactory(parent=child1)
-        grandchild1_1 = NodeFactory(parent=child1)
-        grandchild2_1 = NodeFactory(parent=child1)
-        grandchild3_1 = NodeFactory(parent=child1)
-        grandchild_2 = NodeFactory(parent=child2)
-        grandchild1_2 = NodeFactory(parent=child2)
-        grandchild2_2 = NodeFactory(parent=child2)
-        grandchild3_2 = NodeFactory(parent=child2)
-        greatgrandchild = NodeFactory(parent=grandchild)
-        greatgrandchild1 = NodeFactory(parent=grandchild1)
-        greatgrandchild2 = NodeFactory(parent=grandchild2)
-        greatgrandchild3 = NodeFactory(parent=grandchild3)
+        for _ in range(0, 3):
+            NodeFactory(parent=child1)
+        for _ in range(0, 4):
+            NodeFactory(parent=child2)
+
+        NodeFactory(parent=grandchild)
+        NodeFactory(parent=grandchild1)
+        NodeFactory(parent=grandchild2)
+        NodeFactory(parent=grandchild3)
         greatgrandchild_1 = NodeFactory(parent=grandchild_1)
 
         child.add_node_link(root, auth=Auth(root.creator))
@@ -287,9 +284,9 @@ class TestParentNode:
 
     def test_get_roots_distinct(self):
         top_level = ProjectFactory()
-        child1 = ProjectFactory(parent=top_level)
-        child2 = ProjectFactory(parent=top_level)
-        child3 = ProjectFactory(parent=top_level)
+        ProjectFactory(parent=top_level)
+        ProjectFactory(parent=top_level)
+        ProjectFactory(parent=top_level)
 
         assert AbstractNode.objects.get_roots().count() == 1
         assert top_level in AbstractNode.objects.get_roots()
@@ -308,7 +305,7 @@ class TestParentNode:
         assert child.parent_node._id == project._id
 
     def test_grandchild_has_parent_of_child(self, child):
-        grandchild = NodeFactory(parent=child, description="Spike")
+        grandchild = NodeFactory(parent=child, description='Spike')
         assert grandchild.parent_node._id == child._id
 
     def test_registration_has_no_parent(self, registration):
@@ -325,7 +322,7 @@ class TestParentNode:
 
     def test_recursive_registrations_have_correct_root(self, project, auth):
         child = NodeFactory(parent=project)
-        grandchild = NodeFactory(parent=child)
+        NodeFactory(parent=child)
 
         with disconnected_from_listeners(after_create_registration):
             reg_root = project.register_node(get_default_metaschema(), auth, '', None)
@@ -353,7 +350,7 @@ class TestParentNode:
 
     def test_recursive_forks_have_correct_root(self, project, auth):
         child = NodeFactory(parent=project)
-        grandchild = NodeFactory(parent=child)
+        NodeFactory(parent=child)
 
         fork_root = project.fork_node(auth=auth)
         fork_child = fork_root._nodes.first()
@@ -377,7 +374,7 @@ class TestParentNode:
 
     def test_recursive_templates_have_correct_root(self, project, auth):
         child = NodeFactory(parent=project)
-        grandchild = NodeFactory(parent=child)
+        NodeFactory(parent=child)
 
         template_root = project.use_as_template(auth=auth)
         template_child = template_root._nodes.first()
@@ -1983,12 +1980,12 @@ class TestPrivateLinks:
         mock_property.return_value(mock.MagicMock())
         mock_property.anonymous = True
 
-        link1 = PrivateLinkFactory(key="link1")
+        link1 = PrivateLinkFactory(key='link1')
         link1.nodes.add(node)
         link1.save()
 
         user2 = UserFactory()
-        auth2 = Auth(user=user2, private_key="link1")
+        auth2 = Auth(user=user2, private_key='link1')
 
         assert has_anonymous_link(node, auth2) is True
 
@@ -3361,13 +3358,6 @@ class TestOnNodeUpdate:
         assert task.args[2] is False
         assert 'title' in task.args[3]
 
-    @mock.patch('website.project.tasks.settings.SHARE_URL', None)
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', None)
-    @mock.patch('website.project.tasks.requests')
-    def test_skips_no_settings(self, requests, node, user, request_context):
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        assert requests.post.called is False
-
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
     @mock.patch('website.project.tasks.requests')
@@ -3701,7 +3691,7 @@ class TestTemplateNode:
 
         # create templated node
         project1 = ProjectFactory(creator=user)
-        subproject1 = ProjectFactory(creator=user, parent=project1)
+        ProjectFactory(creator=user, parent=project1)
 
         new = project1.use_as_template(auth=auth)
 

--- a/osf_tests/test_oauth_application.py
+++ b/osf_tests/test_oauth_application.py
@@ -41,12 +41,12 @@ class TestApiOAuth2Application(OsfTestCase):
 
     def test_invalid_home_url_raises_exception(self):
         with pytest.raises(ValidationError):
-            api_app = ApiOAuth2ApplicationFactory(home_url="Totally not a URL")
+            api_app = ApiOAuth2ApplicationFactory(home_url='Totally not a URL')
             api_app.save()
 
     def test_invalid_callback_url_raises_exception(self):
         with pytest.raises(ValidationError):
-            api_app = ApiOAuth2ApplicationFactory(callback_url="itms://itunes.apple.com/us/app/apple-store/id375380948?mt=8")
+            api_app = ApiOAuth2ApplicationFactory(callback_url='itms://itunes.apple.com/us/app/apple-store/id375380948?mt=8')
             api_app.save()
 
     def test_name_cannot_be_blank(self):
@@ -80,4 +80,3 @@ class TestApiOAuth2Application(OsfTestCase):
             self.api_app.deactivate(save=True)
         self.api_app.reload()
         assert self.api_app.is_active is True
-

--- a/osf_tests/test_preprint_summary.py
+++ b/osf_tests/test_preprint_summary.py
@@ -6,7 +6,6 @@ import mock
 import pytest
 import pytz
 import requests
-from django.utils import timezone
 
 from scripts.analytics.preprint_summary import PreprintSummary
 
@@ -59,4 +58,3 @@ class TestPreprintCount:
         data = results[0]
         assert data['provider']['name'] == 'Test 1'
         assert data['provider']['total'] == 1
-

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -304,7 +304,7 @@ class TestRegisterNodeContributors:
     @pytest.fixture()
     def project_two(self, user, auth):
         return factories.ProjectFactory(creator=user)
-    
+
     @pytest.fixture()
     def component(self, user, auth, project_two):
         return factories.NodeFactory(

--- a/osf_tests/test_remind_draft_preregistrations.py
+++ b/osf_tests/test_remind_draft_preregistrations.py
@@ -33,7 +33,6 @@ class TestPreregReminder:
         draft.save()
         return draft
 
-
     def test_trigger_prereg_reminder(self, draft):
         main(dry_run=False)
 

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -13,7 +13,6 @@ from osf_tests.utils import mock_archive
 
 from framework.auth import Auth
 
-from website import settings
 from website.exceptions import NodeStateError
 
 

--- a/osf_tests/test_search_views.py
+++ b/osf_tests/test_search_views.py
@@ -100,17 +100,17 @@ class TestSearchViews(OsfTestCase):
 
         #Test search node
         res = self.app.post_json(
-          api_url_for('search_node'),
-          {'query': self.project.title},
-          auth=factories.AuthUserFactory().auth
+            api_url_for('search_node'),
+            {'query': self.project.title},
+            auth=factories.AuthUserFactory().auth
         )
         assert_equal(res.status_code, 200)
 
         #Test search node includePublic true
         res = self.app.post_json(
-          api_url_for('search_node'),
-          {'query': 'a', 'includePublic': True},
-          auth=self.user_one.auth
+            api_url_for('search_node'),
+            {'query': 'a', 'includePublic': True},
+            auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
         assert_in(self.project_private_user_one._id, node_ids)
@@ -120,9 +120,9 @@ class TestSearchViews(OsfTestCase):
 
         #Test search node includePublic false
         res = self.app.post_json(
-          api_url_for('search_node'),
-          {'query': 'a', 'includePublic': False},
-          auth=self.user_one.auth
+            api_url_for('search_node'),
+            {'query': 'a', 'includePublic': False},
+            auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
         assert_in(self.project_private_user_one._id, node_ids)
@@ -221,11 +221,11 @@ class TestODMTitleSearch(OsfTestCase):
 
         self.user = factories.AuthUserFactory()
         self.user_two = factories.AuthUserFactory()
-        self.project = factories.ProjectFactory(creator=self.user, title="foo")
-        self.project_two = factories.ProjectFactory(creator=self.user_two, title="bar")
-        self.public_project = factories.ProjectFactory(creator=self.user_two, is_public=True, title="baz")
-        self.registration_project = factories.RegistrationFactory(creator=self.user, title="qux")
-        self.folder = factories.CollectionFactory(creator=self.user, title="quux", category='project')
+        self.project = factories.ProjectFactory(creator=self.user, title='foo')
+        self.project_two = factories.ProjectFactory(creator=self.user_two, title='bar')
+        self.public_project = factories.ProjectFactory(creator=self.user_two, is_public=True, title='baz')
+        self.registration_project = factories.RegistrationFactory(creator=self.user, title='qux')
+        self.folder = factories.CollectionFactory(creator=self.user, title='quux', category='project')
         self.dashboard = find_bookmark_collection(self.user)
         self.dashboard.category = 'project'
         self.dashboard.save()

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1381,10 +1381,10 @@ class TestUser(OsfTestCase):
     def test_cannot_remove_primary_email_from_email_list(self):
         with pytest.raises(PermissionsError) as e:
             self.user.remove_email(self.user.username)
-        assert e.value.message == "Can't remove primary email"
+        assert e.value.message == 'Can\'t remove primary email'
 
     def test_add_same_unconfirmed_email_twice(self):
-        email = "test@mail.com"
+        email = 'test@mail.com'
         token1 = self.user.add_unconfirmed_email(email)
         self.user.save()
         self.user.reload()
@@ -1635,7 +1635,6 @@ class TestUserMerging(OsfTestCase):
             else:
                 assert getattr(self.user, k) == v, '{} doesn\'t match expectation'.format(k)
 
-
         assert sorted(self.user.system_tags) == ['other', 'shared', 'user']
 
         # check fields set on merged user
@@ -1692,7 +1691,7 @@ class TestUserMerging(OsfTestCase):
         assert creating_user.external_identity == {}
         assert verified_user.external_identity == {}
         assert no_id_user.external_identity == {}
-        assert no_provider_user.external_identity== {}
+        assert no_provider_user.external_identity == {}
 
         no_provider_user.merge_user(linking_user)
         assert linking_user.external_identity == {}
@@ -1746,7 +1745,7 @@ class TestUserValidation(OsfTestCase):
             data = json.load(url_test_data)
 
         fails_at_end = False
-        for should_pass in data["testsPositive"]:
+        for should_pass in data['testsPositive']:
             try:
                 self.user.social = {'profileWebsites': [should_pass]}
                 self.user.save()
@@ -1755,7 +1754,7 @@ class TestUserValidation(OsfTestCase):
                 fails_at_end = True
                 print('\"' + should_pass + '\" failed but should have passed while testing that the validator ' + data['testsPositive'][should_pass])
 
-        for should_fail in data["testsNegative"]:
+        for should_fail in data['testsNegative']:
             self.user.social = {'profileWebsites': [should_fail]}
             try:
                 with pytest.raises(ValidationError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@
 [flake8]
 ignore = E501,E127,E128,E265,E301,E302,E266,E731,N803,N806
 max-line-length = 100
-exclude = .git,.ropeproject,.tox,docs,setup.py,env,venv,models/migrations,tests/*,osf_tests/*,api_tests/*,scripts/*,src,website/uploads/,website/static/**/*,website/settings/*,framework/forms/*,addons/*/tests/*,env,venv,node_modules,admin/static/*,osf/migrations
+exclude = .git,.ropeproject,.tox,docs,setup.py,env,venv,models/migrations,tests/*,api_tests/*,scripts/*,src,website/uploads/,website/static/**/*,website/settings/*,framework/forms/*,addons/*/tests/*,env,venv,node_modules,admin/static/*,osf/migrations


### PR DESCRIPTION
## Purpose

Flake doesn't check the osf_test directory, it should. Now it does.

## Changes

-  Changes setup.cfg to not exclude the osf_test
-  Removes double quotes, whitespace etc 
-  Removes dupe test `test_skips_no_settings`

## QA Notes

Travis should take care of this.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-247