### PR TITLE
[EMB-16] Route dashboard to ember-osf-web with waffle

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -6,11 +6,11 @@ import math
 import os
 import requests
 import urllib
+import waffle
 
 from django.apps import apps
 from django.db.models import Count
 from flask import request, send_from_directory, Response, stream_with_context
-from waffle.models import Switch
 
 from framework import sentry
 from framework.auth import Auth
@@ -143,7 +143,7 @@ def index():
 
     user_id = get_current_user_id()
     if user_id:  # Logged in: return either landing page or user home page
-        if Switch.objects.get(name='ember_dashboard').is_active():
+        if waffle.switch_is_active('ember_dashboard'):
             return send_from_directory(ember_osf_web_dir, 'index.html')
         else:
             all_institutions = (


### PR DESCRIPTION
## Needs
Devops(?) create the switch (or, if wanted a flag or sample) `ember_dashboard` for choosing whether to use the ember or the legacy version of the dashboard (which should be functionally similar)

## Purpose
Use of ember to recreate the dashboard, rerouting to ember-osf-web when a user is logged in and the waffle switch (ember_dashboard) is active.

## Changes
Add use of waffle switch for serving dashboard.
Serve ember-osf-web when a user goes to route `/` while logged in.

## QA Notes
Test functionality of logged in dashboard, should be similar to current dashboard

## Side Effects
`/` will lead to the Ember-app

## Ticket

https://openscience.atlassian.net/browse/EMB-16