### PR TITLE
Feature/Optimize Meetings Page Serialization with SQL [PLAT-657]

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -170,7 +170,7 @@ def conference_submissions_sql(conf):
         cursor.execute(
             """
             SELECT  json_build_object(
-                    'id', osf_abstractnode.id,
+                    'id', ROW_NUMBER() OVER (ORDER BY 1),
                     'title', osf_abstractnode.title,
                     'nodeUrl', '/' || GUID._id || '/',
                     'author', CASE WHEN AUTHOR.family_name != '' THEN AUTHOR.family_name ELSE AUTHOR.fullname END,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -273,7 +273,12 @@ def conference_submissions_sql(conf):
                            AND UPPER(U0."name" :: TEXT) = UPPER(%s)
                            AND U0."system" = FALSE))
                    AND "osf_abstractnode"."is_deleted" = FALSE
-                   AND "osf_abstractnode"."is_public" = TRUE);
+                   AND "osf_abstractnode"."is_public" = TRUE
+                   AND (SELECT (1) as "contributor_exists"
+                        FROM osf_osfuser
+                        INNER JOIN osf_contributor on osf_osfuser.id = osf_contributor.user_id
+                        WHERE osf_contributor.node_id = osf_abstractnode.id
+                        LIMIT 1) = 1);
 
             """, [submission2_name, conf.name, conference_url, submission1_name, abstract_node_content_type_id, osf_user_content_type_id, conf.endpoint]
         )

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -203,6 +203,7 @@ def conference_submissions_sql(conf):
                         FROM osf_osfuser
                           INNER JOIN osf_contributor ON (osf_contributor.user_id = osf_osfuser.id)
                         WHERE (osf_contributor.node_id = osf_abstractnode.id AND osf_contributor.visible = TRUE)
+                        ORDER BY osf_contributor._order ASC
                         LIMIT 1
                         ) AUTHOR ON TRUE  -- Returns first visible contributor
               LEFT JOIN LATERAL (

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -184,7 +184,7 @@ def conference_submissions_sql(conf):
                     'tags', TAGS_LIST.tag_list
                 )
             FROM osf_abstractnode
-              INNER JOIN "osf_abstractnode_tags" ON ("osf_abstractnode"."id" = "osf_abstractnode_tags"."abstractnode_id")
+              INNER JOIN osf_abstractnode_tags ON (osf_abstractnode.id = osf_abstractnode_tags.abstractnode_id)
               LEFT JOIN (
                 SELECT osf_tag.name as name, osf_abstractnode_tags.abstractnode_id as node_id
                 FROM osf_tag
@@ -236,14 +236,14 @@ def conference_submissions_sql(conf):
                 LIMIT 1
               ) DOWNLOAD_COUNT ON TRUE
             -- Get all the nodes for a specific meeting
-            WHERE ("osf_abstractnode_tags"."tag_id" IN
-                   (SELECT U0."id" AS Col1
-                    FROM "osf_tag" U0
-                    WHERE (U0."system" = FALSE
-                           AND UPPER(U0."name" :: TEXT) = UPPER(%s)
-                           AND U0."system" = FALSE))
-                   AND "osf_abstractnode"."is_deleted" = FALSE
-                   AND "osf_abstractnode"."is_public" = TRUE
+            WHERE (osf_abstractnode_tags.tag_id IN
+                   (SELECT U0.id AS Col1
+                    FROM osf_tag U0
+                    WHERE (U0.system = FALSE
+                           AND UPPER(U0.name :: TEXT) = UPPER(%s)
+                           AND U0.system = FALSE))
+                   AND osf_abstractnode.is_deleted = FALSE
+                   AND osf_abstractnode.is_public = TRUE
                    AND AUTHOR_GUID IS NOT NULL);
 
             """, [submission2_name, conf.name, conference_url, submission1_name, abstract_node_content_type_id, osf_user_content_type_id, conf.endpoint]

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -7,7 +7,6 @@ from django.db import transaction, connection
 from django_bulk_update.helper import bulk_update
 from django.contrib.contenttypes.models import ContentType
 
-from addons.osfstorage.models import OsfStorageFile
 from framework.auth import get_or_create_user
 from framework.exceptions import HTTPError
 from framework.flask import redirect
@@ -145,42 +144,6 @@ def add_poster_by_email(conference, message):
     )
     if node_created and user_created:
         signals.osf4m_user_created.send(user, conference=conference, node=node)
-
-## TODO DELETE
-def _render_conference_node(node, idx, conf):
-    record = OsfStorageFile.objects.filter(node=node).first()
-
-    if not record:
-        download_url = ''
-        download_count = 0
-    else:
-        download_count = record.get_download_count()
-        download_url = node.web_url_for(
-            'addon_view_or_download_file',
-            path=record.path.strip('/'),
-            provider='osfstorage',
-            action='download',
-            _absolute=True,
-        )
-
-    author = node.visible_contributors[0]
-    tags = list(node.tags.filter(system=False).values_list('name', flat=True))
-
-    return {
-        'id': idx,
-        'title': node.title,
-        'nodeUrl': node.url,
-        'author': author.family_name if author.family_name else author.fullname,
-        'authorUrl': author.url,
-        'category': conf.field_names['submission1'] if conf.field_names['submission1'] in tags else conf.field_names['submission2'],
-        'download': download_count,
-        'downloadUrl': download_url,
-        'dateCreated': node.created.isoformat(),
-        'confName': conf.name,
-        'confUrl': web_url_for('conference_results', meeting=conf.endpoint),
-        'tags': ' '.join(tags)
-    }
-
 
 def conference_data(meeting):
     try:


### PR DESCRIPTION
## Purpose

The serialization of meetings pages (`/view/<meeting>/` route) is incredibly slow and expensive. 

## Changes

Replaces the meetings serialization with sql.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-657