### PR TITLE
[hotfix] Fix user workshop CSV [PLAT-700]

### DIFF
--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -564,7 +564,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         user_logs_since_workshop = result_csv[1][-3]
         user_nodes_created_since_workshop = result_csv[1][-2]
 
-        nt.assert_equal(user_id, self.user.id)
+        nt.assert_equal(user_id, self.user._id)
         nt.assert_equal(last_log_date, '')
         nt.assert_equal(user_logs_since_workshop, 0)
         nt.assert_equal(user_nodes_created_since_workshop, 0)


### PR DESCRIPTION
#### Purpose
- Fixes the exported user workshop CSV to return user guids, not pks.

#### Changes
- `user.pk` --> `user._id`
- `len()` --> `.count()` (should speed this up a bit)

#### QA Notes
- No QA needed. Courtney can test on prod when this is up.

#### Side Effects
- None.

#### Ticket
- [PLAT-700](https://openscience.atlassian.net/browse/PLAT-700)
