### PR TITLE
[PLAT-434] Refactor github so repo listing is available to v2

### DIFF
--- a/addons/github/api.py
+++ b/addons/github/api.py
@@ -159,6 +159,9 @@ class GitHubClient(object):
         if self.access_token:
             return self.gh3.revoke_authorization(self.access_token)
 
+    def check_authorization(self):
+        return self.gh3.check_authorization(self.access_token)
+
 
 def ref_to_params(branch=None, sha=None):
 

--- a/addons/github/routes.py
+++ b/addons/github/routes.py
@@ -110,6 +110,16 @@ api_routes = {
             json_renderer,
         ),
 
+        Rule(
+            [
+                '/project/<pid>/github/folders/',
+                '/project/<pid>/node/<nid>/github/folders/',
+            ],
+            'get',
+            views.github_folder_list,
+            json_renderer,
+        ),
+
     ],
     'prefix': '/api/v1'
 }

--- a/addons/github/serializer.py
+++ b/addons/github/serializer.py
@@ -3,7 +3,6 @@ from addons.base.serializer import StorageAddonSerializer
 from website.util import api_url_for
 
 from addons.github.api import GitHubClient
-from addons.github.exceptions import GitHubError
 
 
 class GitHubSerializer(StorageAddonSerializer):
@@ -12,12 +11,7 @@ class GitHubSerializer(StorageAddonSerializer):
 
     def credentials_are_valid(self, user_settings, client):
         if user_settings:
-            client = client or GitHubClient(external_account=user_settings.external_accounts[0])
-            try:
-                client.user()
-            except (GitHubError, IndexError):
-                return False
-        return True
+            return GitHubClient(external_account=user_settings.external_accounts[0]).check_authorization()
 
     def serialized_folder(self, node_settings):
         return {
@@ -34,7 +28,7 @@ class GitHubSerializer(StorageAddonSerializer):
                                 service_name='github'),
             'importAuth': node.api_url_for('github_import_auth'),
             'files': node.web_url_for('collect_file_trees'),
-            'folders': node.api_url_for('github_root_folder'),
+            'folders': node.api_url_for('github_folder_list'),
             'config': node.api_url_for('github_set_config'),
             'deauthorize': node.api_url_for('github_deauthorize_node'),
             'accounts': node.api_url_for('github_account_list'),

--- a/addons/github/templates/github_node_settings.mako
+++ b/addons/github/templates/github_node_settings.mako
@@ -45,7 +45,7 @@
                     <option>-----</option>
                         % if is_owner:
                             % for repo_name in repo_names:
-                                <option value="${repo_name}" ${'selected' if repo_name == github_repo_full_name else ''}>${repo_name}</option>
+                                <option value="${repo_name['path']}" ${'selected' if repo_name == github_repo_full_name else ''}>${repo_name['path']}</option>
                             % endfor
                         % else:
                             <option selected>${github_repo_full_name}</option>

--- a/addons/github/tests/test_serializer.py
+++ b/addons/github/tests/test_serializer.py
@@ -31,6 +31,9 @@ class TestGitHubSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCase):
         self.mock_api_user.return_value = mock.Mock()
         self.mock_api_user.start()
 
+        self.mock_api_credentials_are_valid = mock.patch('addons.github.api.GitHubClient.check_authorization', return_value=True)
+        self.mock_api_credentials_are_valid.start()
+
     def tearDown(self):
         self.mock_api_user.stop()
         super(TestGitHubSerializer, self).tearDown()

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -45,7 +45,9 @@ class TestGitHubConfigViews(GitHubAddonTestCase, OAuthAddonConfigViewsTestCaseMi
     def setUp(self):
         super(TestGitHubConfigViews, self).setUp()
         self.mock_api_user = mock.patch('addons.github.api.GitHubClient.user')
+        self.mock_api_credentials_are_valid = mock.patch('addons.github.api.GitHubClient.check_authorization', return_value=True)
         self.mock_api_user.return_value = mock.Mock()
+        self.mock_api_credentials_are_valid.start()
         self.mock_api_user.start()
 
     def tearDown(self):

--- a/addons/github/views.py
+++ b/addons/github/views.py
@@ -44,15 +44,6 @@ github_import_auth = generic_views.import_auth(
     GitHubSerializer
 )
 
-def _get_folders(node_addon, folder_id):
-    pass
-
-github_folder_list = generic_views.folder_list(
-    SHORT_NAME,
-    FULL_NAME,
-    _get_folders
-)
-
 github_get_config = generic_views.get_config(
     SHORT_NAME,
     GitHubSerializer
@@ -182,6 +173,15 @@ def github_root_folder(*args, **kwargs):
 #########
 # Repos #
 #########
+
+@must_have_addon(SHORT_NAME, 'user')
+@must_have_addon(SHORT_NAME, 'node')
+@must_be_addon_authorizer(SHORT_NAME)
+def github_folder_list(node_addon, **kwargs):
+    """ Returns all repos for user.
+    """
+
+    return node_addon.get_folders()
 
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -19,7 +19,7 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
     })
 
     def get_absolute_url(self, obj):
