### PR TITLE
Shrink inline loading icons on analytics dashboard [PLAT-327]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -685,6 +685,11 @@ div.ball-scale-blue>div, span.ball-scale-blue>div {
     background-color: #BED1E2;
 }
 
+span.ball-pulse-small>div {
+    height: 8px;
+    width: 8px;
+}
+
 /* Make registrations modal scrollable and background hidden
 -------------------------------------------------- */
 

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -23,8 +23,8 @@ $(function(){
 
 keenAnalysis.ready(function(){
     function updateDateRangeDisplay(statsStartDate, statsEndDate) {
-        $('#startDateString').removeClass('ball-pulse ball-scale-blue').text(statsStartDate.toLocaleDateString());
-        $('#endDateString').removeClass('ball-pulse ball-scale-blue').text(statsEndDate.toLocaleDateString());
+        $('#startDateString').removeClass('ball-pulse ball-pulse-small ball-scale-blue').text(statsStartDate.toLocaleDateString());
+        $('#endDateString').removeClass('ball-pulse ball-pulse-small ball-scale-blue').text(statsEndDate.toLocaleDateString());
     }
 
     function toggleDateRangePickerView() {

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -73,13 +73,13 @@
 
         <div id="dateRange" class="pull-right">
           Showing analytics from
-          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-scale-blue" id="startDateString">
+          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-pulse-small ball-scale-blue" id="startDateString">
             <div></div>
             <div></div>
             <div></div>
           </span>
           until
-          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-scale-blue" id="endDateString">
+          <span class="m-l-xs text-bigger f-w-xl ball-pulse ball-pulse-small ball-scale-blue" id="endDateString">
             <div></div>
             <div></div>
             <div></div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix a QA issue regarding 2 inline loading icons being too large for their respective text.

## Changes

Add a CSS class for smaller (8px instead of 15px) pulse balls, and apply that class to 2 relevant loading icons.

## QA Notes

Check the inline loaders for the dates at the top of the analytics dashboard and make sure they load and are smaller than the other pulse balls on the screen.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
None
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-327
