### PR TITLE
[PLAT-435] Dataverse Refactor

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -131,7 +131,11 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         connection = client.connect_from_settings(self)
         dataverse = client.get_dataverse(connection, self.dataverse_alias)
 
-        datasets = client.get_datasets(dataverse)
+        try:
+            datasets = client.get_datasets(dataverse)
+        except Exception as e:
+            raise HTTPError(code=e.code, message=e.message)
+
         return [
             {
                 'name': dataset.title,

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -9,7 +9,7 @@ from framework.exceptions import HTTPError
 from osf.models.files import File, Folder, BaseFileNode
 from framework.auth.core import _get_current_user
 from addons.base import exceptions
-from addons.dataverse.client import connect_from_settings_or_401
+from addons.dataverse import client
 from addons.dataverse.serializer import DataverseSerializer
 from addons.dataverse.utils import DataverseNodeLogger
 
@@ -95,7 +95,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     @property
     def dataset_id(self):
         if self._dataset_id is None and (self.dataverse_alias and self.dataset_doi):
-            connection = connect_from_settings_or_401(self)
+            connection = client.connect_from_settings_or_401(self)
             dataverse = connection.get_dataverse(self.dataverse_alias)
             dataset = dataverse.get_dataset_by_doi(self.dataset_doi)
             self._dataset_id = dataset.id
@@ -124,6 +124,24 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             node=self.owner,
             auth=auth
         )
+
+    def get_folders(self, path=None, folder_id=None):
+        """Get list of datasets from provided Dataverse alias"""
+
+        connection = client.connect_from_settings(self)
+        dataverse = client.get_dataverse(connection, self.dataverse_alias)
+
+        datasets = client.get_datasets(dataverse)
+        return [
+            {
+                'name': dataset.title,
+                'doi': dataset.doi,
+                'addon': 'dataverse',
+                'kind': 'dataset',
+                'path': '/',
+                'id': dataset.id,
+            }
+            for dataset in datasets]
 
     def set_folder(self, dataverse, dataset, auth=None):
         self.dataverse_alias = dataverse.alias

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -129,6 +129,23 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         """Get list of datasets from provided Dataverse alias"""
 
         connection = client.connect_from_settings(self)
+
+        dataverses = connection.get_dataverses()
+        return [
+            {
+                'name': dataverse.title,
+                'alias': dataverse.alias,
+                'id': dataverse.alias,
+                'addon': 'dataverse',
+                'kind': 'dataverse',
+                'path': '/',
+            }
+            for dataverse in dataverses]
+
+    def get_datasets(self, path=None, folder_id=None):
+        """Get list of datasets from provided Dataverse alias"""
+
+        connection = client.connect_from_settings(self)
         dataverse = client.get_dataverse(connection, self.dataverse_alias)
 
         try:

--- a/addons/dataverse/serializer.py
+++ b/addons/dataverse/serializer.py
@@ -54,8 +54,7 @@ class DataverseSerializer(OAuthAddonSerializer):
             'importAuth': node.api_url_for('dataverse_import_auth'),
             'deauthorize': node.api_url_for('dataverse_deauthorize_node'),
             'getDatasets': node.api_url_for('dataverse_get_datasets'),
-            'datasetPrefix': 'https://doi.org/',
-            'dataversePrefix': 'http://{0}/dataverse/'.format(host),
+            'dataversePrefix': 'http://{0}/'.format(host),
             'accounts': api_url_for('dataverse_account_list'),
         }
 

--- a/addons/dataverse/static/dataverseNodeConfig.js
+++ b/addons/dataverse/static/dataverseNodeConfig.js
@@ -132,10 +132,10 @@ function ViewModel(url) {
     };
 
     self.savedDatasetUrl = ko.pureComputed(function() {
-        return (self.urls()) ? self.urls().datasetPrefix + self.savedDatasetDoi() : null;
+        return (self.urls()) ? self.urls().dataversePrefix + 'dataset.xhtml?persistentId=' + self.savedDatasetDoi() : null;
     });
     self.savedDataverseUrl = ko.pureComputed(function() {
-        return (self.urls()) ? self.urls().dataversePrefix + self.savedDataverseAlias() : null;
+        return (self.urls()) ? self.urls().dataversePrefix + 'dataverse/' + self.savedDataverseAlias() : null;
     });
 
     self.selectedDataverseAlias = ko.observable();
