### PR TITLE
Take 2: persistent file download URL accept token: CAS edition! [#PLAT-741]

### DIFF
--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -5,8 +5,10 @@ import mock
 import datetime
 
 import pytest
+import responses
 from nose.tools import *  # noqa
 from dateutil.parser import parse as parse_datetime
+from website import settings
 
 from addons.osfstorage.models import OsfStorageFileNode, OsfStorageFolder
 from framework.auth.core import Auth
@@ -18,6 +20,7 @@ from addons.osfstorage.tests import factories
 from addons.osfstorage.tests.utils import make_payload
 
 from framework.auth import signing
+from framework.auth import cas
 from website.util import rubeus
 
 from osf.models import Tag, QuickFilesNode
@@ -1071,11 +1074,33 @@ class TestFileViews(StorageTestCase):
         redirect = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert redirect.status_code == 400
 
-        # Test token as auth
-        url = base_url.format(file.get_guid()._id)
+    @responses.activate
+    @mock.patch('framework.auth.cas.get_client')
+    def test_download_file_with_token(self, mock_get_client):
+        cas_base_url = 'http://accounts.test.test'
+        client = cas.CasClient(cas_base_url)
+
+        mock_get_client.return_value = client
+
+        base_url = '/download/{}/'
+        file = create_test_file(node=self.node, user=self.user)
+
+        responses.add(
+            responses.Response(
+                responses.GET,
+                '{}/oauth2/profile'.format(cas_base_url),
+                body='{{"id": "{}"}}'.format(self.user._id),
+                status=200,
+            )
+        )
+
+        download_url = base_url.format(file.get_guid()._id)
         token = ApiOAuth2PersonalTokenFactory(owner=self.user)
         headers = {
             'Authorization': str('Bearer {}'.format(token.token_id))
         }
-        redirect = self.app.get(url, headers=headers)
+        redirect = self.app.get(download_url, headers=headers)
+
+        assert mock_get_client.called
+        assert settings.WATERBUTLER_URL in redirect.location
         assert redirect.status_code == 302

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 from __future__ import unicode_literals
 
+import json
 import mock
 import datetime
 
@@ -1089,7 +1090,7 @@ class TestFileViews(StorageTestCase):
             responses.Response(
                 responses.GET,
                 '{}/oauth2/profile'.format(cas_base_url),
-                body='{{"id": "{}"}}'.format(self.user._id),
+                body=json.dumps({'id': '{}'.format(self.user._id)}),
                 status=200,
             )
         )

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -94,7 +94,10 @@ def _get_current_user():
         except cas.CasHTTPError:
             return None
 
-        return OSFUser.load(cas_auth_response.user) if cas_auth_response.authenticated else None
+        return OSFUser.load(
+            cas_auth_response.user,
+            select_for_update=check_select_for_update(request)
+        ) if cas_auth_response.authenticated else None
 
     else:
         return None


### PR DESCRIPTION

## Purpose
Follow up to #8239

Previous hotfix only worked for personal access tokens, make it work for authenticated CAS requests as well!

## Changes

- update method to authenticate thru cas 
- update test for cas

## QA Notes

This might be best tested by our partners with applications that use access tokens for the download URLS -- see https://github.com/CenterForOpenScience/waterbutler/issues/328 and https://github.com/dschreij/QOpenScienceFramework/issues/13

## Side Effects

none anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-741