### PR TITLE
[#PLAT-668]remove Quick Files file with qatest tag from elastic search

### DIFF
--- a/scripts/remove_qa_test_items_from_elastic_and_share.py
+++ b/scripts/remove_qa_test_items_from_elastic_and_share.py
@@ -16,6 +16,7 @@ from framework.database import paginated
 
 logger = logging.getLogger(__name__)
 
+
 def remove_search_index(dry_run=True):
     tag_query = Q()
     title_query = Q()

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -512,8 +512,9 @@ def update_file(file_, index=None, delete=False):
     index = index or INDEX
 
     # TODO: Can remove 'not file_.name' if we remove all base file nodes with name=None
+    file_is_qa = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.tags.all().values_list('name', flat=True)))
     file_node_is_qa = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.node.tags.all().values_list('name', flat=True))) or any(substring in file_.node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
-    if not file_.name or not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving or file_node_is_qa:
+    if not file_.name or not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving or file_node_is_qa or file_is_qa:
         client().delete(
             index=index,
             doc_type='file',

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -512,9 +512,12 @@ def update_file(file_, index=None, delete=False):
     index = index or INDEX
 
     # TODO: Can remove 'not file_.name' if we remove all base file nodes with name=None
-    file_is_qa = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.tags.all().values_list('name', flat=True)))
-    file_node_is_qa = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.node.tags.all().values_list('name', flat=True))) or any(substring in file_.node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
-    if not file_.name or not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving or file_node_is_qa or file_is_qa:
+    file_node_is_qa = bool(
+        set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.tags.all().values_list('name', flat=True))
+    ) or bool(
+        set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.node.tags.all().values_list('name', flat=True))
+    ) or any(substring in file_.node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
+    if not file_.name or not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving or file_node_is_qa:
         client().delete(
             index=index,
             doc_type='file',

--- a/website/search_migration/__init__.py
+++ b/website/search_migration/__init__.py
@@ -304,7 +304,7 @@ FROM osf_abstractnode AS N
             ORDER BY P.is_published DESC, P.created DESC
             LIMIT 1
             ) PREPRINT ON TRUE
-WHERE (TYPE = 'osf.node' OR TYPE = 'osf.registration')
+WHERE (TYPE = 'osf.node' OR TYPE = 'osf.registration' OR TYPE = 'osf.quickfilesnode')
   AND is_public IS TRUE
   AND is_deleted IS FALSE
   AND (spam_status IS NULL OR NOT (spam_status = 2 or (spam_status = 1 AND {spam_flagged_removed_from_search})))
@@ -651,7 +651,7 @@ FROM osf_abstractnode AS N
             AND N._is_preprint_orphan != TRUE
           LIMIT 1
           ) PREPRINT ON TRUE
-WHERE NOT ((TYPE = 'osf.node' OR TYPE = 'osf.registration')
+WHERE NOT ((TYPE = 'osf.node' OR TYPE = 'osf.registration' OR TYPE = 'osf.quickfilesnode')
   AND N.is_public IS TRUE
   AND N.is_deleted IS FALSE
   AND (spam_status IS NULL OR NOT (spam_status = 2 or (spam_status = 1 AND {spam_flagged_removed_from_search})))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Adjust the migrate script to omit qatest quickfile from elastic search and also update elastic search to not include qatest quickfiles.
<!-- Describe the purpose of your changes -->

## Changes
Now any newly created quickfiles with qatest tags should not show up in elastic search and search_migration should omit all qatest quickfiles.
<!-- Briefly describe or list your changes  -->

## QA Notes
Any newly created quickfiles with qatest tags should not show up in search by searching qatest.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
None
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-668
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
