### PR TITLE
[EMB-162][EMB-189] Add support for ember node subpages

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -221,6 +221,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     current_user_can_comment = ser.SerializerMethodField(help_text='Whether the current user is allowed to post comments')
     current_user_permissions = ser.SerializerMethodField(help_text='List of strings representing the permissions '
                                                                    'for the current user on this node.')
+    current_user_is_contributor = ser.SerializerMethodField(help_text='Whether the current user is a contributor on this node.')
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,
@@ -385,6 +386,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         user = self.context['request'].user
         auth = Auth(user if not user.is_anonymous else None)
         return obj.can_comment(auth)
+
+    def get_current_user_is_contributor(self, obj):
+        user = self.context['request'].user
+        user = None if user.is_anonymous else user
+        return obj.is_contributor(user)
 
     class Meta:
         type_ = 'nodes'

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -221,7 +221,6 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     current_user_can_comment = ser.SerializerMethodField(help_text='Whether the current user is allowed to post comments')
     current_user_permissions = ser.SerializerMethodField(help_text='List of strings representing the permissions '
                                                                    'for the current user on this node.')
-    current_user_is_contributor = ser.SerializerMethodField(help_text='Whether the current user is a contributor on this node.')
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,
@@ -386,11 +385,6 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         user = self.context['request'].user
         auth = Auth(user if not user.is_anonymous else None)
         return obj.can_comment(auth)
-
-    def get_current_user_is_contributor(self, obj):
-        user = self.context['request'].user
-        user = None if user.is_anonymous else user
-        return obj.is_contributor(user)
 
     class Meta:
         type_ = 'nodes'
@@ -771,6 +765,12 @@ class NodeDetailSerializer(NodeSerializer):
     Overrides NodeSerializer to make id required.
     """
     id = IDField(source='_id', required=True)
+    current_user_is_contributor = ser.SerializerMethodField(help_text='Whether the current user is a contributor on this node.')
+
+    def get_current_user_is_contributor(self, obj):
+        user = self.context['request'].user
+        user = None if user.is_anonymous else user
+        return obj.is_contributor(user)
 
 
 class NodeForksSerializer(NodeSerializer):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -130,6 +130,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'title',
             'type',
             'current_user_can_comment',
+            'current_user_is_contributor',
             'preprint',
             'subjects']
         # fields that do not appear on registrations

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -96,6 +96,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['title'] == project_public.title
         assert res.json['data']['attributes']['description'] == project_public.description
         assert res.json['data']['attributes']['category'] == project_public.category
+        assert res.json['data']['attributes']['current_user_is_contributor'] is False
         assert_items_equal(
             res.json['data']['attributes']['current_user_permissions'],
             permissions_read)
@@ -107,6 +108,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['title'] == project_public.title
         assert res.json['data']['attributes']['description'] == project_public.description
         assert res.json['data']['attributes']['category'] == project_public.category
+        assert res.json['data']['attributes']['current_user_is_contributor'] is True
         assert_items_equal(
             res.json['data']['attributes']['current_user_permissions'],
             permissions_admin)
@@ -118,6 +120,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['title'] == project_public.title
         assert res.json['data']['attributes']['description'] == project_public.description
         assert res.json['data']['attributes']['category'] == project_public.category
+        assert res.json['data']['attributes']['current_user_is_contributor'] is False
         assert_items_equal(
             res.json['data']['attributes']['current_user_permissions'],
             permissions_read)
@@ -129,6 +132,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['title'] == project_private.title
         assert res.json['data']['attributes']['description'] == project_private.description
         assert res.json['data']['attributes']['category'] == project_private.category
+        assert res.json['data']['attributes']['current_user_is_contributor'] is True
         assert_items_equal(
             res.json['data']['attributes']['current_user_permissions'],
             permissions_admin)
@@ -153,6 +157,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['title'] == project_private.title
         assert res.json['data']['attributes']['description'] == project_private.description
         assert res.json['data']['attributes']['category'] == project_private.category
+        assert res.json['data']['attributes']['current_user_is_contributor'] is True
         assert_items_equal(
             res.json['data']['attributes']['current_user_permissions'],
             permissions_write)

--- a/website/views.py
+++ b/website/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import itertools
 import httplib as http
 import logging
@@ -6,6 +7,7 @@ import math
 import os
 import requests
 import urllib
+import waffle
 
 from django.apps import apps
 from django.db.models import Count
@@ -26,6 +28,7 @@ from website.institutions.views import serialize_institution
 from osf.models import BaseFileNode, Guid, Institution, PreprintService, AbstractNode, Node
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT, INSTITUTION_DISPLAY_NODE_THRESHOLD, DOMAIN
 from website.ember_osf_web.decorators import ember_flag_is_active
+from website.ember_osf_web.views import use_ember_app
 from website.project.model import has_anonymous_link
 from osf.utils import permissions
 from api.preprint_providers.permissions import GroupHelper
@@ -323,6 +326,11 @@ def resolve_guid(guid, suffix=None):
                 return Response(stream_with_context(resp.iter_content()), resp.status_code)
 
             return send_from_directory(ember_osf_web_dir, 'index.html')
+
+        if isinstance(referent, Node) and suffix:
+            page = suffix.strip('/')
+            if waffle.flag_is_active(request, 'ember_project_{}_page'.format(page)):
+                use_ember_app()
 
         url = _build_guid_url(urllib.unquote(referent.deep_url), suffix)
         return proxy_url(url)

--- a/website/views.py
+++ b/website/views.py
@@ -327,8 +327,8 @@ def resolve_guid(guid, suffix=None):
 
             return send_from_directory(ember_osf_web_dir, 'index.html')
 
-        if isinstance(referent, Node) and suffix:
-            page = suffix.strip('/')
+        if isinstance(referent, Node) and not referent.is_registration and suffix:
+            page = suffix.strip('/').split('/')[0]
             if waffle.flag_is_active(request, 'ember_project_{}_page'.format(page)):
                 use_ember_app()
 


### PR DESCRIPTION
## Purpose
Add needed work for ember_osf_web to show a subset of ember pages, such as the registrations page

## Changes
 - Added `current_user_is_contributor` attr to node's serializer: checks if user making the request is a contributor
 - Added check for ember page flags on waffle, when reaching a node guid, to see which app should render the subpage.

## Ticket
https://openscience.atlassian.net/browse/EMB-162
https://openscience.atlassian.net/browse/EMB-189
