### PR TITLE
[hotfix] Use max page_size for waffle API endpoint [PLAT-744]

### DIFF
--- a/api/waffle/views.py
+++ b/api/waffle/views.py
@@ -6,6 +6,7 @@ from rest_framework import permissions as drf_permissions
 
 from api.base.views import JSONAPIBaseView
 from api.base.permissions import TokenHasScope
+from api.base.pagination import MaxSizePagination
 from api.waffle.serializers import WaffleSerializer
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -59,6 +60,7 @@ class WaffleList(JSONAPIBaseView, generics.ListAPIView):
     serializer_class = WaffleSerializer
     view_category = 'waffle'
     view_name = 'waffle-list'
+    pagination_class = MaxSizePagination
 
     # overrides ListAPIView
     def get_queryset(self):

--- a/api_tests/waffle/views/test_waffle_list.py
+++ b/api_tests/waffle/views/test_waffle_list.py
@@ -7,6 +7,7 @@ from osf_tests.factories import (
     SampleFactory,
     SwitchFactory
 )
+from api.base.pagination import MaxSizePagination
 
 @pytest.mark.django_db
 class TestWaffleList:
@@ -67,3 +68,7 @@ class TestWaffleList:
         assert len(res.json['data']) == 1
         assert res.json['data'][0]['attributes']['name'] == 'inactive_switch'
         assert not res.json['data'][0]['attributes']['active']
+
+    def test_page_size(self, app, url, user):
+        res = app.get(url)
+        assert res.json['links']['meta']['per_page'] == MaxSizePagination.page_size


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently, visiting page 2 of the waffle endpoints results in an error: https://staging-api.osf.io/v2/_waffle/?page=2

A proposed solution to this on the tickets is that the waffle endpoint doens't really need pagination, and so a similarly un-restricted pagination (like the Institution list) should be used instead.

## Changes

- Use `MaxSizePagination` as the `pagination_class` for the waffle list API route (same `pagination_class` as the `InstitutionList`

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Should not need QA, but a quick check of https://staging-api.osf.io/v2/_waffle/ and or  https://api.osf.io/v2/_waffle/ should show ` "per_page": 1000,` at the bottom in the `meta` section, along with `null` for last, previous, and next pages.

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-744