### PR TITLE
[EMB-171] Handle toMany relationships for create/update in v2 api

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -19,6 +19,16 @@ class JSONAPIParser(JSONParser):
     media_type = 'application/vnd.api+json'
     renderer_class = JSONAPIRenderer
 
+    @staticmethod
+    def get_relationship(data, related_resource):
+        target_type = data.get('type')
+        if not target_type:
+            raise JSONAPIException(source={'pointer': 'data/relationships/{}/data/type'.format(related_resource)},
+                                   detail=NO_TYPE_ERROR)
+
+        id = data.get('id')
+        return {'id': id, 'target_type': target_type}
+
     # Overrides JSONParser
     def flatten_relationships(self, relationships):
         """
@@ -38,12 +48,10 @@ class JSONAPIParser(JSONParser):
         if not data:
             raise JSONAPIException(source={'pointer': 'data/relationships/{}/data'.format(related_resource)}, detail=NO_DATA_ERROR)
 
-        target_type = data.get('type')
-        if not target_type:
-            raise JSONAPIException(source={'pointer': 'data/relationships/{}/data/type'.format(related_resource)}, detail=NO_TYPE_ERROR)
-
-        id = data.get('id')
-        return {'id': id, 'target_type': target_type}
+        if isinstance(data, list):
+            return [self.get_relationship(item, related_resource) for item in data]
+        else:
+            return self.get_relationship(data, related_resource)
 
     def flatten_data(self, resource_object, parser_context, is_list):
         """
@@ -82,7 +90,17 @@ class JSONAPIParser(JSONParser):
 
         if relationships:
             relationships = self.flatten_relationships(relationships)
-            parsed.update(relationships)
+            if isinstance(relationships, list):
+                relationship_values = []
+                relationship_key = None
+                for relationship in relationships:
+                    for key, value in relationship.iteritems():
+                        relationship_values.append(value)
+                        relationship_key = key
+                relationship = {relationship_key: relationship_values}
+                parsed.update(relationship)
+            else:
+                parsed.update(relationships)
 
         return parsed
 
@@ -196,8 +214,14 @@ class JSONAPIMultipleRelationshipsParser(JSONAPIParser):
         rel = {}
         for resource in relationships:
             ret = super(JSONAPIMultipleRelationshipsParser, self).flatten_relationships({resource: relationships[resource]})
-            if ret.get('target_type') and ret.get('id'):
-                rel[resource] = ret['id']
+            if isinstance(ret, list):
+                rel = []
+                for item in ret:
+                    if item.get('target_type') and item.get('id'):
+                        rel.append({resource: item['id']})
+            else:
+                if ret.get('target_type') and ret.get('id'):
+                    rel[resource] = ret['id']
         return rel
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -700,6 +700,9 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             filters.append({'field_name': field_name, 'value': value})
         return filters if filters else None
 
+    def to_internal_value(self, data):
+        return data
+
     # Overrides HyperlinkedIdentityField
     def to_representation(self, value):
         request = self.context.get('request', None)
@@ -768,6 +771,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                     return relationship
                 relationship['data'] = {'id': related_id, 'type': related_type}
         return relationship
+
 
 class FileCommentRelationshipField(RelationshipField):
     def get_url(self, obj, view_name, request, format):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1256,7 +1256,12 @@ class JSONAPISerializer(BaseAPISerializer):
                         representation = field.to_representation(attribute)
                 except SkipField:
                     continue
-                if getattr(field, 'json_api_link', False) or getattr(nested_field, 'json_api_link', False):
+                child_is_link = False
+                if hasattr(field, 'child_relation'):
+                    child_is_link = getattr(field.child_relation, 'json_api_link', False)
+                if getattr(field, 'json_api_link', False) or \
+                        getattr(nested_field, 'json_api_link', False) or \
+                        child_is_link:
                     # If embed=field_name is appended to the query string or 'always_embed' flag is True, directly embed the
                     # results in addition to adding a relationship link
                     if embeds and (field.field_name in embeds or getattr(field, 'always_embed', None)):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -35,6 +35,45 @@ from website.project.model import NodeUpdateError
 from osf.utils import permissions as osf_permissions
 
 
