### PR TITLE
Feature/Adding Registered Contributor through Unregistered Contributor Form [PLAT-54]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2049,13 +2049,17 @@ class TestUserInviteViews(OsfTestCase):
         expected['email'] = email
         assert_equal(res.json['contributor'], expected)
 
-    def test_invite_contributor_post_if_emaiL_already_registered(self):
+    def test_invite_contributor_post_if_email_already_registered(self):
         reg_user = UserFactory()
-        # Tries to invite user that is already regiestered
+        name, email = fake.name(), reg_user.username
+        # Tries to invite user that is already registered - this is now permitted.
         res = self.app.post_json(self.invite_url,
-                                 {'fullname': fake.name(), 'email': reg_user.username},
-                                 auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, http.BAD_REQUEST)
+                                 {'fullname': name, 'email': email},
+                                 auth=self.user.auth)
+        contrib = res.json['contributor']
+        assert_equal(contrib['id'], reg_user._id)
+        assert_equal(contrib['fullname'], name)
+        assert_equal(contrib['email'], email)
 
     def test_invite_contributor_post_if_user_is_already_contributor(self):
         unreg_user = self.project.add_unregistered_contributor(

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -791,10 +791,7 @@ def invite_contributor_post(node, **kwargs):
     # Check if email is in the database
     user = get_user(email=email)
     if user:
-        if user.is_registered:
-            msg = 'User is already in database. Please go back and try your search again.'
-            return {'status': 400, 'message': msg}, 400
-        elif node.is_contributor(user):
+        if node.is_contributor(user):
             msg = 'User with this email address is already a contributor to this project.'
             return {'status': 400, 'message': msg}, 400
         elif not user.is_confirmed:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Currently adding an unregistered contributor with an email address that is already being used shows an error message that the user is already in the database, forcing the user to go back and search again.

## Changes
Quick fix, remove check that user is already registered. Just go ahead and add the user as a r/w contributor. 

### Before

<img width="738" alt="screen shot 2018-04-05 at 10 51 47 am" src="https://user-images.githubusercontent.com/9755598/38376987-75d24cac-38bf-11e8-9e28-02f27a2807db.png">


### After
<img width="720" alt="screen shot 2018-04-05 at 10 50 58 am" src="https://user-images.githubusercontent.com/9755598/38376976-7152fec4-38bf-11e8-8e0e-e2bf4ac54dc5.png">

## QA Notes
- No advance prep needed.
- Go to your Add contributors page on a project
- Search for a contributor that already exists.
- Ignore search results, instead click on " add user as an unregistered contributor."
- Enter in name, and known email in the Add Unregistered Contributor form, email should belong to a registered user
- Confirm that user is selected to be added to project as r/w contributor instead of an error being thrown.

## Documentation
Not needed.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-54