### PR TITLE
[IN-87][OSF] Rename group whenever _id of preprint provider changes

### DIFF
--- a/osf/models/preprint_provider.py
+++ b/osf/models/preprint_provider.py
@@ -118,13 +118,11 @@ class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, DirtyFieldsMixin, Bas
         old_id = dirty_fields.get('_id', None)
         if old_id:
             for permission_type in GROUPS.keys():
-                group_name = GROUP_FORMAT.format(provider_id=old_id, group=permission_type)
-                try:
-                    permission_group = Group.objects.get(name=group_name)
-                    permission_group.name = GROUP_FORMAT.format(provider_id=self._id, group=permission_type)
-                    permission_group.save()
-                except Group.DoesNotExist:
-                    pass
+                Group.objects.filter(
+                    name=GROUP_FORMAT.format(provider_id=old_id, group=permission_type)
+                ).update(
+                    name=GROUP_FORMAT.format(provider_id=self._id, group=permission_type)
+                )
 
         return super(PreprintProvider, self).save(*args, **kwargs)
 

--- a/osf/models/preprint_provider.py
+++ b/osf/models/preprint_provider.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from django.contrib.postgres import fields
+from django.contrib.auth.models import Group
 from api.taxonomies.utils import optimize_subject_query
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from dirtyfields import DirtyFieldsMixin
 
-from api.preprint_providers.permissions import GroupHelper, PERMISSIONS
+from api.preprint_providers.permissions import GroupHelper, PERMISSIONS, GROUP_FORMAT, GROUPS
 from osf.models.base import BaseModel, ObjectIDMixin
 from osf.models.licenses import NodeLicense
 from osf.models.mixins import ReviewProviderMixin
@@ -16,7 +18,7 @@ from website import settings
 from website.util import api_v2_url
 
 
-class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, BaseModel):
+class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, DirtyFieldsMixin, BaseModel):
 
     PUSH_SHARE_TYPE_CHOICES = (('Preprint', 'Preprint'),
                                ('Thesis', 'Thesis'),)
@@ -111,6 +113,20 @@ class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, BaseModel):
         path = '/preprint_providers/{}/'.format(self._id)
         return api_v2_url(path)
 
+    def save(self):
+        dirty_fields = self.get_dirty_fields()
+        old_id = dirty_fields['_id']
+        if old_id:
+            for permission_type in GROUPS.keys():
+                group_name = GROUP_FORMAT.format(provider_id=old_id, group=permission_type)
+                try:
+                    permission_group = Group.objects.get(name=group_name)
+                    permission_group.name = GROUP_FORMAT.format(provider_id=self._id, group=permission_type)
+                    permission_group.save()
+                except Group.DoesNotExist:
+                    pass
+
+        return super(PreprintProvider, self).save()
 
 def rules_to_subjects(rules):
     if not rules:

--- a/osf/models/preprint_provider.py
+++ b/osf/models/preprint_provider.py
@@ -113,9 +113,9 @@ class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, DirtyFieldsMixin, Bas
         path = '/preprint_providers/{}/'.format(self._id)
         return api_v2_url(path)
 
-    def save(self):
+    def save(self, *args, **kwargs):
         dirty_fields = self.get_dirty_fields()
-        old_id = dirty_fields['_id']
+        old_id = dirty_fields.get('_id', None)
         if old_id:
             for permission_type in GROUPS.keys():
                 group_name = GROUP_FORMAT.format(provider_id=old_id, group=permission_type)
@@ -126,7 +126,7 @@ class PreprintProvider(ObjectIDMixin, ReviewProviderMixin, DirtyFieldsMixin, Bas
                 except Group.DoesNotExist:
                     pass
 
-        return super(PreprintProvider, self).save()
+        return super(PreprintProvider, self).save(*args, **kwargs)
 
 def rules_to_subjects(rules):
     if not rules:


### PR DESCRIPTION
## Purpose

Currently, if `_id` of a `PreprintProvider` changes, its corresponding `Group` would not rename to reflect the changes. This PR fixes the problem by automatically updating the name of the `Group` whenever `_id` changes.

## Changes

Add `DirtyFieldsMixin` to `PreprintProvider` model, enabling us to use `get_dirty_fields()` in `save()` to get the `_id` before and after the change, and update the names of corresponding `Group` instances accordingly.

## QA Notes

Try to create a new PreprintProvider, the change its `_id` and see if names of corresponding `Group` instances change.

## Side Effects

None

## Ticket

https://openscience.atlassian.net/browse/IN-87