+def get_institutions_to_add_remove(institutions, new_institutions):
+    diff = relationship_diff(
+        current_items={inst._id: inst for inst in institutions.all()},
+        new_items={inst['_id']: inst for inst in new_institutions}
+    )
+
+    insts_to_add = []
+    for inst_id in diff['add']:
+        inst = Institution.load(inst_id)
+        if not inst:
+            raise exceptions.NotFound(detail='Institution with id "{}" was not found'.format(inst_id))
+        insts_to_add.append(inst)
+
+    return insts_to_add, diff['remove'].values()
+
+
+def update_institutions(node, new_institutions, user, post=False):
+    add, remove = get_institutions_to_add_remove(
+        institutions=node.affiliated_institutions,
+        new_institutions=new_institutions
+    )
+
+    if post and not len(add):
+        raise RelationshipPostMakesNoChanges
+
+    if not post:
+        for inst in remove:
+            if not user.is_affiliated_with_institution(inst) and not node.has_permission(user, 'admin'):
+                raise exceptions.PermissionDenied(
+                    detail='User needs to be affiliated with {}'.format(inst.name))
+            node.remove_affiliated_institution(inst, user)
+
+    for inst in add:
+        if not user.is_affiliated_with_institution(inst):
+            raise exceptions.PermissionDenied(
+                detail='User needs to be affiliated with {}'.format(inst.name))
+        node.add_affiliated_institution(inst, user)
+
+
 class NodeTagField(ser.Field):
     def to_representation(self, obj):
         if obj is not None:
@@ -281,7 +320,10 @@ class NodeSerializer(JSONAPISerializer):
         related_view='nodes:node-institutions',
         related_view_kwargs={'node_id': '<_id>'},
         self_view='nodes:node-relationships-institutions',
