### PR TITLE
[EMB-171] Fix bad serialization of node id in affiliated_institution urls

### DIFF
--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1005,9 +1005,12 @@ class TestNodeCreate:
             expect_errors=True,
             auth=user_one.auth)
         assert res.status_code == 201
+        self_link = res.json['data']['links']['self']
         assert res.json['data']['attributes']['title'] == public_project['data']['attributes']['title']
         assert res.json['data']['attributes']['description'] == public_project['data']['attributes']['description']
         assert res.json['data']['attributes']['category'] == public_project['data']['attributes']['category']
+        assert res.json['data']['relationships']['affiliated_institutions']['links']['self']['href'] ==  \
+               '{}relationships/institutions/'.format(self_link)
         assert res.content_type == 'application/vnd.api+json'
         pid = res.json['data']['id']
         project = AbstractNode.load(pid)


### PR DESCRIPTION
## Purpose

Fix serialization of affiliated_institution relationships so that they won't think that the node's `id` is the institution's `id`

## Changes

1. Add a test for the condition
2. Dereference the child_relation field some more in the to_representation method of the base serializer so it's serializing the right info and not the parent field's info

## QA Notes

We could glance at some other relationship field link serializations to make sure nothing else broke.

## Side Effects

This should only affect fields with a child_relationship, so it should be limited to the affiliated_institutions relationship

## Ticket

https://openscience.atlassian.net/browse/EMB-171
