### PR TITLE
Update loading icons to ball-scale and ball-pulse [PLAT-327]

### DIFF
--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -47,7 +47,9 @@
                 </div>
                 <div id="grid">
                     <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
+                        <div class="ball-scale ball-scale-blue">
+                            <div></div>
+                        </div>
                         <p class="m-t-sm fg-load-message"> Loading wiki pages...  </p>
                     </div>
                 </div>
@@ -261,7 +263,9 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="spinner-loading-wrapper">
-                <div class="logo-spin logo-xl"></div>
+                <div class="ball-scale ball-scale-blue">
+                    <div></div>
+                </div>
                  <p class="m-t-sm fg-load-message"> Renaming wiki...  </p>
             </div>
         </div>

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -681,7 +681,7 @@ button.close {
     margin-right: 15px;
 }
 
-div.ball-scale-blue>div {
+div.ball-scale-blue>div, span.ball-scale-blue>div {
     background-color: #BED1E2;
 }
 

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -205,7 +205,7 @@ var LogFeed = {
             ]) :
             // Show OSF spinner while there is a pending log request
             ctrl.logRequestPending() ?  m('.spinner-loading-wrapper', [
-                m('.logo-spin.logo-lg'),
+                m('.ball-scale.ball-scale-blue', [m('div')]),
                 m('p.m-t-sm.fg-load-message', 'Loading logs...')
             ]) :
             // Display each log item (text and user image)

