### PR TITLE
[feature] Handle disabled and public wikis [PLAT-543][PLAT-771]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -99,6 +99,7 @@ from api.requests.serializers import NodeRequestSerializer, NodeRequestCreateSer
 from api.requests.views import NodeRequestMixin
 from api.users.views import UserMixin
 from api.users.serializers import UserSerializer
+from api.wikis.permissions import IsEnabled
 from api.wikis.serializers import NodeWikiSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
@@ -1420,7 +1421,8 @@ class NodeWikiList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ListF
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals
+        ExcludeWithdrawals,
+        IsEnabled
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]

--- a/api/wikis/permissions.py
+++ b/api/wikis/permissions.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
-from rest_framework import exceptions
 from rest_framework import permissions
 
 from api.base.utils import get_user_auth
 from addons.wiki.models import WikiPage, WikiVersion
-from osf.models import AbstractNode
 
 
 class ContributorOrPublic(permissions.BasePermission):
@@ -46,19 +44,4 @@ class ExcludeWithdrawalsWikiVersion(permissions.BasePermission):
         node = obj.wiki_page.node
         if node and node.is_retracted:
             return False
-        return True
-
-
-class IsEnabled(permissions.BasePermission):
-
-    def has_object_permission(self, request, view, obj):
-        assert isinstance(obj, (WikiPage, WikiVersion, AbstractNode)), 'obj must be a WikiPage, WikiVersion, or AbstractNode, got {}'.format(obj)
-        if isinstance(obj, WikiPage):
-            node = obj.node
-        elif isinstance(obj, WikiVersion):
-            node = obj.wiki_page.node
-        else:
-            node = obj
-        if node.addons_wiki_node_settings.deleted:
-            raise exceptions.NotFound(detail='The wiki for this node has been disabled.')
         return True

--- a/api/wikis/permissions.py
+++ b/api/wikis/permissions.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from rest_framework import exceptions
 from rest_framework import permissions
-from addons.wiki.models import WikiPage, WikiVersion
 
 from api.base.utils import get_user_auth
+from addons.wiki.models import WikiPage, WikiVersion
+from osf.models import AbstractNode
 
 
 class ContributorOrPublic(permissions.BasePermission):
@@ -12,9 +14,10 @@ class ContributorOrPublic(permissions.BasePermission):
         auth = get_user_auth(request)
         if request.method in permissions.SAFE_METHODS:
             return obj.node.is_public or obj.node.can_view(auth)
-        else:
-            return obj.node.can_edit(auth)
-
+        return (
+            obj.node.can_edit(auth)
+            or obj.node.addons_wiki_node_settings.is_publicly_editable
+        )
 
 class ContributorOrPublicWikiVersion(permissions.BasePermission):
 
@@ -23,13 +26,13 @@ class ContributorOrPublicWikiVersion(permissions.BasePermission):
         auth = get_user_auth(request)
         if request.method in permissions.SAFE_METHODS:
             return obj.wiki_page.node.is_public or obj.wiki_page.node.can_view(auth)
-        else:
-            return obj.wiki_page.node.can_edit(auth)
+        return obj.wiki_page.node.can_edit(auth)
 
 
 class ExcludeWithdrawals(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, WikiPage), 'obj must be a WikiPage, got {}'.format(obj)
         node = obj.node
         if node and node.is_retracted:
             return False
@@ -39,7 +42,23 @@ class ExcludeWithdrawals(permissions.BasePermission):
 class ExcludeWithdrawalsWikiVersion(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, WikiVersion), 'obj must be a WikiVersion, got {}'.format(obj)
         node = obj.wiki_page.node
         if node and node.is_retracted:
             return False
+        return True
+
+
+class IsEnabled(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, (WikiPage, WikiVersion, AbstractNode)), 'obj must be a WikiPage, WikiVersion, or AbstractNode, got {}'.format(obj)
+        if isinstance(obj, WikiPage):
+            node = obj.node
+        elif isinstance(obj, WikiVersion):
+            node = obj.wiki_page.node
+        else:
+            node = obj
+        if node.addons_wiki_node_settings.deleted:
+            raise exceptions.NotFound(detail="The wiki for this node has been disabled.")
         return True

--- a/api/wikis/permissions.py
+++ b/api/wikis/permissions.py
@@ -60,5 +60,5 @@ class IsEnabled(permissions.BasePermission):
         else:
             node = obj
         if node.addons_wiki_node_settings.deleted:
-            raise exceptions.NotFound(detail="The wiki for this node has been disabled.")
+            raise exceptions.NotFound(detail='The wiki for this node has been disabled.')
         return True

--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -1,7 +1,7 @@
 import sys
 
 from rest_framework import serializers as ser
