### PR TITLE
Feature/Add One-Off Dismissable Alert for Zotero Group Libraries [PLAT-496]

### DIFF
--- a/website/static/js/pages/project-addons-page.js
+++ b/website/static/js/pages/project-addons-page.js
@@ -2,6 +2,7 @@
 var $ = require('jquery');
 var bootbox = require('bootbox');
 var $osf = require('js/osfHelpers');
+var Cookie = require('js-cookie');
 var ctx = window.contextVars;
 
 var changeAddonSettingsSuccess = function () {
@@ -13,6 +14,18 @@ var changeAddonSettingsFailure = function () {
     var msg = 'Sorry, we had trouble saving your settings. If this persists please contact <a href="mailto: support@osf.io">support@osf.io</a>';
     $osf.growl('Failure', msg, 'danger');
 };
+
+$(function(){
+    // Make zotero group library message permanently dismissible
+    var zoteroPersistKey = 'zoteroGroupDismiss';
+    var $zoteroPersist = $('#zoteroWarningCancel').click(function() {
+        Cookie.set(zoteroPersistKey, '1', {path: '/'});
+    });
+    var dismissed = Cookie.get(zoteroPersistKey) === '1';
+    if (!dismissed) {
+        $('#zotero-group-library-alert').show();
+    }
+});
 
 
 $('.addon-container').each(function(ind, elm) {
@@ -88,4 +101,3 @@ var filterAddons = function(event) {
 
 $('#filter-addons').keyup(filterAddons);
 $('.addon-categories').click(filterAddons);
-

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -117,20 +117,20 @@
                             ${render_node_settings(addon)}
                         % endif
                         % if addon['addon_short_name'] == 'zotero':
-                           <div id='zotero-group-library-alert' class="scripted dismissible-alerts">
-                               <div class="alert alert-info">
+                           <div id='zotero-group-library-alert' class='scripted dismissible-alerts'>
+                               <div class='alert alert-info'>
                                    <div>
                                        <h4>Don’t see your Zotero group libraries?</h4>
                                        <p>
                                            You may need to reauthorize your Zotero access token.
-                                           Follow the steps in the <a href='#' target='_black'>help guide</a> to resolve the issue.
+                                           Follow the steps in the <a href='http://help.osf.io/a/850167-reauthorize-zotero' target='_black'>help guide</a> to resolve the issue.
                                        </p>
                                        <p>
-                                           Contact <a href="mailto:support@osf.io">support@osf.io</a> if you have questions.
+                                           Contact <a href='mailto:support@osf.io'>support@osf.io</a> if you have questions.
                                        </p>
                                    </div>
                                    <div>
-                                       <button type="button" id="zoteroWarningCancel" class="btn btn-danger" data-dismiss="alert" aria-label="Close">Dismiss</button>
+                                       <button type='button' id='zoteroWarningCancel' class='btn btn-danger' data-dismiss='alert' aria-label='Close'>Dismiss</button>
                                    </div>
                                </div>
                            </div>

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -116,6 +116,25 @@
                         % if addon.get('node_settings_template'):
                             ${render_node_settings(addon)}
                         % endif
+                        % if addon['addon_short_name'] == 'zotero':
+                           <div id='zotero-group-library-alert' class="scripted dismissible-alerts">
+                               <div class="alert alert-info">
+                                   <div>
+                                       <h4>Don’t see your Zotero group libraries?</h4>
+                                       <p>
+                                           You may need to reauthorize your Zotero access token.
+                                           Follow the steps in the <a href='#' target='_black'>help guide</a> to resolve the issue.
+                                       </p>
+                                       <p>
+                                           Contact <a href="mailto:support@osf.io">support@osf.io</a> if you have questions.
+                                       </p>
+                                   </div>
+                                   <div>
+                                       <button type="button" id="zoteroWarningCancel" class="btn btn-danger" data-dismiss="alert" aria-label="Close">Dismiss</button>
+                                   </div>
+                               </div>
+                           </div>
+                        % endif
                         % if not loop.last:
                             <hr />
                         % endif
@@ -159,4 +178,3 @@
     % endfor
 
 </%def>
-

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -117,23 +117,21 @@
                             ${render_node_settings(addon)}
                         % endif
                         % if addon['addon_short_name'] == 'zotero':
-                           <div id='zotero-group-library-alert' class='scripted dismissible-alerts'>
-                               <div class='alert alert-info'>
-                                   <div>
-                                       <h4>Don’t see your Zotero group libraries?</h4>
-                                       <p>
-                                           You may need to reauthorize your Zotero access token.
-                                           Follow the steps in the <a href='http://help.osf.io/a/850167-reauthorize-zotero' target='_black'>help guide</a> to resolve the issue.
-                                       </p>
-                                       <p>
-                                           Contact <a href='mailto:support@osf.io'>support@osf.io</a> if you have questions.
-                                       </p>
-                                   </div>
-                                   <div>
-                                       <button type='button' id='zoteroWarningCancel' class='btn btn-danger' data-dismiss='alert' aria-label='Close'>Dismiss</button>
-                                   </div>
-                               </div>
-                           </div>
+                            <div id='zotero-group-library-alert' class='scripted dismissible-alerts'>
+                                <div class="alert alert-info alert-dismissible" role="alert">
+                                    <button type="button" id="zoteroWarningCancel" class="close" data-dismiss="alert" aria-label="Close"
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                <div>
+                                <h4>Don’t see your Zotero group libraries?</h4>
+                                <p>
+                                    You may need to reauthorize your Zotero access token.
+                                    Follow the steps in the <a class="alert-link" href='http://help.osf.io/a/850167-reauthorize-zotero' target="_black">help guide</a> to resolve the issue.
+                                </p>
+                                <p>
+                                    Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
+                                </p>
+                            </div>
                         % endif
                         % if not loop.last:
                             <hr />


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Zotero users with existing keys who wish to use zotero group libraries will need to reauthenticate to get a key with correct permissions.

## Changes
If zotero configured, on the Project Addons tab, add a dismissable warning similar to our maintenance alerts.   Uses cookies to track whether user has dismissed alert.  Appearance similar to https://github.com/CenterForOpenScience/osf.io/pull/7749.
## QA Notes

- Banner should appear beneath zotero section on Project Addons tab.
- Check that links are correct.
- Check that once the banner is dismissed it doesn't reappear unless cookies are cleared.
![giphy 1](https://user-images.githubusercontent.com/9755598/36614688-189d4834-18a3-11e8-8fd1-ff2376a40294.gif)

<img width="707" alt="screen shot 2018-02-23 at 2 12 09 pm" src="https://user-images.githubusercontent.com/9755598/36614829-97e01ec8-18a3-11e8-9fe6-819cedf05059.png">

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-496