--- a/website/static/js/filepage/util.js
+++ b/website/static/js/filepage/util.js
@@ -31,7 +31,7 @@ var Spinner = m.component({
     controller: function(){},
     view: function() {
         return m('.spinner-loading-wrapper', [
-            m('.logo-spin.logo-lg'),
+            m('.ball-scale.ball-scale-blue', [m('div')]),
             m('p.m-t-sm.fg-load-message', ' Loading... ')
         ]);
     }

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -16,7 +16,7 @@ $(function() {
         width: '100%',
         interactive: window.contextVars.currentUser.canEdit,
         maxChars: 128,
-        defaultText: 'add a tag to enhance discoverability',
+        defaultText: 'Add a tag to enhance discoverability',
         onAddTag: function (tag) {
             var url = tagUrl;
             var request = $osf.postJSON(url, {'tag': tag });

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -225,9 +225,9 @@ $(document).ready(function () {
         width: '100%',
         interactive: window.contextVars.currentUser.canEditTags,
         maxChars: 128,
-        defaultText: 'add a tag to enhance discoverability',
+        defaultText: 'Add a tag to enhance discoverability',
         onAddTag: function(tag) {
-            $('#node-tags_tag').attr('data-default', 'add a tag');
+            $('#node-tags_tag').attr('data-default', 'Add a tag');
             window.contextVars.node.tags.push(tag);
             var payload = {
                 data: {

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -23,8 +23,8 @@ $(function(){
 
 keenAnalysis.ready(function(){
     function updateDateRangeDisplay(statsStartDate, statsEndDate) {
-        $('#startDateString').removeClass('logo-spin logo-sm').text(statsStartDate.toLocaleDateString());
-        $('#endDateString').removeClass('logo-spin logo-sm').text(statsEndDate.toLocaleDateString());
+        $('#startDateString').removeClass('ball-pulse ball-scale-blue').text(statsStartDate.toLocaleDateString());
+        $('#endDateString').removeClass('ball-pulse ball-scale-blue').text(statsEndDate.toLocaleDateString());
     }
 
     function toggleDateRangePickerView() {

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -56,7 +56,9 @@
                 <form id="selectNotifications" class="osf-treebeard-minimal">
                     <div id="grid">
                         <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-lg"></div>
+                            <div class="ball-scale ball-scale-blue">
+                                <div></div>
+                            </div>
                             <p class="m-t-sm fg-load-message"> Loading notification settings... </p>
                         </div>
                     </div>

--- a/website/templates/project/addon/citations_widget.mako
+++ b/website/templates/project/addon/citations_widget.mako
@@ -10,7 +10,9 @@ window.contextVars = $.extend(true, {}, window.contextVars, {
 </div>
 <div id="${short_name}Widget" class="citation-widget">
     <div class="spinner-loading-wrapper">
-        <div class="logo-spin logo-lg"></div>
+        <div class="ball-scale ball-scale-blue">
+            <div></div>
+        </div>
         <p class="m-t-sm fg-load-message"> Loading citations...</p>
     </div>
 </div>

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -302,7 +302,9 @@
                     <div class="osf-treebeard">
                         <div id="addContributorsTreebeard">
                             <div class="spinner-loading-wrapper">
-                                <div class="logo-spin logo-md"></div>
+                                <div class="ball-scale ball-scale-blue">
+                                    <div></div>
+                                </div>
                                 <p class="m-t-sm fg-load-message"> Loading projects and components...  </p>
                             </div>
                         </div>

--- a/website/templates/project/nodes_delete.mako
+++ b/website/templates/project/nodes_delete.mako
@@ -28,7 +28,9 @@
                         <div class="osf-treebeard">
                             <div id="nodesDeleteTreebeard">
                                 <div class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-md"></div>
+                                    <div class="ball-scale ball-scale-blue">
+                                        <div></div>
+                                    </div>
                                     <p class="m-t-sm fg-load-message"> Loading projects and components...  </p>
                                 </div>
                             </div>

--- a/website/templates/project/nodes_privacy.mako
+++ b/website/templates/project/nodes_privacy.mako
@@ -37,7 +37,9 @@
                         <div class="osf-treebeard">
                             <div id="nodesPrivacyTreebeard">
                                 <div class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-md"></div>
+                                    <div class="ball-scale ball-scale-blue">
+                                        <div></div>
+                                    </div>
                                     <p class="m-t-sm fg-load-message"> Loading projects and components...  </p>
                                 </div>
                             </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -347,7 +347,9 @@
             %endif
                     <div id="treeGrid">
                         <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-lg"></div>
+                            <div class="ball-scale ball-scale-blue">
+                                <div></div>
+                            </div>
                              <p class="m-t-sm fg-load-message"> Loading files...  </p>
                         </div>
                     </div>
@@ -432,7 +434,9 @@
             <div class="panel-body">
                 <div id="logFeed">
                     <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
+                        <div class="ball-scale ball-scale-blue">
+                            <div></div>
+                        </div>
                          <p class="m-t-sm fg-load-message"> Loading logs...  </p>
                     </div>
                 </div>

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -16,7 +16,9 @@
   </div>
   <div data-bind="attr: {id: $data.uid}, osfUploader"><!-- TODO: osfUploader attribute may not connect to anything? -->
     <div class="spinner-loading-wrapper">
-      <div class="logo-spin logo-lg"></div>
+      <div class="ball-scale ball-scale-blue">
+          <div></div>
+      </div>
       <p class="m-t-sm fg-load-message"> Loading files...  </p>
     </div>
   </div>
@@ -43,8 +45,12 @@
   <span data-bind="visible: showUploader">
     <div data-bind="attr: {id: $data.uid}, osfUploader">
       <div class="container">
-	<p class="m-t-sm fg-load-message">
-          <span class="logo-spin logo-sm"></span>  Loading files...
+	      <p class="m-t-sm fg-load-message">
+          <span class="ball-pulse ball-scale-blue">
+              <div></div>
+              <div></div>
+              <div></div>
+          </span>  Loading files...
         </p>
       </div>
     </div>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -53,7 +53,9 @@
   <div role="tabpanel" class="tab-pane" id="drafts">
     <div id="draftRegistrationsScope" class="row scripted" style="min-height: 150px;padding-top:20px;">
       <div data-bind="visible: loadingDrafts" class="spinner-loading-wrapper">
-        <div class="logo-spin logo-lg"></div>
+        <div class="ball-scale ball-scale-blue">
+          <div></div>
+        </div>
       </div>
       <form id="newDraftRegistrationForm" method="POST" style="display:none">
         <!-- ko if: selectedSchema() -->

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -178,7 +178,9 @@
                             <form id="wikiSettings" class="osf-treebeard-minimal">
                                 <div id="wgrid">
                                     <div class="spinner-loading-wrapper">
-                                        <div class="logo-spin logo-lg"></div>
+                                        <div class="ball-scale ball-scale-blue">
+                                            <div></div>
+                                        </div>
                                         <p class="m-t-sm fg-load-message"> Loading wiki settings...  </p>
                                     </div>
                                 </div>
@@ -249,7 +251,9 @@
                         <form id="notificationSettings" class="osf-treebeard-minimal">
                             <div id="grid">
                                 <div class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
+                                    <div class="ball-scale ball-scale-blue">
+                                        <div></div>
+                                    </div>
                                     <p class="m-t-sm fg-load-message"> Loading notification settings...  </p>
                                 </div>
                             </div>

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -72,8 +72,18 @@
       <div class="col-sm-12">
 
         <div id="dateRange" class="pull-right">
-          Showing analytics from <span class="m-l-xs text-bigger f-w-xl logo-spin logo-sm" id="startDateString"></span>
-          until <span class="m-l-xs text-bigger f-w-xl logo-spin logo-sm" id="endDateString"></span>
+          Showing analytics from
+          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-scale-blue" id="startDateString">
+            <div></div>
+            <div></div>
+            <div></div>
+          </span>
+          until
+          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-scale-blue" id="endDateString">
+            <div></div>
+            <div></div>
+            <div></div>
+          </span>
           <button class="btn btn-default m-l-xs" id="showDateRangeForm">Update</button>
         </div>
 

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -49,7 +49,9 @@
       <div class="osf-panel-body-flex file-page reset-height">
         <div id="grid">
           <div class="spinner-loading-wrapper">
-            <div class="logo-spin logo-lg"></div>
+            <div class="ball-scale ball-scale-blue">
+                <div></div>
+            </div>
             <p class="m-t-sm fg-load-message"> Loading files...  </p>
           </div>
         </div>

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -106,7 +106,9 @@
 
                             <div id="submissions-grid">
                                 <div id="allMeetingsLoader" class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
+                                    <div class="ball-scale ball-scale-blue">
+                                        <div></div>
+                                    </div>
                                     <p class="m-t-sm fg-load-message"> Loading submissions...</p>
                                 </div>
                             </div>

--- a/website/templates/util/render_addon_widget.mako
+++ b/website/templates/util/render_addon_widget.mako
@@ -127,7 +127,9 @@
                     </div>
                     <div id="${addon_data['short_name']}Widget" class="citation-widget">
                         <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-lg"></div>
+                            <div class="ball-scale ball-scale-blue">
+                                <div></div>
+                            </div>
                             <p class="m-t-sm fg-load-message"> Loading citations...</p>
                         </div>
                     </div>

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -113,7 +113,9 @@
                 Recent Activity
                 <div id="logFeed-${summary['primary_id'] if not summary['primary'] else summary['id']}">
                     <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
+                        <div class="ball-scale ball-scale-blue">
+                            <div></div>
+                        </div>
                          <p class="m-t-sm fg-load-message"> Loading logs...  </p>
                     </div>
                 </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Replace the old OSF logo spinners with the new pulsing/scaling loading icons as per updated OSF-style guidelines.
<!-- Describe the purpose of your changes -->

## Changes
* Replace inline loading spinners with pulsing loading icons.
* Replace all other loading spinners with scaling loading icons.
* Include `span`s in `.ball-scale-blue` css rule, along with the already-included `div`s to simplify inline loading icons.
* Fix minor capitalization issue in tags form
<!-- Briefly describe or list your changes  -->

## QA Notes
It should be confirmed that the loaders for the dates on the analytics page do in fact appear, and that they appear in-line. Analytics isn't loading at all for me.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
None that I can think of.
<!-- Any possible side effects? -->

## Ticket
[https://openscience.atlassian.net/browse/PLAT-327](https://openscience.atlassian.net/browse/PLAT-327)
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
