### PR TITLE
[PLAT-486] Get rid of bad JS syntax for DND

### DIFF
--- a/addons/wiki/static/dragNDrop.js
+++ b/addons/wiki/static/dragNDrop.js
@@ -65,8 +65,10 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
             url: ctx.waterbutlerURL + 'v1/resources/' + ctx.node.id + '/providers/osfstorage' + encodeURI(path) + '?meta=',
             beforeSend: $osf.setXHRAuthorization,
         }).done(function (response) {
-            fileNames = response.data.map(file => file.attributes.name);
-            if (!!path) {
+            fileNames = response.data.map(function(file) {
+                return file.attributes.name;
+            });
+            if (path) {
                 var newName;
                 $.each(files, function (i, file) {
                     if (fileNames.indexOf(file.name) !== -1) {


### PR DESCRIPTION
## Purpose

ES2015 syntax was cause Jenkins to fail this fixes that.

## Changes

- Small syntax change


## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-486