### PR TITLE
Feature/Update or Replace Dependencies for Python3 [PLAT-726]

### DIFF
--- a/addons/box/requirements.txt
+++ b/addons/box/requirements.txt
@@ -1,1 +1,1 @@
-box.py
+boxsdk==1.5.5

--- a/addons/box/serializer.py
+++ b/addons/box/serializer.py
@@ -1,8 +1,10 @@
 from addons.base.serializer import StorageAddonSerializer
+from addons.box import settings
 
 from website.util import api_url_for
 
-from box.client import BoxClient, BoxClientException
+from boxsdk import Client, OAuth2
+from boxsdk.exception import BoxAPIException
 
 class BoxSerializer(StorageAddonSerializer):
 
@@ -15,10 +17,11 @@ class BoxSerializer(StorageAddonSerializer):
                 return True
 
         if user_settings:
-            client = client or BoxClient(user_settings.external_accounts[0].oauth_key)
+            oauth = OAuth2(client_id=settings.BOX_KEY, client_secret=settings.BOX_SECRET, access_token=user_settings.external_accounts[0].oauth_key)
+            client = client or Client(oauth)
             try:
-                client.get_user_info()
-            except (BoxClientException, IndexError):
+                client.user()
+            except (BoxAPIException, IndexError):
                 return False
         return True
 

--- a/addons/box/tests/utils.py
+++ b/addons/box/tests/utils.py
@@ -180,12 +180,12 @@ class MockBox(object):
 
 @contextmanager
 def patch_client(target, mock_client=None):
-    """Patches a function that returns a BoxClient, returning an instance
+    """Patches a function that returns a Box Client, returning an instance
     of MockBox instead.
 
     Usage: ::
 
