### PR TITLE
[EMB-16] Allow user-nodes to be sorted

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -543,7 +543,6 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMix
         return (
             self.get_queryset_from_request()
             .select_related('node_license')
-            .order_by('-modified', )
             .include('contributor__user__guids', 'root__guids', limit_includes=10)
         )
 

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -149,6 +149,26 @@ class TestUserNodes:
         assert deleted_project_user_one._id not in ids
         assert registration._id not in ids
 
+        url = '/{}users/{}/nodes/?sort=-title'.format(API_BASE, user_one._id)
+        res = app.get(url, auth=user_one.auth)
+
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+
+        assert public_project_user_one._id == ids[0]
+        assert private_project_user_one._id == ids[1]
+
+        url = '/{}users/{}/nodes/?sort=title'.format(API_BASE, user_one._id)
+        res = app.get(url, auth=user_one.auth)
+
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+
+        assert public_project_user_one._id == ids[1]
+        assert private_project_user_one._id == ids[0]
+
 
 @pytest.mark.django_db
 class TestUserNodesPreprintsFiltering:


### PR DESCRIPTION
## Purpose
User nodes endpoint need to be able to be sorted.

## Changes
Remove hardcoding of user-node sort endpoint and add tests

## QA Notes
Attempt sorting of the user-nodes endpoint.