### PR TITLE
[PLAT-738] Fix Zotero clipboard button 

### DIFF
--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -117,7 +117,7 @@ var makeButtons = function(item, col, buttons) {
                         class: button.css,
                         'data-toggle': 'tooltip',
                         'data-placement': 'bottom',
-                        'data-clipboard-target': item.data.csl ? item.data.csl.id : button.clipboard,
+                        'data-clipboard-target': item.data.csl ? '[id*="' + item.data.csl.id + '"]' : button.clipboard,
                         config: mergeConfigs(button.config, tooltipConfig),
                         onclick: button.onclick ?
                             function(event) {


### PR DESCRIPTION
## Purpose

Currently the Zotero clipboard button is broken this fixes it.

## Changes

- Changes the selector a bit so it accepts zotero ids which contain a slash.

## QA Notes

Connect to Zoterro and click the copy button to the right of the citation label, the label should be highlighted and you should be able to paste the text of the label.

## Documentation

Simple bug fix shouldn't need any docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-738