@@ -153,7 +153,7 @@ function ViewModel(url) {
         for (var i = 0; i < self.datasets().length; i++) {
             var data = self.datasets()[i];
             if (data.doi === self.selectedDatasetDoi()) {
-                return data.title;
+                return data.name;
             }
         }
         return null;

--- a/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/addons/dataverse/templates/dataverse_node_settings.mako
@@ -88,12 +88,12 @@
                                     <select class="form-control"
                                             data-bind="options: datasets,
                                                        optionsValue: 'doi',
-                                                       optionsText: 'title',
+                                                       optionsText: 'name',
                                                        value: selectedDatasetDoi">
                                     </select>
                                 </div>
                                 <div data-bind="if: showNoDatasets">
-                                    <div class="text-info" style="padding-top: 8px">
+                                    <div class="text-muted" style="padding-top: 8px">
                                         No datasets available.
                                     </div>
                                 </div>

--- a/addons/dataverse/tests/test_views.py
+++ b/addons/dataverse/tests/test_views.py
@@ -86,7 +86,7 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
 
         assert_equal(len(res.json['datasets']), 3)
         first = res.json['datasets'][0]
-        assert_equal(first['title'], 'Example (DVN/00001)')
+        assert_equal(first['name'], 'Example (DVN/00001)')
         assert_equal(first['doi'], 'doi:12.3456/DVN/00001')
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')

--- a/addons/dataverse/views.py
+++ b/addons/dataverse/views.py
@@ -154,7 +154,7 @@ def dataverse_set_config(node_addon, auth, **kwargs):
 def dataverse_get_datasets(node_addon, **kwargs):
     """Get list of datasets from provided Dataverse alias"""
     node_addon.dataverse_alias = request.json.get('alias')
-    return {'alias': node_addon.dataverse_alias, 'datasets': node_addon.get_folders()}, http.OK
+    return {'alias': node_addon.dataverse_alias, 'datasets': node_addon.get_datasets()}, http.OK
 
 ## Crud ##
 

--- a/addons/dataverse/views.py
+++ b/addons/dataverse/views.py
@@ -153,6 +153,7 @@ def dataverse_set_config(node_addon, auth, **kwargs):
 @must_have_addon(SHORT_NAME, 'node')
 def dataverse_get_datasets(node_addon, **kwargs):
     """Get list of datasets from provided Dataverse alias"""
+    node_addon.dataverse_alias = request.json.get('alias')
     return {'alias': node_addon.dataverse_alias, 'datasets': node_addon.get_folders()}, http.OK
 
 ## Crud ##

--- a/api/addons/views.py
+++ b/api/addons/views.py
@@ -51,7 +51,7 @@ class AddonSettingsMixin(object):
             authorizer = None
             if owner_type == 'user':
                 authorizer = addon_settings.owner
-            elif getattr(addon_settings, 'user_settings'):
+            elif getattr(addon_settings, 'user_settings', False):
                 authorizer = addon_settings.user_settings.owner
             if authorizer and authorizer != self.request.user:
                 raise PermissionDenied('Must be addon authorizer to list folders')

--- a/api/addons/views.py
+++ b/api/addons/views.py
@@ -51,7 +51,7 @@ class AddonSettingsMixin(object):
             authorizer = None
             if owner_type == 'user':
                 authorizer = addon_settings.owner
-            elif hasattr(addon_settings, 'user_settings'):
+            elif getattr(addon_settings, 'user_settings'):
                 authorizer = addon_settings.user_settings.owner
             if authorizer and authorizer != self.request.user:
                 raise PermissionDenied('Must be addon authorizer to list folders')

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -685,7 +685,7 @@ class TestNodeBitbucketAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
         }
 
 
-class MockConnection():
+class MockConnection(object):
 
     def get_dataverses(self):
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -685,6 +685,17 @@ class TestNodeBitbucketAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
         }
 
 
+class MockConnection():
+
+    def get_dataverses(self):
+
+        class MockDataverse():
+            title = 'dataverse title'
+            alias = '1234'
+
+        return [MockDataverse()]
+
+
 class TestNodeDataverseAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'dataverse'
     AccountFactory = DataverseAccountFactory
@@ -697,23 +708,16 @@ class TestNodeDataverseAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             'owner': self.node
         }
 
-    @mock.patch('addons.dataverse.models.client')
-    def test_folder_list_GET_expected_behavior(self, mock_folder):
-        mock_folder.get_datasets = lambda _ : [
-            type('mock_dataset',
-                 (object,),
-                 {'title': 'dataset title',
-                  'doi': 'doi 12345',
-                  'id':'1234'})()
-        ]
+    @mock.patch('addons.dataverse.models.client.connect_from_settings', return_value=MockConnection())
+    def test_folder_list_GET_expected_behavior(self, mock_client):
 
         res = self.app.get(
             self.folder_url,
             auth=self.user.auth)
         print(res.json)
         addon_data = res.json['data'][0]['attributes']
-        assert_equal(addon_data['kind'], 'dataset')
-        assert_equal(addon_data['name'], 'dataset title')
+        assert_equal(addon_data['kind'], 'dataverse')
+        assert_equal(addon_data['name'], 'dataverse title')
         assert_equal(addon_data['path'], '/')
         assert_equal(addon_data['folder_id'], "1234")
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -697,6 +697,26 @@ class TestNodeDataverseAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             'owner': self.node
         }
 
+    @mock.patch('addons.dataverse.models.client')
+    def test_folder_list_GET_expected_behavior(self, mock_folder):
+        mock_folder.get_datasets = lambda _ : [
+            type('mock_dataset',
+                 (object,),
+                 {'title': 'dataset title',
+                  'doi': 'doi 12345',
+                  'id':'1234'})()
+        ]
+
+        res = self.app.get(
+            self.folder_url,
+            auth=self.user.auth)
+        print(res.json)
+        addon_data = res.json['data'][0]['attributes']
+        assert_equal(addon_data['kind'], 'dataset')
+        assert_equal(addon_data['name'], 'dataset title')
+        assert_equal(addon_data['path'], '/')
+        assert_equal(addon_data['folder_id'], "1234")
+
 
 class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'github'


### PR DESCRIPTION
## Purpose

Allows us to access Dataverse datasets via v2 API.  Also there were some incidental style fixes which a threw in rather then make a new ticket.

## Changes


Refactor:
- add get_folder method to model
- adapt view to use model method
- refactor front end to use "name" instead of "title", in accordance with API standard

Style:
- Fix broken Dataverse and dataset link
- Change text color from blue to black

## QA Notes

Style changes below.

<img width="909" alt="screen shot 2018-03-26 at 12 07 23 pm" src="https://user-images.githubusercontent.com/9688518/37918361-d25d27d6-30ee-11e8-9f9d-49ba7358a2cb.png">

## Side Effects

Because the the Dataverse Repo -> Dataverse -> Dataset -> File sturcture of Dataverse, this needs a degree more configuration from the other addons. So to get Datasets to appear via the API you have to select a Dataverse with a Dataset via the UI.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-435