### PR TITLE
[PLAT-768][hotfix] Fix case so downloading file by guid works better

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -670,7 +670,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         format = extras.get('format')
         _, extension = os.path.splitext(file_node.name)
         # avoid rendering files with the same format type.
-        if format and '.{}'.format(format) != extension:
+        if format and '.{}'.format(format.lower()) != extension.lower():
             return redirect('{}/export?format={}&url={}'.format(MFR_SERVER_URL, format, urllib.quote(file_node.generate_waterbutler_url(
                 **dict(extras, direct=None, version=version.identifier, _internal=extras.get('mode') == 'render')
             ))))

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -637,6 +637,32 @@ class TestAddonFileViews(OsfTestCase):
         ret.versions.add(version)
         return ret
 
+    def get_uppercased_ext_test_file(self):
+        version = file_models.FileVersion(identifier='1')
+        version.save()
+        ret = GithubFile(
+            name='Test2.pdf',
+            node=self.project,
+            path='/test/Test2',
+            materialized_path='/test/Test2',
+        )
+        ret.save()
+        ret.versions.add(version)
+        return ret
+
+    def get_ext_test_file(self):
+        version = file_models.FileVersion(identifier='1')
+        version.save()
+        ret = GithubFile(
+            name='Test2.pdf',
+            node=self.project,
+            path='/test/Test2',
+            materialized_path='/test/Test2',
+        )
+        ret.save()
+        ret.versions.add(version)
+        return ret
+
     def get_mako_return(self):
         ret = serialize_node(self.project, Auth(self.user), primary=True)
         ret.update({
@@ -679,7 +705,7 @@ class TestAddonFileViews(OsfTestCase):
         assert_equals(resp.status_code, 302)
         assert_equals(resp.location, 'http://localhost:80/{}/'.format(guid._id))
 
-    def test_action_download_redirects_to_download(self):
+    def test_action_download_redirects_to_download_with_param(self):
         file_node = self.get_test_file()
         guid = file_node.get_guid(create=True)
 
@@ -688,6 +714,28 @@ class TestAddonFileViews(OsfTestCase):
         assert_equals(resp.status_code, 302)
         location = furl.furl(resp.location)
         assert_urls_equal(location.url, file_node.generate_waterbutler_url(action='download', direct=None, version=''))
+
+    def test_action_download_redirects_to_download_with_path(self):
+        file_node = self.get_uppercased_ext_test_file()
+        guid = file_node.get_guid(create=True)
+
+        resp = self.app.get('/{}/download?format=pdf'.format(guid._id), auth=self.user.auth)
+
+        assert_equals(resp.status_code, 302)
+        location = furl.furl(resp.location)
+        assert_equal(location.url, file_node.generate_waterbutler_url(action='download', direct=None, version='', format='pdf'))
+
+
+    def test_action_download_redirects_to_download_with_path_uppercase(self):
+        file_node = self.get_uppercased_ext_test_file()
+        guid = file_node.get_guid(create=True)
+
+        resp = self.app.get('/{}/download?format=pdf'.format(guid._id), auth=self.user.auth)
+
+        assert_equals(resp.status_code, 302)
+        location = furl.furl(resp.location)
+        assert_equal(location.url, file_node.generate_waterbutler_url(action='download', direct=None, version='', format='pdf'))
+
 
     def test_action_download_redirects_to_download_with_version(self):
         file_node = self.get_test_file()


### PR DESCRIPTION
## Purpose

Fix bug where loading a file with an all upper case extension caused the file not to be downloaded properly.

## Changes

- downcases the extension comparison.

## QA Notes

There are test files and good instructions attached on the ticket.

# Documentation

Not really necessary as a hotfix.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-768