### PR TITLE
Fix unresolved registration GUIDs that think they point to a node [PLAT-714]

### DIFF
--- a/api/guids/serializers.py
+++ b/api/guids/serializers.py
@@ -1,6 +1,6 @@
 import urlparse
 
-from osf.models import OSFUser, AbstractNode, Guid, BaseFileNode
+from osf.models import OSFUser, AbstractNode, Registration, Guid, BaseFileNode
 from website import settings as website_settings
 
 from api.base.utils import absolute_reverse
@@ -8,7 +8,9 @@ from api.base.utils import absolute_reverse
 from api.base.serializers import (JSONAPISerializer, IDField, TypeField, RelationshipField, LinksField)
 
 def get_type(record):
-    if isinstance(record, AbstractNode):
+    if isinstance(record, Registration):
+        return 'registrations'
+    elif isinstance(record, AbstractNode):
         return 'nodes'
     elif isinstance(record, OSFUser):
         return 'users'
@@ -27,6 +29,9 @@ def get_related_view_kwargs(record):
     kind = get_type(record)
     # slight hack, works for existing types
     singular = kind.rstrip('s')
+    # The registration view_kwarg is node_id
+    if singular == 'registration':
+        singular = 'node'
     return {
         '{}_id'.format(singular): '<_id>'
     }

--- a/api_tests/guids/views/test_guid_detail.py
+++ b/api_tests/guids/views/test_guid_detail.py
@@ -24,7 +24,11 @@ class TestGuidDetail:
     def project(self):
         return ProjectFactory()
 
-    def test_redirects(self, app, project, user):
+    @pytest.fixture()
+    def registration(self):
+        return RegistrationFactory()
+
+    def test_redirects(self, app, project, registration, user):
         # test_redirect_to_node_view
         url = '/{}guids/{}/'.format(API_BASE, project._id)
         res = app.get(url, auth=user.auth)
@@ -34,7 +38,6 @@ class TestGuidDetail:
         assert res.location == redirect_url
 
         # test_redirect_to_registration_view
-        registration = RegistrationFactory()
         url = '/{}guids/{}/'.format(API_BASE, registration._id)
         res = app.get(url, auth=user.auth)
         redirect_url = '{}{}registrations/{}/'.format(
@@ -144,3 +147,13 @@ class TestGuidDetail:
         referent = res.json['data']['embeds']['referent']['data']
         assert referent['id'] == project._id
         assert referent['type'] == 'nodes'
+
+    def test_resolve_registration(self, app, registration, user):
+        url = '{}{}guids/{}/?resolve=false'.format(API_DOMAIN, API_BASE, registration._id)
+        res = app.get(url, auth=user.auth)
+        related_url = '{}{}registrations/{}/'.format(API_DOMAIN, API_BASE, registration._id)
+        referent = res.json['data']['relationships']['referent']
+
+        assert referent['links']['related']['href'] == related_url
+        assert referent['data']['id'] == registration._id
+        assert referent['data']['type'] == 'registrations'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The GUID serializer for previewing a referent with `?resolve=false` was showing a `nodes` related href and type instead of `registrations` 

## Changes
- Update `get_type` to return `registrations` for a registration Record
- ... while still using `node_id` for the view_kwarg
- Test to check for proper type and related URL

## QA Notes

Pretty simple!

- Visit the GUID endpoint of a registration with the `?resolve=false` query param
    - eg: `http://staging-api.osf.io/v2/guids/<registration_id>/?resolve=false`
- Ensure the relationships referent data type is  `registrations`
- Ensure the relationships links href leads to the registration 

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-714