### PR TITLE
[PLAT-486] More dnd fixes

### DIFF
--- a/addons/wiki/static/dragNDrop.js
+++ b/addons/wiki/static/dragNDrop.js
@@ -41,8 +41,8 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
     var promises = [];
     var editor = ace.edit('editor');
     editor.disable();
-    getOrCreateWikiImagesFolder().fail(function() {
-        notUploaded(multiple);
+    getOrCreateWikiImagesFolder().fail(function(response) {
+        notUploaded(response, multiple);
         editor.enable();
     }).done(function(path) {
         $.ajax({ // Check to makes sure we don't overwrite a file with the same name.
@@ -76,7 +76,6 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
                                 data: file,
                             }).done(function (response) {
                                 urls.splice(i, 0, response.data.links.download + '?mode=render');
-                                editor.enable();
                             }).fail(function (response) {
                                 notUploaded(response, false, cm, init, fixupInputArea, path, file);
                             })
@@ -88,10 +87,13 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
                         cm.doLinkOrImage(init, null, true, url, multiple, num + i);
                     });
                     fixupInputArea();
+                    editor.enable();
                 });
             } else {
                 notUploaded(null, multiple);
             }
+        }).fail(function (response) {
+            notUploaded(response, false, cm, init, fixupInputArea, path);
         });
     });
 };
@@ -285,6 +287,7 @@ var addDragNDrop = function(editor, panels, cm, TextareaState) {
 
 var notUploaded = function(response, multiple, cm, init, fixupInputArea, path, file) {
     var files = multiple ? 'Files' : 'File';
+    var editor = ace.edit('editor');
     if (response.status === 403) {
         $osf.growl('Error', 'File not uploaded. You do not have permission to upload files to' +
             ' this project.', 'danger');

--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -167,9 +167,7 @@
                                 <li><span data-bind="text: andOthersMessage"></span></li>
                               </ul>
                               <div id="wmd-button-bar"></div>
-                              <div id="aceLoadingBall" class="ball-pulse ball-dark absolute-center">
-                                  <div></div>
-                                  <div></div>
+                              <div id="aceLoadingBall" class="ball-scale ball-scale-blue absolute-center">
                                   <div></div>
                               </div>
                               <div id="editor" class="wmd-input wiki-editor"

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1228,7 +1228,7 @@ function _removeEvent (event, items, col) {
         var detail;
         if(items[0].data.materialized.substring(0, WIKI_IMAGES_FOLDER_PATH.length) === WIKI_IMAGES_FOLDER_PATH) {
             detail = m('span', 'This file may be linked to your wiki(s). Deleting it will remove the' +
-                ' image embedded in your wiki(s).');
+                ' image embedded in your wiki(s). ');
         } else {
             detail = '';
         }
@@ -1283,7 +1283,7 @@ function _removeEvent (event, items, col) {
                         }
                         if(n.data.materialized.substring(0, WIKI_IMAGES_FOLDER_PATH.length) === WIKI_IMAGES_FOLDER_PATH) {
                             return m('p.text-danger', m('b', n.data.name), ' may be linked to' +
-                                ' your wiki(s). Deleting them will remove images embedded in your wiki(s).');
+                                ' your wiki(s). Deleting them will remove images embedded in your wiki(s). ');
                         } else {
                             return m('.fangorn-canDelete.text-success.break-word', n.data.name);
                         }


### PR DESCRIPTION
## Purpose

Follow up on QA catches for DnD.

## Changes

- Change loading indicator 
- Fix show permissions messages shows
- Make sure  loading indicators go away right when links are being drawn
- Fix delete wiki language when deleting a single file

## QA Notes

- Upload a bunch of files and make sure the loading indicators disappear right before the links are drawn.
- Delete a single file in the wiki images folder and make sure the sentences have spaces after the period.
- upload something to a public wiki without permission.
- Make sure we have a single pulsing ball.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-486