### PR TITLE
Feature/Persistent download links: allow storage providers without versions to work [OSF-8982]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -717,7 +717,6 @@ def persistent_file_download(auth, **kwargs):
         return auth_redirect
 
     query_params = request.args.to_dict()
-    query_params.setdefault(file.version_identifier, file.versions.first().identifier)
 
     return redirect(
         file.generate_waterbutler_url(**query_params),


### PR DESCRIPTION
## Purpose

Not every file has versions (if it is not an OSFStorage file). Persistent file downloads would break if there weren't file versions. I also didn't need to set the latest version as the default download because downloading the latest version also happens by default.

## Changes

Removed adding latest file version to query params. Latest version is already downloaded by default. 

## QA Notes
All storage providers and versioning for them should work.

## Side Effects

None expected.

## Ticket

https://openscience.atlassian.net/browse/OSF-8982