-        self_view_kwargs={'node_id': '<_id>'}
+        self_view_kwargs={'node_id': '<_id>'},
+        read_only=False,
+        many=True,
+        required=False,
     )
 
     root = RelationshipField(
@@ -439,6 +481,13 @@ class NodeSerializer(JSONAPISerializer):
                 raise exceptions.NotFound
             if not template_node.has_permission(user, 'read', check_parent=False):
                 raise exceptions.PermissionDenied
+            if 'affiliated_institutions' in validated_data:
+                institutions_list = validated_data.pop('affiliated_institutions')
+                new_institutions = [{'_id': institution} for institution in institutions_list]
+                instance = self.context['view'].get_object()
+                node = instance['self']
+                update_institutions(node, new_institutions, user, post=True)
+                node.save()
 
             validated_data.pop('creator')
             changed_data = {template_from: validated_data}
@@ -475,18 +524,22 @@ class NodeSerializer(JSONAPISerializer):
         the request to be in the serializer context.
         """
         assert isinstance(node, AbstractNode), 'node must be a Node'
+        user = self.context['request'].user
         auth = get_user_auth(self.context['request'])
 
-        # Update tags
-        if 'tags' in validated_data:
-            new_tags = set(validated_data.pop('tags', []))
-            node.update_tags(new_tags, auth=auth)
-
         if validated_data:
-
+            if 'tags' in validated_data:
+                new_tags = set(validated_data.pop('tags', []))
+                node.update_tags(new_tags, auth=auth)
             if 'license_type' in validated_data or 'license' in validated_data:
                 license_details = get_license_details(node, validated_data)
                 validated_data['node_license'] = license_details
+            if 'affiliated_institutions' in validated_data:
+                institutions_list = validated_data.pop('affiliated_institutions')
+                new_institutions = [{'_id': institution} for institution in institutions_list]
+
+                update_institutions(node, new_institutions, user)
+                node.save()
 
             try:
                 node.update(validated_data, auth=auth)
@@ -1016,21 +1069,6 @@ class NodeInstitutionsRelationshipSerializer(BaseAPISerializer):
     class Meta:
         type_ = 'institutions'
 
-    def get_institutions_to_add_remove(self, institutions, new_institutions):
-        diff = relationship_diff(
-            current_items={inst._id: inst for inst in institutions.all()},
-            new_items={inst['_id']: inst for inst in new_institutions}
-        )
-
-        insts_to_add = []
-        for inst_id in diff['add']:
-            inst = Institution.load(inst_id)
-            if not inst:
-                raise exceptions.NotFound(detail='Institution with id "{}" was not found'.format(inst_id))
-            insts_to_add.append(inst)
-
-        return insts_to_add, diff['remove'].values()
-
     def make_instance_obj(self, obj):
         return {
             'data': obj.affiliated_institutions.all(),
@@ -1040,22 +1078,7 @@ class NodeInstitutionsRelationshipSerializer(BaseAPISerializer):
     def update(self, instance, validated_data):
         node = instance['self']
         user = self.context['request'].user
-
-        add, remove = self.get_institutions_to_add_remove(
-            institutions=instance['data'],
-            new_institutions=validated_data['data']
-        )
-
-        for inst in remove:
-            if not user.is_affiliated_with_institution(inst) and not node.has_permission(user, 'admin'):
-                raise exceptions.PermissionDenied(detail='User needs to be affiliated with {}'.format(inst.name))
-            node.remove_affiliated_institution(inst, user)
-
-        for inst in add:
-            if not user.is_affiliated_with_institution(inst):
-                raise exceptions.PermissionDenied(detail='User needs to be affiliated with {}'.format(inst.name))
-            node.add_affiliated_institution(inst, user)
-
+        update_institutions(node, validated_data['data'], user)
         node.save()
 
         return self.make_instance_obj(node)
@@ -1064,20 +1087,7 @@ class NodeInstitutionsRelationshipSerializer(BaseAPISerializer):
         instance = self.context['view'].get_object()
         user = self.context['request'].user
         node = instance['self']
-
-        add, remove = self.get_institutions_to_add_remove(
-            institutions=instance['data'],
-            new_institutions=validated_data['data']
-        )
-        if not len(add):
-            raise RelationshipPostMakesNoChanges
-
-        for inst in add:
-            if not user.is_affiliated_with_institution(inst):
-                raise exceptions.PermissionDenied(detail='User needs to be affiliated with {}'.format(inst.name))
-
-        for inst in add:
-            node.add_affiliated_institution(inst, user)
+        update_institutions(node, validated_data['data'], user, post=True)
         node.save()
 
         return self.make_instance_obj(node)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -188,6 +188,8 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
     required_write_scopes = [CoreScopes.NODE_BASE_WRITE]
     model_class = apps.get_model('osf.AbstractNode')
 
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
+
     serializer_class = NodeSerializer
     view_category = 'nodes'
     view_name = 'node-list'

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -215,8 +215,11 @@ class TestApiBaseSerializers(ApiTestCase):
         for relation in relationships.values():
             if relation == {}:
                 continue
-            link = relation['links'].values()[0]
-            assert_not_in('count', link['meta'])
+            link = {}
+            if not isinstance(relation, list):
+                link = relation['links'].values()[0]
+            link_meta = link.get('meta', {})
+            assert_not_in('count', link_meta)
 
     def test_counts_included_in_link_fields_with_related_counts_query_param(
             self):
@@ -229,7 +232,8 @@ class TestApiBaseSerializers(ApiTestCase):
             field = NodeSerializer._declared_fields[key]
             if getattr(field, 'field', None):
                 field = field.field
-            if (field.related_meta or {}).get('count'):
+            related_meta = getattr(field, 'related_meta', {})
+            if related_meta and related_meta.get('count', False):
                 link = relation['links'].values()[0]
                 assert_in('count', link['meta'], field)
 
@@ -240,8 +244,11 @@ class TestApiBaseSerializers(ApiTestCase):
         for relation in relationships.values():
             if relation == {}:
                 continue
-            link = relation['links'].values()[0]
-            assert_not_in('count', link['meta'])
+            link = {}
+            if not isinstance(relation, list):
+                link = relation['links'].values()[0]
+            link_meta = link.get('meta', {})
+            assert_not_in('count', link_meta)
 
     def test_invalid_related_counts_value_raises_bad_request(self):
 
@@ -283,11 +290,14 @@ class TestApiBaseSerializers(ApiTestCase):
             field = NodeSerializer._declared_fields[key]
             if getattr(field, 'field', None):
                 field = field.field
-            link = relation['links'].values()[0]
-            if (field.related_meta or {}).get('count') and key == 'children':
+            link = {}
+            if not isinstance(relation, list):
+                link = relation['links'].values()[0]
+            related_meta = getattr(field, 'related_meta', {})
+            if related_meta and related_meta.get('count', False) and key == 'children':
                 assert_in('count', link['meta'])
             else:
-                assert_not_in('count', link['meta'])
+                assert_not_in('count', link.get('meta', {}))
 
     def test_counts_included_in_children_and_contributors_fields_with_field_csv_related_counts_query_param(
             self):
@@ -303,12 +313,14 @@ class TestApiBaseSerializers(ApiTestCase):
             field = NodeSerializer._declared_fields[key]
             if getattr(field, 'field', None):
                 field = field.field
-            link = relation['links'].values()[0]
-            if (field.related_meta or {}).get('count') and \
-                            key == 'children' or key == 'contributors':
+            link = {}
+            if not isinstance(relation, list):
+                link = relation['links'].values()[0]
+            related_meta = getattr(field, 'related_meta', {})
+            if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
                 assert_in('count', link['meta'])
             else:
-                assert_not_in('count', link['meta'])
+                assert_not_in('count', link.get('meta', {}))
 
     def test_error_when_requesting_related_counts_for_attribute_field(self):
 

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -215,11 +215,15 @@ class TestApiBaseSerializers(ApiTestCase):
         for relation in relationships.values():
             if relation == {}:
                 continue
-            link = {}
-            if not isinstance(relation, list):
+            if isinstance(relation, list):
+                for item in relation:
+                    link = item['links'].values()[0]
+                    link_meta = link.get('meta', {})
+                    assert_not_in('count', link_meta)
+            else:
                 link = relation['links'].values()[0]
-            link_meta = link.get('meta', {})
-            assert_not_in('count', link_meta)
+                link_meta = link.get('meta', {})
+                assert_not_in('count', link_meta)
 
     def test_counts_included_in_link_fields_with_related_counts_query_param(
             self):
@@ -244,11 +248,15 @@ class TestApiBaseSerializers(ApiTestCase):
         for relation in relationships.values():
             if relation == {}:
                 continue
-            link = {}
-            if not isinstance(relation, list):
+            if isinstance(relation, list):
+                for item in relation:
+                    link = item['links'].values()[0]
+                    link_meta = link.get('meta', {})
+                    assert_not_in('count', link_meta)
+            else:
                 link = relation['links'].values()[0]
-            link_meta = link.get('meta', {})
-            assert_not_in('count', link_meta)
+                link_meta = link.get('meta', {})
+                assert_not_in('count', link_meta)
 
     def test_invalid_related_counts_value_raises_bad_request(self):
 
@@ -290,14 +298,21 @@ class TestApiBaseSerializers(ApiTestCase):
             field = NodeSerializer._declared_fields[key]
             if getattr(field, 'field', None):
                 field = field.field
-            link = {}
-            if not isinstance(relation, list):
-                link = relation['links'].values()[0]
-            related_meta = getattr(field, 'related_meta', {})
-            if related_meta and related_meta.get('count', False) and key == 'children':
-                assert_in('count', link['meta'])
+            if isinstance(relation, list):
+                for item in relation:
+                    link = item['links'].values()[0]
+                    related_meta = getattr(field, 'related_meta', {})
+                    if related_meta and related_meta.get('count', False) and key == 'children':
+                        assert_in('count', link['meta'])
+                    else:
+                        assert_not_in('count', link.get('meta', {}))
             else:
-                assert_not_in('count', link.get('meta', {}))
+                link = relation['links'].values()[0]
+                related_meta = getattr(field, 'related_meta', {})
+                if related_meta and related_meta.get('count', False) and key == 'children':
+                    assert_in('count', link['meta'])
+                else:
+                    assert_not_in('count', link.get('meta', {}))
 
     def test_counts_included_in_children_and_contributors_fields_with_field_csv_related_counts_query_param(
             self):
@@ -313,14 +328,21 @@ class TestApiBaseSerializers(ApiTestCase):
             field = NodeSerializer._declared_fields[key]
             if getattr(field, 'field', None):
                 field = field.field
-            link = {}
-            if not isinstance(relation, list):
-                link = relation['links'].values()[0]
-            related_meta = getattr(field, 'related_meta', {})
-            if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
-                assert_in('count', link['meta'])
+            if isinstance(relation, list):
+                for item in relation:
+                    link = item['links'].values()[0]
+                    related_meta = getattr(field, 'related_meta', {})
+                    if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
+                        assert_in('count', link['meta'])
+                    else:
+                        assert_not_in('count', link.get('meta', {}))
             else:
-                assert_not_in('count', link.get('meta', {}))
+                link = relation['links'].values()[0]
+                related_meta = getattr(field, 'related_meta', {})
+                if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
+                    assert_in('count', link['meta'])
+                else:
+                    assert_not_in('count', link.get('meta', {}))
 
     def test_error_when_requesting_related_counts_for_attribute_field(self):
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -21,6 +21,7 @@ from osf_tests.factories import (
     PrivateLinkFactory,
     PreprintFactory,
     IdentifierFactory,
+    InstitutionFactory,
 )
 from rest_framework import exceptions
 from tests.base import fake
@@ -287,8 +288,19 @@ class TestNodeDetail:
 class NodeCRUDTestCase:
 
     @pytest.fixture()
-    def user_two(self):
-        return AuthUserFactory()
+    def institution_one(self):
+        return InstitutionFactory()
+
+    @pytest.fixture()
+    def institution_two(self):
+        return InstitutionFactory()
+
+    @pytest.fixture()
+    def user_two(self, institution_one, institution_two):
+        auth_user = AuthUserFactory()
+        auth_user.affiliated_institutions.add(institution_one)
+        auth_user.affiliated_institutions.add(institution_two)
+        return auth_user
 
     @pytest.fixture()
     def title(self):
@@ -348,19 +360,50 @@ class NodeCRUDTestCase:
 
     @pytest.fixture()
     def make_node_payload(self):
-        def payload(node, attributes):
-            return {
+        def payload(node, attributes, relationships=None):
+
+            payload_data = {
                 'data': {
                     'id': node._id,
                     'type': 'nodes',
                     'attributes': attributes,
                 }
             }
+
+            if relationships:
+                payload_data['data']['relationships'] = relationships
+
+            return payload_data
         return payload
 
 
 @pytest.mark.django_db
 class TestNodeUpdate(NodeCRUDTestCase):
+
+    def test_node_institution_update(self, app, user_two, project_private, url_private, make_node_payload,
+                                     institution_one, institution_two):
+        project_private.add_contributor(
+            user_two,
+            permissions=(permissions.READ, permissions.WRITE, permissions.ADMIN),
+            auth=Auth(project_private.creator)
+        )
+        affiliated_institutions = {
+            'affiliated_institutions':
+                {'data': [
+                    {
+                        'type': 'institutions',
+                        'id': institution_one.name
+                    },
+                    {
+                        'type': 'institutions',
+                        'id': institution_two.name
+                    },
+                ]
+                }
+        }
+        payload = make_node_payload(project_private, {'public': False}, relationships=affiliated_institutions)
+        res = app.patch_json_api(url_private, payload, auth=user_two.auth, expect_errors=False)
+        assert res.status_code == 200
 
     def test_node_update_invalid_data(self, app, user, url_public):
         res = app.put_json_api(

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -392,11 +392,11 @@ class TestNodeUpdate(NodeCRUDTestCase):
                 {'data': [
                     {
                         'type': 'institutions',
-                        'id': institution_one.name
+                        'id': institution_one._id
                     },
                     {
                         'type': 'institutions',
-                        'id': institution_two.name
+                        'id': institution_two._id
                     },
                 ]
                 }
@@ -404,6 +404,9 @@ class TestNodeUpdate(NodeCRUDTestCase):
         payload = make_node_payload(project_private, {'public': False}, relationships=affiliated_institutions)
         res = app.patch_json_api(url_private, payload, auth=user_two.auth, expect_errors=False)
         assert res.status_code == 200
+        institutions = project_private.affiliated_institutions.all()
+        assert institution_one in institutions
+        assert institution_two in institutions
 
     def test_node_update_invalid_data(self, app, user, url_public):
         res = app.put_json_api(

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -931,7 +931,6 @@ class TestNodeCreate:
     def category(self):
         return 'data'
 
-
     @pytest.fixture()
     def public_project(self, title, description, category, institution_one):
         return {

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -324,10 +324,19 @@ class TestNodeDetailViewOnlyLinks:
         assert res.status_code == 200
         res_relationships = res.json['data']['relationships']
         for key, value in res_relationships.iteritems():
-            if value['links'].get('related'):
-                assert private_node_one_private_link.key in value['links']['related']['href']
-            if value['links'].get('self'):
-                assert private_node_one_private_link.key in value['links']['self']['href']
+            if isinstance(value, list):
+                for relationship in value:
+                    links = relationship.get('links', {})
+                    if links.get('related', False):
+                        assert private_node_one_private_link.key in links['related']['href']
+                    if links.get('self', False):
+                        assert private_node_one_private_link.key in links['self']['href']
+            else:
+                links = value.get('links', {})
+                if links.get('related', False):
+                    assert private_node_one_private_link.key in links['related']['href']
+                if links.get('self', False):
+                    assert private_node_one_private_link.key in links['self']['href']
 
     #   test_view_only_key_in_self_and_html_links
         res = app.get(


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

In EmberOSF, we have some terrible hacks in to handle updating relationships that go to many relationships. In particular, the affiliated_institutions relationship on nodes. The reason is that the preferred method of updating that information, by including it in the relationship field of the POST or PATCH request, only worked with 1 to 1 relationships, such as Preprint->Node or Node->License. This generalizes everything to allow that to work with toMany relationships, and in particular adds support for Node->affiliated_institutions.

## Changes

1. Update parsers to handle lists
2. Update affiliated_institutions field to be writeable, not be required, and have "many"
3. Update base serializer to handle where everything broke when "many" was activated (mostly related to not realizing that fields also have child_relations that need to be checked)
4. Add parser classes to node list view so creation worked
5. Update tests to handle relationships that were lists

## QA Notes

If preprints creation/updating still works, then this should all be fine. We aren't using the multiple feature until the Dashboard is in, and it's mostly making sure the rest of the API didn't break.  Any runscope tests that create or patch with relationships (preprints or node licenses) would be good to run as well, though we have pretty thorough test coverage on this.

## Side Effects

Potentially. The most suspicious change was overriding the `to_internal_value` method on the Relationship field, which was weird that it hadn't been necessary before but is now. I suspect it's somehow related to having that field be accessed indirectly with `child_relations`.

## Ticket

https://openscience.atlassian.net/browse/EMB-171
