### PR TITLE
Feature/Report on number of files, public files in OSFS [PLAT-725]

### DIFF
--- a/scripts/analytics/file_summary.py
+++ b/scripts/analytics/file_summary.py
@@ -1,0 +1,78 @@
+import django
+django.setup()
+
+from django.db.models import Q
+import pytz
+import logging
+from dateutil.parser import parse
+from datetime import datetime, timedelta
+from django.utils import timezone
+
+from website.app import init_app
+from scripts.analytics.base import SummaryAnalytics
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class FileSummary(SummaryAnalytics):
+
+    @property
+    def collection_name(self):
+        return 'file_summary'
+
+    def get_events(self, date):
+        super(FileSummary, self).get_events(date)
+        from addons.osfstorage.models import OsfStorageFile
+
+        # Convert to a datetime at midnight for queries and the timestamp
+        timestamp_datetime = datetime(date.year, date.month, date.day).replace(tzinfo=pytz.UTC)
+        query_datetime = timestamp_datetime + timedelta(days=1)
+
+        file_qs = OsfStorageFile.objects.filter()
+
+        public_query = Q(node__is_public=True)
+        private_query = Q(node__is_public=False)
+
+        daily_query = Q(created__gte=timestamp_datetime)
+
+        totals = {
+            'keen': {
+                'timestamp': timestamp_datetime.isoformat()
+            },
+            # OsfStorageFiles - the number of files on OsfStorage
+            'osfstorage_files_including_quickfiles': {
+                'total': file_qs.count(),
+                'public': file_qs.filter(public_query).count(),
+                'private': file_qs.filter(private_query).count(),
+                'total_daily': file_qs.filter(daily_query).count(),
+                'public_daily': file_qs.filter(public_query & daily_query).count(),
+                'private_daily': file_qs.filter(private_query & daily_query).count(),
+            },
+        }
+
+        logger.info(
+            'OsfStorage Files counted. Files: {}'.format(
+                totals['osfstorage_files_including_quickfiles']['total'],
+            )
+        )
+
+        return [totals]
+
+
+def get_class():
+    return FileSummary
+
+
+if __name__ == '__main__':
+    init_app()
+    file_summary = FileSummary()
+    args = file_summary.parse_args()
+    yesterday = args.yesterday
+    if yesterday:
+        date = (timezone.now() - timedelta(days=1)).date()
+    else:
+        date = parse(args.date).date() if args.date else None
+    events = file_summary.get_events(date)
+    file_summary.send_events(events)

--- a/scripts/analytics/file_summary.py
+++ b/scripts/analytics/file_summary.py
@@ -2,7 +2,6 @@ import django
 django.setup()
 
 from django.db.models import Q
-import pytz
 import logging
 from dateutil.parser import parse
 from datetime import datetime, timedelta
@@ -27,10 +26,10 @@ class FileSummary(SummaryAnalytics):
         from addons.osfstorage.models import OsfStorageFile
 
         # Convert to a datetime at midnight for queries and the timestamp
-        timestamp_datetime = datetime(date.year, date.month, date.day).replace(tzinfo=pytz.UTC)
+        timestamp_datetime = datetime(date.year, date.month, date.day).replace(tzinfo=timezone.utc)
         query_datetime = timestamp_datetime + timedelta(days=1)
 
-        file_qs = OsfStorageFile.objects.filter()
+        file_qs = OsfStorageFile.objects
 
         public_query = Q(node__is_public=True)
         private_query = Q(node__is_public=False)

--- a/scripts/analytics/run_keen_summaries.py
+++ b/scripts/analytics/run_keen_summaries.py
@@ -4,6 +4,7 @@ django.setup()
 from framework.celery_tasks import app as celery_app
 from scripts.analytics.user_summary import UserSummary
 from scripts.analytics.node_summary import NodeSummary
+from scripts.analytics.file_summary import FileSummary
 from scripts.analytics.preprint_summary import PreprintSummary
 from scripts.analytics.institution_summary import InstitutionSummary
 from scripts.analytics.base import DateAnalyticsHarness
@@ -13,7 +14,7 @@ class SummaryHarness(DateAnalyticsHarness):
 
     @property
     def analytics_classes(self):
-        return [NodeSummary, UserSummary, InstitutionSummary, PreprintSummary]
+        return [NodeSummary, FileSummary, UserSummary, InstitutionSummary, PreprintSummary]
 
 
 @celery_app.task(name='scripts.analytics.run_keen_summaries')


### PR DESCRIPTION
## Purpose

We need to include the number of files/number of public files on the OSF in the daily summaries we send to Keen.

## Changes

Added file_summary script, similar to node_summary, that calculates
- total # of files in OSFStorage (includes quickfiles)
- total # of public files in OSFStorage, (includes quickfiles)
- total # of private files in OSFStorage
- total # of files added today in OSFStorage (includes quickfiles)
- total # of public added today in OSFStorage, (includes quickfiles)
- Total # of private files added today

## QA Notes

No QA testing needed

## Side Effects

None

## Ticket
https://openscience.atlassian.net/browse/PLAT-725