### PR TITLE
[PLAT-757] "Mock" unauthenticated users for Waffle

### DIFF
--- a/website/ember_osf_web/decorators.py
+++ b/website/ember_osf_web/decorators.py
@@ -15,7 +15,10 @@ def ember_flag_is_active(flag_name):
     def decorator(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            request.user = _get_current_user()
+            # Waffle does not enjoy NoneTypes as user values.
+            mock_user = type('Mock User', (object,), {'is_authenticated': False})()
+            request.user = _get_current_user() or mock_user
+
             if waffle.flag_is_active(request, flag_name):
                 return use_ember_app()
             else:


### PR DESCRIPTION
## Purpose

If you are an unauthenticated user and you go to a page with a Waffle flagged decorator you will an error message detailed in the ticket. This fix prevents the error and restored the expected behavior.

## Changes

- Changes the decorator so it passes an object that represents a unauthenticated user instead of a NoneType.

## QA Notes

To reproduce with the admin app:
- Pick a precreated flag that corresponds to a page. For example: I picked the "ember_support_page" for my testing.
- Add a group to that flag (use the magnifying glass icon to search by name)
- Log out
- Go to page that corresponds to flag you set. if you can see the page without error you're good.


# Documentation

I'm going to write some short docs on Waffle on Notion. 

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-757