### PR TITLE
[EMB-111] Remove quickfiles link in profile page

### DIFF
--- a/website/static/js/components/quickFiles.js
+++ b/website/static/js/components/quickFiles.js
@@ -71,7 +71,7 @@ var QuickFile = {
     },
 
     view: function(ctrl)  {
-        var viewBase = window.location.origin + '/quickfiles';
+        var viewBase = window.location.origin;
         var viewUrl = ctrl.file.attributes.guid ? viewBase + '/' + ctrl.file.attributes.guid : viewBase + ctrl.file.attributes.path;
         return m('div', [
             m('li.project list-group-item list-group-item-node cite-container', [


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix file links on the quickfiles section of a user's profile.

## Changes
No longer adds quickfiles to file links on the profile page

## Ticket
https://openscience.atlassian.net/browse/EMB-111
