### PR TITLE
Feature/Fix download file versions for persistent download links

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -717,7 +717,7 @@ def persistent_file_download(auth, **kwargs):
         return auth_redirect
 
     query_params = request.args.to_dict()
-    query_params.setdefault('version', file.versions.first().identifier)
+    query_params.setdefault(file.version_identifier, file.versions.first().identifier)
 
     return redirect(
         file.generate_waterbutler_url(**query_params),


### PR DESCRIPTION
## Purpose

Persistent download links were always downloading the latest version of a file. 

## Changes

Use `version_identifier` instead of the string "version" in query parameters when resolving links.  (We were ending up with both "revision" and "version" in query_params)

## QA Notes
Retest file version downloads. 

## Side Effects
None expected

## Ticket

https://openscience.atlassian.net/browse/OSF-8982