-from rest_framework.exceptions import ValidationError, MethodNotAllowed
+from rest_framework.exceptions import ValidationError, MethodNotAllowed, NotFound
 
 from api.base.exceptions import Conflict
 from addons.wiki.exceptions import (
@@ -128,6 +128,9 @@ class NodeWikiSerializer(WikiSerializer):
         node = validated_data.get('node')
         name = validated_data.get('page_name')
         content = validated_data.get('content', '')
+
+        if node.addons_wiki_node_settings.deleted:
+            raise NotFound(detail='The wiki for this node has been disabled.')
 
         if node.get_wiki_page(name=name):
             raise Conflict("A wiki page with the name '{}' already exists.".format(name))

--- a/api/wikis/views.py
+++ b/api/wikis/views.py
@@ -16,7 +16,6 @@ from api.wikis.permissions import (
     ExcludeWithdrawals,
     ContributorOrPublicWikiVersion,
     ExcludeWithdrawalsWikiVersion,
-    IsEnabled,
 )
 from api.wikis.serializers import (
     WikiSerializer,
@@ -42,6 +41,9 @@ class WikiMixin(object):
         wiki = WikiPage.load(pk)
         if not wiki:
             raise NotFound
+
+        if wiki.node.addons_wiki_node_settings.deleted:
+            raise NotFound(detail='The wiki for this node has been disabled.')
 
         if wiki.deleted:
             raise Gone
@@ -125,8 +127,7 @@ class WikiDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, WikiMix
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals,
-        IsEnabled
+        ExcludeWithdrawals
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
@@ -162,8 +163,7 @@ class WikiContent(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals,
-        IsEnabled
+        ExcludeWithdrawals
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
@@ -190,8 +190,7 @@ class WikiVersions(JSONAPIBaseView, generics.ListCreateAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals,
-        IsEnabled
+        ExcludeWithdrawals
     )
     view_category = 'wikis'
     view_name = 'wiki-versions'
@@ -215,8 +214,7 @@ class WikiVersionDetail(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublicWikiVersion,
-        ExcludeWithdrawalsWikiVersion,
-        IsEnabled
+        ExcludeWithdrawalsWikiVersion
     )
 
     serializer_class = WikiVersionSerializer
@@ -241,8 +239,7 @@ class WikiVersionContent(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublicWikiVersion,
-        ExcludeWithdrawalsWikiVersion,
-        IsEnabled
+        ExcludeWithdrawalsWikiVersion
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]

--- a/api/wikis/views.py
+++ b/api/wikis/views.py
@@ -16,6 +16,7 @@ from api.wikis.permissions import (
     ExcludeWithdrawals,
     ContributorOrPublicWikiVersion,
     ExcludeWithdrawalsWikiVersion,
+    IsEnabled,
 )
 from api.wikis.serializers import (
     WikiSerializer,
@@ -124,7 +125,8 @@ class WikiDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, WikiMix
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals
+        ExcludeWithdrawals,
+        IsEnabled
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
@@ -160,7 +162,8 @@ class WikiContent(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals
+        ExcludeWithdrawals,
+        IsEnabled
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
@@ -187,7 +190,8 @@ class WikiVersions(JSONAPIBaseView, generics.ListCreateAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        ExcludeWithdrawals
+        ExcludeWithdrawals,
+        IsEnabled
     )
     view_category = 'wikis'
     view_name = 'wiki-versions'
@@ -211,7 +215,8 @@ class WikiVersionDetail(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublicWikiVersion,
-        ExcludeWithdrawalsWikiVersion
+        ExcludeWithdrawalsWikiVersion,
+        IsEnabled
     )
 
     serializer_class = WikiVersionSerializer
@@ -236,7 +241,8 @@ class WikiVersionContent(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublicWikiVersion,
-        ExcludeWithdrawalsWikiVersion
+        ExcludeWithdrawalsWikiVersion,
+        IsEnabled
     )
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -13,6 +13,7 @@ from addons.wiki.tests.factories import (
 )
 
 from api.base.settings.defaults import API_BASE
+from framework.auth.core import Auth
 
 from osf.models import Guid
 from osf_tests.factories import (
@@ -453,6 +454,12 @@ class TestWikiDetailView(ApiWikiTestCase):
         assert_in(
             expected_comments_relationship_url,
             res.json['data']['relationships']['comments']['links']['related']['href'])
+
+    def test_do_not_return_disabled_wiki(self):
+        self._set_up_public_project_with_wiki_page()
+        self.public_project.delete_addon('wiki', auth=Auth(self.user))
+        res = self.app.get(self.public_url, expect_errors=True)
+        assert res.status_code == 404
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
#### Purpose
- Adds handling for disabled wikis and publicly editable wikis.

#### Changes
- Added check for disabled wikis in WikiMixin and NodeWikiList.
- Added `is_publicly_editable` permission check.
- Added tests.

#### QA Notes
- Attempting to access **any** wiki endpoint should fail if the wiki is disabled (404).
- Editing a publicly editable wiki (POST to /v2/wikis/<id>/versions/) as a non-contributor should succeed (201). 
- Attempting to create, delete, or rename a wiki page as a non-contributor, even if the wiki is publicly editable, should fail (403). 

#### Documentation
- I'll update https://github.com/CenterForOpenScience/developer.osf.io/pull/8 when I merge.

#### Side Effects
- None expected.

#### Tickets
- [PLAT-543](https://openscience.atlassian.net/browse/PLAT-543)
- [PLAT-771](https://openscience.atlassian.net/browse/PLAT-771)
