### PR TITLE
Feature/ Handle wiki `edit` URL param [PLAT-99]

### DIFF
--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -84,7 +84,7 @@ class TestWikiViews(OsfTestCase):
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
 
-    def test_wiki_url_with_edit_get_returns_403_with_no_write_permission(self):
+    def test_wiki_url_with_edit_get_redirects_to_no_edit_params_with_no_write_permission(self):
         self.project.update_node_wiki('funpage', 'Version 1', Auth(self.user))
         self.project.update_node_wiki('funpage', 'Version 2', Auth(self.user))
         self.project.save()
@@ -94,15 +94,16 @@ class TestWikiViews(OsfTestCase):
             wname='funpage',
             compare=1,
         )
-        res = self.app.get(url)
+        res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
 
+        # Public project, can_view, redirects without edit params
         url = self.project.web_url_for(
             'project_wiki_view',
             wname='funpage',
         ) + '?edit'
-        res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.get(url).maybe_follow()
+        assert_equal(res.status_code, 200)
 
         # Check publicly editable
         wiki = self.project.get_addon('wiki')

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -240,6 +240,8 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
         if 'edit' in request.args:
             if wiki_settings.is_publicly_editable:
                 raise HTTPError(http.UNAUTHORIZED)
+            if node.can_view(auth):
+                return redirect(node.web_url_for('project_wiki_view', wname=wname, _guid=True))
             raise HTTPError(http.FORBIDDEN)
         sharejs_uuid = None
 


### PR DESCRIPTION
## Purpose

Navigating to a *public* project's wiki with edit params (`localhost:5000/fs5ql/wiki/home/?edit&view&menu`) as a logged-out user returns a 403.  Instead, the public wiki should be displayed, and the edit parameter removed.

## Changes
- 2-line change: If `edit param present, user does not have permission to edit, but has permission to view, redirect to the wiki but remove the edit parameter.

- Have this logic occur after check for whether wiki is publicly editable because we still want the user to be prompted to login.

## QA Notes
1. create a project
2. make the project public
3. add content to the wiki and click `save`
4. once the page is refreshed, click the 'edit' button on the wiki page
5. copy the url with url parameters
5. open a new incognito browser
6. paste in the url
7. confirm that url works, and edit parameters are removed.

** Verify that behavior for publicly editable wikis is unchanged. If you are logged out and navigate to a publicly editable wiki, confirm that you are unable to access wiki without logging in.
## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-99
