### PR TITLE
[PLAT-187] Fix addon re-authorization link

### DIFF
--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -789,9 +789,9 @@ class BaseOAuthNodeSettings(BaseNodeSettings):
             )
 
             if not auth or auth.user != removed:
-                url = node.web_url_for('node_setting')
+                url = node.web_url_for('node_addons')
                 message += (
-                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Add-ons</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -791,7 +791,7 @@ class BaseOAuthNodeSettings(BaseNodeSettings):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_addons')
                 message += (
-                    u' You can re-authenticate on the <u><a href="{url}">Add-ons</a></u> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">add-ons</a></u> page.'
                 ).format(url=url)
             #
             return message


### PR DESCRIPTION
## Purpose

The warning when you have to re-authorize an addon when removing a contributor with an addon authorized is incorrect, this fix corrects it.

## Changes

- Simple HTML changes

## QA Notes

1. User A, create a project
2. Add User B with admin or write permissions
3. User B, configure an addon
4. User A, remove User B as a contrib

You should see a message with a link click the link and see that it goes to the addons page.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-187