### PR TITLE
[IN-90][OSF] Remove bower from registries in docker-compose.override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -93,8 +93,6 @@ services:
 ##        (rm -r node_modules || true) &&
 ##        yarn --frozen-lockfile &&
 ##        yarn link @centerforopenscience/ember-osf &&
-##        (rm -r bower_components || true) &&
-##        ./node_modules/.bin/bower install --allow-root --config.interactive=false &&
 ##        yarn start --host 0.0.0.0 --port 4202 --live-reload-port 41955
 
 #  reviews:


### PR DESCRIPTION
## Purpose

To remove commands involving `bower_components` and `bower install` from Registries in `docker-compose.override`.  Bower is being removed from Registries, so it needs to be removed from `docker-compose.override` in order for Registries to still run.

## Changes

Remove:
- `(rm -r bower_components || true)`
- `./node_modules/.bin/bower install --allow-root --config.interactive=false`

## QA Notes

This will just remove commands that involve bower from the process of starting Registries; there aren't any changes that can be visually seen.

## Ticket

https://openscience.atlassian.net/browse/IN-90
