### PR TITLE
Fix Register Reports Landing Page

### DIFF
--- a/website/registries/views.py
+++ b/website/registries/views.py
@@ -57,3 +57,8 @@ def draft_registrations(auth, **kwargs):
             for draft in drafts
         ],
     }
+
+
+def registries_landing_page(**kwargs):
+    # placeholder for developer who don't have ember app set up.
+    return {}


### PR DESCRIPTION
## Purpose

Register Reports Landing Page is breaking this unbreaks it.

## Changes

- Adds back in placeholder view for registries.

## QA Notes

Falls under normal testing for Register Reports landing page.

## Side Effects

None that I know of.

## Ticket

None