### PR TITLE
[EMB-111] Fix profile links and add ability to resolve quickfiles path -> guid

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -1259,6 +1259,14 @@ def make_url_map(app):
             'get',
             addon_views.addon_view_or_download_file_legacy,
             json_renderer
+        ),
+        Rule(
+            [
+                '/quickfiles/<fid>/'
+            ],
+            'get',
+            addon_views.addon_view_or_download_quickfile,
+            json_renderer
         )
     ])
 

--- a/website/static/js/components/quickFiles.js
+++ b/website/static/js/components/quickFiles.js
@@ -71,8 +71,8 @@ var QuickFile = {
     },
 
     view: function(ctrl)  {
-        var viewBase = window.location.origin + '/quickfiles';
-        var viewUrl = ctrl.file.attributes.guid ? viewBase + '/' + ctrl.file.attributes.guid : viewBase + ctrl.file.attributes.path;
+        var viewBase = window.location.origin;
+        var viewUrl = ctrl.file.attributes.guid ? viewBase + '/' + ctrl.file.attributes.guid : viewBase + '/quickfiles' + ctrl.file.attributes.path;
         return m('div', [
             m('li.project list-group-item list-group-item-node cite-container', [
                 m('h4.list-group-item-heading', [


### PR DESCRIPTION
## Purpose
Fix profile links

## Changes
Reintroduce `/quickfiles/path` route, which creates a guid for the file and reroutes to their /guid file detail page
Change logic in the profile page to resolve quickfiles with guids to their file-detail page directly. 

## Ticket
https://openscience.atlassian.net/browse/EMB-111
