### PR TITLE
[PLAT-695] Upgrade Dropbox client version to use v2 auth endpoints

### DIFF
--- a/addons/dropbox/requirements.txt
+++ b/addons/dropbox/requirements.txt
@@ -1,1 +1,1 @@
-dropbox==7.2.1
+dropbox==8.7.1


### PR DESCRIPTION
## Purpose

Old dropbox client is going to be depreciated, this upgrades to 8.7.1 to avoid problems arising from that.

## Changes

- bumps version number
- slightly reshuffle imports to accomdate changes.

## QA Notes

Connect/disconnect to the Dropbox addon. There should be no user facing changes.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-695