### PR TITLE
[IN-94][OSF] Show preprint doi in citation

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -44,8 +44,7 @@ def preprint_csl(preprint, node):
 
     if article_doi:
         csl['DOI'] = article_doi
-    else:
-        if preprint_doi and preprint.is_published and preprint.preprint_doi_created:
+    elif preprint_doi and preprint.is_published and preprint.preprint_doi_created:
             csl['DOI'] = preprint_doi
 
     return csl

--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -39,9 +39,14 @@ def preprint_csl(preprint, node):
     if csl.get('DOI'):
         csl.pop('DOI')
 
-    doi = preprint.article_doi
-    if doi:
-        csl['DOI'] = doi
+    article_doi = preprint.article_doi
+    preprint_doi = preprint.preprint_doi
+
+    if article_doi:
+        csl['DOI'] = article_doi
+    else:
+        if preprint_doi:
+            csl['DOI'] = preprint_doi
 
     return csl
 

--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -45,7 +45,7 @@ def preprint_csl(preprint, node):
     if article_doi:
         csl['DOI'] = article_doi
     else:
-        if preprint_doi:
+        if preprint_doi and preprint.is_published and preprint.preprint_doi_created:
             csl['DOI'] = preprint_doi
 
     return csl


### PR DESCRIPTION
## Purpose

Show preprint DOI in the citation if there is no user-specified DOI.

## Changes

In `utils.py`, the `preprint_csl` method is modified to use `preprint_doi`.

## QA Notes

Basically, the peer-reviewed DOI should always be included in the citation, and it would fall back to using self-generated DOI if peer-reviewed DOI is not provided by the user.
For moderated preprint services, if the preprint is not yet approved, it would not use the self-generated DOI if peer-reviewed DOI is not provided. However, the peer-reviewed DOI should show in citation even if the preprint is not yet approved.

## Side Effects

None.

## Ticket

https://openscience.atlassian.net/browse/IN-94
