### PR TITLE
[IN-95][OSF] Change navbar to take in new osf-style navbar styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@centerforopenscience/list-of-licenses": "1.0.0",
     "@centerforopenscience/markdown-it-toc": "~1.1.1",
-    "@centerforopenscience/osf-style": "1.6.0",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
     "URIjs": "^1.14.1",
     "assets-webpack-plugin": "^0.1.0",
     "babel-loader": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@centerforopenscience/list-of-licenses": "1.0.0",
     "@centerforopenscience/markdown-it-toc": "~1.1.1",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
     "URIjs": "^1.14.1",
     "assets-webpack-plugin": "^0.1.0",
     "babel-loader": "^4.1.0",

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -5,12 +5,6 @@
 <nav class="navbar navbar-inverse navbar-fixed-top" id="navbarScope" role="navigation">
     <div class="container">
         <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" aria-label="Toggle secondary navigation"}}>
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
         <a class="navbar-brand" href="/" aria-label="Go home"><span class="osf-navbar-logo"></span></a>
         <div class="service-name">
             <a href="${service_url}">
@@ -29,6 +23,12 @@
                 <li><a data-bind="click: trackClick.bind($data, 'Meetings')" href="${domain}meetings/">OSF<b>MEETINGS</b></a></li>
             </ul>
         </div>
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#secondary-navigation" aria-label="Toggle secondary navigation"}}>
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
     </div>
     <div id="navbar" class="navbar-collapse collapse navbar-right">
         <ul class="nav navbar-nav"></ul>
@@ -48,7 +48,7 @@
             </li>
             <li class="navbar-donate-button"><a id="navbar-donate" data-bind="click: trackClick.bind($data, 'Donate')" href="https://cos.io/donate">Donate</a></li>
             % if user_name and display_name:
-            <li class="dropdown">
+            <li class="dropdown secondary-nav-dropdown">
                 <a class="dropdown-toggle btn-link" data-toggle="dropdown" role="button" aria-expanded="false" aria-label="Toggle auth dropdown">
                     <div class="osf-profile-image">
                         <img src="${user_profile_image}" alt="User profile image">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@centerforopenscience/markdown-it-toc/-/markdown-it-toc-1.1.1.tgz#633c6367cf783a51a080e75a9cd62fd62037e140"
 
-"@centerforopenscience/osf-style@1.6.0":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.6.0.tgz#bc04073732790ef814f7999aa371a64325be093a"
+  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 
 URIjs@^1.14.1:
   version "1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@centerforopenscience/markdown-it-toc/-/markdown-it-toc-1.1.1.tgz#633c6367cf783a51a080e75a9cd62fd62037e140"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
   version "1.6.0"
   resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 


### PR DESCRIPTION
## Purpose

osf-style is now adding `flexbox` to the navbar styles from [this PR](https://github.com/CenterForOpenScience/osf-style/pull/111).  The current osf.io navbar should change in order to reflect these new styles.

## Changes

- Move navbar collapsed button to the right of the other elements within its container
- Add `secondary-nav-dropdown` class to user details dropdown

## QA Notes

This should be tested with https://github.com/CenterForOpenScience/osf-style/pull/111 which adds the styles to the navbar

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Notes

Relies on https://github.com/CenterForOpenScience/osf-style/pull/111 to actually see the desired changes

Will need to update to the latest osf-style after other PR is merged