### PR TITLE
Use yarn bootstrap instead of bower bootstrap [PLAT-510]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "osf",
   "dependencies": {
-    "bootstrap": "^3.3.7",
     "ace-builds": "1.1.8",
     "bootstrap.growl": "2.0.0",
     "jquery": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-loader": "^4.1.0",
     "body-parser": "~1.12.0",
     "bootbox": "^4.4.0",
+    "bootstrap": "3.3.7",
     "bower": "^1.3.12",
     "css-loader": "^0.9.1",
     "diff": "~2.2.2",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -85,6 +85,7 @@ var entry = {
         'mithril',
         // Main CSS files that get loaded above the fold
         nodePath('select2/select2.css'),
+        nodePath('bootstrap/dist/css/bootstrap.css'),
         '@centerforopenscience/osf-style',
         staticPath('css/style.css'),
     ],
@@ -139,7 +140,7 @@ var resolve = {
         'knockout-sortable': staticPath('vendor/knockout-sortable/knockout-sortable.js'),
         'bootstrap-editable': staticPath('vendor/bootstrap-editable-custom/js/bootstrap-editable.js'),
         'jquery-blockui': staticPath('vendor/jquery-blockui/jquery.blockui.js'),
-        'bootstrap': staticPath('vendor/bower_components/bootstrap/dist/js/bootstrap.min.js'),
+        'bootstrap': nodePath('bootstrap/dist/js/bootstrap.js'),
         'Caret.js': staticPath('vendor/bower_components/Caret.js/dist/jquery.caret.min.js'),
         'osf-panel': staticPath('vendor/bower_components/osf-panel/dist/jquery-osfPanel.min.js'),
         'jquery-qrcode': staticPath('vendor/bower_components/jquery-qrcode/jquery.qrcode.min.js'),

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -384,7 +384,6 @@
         <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script>window.jQuery.ui || document.write('<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js">\x3C/script>')</script>
     % else:
-        <link rel="stylesheet" href="/static/vendor/bower_components/bootstrap/dist/css/bootstrap.min.css">
         <script src="/static/vendor/bower_components/jquery/dist/jquery.min.js"></script>
         <script src="/static/vendor/bower_components/jquery-ui/jquery-ui.min.js"></script>
     % endif

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,7 +487,7 @@ bootbox@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/bootbox/-/bootbox-4.4.0.tgz#ff7f898fb87d4527e547feb64158f88450d1a0c9"
 
-bootstrap@~3.3.2:
+bootstrap@3.3.7, bootstrap@~3.3.2:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
These commits remove the bower bootstrap import in the base mako template, and add bootstrap to webpack. The purpose of this PR is to remove the need for bootstrap to load independently from the rest of the webpacked CSS, hopefully reducing page load time.
<!-- Describe the purpose of your changes -->

## Changes
* Installed bootstrap via yarn
* Added bootstrap CSS to webpack config
* Changed reference to bootstrap JS from bower copy to yarn copy
* Removed bower bootstrap import from base mako template
<!-- Briefly describe or list your changes  -->

## QA Notes
N/A
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
None that I can think of.
<!-- Any possible side effects? -->

## Ticket
[https://openscience.atlassian.net/browse/PLAT-510](https://openscience.atlassian.net/browse/PLAT-510)
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
