### PR TITLE
[PLAT-554] Prevent a table rewrite when adding access_requests_enabled field

### DIFF
--- a/osf/migrations/0077_add_noderequest_model.py
+++ b/osf/migrations/0077_add_noderequest_model.py
@@ -50,10 +50,28 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
         ),
+        # We add the access_requests_enabled field in two steps
+        #    1. Add the field
+        #    2. Adding a default value of True
+        # This prevents an expensive table rewrite from locking the node table.
         migrations.AddField(
             model_name='abstractnode',
             name='access_requests_enabled',
-            field=models.BooleanField(db_index=True, default=True),
+            field=models.NullBooleanField(db_index=True),
+        ),
+        # Adding a default does not require a table rewrite
+        migrations.RunSQL(
+            [
+                'ALTER TABLE "osf_abstractnode" ALTER COLUMN "access_requests_enabled" SET DEFAULT TRUE',
+                'ALTER TABLE "osf_abstractnode" ALTER COLUMN "access_requests_enabled" DROP DEFAULT;',
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name='abstractnode',
+                    name='access_requests_enabled',
+                    field=models.NullBooleanField(default=True, db_index=True),
+                )
+            ],
         ),
         migrations.AddField(
             model_name='noderequest',

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -302,7 +302,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     is_fork = models.BooleanField(default=False, db_index=True)
     is_public = models.BooleanField(default=False, db_index=True)
     is_deleted = models.BooleanField(default=False, db_index=True)
-    access_requests_enabled = models.BooleanField(default=True, db_index=True)
+    access_requests_enabled = models.NullBooleanField(default=True, db_index=True)
     node_license = models.ForeignKey('NodeLicenseRecord', related_name='nodes',
                                      on_delete=models.SET_NULL, null=True, blank=True)
 


### PR DESCRIPTION

## Purpose

The `0077_add_noderequest_model` locks the abstractnode table for a long time: 1.5min locally before crashing.

The vast majority of the time is spent adding the `access_requests_enabled` field because it has a default value and therefore results in a a table rewrite:

```
ALTER TABLE "osf_abstractnode" ADD COLUMN "access_requests_enabled" boolean DEFAULT true NOT NULL;
```

## Changes

Prevent a table rewrite by breaking it down into multiple steps:

- Add the field as nullable with no defaults
- Add the field default

For reference: https://pankrat.github.io/2015/django-migrations-without-downtimes/

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-554

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
