### PR TITLE
Feature/Add a "Create view-only link" link on Project Page [PLAT-374]

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -111,6 +111,13 @@
                                         Remove from bookmarks
                                     </a>
                                 </li>
+                                % if 'admin' in user['permissions'] and not node['is_registration']:  ## Create view-only link
+                                    <li>
+                                        <a href="${node['url']}settings/#createVolsAnchor">
+                                            Create view-only link
+                                        </a>
+                                    </li>
+                                % endif ## End create view-only link
                                 % if node['is_public']:
                                     <li class="keep-open" id="shareButtonsPopover">
                                         <a href="#" role="button">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Makes view-only link feature more visible.

## Changes

Add a "Create view-only link" link to the More Actions meatball menu on the project overview page.

- Links to the view-only links section of the project settings page
- Only visible if user is an admin contributor and the node is not a registration.


## QA Notes
Verify that "Create view-only link" visible in the More Actions menu, under the same scenarios that the "Create view only link" section is visible on the project settings page.

- Create a project
- As admin contributor verify "Create view-only link" visible in More Actions menu
- Add a read/write contributor. Login as read-write contributor. Verify "Create view-only link" *not* visible
- Create a registration of the project.  Login as admin contributor.  Verify "Create view-only link" *not* visible
- Verify that public/private setting on project doesn't influence whether link is visible.

## Screenshots:
### Where link redirects
<img width="1078" alt="screen shot 2018-04-17 at 12 23 22 pm" src="https://user-images.githubusercontent.com/9755598/38885979-2e994316-423a-11e8-9d10-4e726b3a2d86.png">

### Private Project, Logged in as admin contributor:
<img width="1080" alt="screen shot 2018-04-17 at 12 01 54 pm" src="https://user-images.githubusercontent.com/9755598/38885736-955d5a5c-4239-11e8-932a-69e9a745850d.png">

### Public Project, Logged in as admin contributor:
<img width="1035" alt="screen shot 2018-04-17 at 12 02 27 pm" src="https://user-images.githubusercontent.com/9755598/38885790-bb1c892a-4239-11e8-84ba-fa18edf750b9.png">

### Registration, Logged in as admin contributor:
<img width="1048" alt="screen shot 2018-04-17 at 12 05 26 pm" src="https://user-images.githubusercontent.com/9755598/38885836-d4c70c60-4239-11e8-8dab-b4503ebd8e39.png">

### Public project, Logged in as R/W Contributor:
<img width="1042" alt="screen shot 2018-04-17 at 12 06 59 pm" src="https://user-images.githubusercontent.com/9755598/38885868-ec300a50-4239-11e8-8b59-dddf91663b0f.png">

### Public project, Logged out
<img width="1073" alt="screen shot 2018-04-17 at 12 07 39 pm" src="https://user-images.githubusercontent.com/9755598/38885909-046cffd8-423a-11e8-92c5-69e575d0d89d.png">

## Documentation

None needed unless we are updating external docs with Request Project Access information, then these links would appear in screenshots of functionality

## Side Effects

None, this is a minor change.

## Ticket

https://openscience.atlassian.net/browse/PLAT-374