-        with patch_client('addons.box.views.BoxClient') as client:
+        with patch_client('addons.box.views.Client') as client:
             # test view that uses the box client.
     """
     with mock.patch(target) as client_getter:

--- a/addons/box/tests/utils.py
+++ b/addons/box/tests/utils.py
@@ -159,7 +159,7 @@ class MockBox(object):
             ret['path'] = path
         return ret
 
-    def get_folder(*args, **kwargs):
+    def folder(*args, **kwargs):
         return mock_responses['folder']
 
     def get_file_and_metadata(*args, **kwargs):
@@ -174,7 +174,7 @@ class MockBox(object):
             each['path'] = path
         return ret
 
-    def get_user_info(self):
+    def user(self):
         return {'display_name': 'Mr. Box'}
 
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -782,17 +782,17 @@ class TestNodeBoxAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
             'id': '0'
         }
 
-    @mock.patch('addons.box.models.BoxClient.get_folder')
-    def test_settings_detail_PUT_all_sets_settings(self, mock_get):
-        mock_get.return_value = {
-            'id': self._mock_folder_info['folder_id'],
-            'name': 'FAKEFOLDERNAME',
-            'path_collection': {'entries': {}}
-        }
-        with mock.patch('addons.box.models.Provider.refresh_oauth_key') as mock_update:
-            super(
-                TestNodeBoxAddon,
-                self).test_settings_detail_PUT_all_sets_settings()
+    def test_settings_detail_PUT_all_sets_settings(self):
+        with mock.patch('addons.box.models.Client.folder') as folder_mock:
+            folder_mock.return_value.get.return_value = {
+                'id': self._mock_folder_info['folder_id'],
+                'name': 'FAKEFOLDERNAME',
+                'path_collection': {'entries': {}}
+            }
+            with mock.patch('addons.box.models.Provider.refresh_oauth_key') as mock_update:
+                super(
+                    TestNodeBoxAddon,
+                    self).test_settings_detail_PUT_all_sets_settings()
 
 
 class TestNodeDropboxAddon(

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ sendgrid-django==2.0.0
 
 # Analytics requirements
 keen==0.5.1
-python-geoip-geolite2-yplan==2017.404
+maxminddb-geolite2==2018.308
 
 # OSF models
 django-typed-models==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ celery==4.1.0
 kombu==4.1.0
 vine==1.1.4
 httplib2==0.10.3
-hurry.filesize==0.9
+bitmath==1.3.1.2
 itsdangerous==0.24
 lxml==3.4.1
 mailchimp==2.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ celery==4.1.0
 kombu==4.1.0
 vine==1.1.4
 httplib2==0.10.3
-bitmath==1.3.1.2
 itsdangerous==0.24
 lxml==3.4.1
 mailchimp==2.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ sendgrid-django==2.0.0
 
 # Analytics requirements
 keen==0.5.1
-python-geoip-geolite2==2015.0303
+python-geoip-geolite2-yplan==2017.404
 
 # OSF models
 django-typed-models==0.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,7 +11,7 @@ nose
 factory-boy==2.7.0
 webtest-plus==0.3.3
 mock==1.0.1
-fake-factory==0.5.4
+faker==0.8.12
 schema==0.3.1
 responses==0.8.1
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -7,7 +7,7 @@ from flask import request
 from flask import send_from_directory
 from django.core.urlresolvers import reverse
 
-from geoip import geolite2
+from geolite2 import geolite2
 
 from framework import status
 from framework import sentry
@@ -59,7 +59,7 @@ def get_globals():
     """
     user = _get_current_user()
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.affiliated_institutions.all()] if user else []
-    location = geolite2.lookup(request.remote_addr) if request.remote_addr else None
+    location = geolite2.reader().get(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:
             inst_id = Institution.objects.get(domains__icontains=[request.host])._id

--- a/website/routes.py
+++ b/website/routes.py
@@ -83,8 +83,8 @@ def get_globals():
         'user_institutions': user_institutions if user else None,
         'display_name': user.fullname if user else '',
         'anon': {
-            'continent': getattr(location, 'continent', None),
-            'country': getattr(location, 'country', None),
+            'continent': (location or {}).get('continent', {}).get('code', None),
+            'country': (location or {}).get('country', {}).get('iso_code', None),
         },
         'use_cdn': settings.USE_CDN_FOR_CLIENT_LIBS,
         'sentry_dsn_js': settings.SENTRY_DSN_JS if sentry.enabled else None,

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -4,7 +4,6 @@ formatted hgrid list/folders.
 """
 import logging
 
-import bitmath
 from django.utils import timezone
 
 from framework import sentry
@@ -31,10 +30,6 @@ DEFAULT_PERMISSIONS = {
     'view': True,
     'edit': False,
 }
-
-def format_filesize(size):
-    return bitmath.filesize.size(size, system=bitmath.filesize.alternative)
-
 
 def default_urls(node_api, short_name):
     return {

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -4,7 +4,7 @@ formatted hgrid list/folders.
 """
 import logging
 
-import hurry.filesize
+import bitmath
 from django.utils import timezone
 
 from framework import sentry
@@ -33,7 +33,7 @@ DEFAULT_PERMISSIONS = {
 }
 
 def format_filesize(size):
-    return hurry.filesize.size(size, system=hurry.filesize.alternative)
+    return bitmath.filesize.size(size, system=bitmath.filesize.alternative)
 
 
 def default_urls(node_api, short_name):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

We have dependencies preventing us from upgrading to Python 3.

## Changes
Certain dependencies were updated/replaced to ensure they are python-3 compatible

- **fake-factory** (renamed to faker; latest version supports py3: https://github.com/joke2k/faker)
- **python-geoip-geolite2** ~~(no new updates but has a py3 fork)~~  Using [maxminddb-geolite2](https://pypi.python.org/pypi/maxminddb-geolite2) instead which has py3 compatibility
-  **hurry.filesize** ~~(no new updates, but there are py3 alternatives such as https://github.com/tbielawa/bitmath).~~ Removed this dependency. It appears to be unused.
- **box.py** (no new updates, but official sdk supports py3: https://github.com/box/box-python-sdk)

## QA Notes

- I would test Box addon thoroughly; making sure there are no changes.  Whatever typical regression test is done for Box.  As part of this make sure deleted folders/files don't show up.
- Ensure that country code and continent code still being sent to Keen under anonymized location data section in public collections.  For example, Staging - OSF - Public collection.  Sometimes these values are null.

<img width="181" alt="screen shot 2018-04-10 at 11 23 42 am" src="https://user-images.githubusercontent.com/9755598/38569732-b3645452-3cb1-11e8-88e5-ccc7240a8fbf.png">


## Documentation

None needed.

## Side Effects

Should be none.

## Ticket

https://openscience.atlassian.net/browse/PLAT-726
