### PR TITLE
Add includes and select related to optimize get.InstitutionNodeList [PLAT-548]

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -157,7 +157,11 @@ class InstitutionNodeList(JSONAPIBaseView, generics.ListAPIView, InstitutionMixi
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         institution = self.get_institution()
-        return institution.nodes.filter(is_public=True, is_deleted=False, type='osf.node')
+        return (
+            institution.nodes.filter(is_public=True, is_deleted=False, type='osf.node')
+            .select_related('node_license', 'preprint_file')
+            .include('contributor__user__guids', 'root__guids', 'tags', limit_includes=10)
+        )
 
     # overrides RetrieveAPIView
     def get_queryset(self):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -327,9 +327,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     @cached_property
     def parent_node(self):
-        # TODO: Use .filter when chaining is fixed in django-include
         try:
-            node_rel = next(parent for parent in self._parents.all() if not parent.is_node_link)
+            node_rel = next(parent for parent in self._parents.filter(is_node_link=False))
         except StopIteration:
             node_rel = None
         if node_rel:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
According to NewRelic, the `InstitutionNodeList.get` endpoint has one of the slowest average response times.  Add query optimizations to speed this up. This will cut queries from ~66 to ~39 (or ~89 to ~51 depending on cacheing)

## Changes

- add include and select_related to `InstitutionNodeList` queryset
- Try removing a `#TODO` and using filter in the `parent_node` property, seems to work now?

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Should not need QA!

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-548