### PR TITLE
Enhanced Test Reporting for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,12 @@ before_install:
     #     export LD_LIBRARY_PATH=/tmp/libpcre/lib/x86_64-linux-gnu:/tmp/libjemalloc/usr/lib/x86_64-linux-gnu:/tmp/varnish/usr/lib/varnish
     #     /tmp/varnish/usr/sbin/varnishd -n /tmp -p feature=+esi_disable_xml_check -p vmod_dir=/tmp/varnish/usr/lib/varnish/vmods -F -f $PROJECT_DIR/tests/test_files/varnish.vcl -a *:8080 > /dev/null & export VARNISH_PID=$!
     #   fi
+    # Install and configure Testspace client
+    - mkdir -p $HOME/bin
+    - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+    - cd $TRAVIS_BUILD_DIR
+    - testspace config url $TS_ORG.testspace.com
+
 install:
     - cd $PROJECT_DIR
     - cp website/settings/local-travis.py website/settings/local.py
@@ -145,7 +151,10 @@ install:
 # Run Python tests (core and addon) and JS tests
 script:
     - invoke test_travis_$TEST_BUILD -n 4
-
+    
+after_script:
+    - testspace testresults.xml{.};
+ 
 before_cache:
   - rm -Rf $HOME/.cache/pip/http
   - rm -f $HOME/.cache/pip/log/debug.log

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -297,6 +297,7 @@ def test_module(ctx, module=None, numprocesses=None, nocapture=False, params=Non
         args = ['-s']
     if numprocesses > 1:
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
+    args.append('--junitxml=testresults.xml')
     modules = [module] if isinstance(module, basestring) else module
     args.extend(modules)
     if params:


### PR DESCRIPTION
We’ve made a few changes to demonstrate how [Testspace.com](https://www.testspace.com/) could be used by your team to better represent your testing. We organized your test results in folders based on the repo:
  - `api_tests`
  - `addons`
  - etc.

Because of the large volume of tests cases (> 6k) and the size of the Travis Logs, we think Testspace could be useful for your team, especially for outside contributors. The Note that there is **no** impact on the workflow. 

YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:osf.io.

#### Some of the benefits for your team and contributors 

* Represent all of your tests in an organized fashion controlled by your source repo 
* Detailed timing, stdout/stderr output, etc., even when not failing
* Test Failures can be filtering on, speeding up the resolution process; versus using a Travis Log
* Can push other content such as code coverage, static analysis, HTML, log files, etc.

----

Note, we created a branch to include your `karma tests`, using the **sudo: required**. This was based on the [Travis Issue 8836](https://github.com/travis-ci/travis-ci/issues/8836).  

The branch containing *Karma tests* is [here](https://open.testspace.com/spaces/78089).  Hit the `1 Failures` to see how we filter on failures. 