### PR TITLE
[PLAT-637] Give embargos an is_deleted property

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -396,6 +396,10 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
         return self.state == self.COMPLETED
 
     @property
+    def is_deleted(self):
+        return self._get_registration().is_deleted
+
+    @property
     def embargo_end_date(self):
         if self.state == self.APPROVED:
             return self.end_date

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 def main(dry_run=True):
-    pending_embargoes = Embargo.objects.filter(state=Embargo.UNAPPROVED)
+    pending_embargoes = Embargo.objects.filter(state=Embargo.UNAPPROVED, is_deleted=False)
     for embargo in pending_embargoes:
         if should_be_embargoed(embargo):
             if dry_run:
@@ -66,7 +66,7 @@ def main(dry_run=True):
                             'registration {}. Continuing...'.format(parent_registration))
                         logger.exception(err)
 
-    active_embargoes = Embargo.objects.filter(state=Embargo.APPROVED)
+    active_embargoes = Embargo.objects.filter(state=Embargo.APPROVED, is_deleted=False)
     for embargo in active_embargoes:
         if embargo.end_date < timezone.now():
             if dry_run:


### PR DESCRIPTION
## Purpose

Embargoes were getting stuck because their parent registrations were getting deleted. This fix identifies deleted embargoes and filters them out where they're not needed.

## Changes

- Add is_deleted property to embargo model
- adds to conditionals so scripts recognize deleted  embargoes

## QA Notes

Not a lot we can do QA wise this really only effects a script which runs each night.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-637