-        if obj['addon'] in ('s3', 'figshare', ):
+        if obj['addon'] in ('s3', 'figshare', 'github'):
             # These addons don't currently support linking anything other
             # than top-level objects.
             return

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -4,6 +4,8 @@ import abc
 import mock
 import pytest
 from nose.tools import *  # flake8: noqa
+from github3.repos import Repository
+
 
 from addons.bitbucket.tests.factories import BitbucketAccountFactory, BitbucketNodeSettingsFactory
 from addons.box.tests.factories import BoxAccountFactory, BoxNodeSettingsFactory
@@ -505,7 +507,7 @@ class NodeAddonFolderMixin(object):
 
         if not wrong_type:
             addon_data = res.json['data'][0]['attributes']
-            assert_equal(addon_data['kind'], 'folder')
+            assert_in(addon_data['kind'], ('folder', 'repo'))
             assert_equal(addon_data['name'], self._mock_folder_result['name'])
             assert_equal(addon_data['path'], self._mock_folder_result['path'])
             assert_equal(
@@ -710,6 +712,40 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             'user': 'abc',
             'owner': self.node
         }
+
+    @mock.patch('addons.github.models.GitHubClient')
+    def test_folder_list_GET_expected_behavior(self, mock_client):
+        mock_repo = Repository.from_json({
+            'name': 'test',
+            'id': '12345',
+            'owner':
+                {'login': 'test name'}
+        })
+
+        mock_connection = mock.MagicMock()
+        mock_client.return_value = mock_connection
+        mock_connection.repos = mock.MagicMock(return_value=[mock_repo])
+        mock_connection.my_orgs_repos = mock.MagicMock(return_value=[mock_repo])
+
+        res = self.app.get(
+            self.folder_url,
+            auth=self.user.auth)
+
+        addon_data = res.json['data'][0]['attributes']
+        assert_in(addon_data['kind'], ('folder', 'repo'))
+        assert_equal(addon_data['name'], self._mock_folder_result['name'])
+        assert_equal(addon_data['path'], self._mock_folder_result['path'])
+        assert_equal(
+            addon_data['folder_id'],
+            self._mock_folder_result['id'])
+
+    @property
+    def _mock_folder_result(self):
+        return {u'path': u'test name/test',
+                u'kind': u'repo',
+                u'name': u'test',
+                u'provider': u'github',
+                u'id': u'12345'}
 
 
 class TestNodeMendeleyAddon(

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1269,6 +1269,8 @@ class TestViewUtils(OsfTestCase):
         self.cookie = itsdangerous.Signer(settings.SECRET_KEY).sign(self.session._id)
         self.configure_addon()
         self.JWE_KEY = jwe.kdf(settings.WATERBUTLER_JWE_SECRET.encode('utf-8'), settings.WATERBUTLER_JWE_SALT.encode('utf-8'))
+        self.mock_api_credentials_are_valid = mock.patch('addons.github.api.GitHubClient.check_authorization', return_value=True)
+        self.mock_api_credentials_are_valid.start()
 
     def configure_addon(self):
         self.user.add_addon('github')


### PR DESCRIPTION
## Purpose

Embosf wants to access the providers folder info via the API, lets oblige them.

## Changes

- Move folder listing function to model
- Add new test for model
- Minor change to addon config template, to keep UI working.
- Let serializer know Github is a top level only provider.

## QA Notes
* Check configuring GH repos (code that populates the dropdown of repos was changed here)
* You're going to have to create Github account with a few repos and connect to it. Check the appropriate API endpoint, it should look like this:
<img width="1440" alt="screen shot 2018-02-28 at 3 11 48 pm" src="https://user-images.githubusercontent.com/9688518/36810973-4fd0ec84-1c9a-11e8-9fae-857fb047257a.png">


## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-434