### PR TITLE
Check for header auth token on persistent file download

### DIFF
--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -28,7 +28,7 @@ from addons.base.views import make_auth
 from addons.osfstorage import settings as storage_settings
 from api_tests.utils import create_test_file
 
-from osf_tests.factories import ProjectFactory
+from osf_tests.factories import ProjectFactory, ApiOAuth2PersonalTokenFactory
 
 def create_record_with_version(path, node_settings, **kwargs):
     version = factories.FileVersionFactory(**kwargs)
@@ -1070,3 +1070,12 @@ class TestFileViews(StorageTestCase):
         url = base_url.format(folder._id)
         redirect = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert redirect.status_code == 400
+
+        # Test token as auth
+        url = base_url.format(file.get_guid()._id)
+        token = ApiOAuth2PersonalTokenFactory(owner=self.user)
+        headers = {
+            'Authorization': str('Bearer {}'.format(token.token_id))
+        }
+        redirect = self.app.get(url, headers=headers)
+        assert redirect.status_code == 302

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -78,10 +78,15 @@ def get_current_user_id():
 
 # TODO - rename to _get_current_user_from_session /HRYBACKI
 def _get_current_user():
-    from osf.models import OSFUser
+    from osf.models import OSFUser, ApiOAuth2PersonalToken
+    from framework.auth.cas import parse_auth_header
     current_user_id = get_current_user_id()
+    header_token = request.headers.get('Authorization', None)
     if current_user_id:
         return OSFUser.load(current_user_id, select_for_update=check_select_for_update(request))
+    elif header_token and 'bearer' in header_token.lower():
+        token = ApiOAuth2PersonalToken.objects.filter(token_id=parse_auth_header(header_token))
+        return token.get().owner if token else None
     else:
         return None
 
@@ -177,15 +182,7 @@ class Auth(object):
 
     @classmethod
     def from_kwargs(cls, request_args, kwargs):
-        from osf.models import ApiOAuth2PersonalToken
-        from framework.auth.cas import parse_auth_header
-
-        header_token = request.headers.get('Authorization', None)
-        if header_token and 'bearer' in header_token.lower():
-            token = ApiOAuth2PersonalToken.objects.filter(token_id=parse_auth_header(header_token))
-            user = token.get().owner if token else None
-        else:
-            user = request_args.get('user') or kwargs.get('user') or _get_current_user()
+        user = request_args.get('user') or kwargs.get('user') or _get_current_user()
         private_key = request_args.get('view_only')
         return cls(
             user=user,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

With the addition of the new shiny persistent file download route (#8107), users couldn't provide an oauth token as they used to in order to authenticate for download requests. Let's fix that!

## Changes

- add check in `_get_current_user` method to look for token. This is eventually called from the `@collect_auth` decorator
- test for getting with token in header

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
I do believe that @TimErrington was the one who reported this bug because of a script he runs regularly, so perhaps this would be best tested by him!


## Side Effects

Any route using the `get_user` method from `core.py` can now pass a token in the header, which is nice!

## Ticket

https://openscience.atlassian.net/browse/PLAT-741