### PR TITLE
Script to add eartharxiv subjects under Planetary Sciences [PLAT-718]

### DIFF
--- a/scripts/remove_after_use/add_eartharxiv_subjects.py
+++ b/scripts/remove_after_use/add_eartharxiv_subjects.py
@@ -1,0 +1,56 @@
+
+import logging
+import django
+django.setup()
+
+from osf.models import Subject, PreprintProvider
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    eartharxiv = PreprintProvider.objects.get(_id='eartharxiv')
+    physical_sciences_mathmatics = Subject.objects.get(text='Physical Sciences and Mathematics', provider=eartharxiv)
+    earth_sciences = Subject.objects.get(text='Earth Sciences', provider=eartharxiv)
+
+    logger.info('creating subject Planetary Sciences')
+    planetary_sciences = Subject.objects.create(
+        provider=eartharxiv,
+        parent=physical_sciences_mathmatics,
+        text='Planetary Sciences',
+        bepress_subject=earth_sciences
+    )
+
+    new_ps_children = [
+        'Planetary Biogeochemistry',
+        'Planetary Cosmochemistry',
+        'Planetary Geochemistry',
+        'Planetary Geology',
+        'Planetary Geomorphology',
+        'Planetary Geophysics and Seismology',
+        'Planetary Glaciology',
+        'Planetary Hydrology',
+        'Planetary Mineral Physics',
+        'Planetary Paleobiology',
+        'Planetary Paleontology',
+        'Planetary Sedimentology',
+        'Planetary Soil Science',
+        'Planetary Stratigraphy',
+        'Planetary Tectonics and Structure',
+        'Planetary Volcanology',
+        'Other Planetary Sciences'
+    ]
+
+    for child_text in new_ps_children:
+        logger.info('creating subject {}'.format(child_text))
+        Subject.objects.create(
+            provider=eartharxiv,
+            parent=planetary_sciences,
+            text=child_text,
+            bepress_subject=earth_sciences
+        )
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add a couple subjects for eartharxiv!

## Changes

Add new subjects underneath Physical Sciences and Mathematics, consisting of "Planetary Science" and a bunch of children! See ticket for list of children!

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
This is pretty simple so I'm not sure it needs QA but just in case:

- The new subjects show up on the side search bar under the hierarchy Physical Sciences and Mathematics > Planetary Science > all the children
- You can choose the subjects when creating the a new eartharxiv preprint

## Side Effects
nope

## Ticket
https://openscience.atlassian.net/browse/PLAT-718