### PR TITLE
[IN-210] Order moderators by fullname

### DIFF
--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -262,7 +262,7 @@ class PreprintProviderModeratorsList(ModeratorMixin, JSONAPIBaseView, generics.L
             When(groups=admin_group, then=Value('admin')),
             default=Value('moderator'),
             output_field=CharField()
-        ))
+        )).order_by('fullname')
 
     def get_queryset(self):
         return self.get_queryset_from_request()

--- a/api_tests/preprint_providers/views/test_preprint_provider_moderator_list.py
+++ b/api_tests/preprint_providers/views/test_preprint_provider_moderator_list.py
@@ -126,3 +126,16 @@ class TestPreprintProviderModeratorList:
         assert res.json['data']['attributes']['permission_group'] == 'moderator'
         assert 'email' not in res.json['data']['attributes']
         assert mock_mail.call_count == 1
+
+    def test_list_moderators_alphabetically(self, app, url, admin, moderator, provider):
+        admin.fullname = 'Alice Alisdottir'
+        moderator.fullname = 'Bob Bobsson'
+        new_mod = AuthUserFactory(fullname='Cheryl Cherylsdottir')
+        GroupHelper(provider).get_group('moderator').user_set.add(new_mod)
+        admin.save()
+        moderator.save()
+        res = app.get(url, auth=admin.auth)
+        assert len(res.json['data']) == 3
+        assert res.json['data'][0]['id'] == admin._id
+        assert res.json['data'][1]['id'] == moderator._id
+        assert res.json['data'][2]['id'] == new_mod._id


### PR DESCRIPTION
## Purpose
Frontend needs consistent ordering

## Changes
* `order_by` `fullname`
* Add a test

## QA Notes
Low need. To test, ensure that the list of mods for any given PreprintProvider is ordered alphabetically

## Side Effects
None expected

## Ticket
[[IN-210]](https://openscience.atlassian.net/browse/IN=210)
