### PR TITLE
Fix/Category and Default Sort - Meetings Page Serialization [PLAT-657]

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -238,7 +238,7 @@ def conference_submissions_sql(conf):
                    AND osf_abstractnode.is_deleted = FALSE
                    AND osf_abstractnode.is_public = TRUE
                    AND AUTHOR_GUID IS NOT NULL)
-            ORDER BY DOWNLOAD_COUNT;
+            ORDER BY DOWNLOAD_COUNT DESC NULLS LAST;
 
             """, [
                 submission1_name,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -238,7 +238,7 @@ def conference_submissions_sql(conf):
                    AND osf_abstractnode.is_deleted = FALSE
                    AND osf_abstractnode.is_public = TRUE
                    AND AUTHOR_GUID IS NOT NULL)
-            ORDER BY DOWNLOAD_COUNT DESC NULLS LAST;
+            ORDER BY osf_abstractnode.created DESC;
 
             """, [
                 submission1_name,


### PR DESCRIPTION
## Purpose

Tweaks for meetings page serialization in SQL

## Changes

- Add default sort order on created - recently created first
- Do a better job of figuring out what meeting category is.   Now looks in array of tag names on meeting to see if certain tag is present. 
  - For example, meeting with tags ["SPSP2016", "poster", "science"] would be categorized as a poster.
  - In previous version, was searching through concatenated list of strings "SPSP2016 poster science" for the word "poster".  So a project tagged as "imposter" would show up as a poster. Silly me.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-657