### PR TITLE
[PLAT-486] Loading indicator dnd fix

### DIFF
--- a/addons/wiki/static/dragNDrop.js
+++ b/addons/wiki/static/dragNDrop.js
@@ -62,7 +62,6 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
                     name = newName ? newName : file.name;
                     if (validImgExtensions.indexOf(ext.toLowerCase()) <= -1) {
                         $osf.growl('Error', 'This file type cannot be embedded  (' + file.name + ')', 'danger');
-                        editor.enable();
                     } else {
                         var waterbutlerURL = ctx.waterbutlerURL + 'v1/resources/' + ctx.node.id + '/providers/osfstorage' + encodeURI(path) + '?name=' + encodeURI(name) + '&type=file';
                         $osf.trackClick('wiki', 'dropped-image', ctx.node.id);


### PR DESCRIPTION
## Purpose

If you drag and drop multiple file types and one is invalid the loading indicator goes away prematurely, this fix ensures it sticks around until all files have been dealt with.

## Changes

- Stop editor from being prematurely re-enabled.

## QA Notes

Upload a bunch of valid images, then include a bad one, check that the loading indicator doesn't leave prematurely.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-486