### PR TITLE
[PLAT-216] fix onboarder redirect

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1384,6 +1384,8 @@ RegistrationManager.prototype.init = function() {
                 schemaName = 'Prereg Challenge';
             } else if (urlParams.campaign === 'erpc') {
                 schemaName = 'Election Research Preacceptance Competition';
+            } else if (urlParams.campaign === 'registered_report') {
+                schemaName = 'Registered Report Protocol Preregistration';
             }
             if (schemaName) {
                 $osf.block();
@@ -1391,10 +1393,15 @@ RegistrationManager.prototype.init = function() {
                     var preregSchema = self.schemas().filter(function(schema) {
                         return schema.name === schemaName;
                     })[0];
-                    preregSchema.askConsent(true).then(function() {
+                    if(urlParams.campaign === 'prereg') {
+                        preregSchema.askConsent(true).then(function () {
+                            self.selectedSchema(preregSchema);
+                            $('#newDraftRegistrationForm').submit();
+                        });
+                    } else {
                         self.selectedSchema(preregSchema);
                         $('#newDraftRegistrationForm').submit();
-                    });
+                    }
                 }).always($osf.unblock);
             }
         }

--- a/website/templates/registered_reports_landing.mako
+++ b/website/templates/registered_reports_landing.mako
@@ -151,5 +151,6 @@
 <%include file="components/autocomplete.mako"/>
 <script type="text/javascript">
   window.contextVars = window.contextVars || {};
+  window.contextVars.campaign = ${campaign_short | sjson};
 </script>
 </%def>


### PR DESCRIPTION
## Purpose

If a user creates a registration from the /rr page this opens a rr draft immediately. 

## Changes

- JS changes to send you to a new draft right after a click the registration.

## QA Notes

Create a registration from the /rr page after some loading you should directly into a draft.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-216