### PR TITLE
[EMB-174] [Hotfix] Match footer to Embosf styling

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -128,7 +128,8 @@ def get_globals():
         'custom_citations': settings.CUSTOM_CITATIONS,
         'osf_support_email': settings.OSF_SUPPORT_EMAIL,
         'osf_contact_email': settings.OSF_CONTACT_EMAIL,
-        'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=reverse('wafflejs'))
+        'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=reverse('wafflejs')),
+        'footer_links': settings.FOOTER_LINKS,
     }
 
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1913,3 +1913,20 @@ CUSTOM_CITATIONS = {
 }
 
 PREPRINTS_ASSETS = '/static/img/preprints_assets/'
+
+FOOTER_LINKS = {
+    'terms': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md',
+    'privacyPolicy': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md',
+    'cookies': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies',
+    'cos': 'https://cos.io',
+    'statusPage': 'https://status.cos.io/',
+    'apiDocs': 'https://developer.osf.io/',
+    'topGuidelines': 'http://cos.io/top/',
+    'rpp': 'https://osf.io/ezcuj/wiki/home/',
+    'rpcb': 'https://osf.io/e81xl/wiki/home/',
+    'twitter': 'http://twitter.com/OSFramework',
+    'facebook': 'https://www.facebook.com/CenterForOpenScience/',
+    'googleGroup': 'https://groups.google.com/forum/#!forum/openscienceframework',
+    'github': 'https://www.github.com/centerforopenscience',
+    'googlePlus': 'https://plus.google.com/b/104751442909573665859',
+}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -39,11 +39,17 @@ a {
 /* Footer
 -------------------------------------------------- */
 .footer {
-    text-shadow: 0 1px 0 #fff;
-    border-top: 1px solid #e5e5e5;
-    border-bottom: 1px solid #e5e5e5;
+    padding-top: 10px;
+    margin-top: 0;
+    text-shadow: 0 1px 0 #FFF;
     width: 100%;
-    color: #555;
+    color: #515151;
+    text-align: center;
+    background-color: #efefef;
+}
+
+.footer a {
+    color: #2d6a9f;
 }
 
 

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -165,7 +165,6 @@
 
 
     ${self.footer()}
-    <%include file="copyright.mako"/>
         <%!
             import hashlib
 

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -1,34 +1,64 @@
-<footer class="footer m-t-lg m-b-lg p-lg bg-color-light">
-    <div class="container">
+<% from datetime import datetime %>
+<footer class="footer">
+    <div class="container-fluid">
         <div class="row">
-            <div class="col-sm-2 col-md-3 col-md-offset-1">
-                <h4>OSF</h4>
-                <ul>
-                    <li><a href="https://status.cos.io/">Status</a></li>
-                    <li><script type="text/javascript">document.write("<n uers=\"znvygb:pbagnpg@bfs.vb\" ery=\"absbyybj\">Pbagnpg</n>".replace(/[a-zA-Z]/g,function(e){return String.fromCharCode((e<="Z"?90:122)>=(e=e.charCodeAt(0)+13)?e:e-26)}));</script><noscript>Contact OSF: <span class="obfuscated-email-noscript"><strong><u>cont<span style="display:none;">null</span>act@<span style="display:none;">null</span>osf.<span style="display:none;">null</span>io</u></strong></span></noscript></li>
-                    <li><a href="${domain}support">FAQ/Guides</a></li>
-                    <li><a href="https://api.osf.io/v2/docs/">API</a></li>
-                    <li><a href="https://github.com/CenterForOpenScience/osf.io">Source Code</a></li>
-                </ul>
+            <div class="col-sm-12 col-md-8 col-md-offset-2">
+                <p>
+                    <span>
+                        Copyright &copy; 2011-${datetime.utcnow().year}
+                    </span>
+                    <a href="${footer_links['cos']}">
+                        Center for Open Science
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['terms']}">
+                        Terms&nbsp;of&nbsp;use
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['privacyPolicy']}">
+                        Privacy&nbsp;policy
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['statusPage']}">
+                        Status
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['apiDocs']}">
+                        API
+                    </a>
+                    <br>
+                    <a href="${footer_links['topGuidelines']}">
+                        TOP guidelines
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['rpp']}">
+                        Reproducibility&nbsp;Project: Psychology
+                    </a>
+                    <span>
+                        |
+                    </span>
+                    <a href="${footer_links['rpcb']}">
+                        Reproducibility&nbsp;Project: Cancer Biology
+                    </a>
+                </p>
+                <p>
+                    <a href="${footer_links['twitter']}" aria-label="Twitter"><i class="fa fa-twitter fa-2x"></i></a>
+                    <a href="${footer_links['facebook']}" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
+                    <a href="${footer_links['googleGroup']}" aria-label="Google Group"><i class="fa fa-group fa-2x"></i></a>
+                    <a href="${footer_links['github']}" aria-label="GitHub"><i class="fa fa-github fa-2x"></i></a>
+                    <a href="${footer_links['googlePlus']}" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
+                </p>
             </div>
-            <div class="col-sm-5 col-md-4">
-                <h4>Center for Open Science</h4>
-                <ul>
-                    <li><a href="http://cos.io">Home</a></li>
-                    <li><a href="${domain}ezcuj/wiki/home/">Reproducibility Project: Psychology</a></li>
-                    <li><a href="${domain}e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a></li>
-                    <li><a href="http://cos.io/top/">TOP Guidelines</a></li>
-                     <li><a href="https://www.crowdrise.com/donate/charity/centerforopenscience">Donate</a></li>
-               </ul>
-            </div>
-            <div class="col-sm-4 col-md-3">
-                <h4>Socialize</h4>
-                <a href="http://twitter.com/OSFramework" aria-label="Twitter"><i class="fa fa-twitter fa-2x"></i></a>
-                <a href="https://www.facebook.com/CenterForOpenScience/" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
-                <a href="https://groups.google.com/forum/#!forum/openscienceframework" aria-label="Google Group"><i class="fa fa-group fa-2x"></i></a>
-                <a href="https://www.github.com/centerforopenscience" aria-label="GitHub"><i class="fa fa-github fa-2x"></i></a>
-                <a href="https://plus.google.com/b/104751442909573665859" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
-            </div> <!-- column -->
         </div>
     </div>
-</footer><!-- end footer -->
+</footer>


### PR DESCRIPTION
## Purpose

Make the footer better.

## Deployment note

This should not be merged/deployed until the Embosf version of this ticket (https://github.com/CenterForOpenScience/ember-osf-web/pull/190) is deployed with ember-osf-web 0.3.0.

## Changes
1. Move relevant parts of copyright footer into the footer
2. Remove most of the footer
3. Change the colors so that they are more accessible
4. Adjust the style in other ways
5. Merge the strings into the footer

Before:

<img width="1175" alt="footer-before" src="https://user-images.githubusercontent.com/6599111/38881747-895c7ee8-4236-11e8-99fc-106b90a90678.png">

After:

<img width="1031" alt="footer-after" src="https://user-images.githubusercontent.com/6599111/38881751-8ee39428-4236-11e8-8572-113b2c615d10.png">

## QA Notes

This is all pretty simple; all static links and the like. The copyright date range should still be accurate. We aren't going to do the analytics tracking on the legacy OSF; when pages are embosfed, they'll get more analytics tracking on the footer links.

## Documentation

No docs necessary

## Side Effects

I hope not.

## Ticket

https://openscience.atlassian.net/browse/EMB-174