### PR TITLE
[PLAT-486] Fix Drag and drop bugs

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1261,10 +1261,7 @@ function _removeEvent (event, items, col) {
         var mithrilContentMultiple;
         var mithrilButtonsMultiple;
         items.forEach(function(item, index, arr){
-            if(item.data.materialized.substring(0, WIKI_IMAGES_FOLDER_PATH.length) === WIKI_IMAGES_FOLDER_PATH) {
-                deleteMessage.push(m('p.text-danger',  m('b', item.data.name), ' may be linked to' +
-                    ' your wiki(s). Deleting them will remove images embedded in your wiki(s).'));
-            } else if(!item.data.permissions.edit){
+            if(!item.data.permissions.edit){
                 canDelete = false;
                 noDeleteList.push(item);
             } else {
@@ -1284,7 +1281,12 @@ function _removeEvent (event, items, col) {
                                 m('i.fa.fa-folder'), m('b', ' ' + n.data.name)
                                 ]);
                         }
-                        return m('.fangorn-canDelete.text-success.break-word', n.data.name);
+                        if(n.data.materialized.substring(0, WIKI_IMAGES_FOLDER_PATH.length) === WIKI_IMAGES_FOLDER_PATH) {
+                            return m('p.text-danger', m('b', n.data.name), ' may be linked to' +
+                                ' your wiki(s). Deleting them will remove images embedded in your wiki(s).');
+                        } else {
+                            return m('.fangorn-canDelete.text-success.break-word', n.data.name);
+                        }
                     })
                 ]);
             mithrilButtonsMultiple = m('div', [


### PR DESCRIPTION
## Purpose

There was a bug caused by dropping multiple 409ing files causing the wiki links not to draw properly, this fixes that.

While testing that I notice there was another bug preventing the user from deleting multiple files in the Wiki images folder, this fixes that too.

## Changes

- Reorders API requests so we check for duplicate names before upload
- Handle special delete warnings differently.

## QA Notes

Upload multiple 409ing and non-409ing files and delete multiples from the files page.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-486