### PR TITLE
[EMB-221] Hide deleted forks on a node's forks list view

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -854,7 +854,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
 
     # overrides ListCreateAPIView
     def get_queryset(self):
-        all_forks = self.get_node().forks.exclude(type='osf.registration').order_by('-forked_date')
+        all_forks = self.get_node().forks.exclude(type='osf.registration').exclude(is_deleted=True).order_by('-forked_date')
         auth = get_user_auth(self.request)
 
         node_pks = [node.pk for node in all_forks if node.can_view(auth)]

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -191,6 +191,20 @@ class TestNodeForksList:
         # confirm registration of fork does not show up in public data
         assert len(res.json['data']) == 0
 
+    def test_forks_list_does_not_show_deleted_forks(
+            self, app, user, public_fork, public_project_url):
+
+        # confirm user can see the fork
+        res = app.get(public_project_url, auth=user.auth)
+        assert len(res.json['data']) == 1
+
+        public_fork.is_deleted = True
+        public_fork.save()
+
+        # confirm fork no longer shows on public project's forks list
+        res = app.get(public_project_url, auth=user.auth)
+        assert len(res.json['data']) == 0
+
 
 @pytest.mark.django_db
 class TestNodeForkCreate:

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -181,25 +181,22 @@ class TestNodeForksList:
         assert res.json['errors'][0]['detail'] == exceptions.PermissionDenied.default_detail
 
     def test_forks_list_does_not_show_registrations_of_forks(
-            self, app, public_project, public_fork, public_project_url):
+            self, app, user, public_project, public_fork, public_project_url):
         reg = RegistrationFactory(project=public_fork, is_public=True)
 
         # confirm registration shows up in node forks
         assert reg in public_project.forks.all()
-        res = app.get(public_project_url)
-
-        # confirm registration of fork does not show up in public data
-        assert len(res.json['data']) == 0
-
-    def test_forks_list_does_not_show_deleted_forks(
-            self, app, user, public_fork, public_project_url):
-
-        # confirm user can see the fork
+        assert len(public_project.forks.all()) == 2
         res = app.get(public_project_url, auth=user.auth)
+
+        # confirm registration of fork does not show up in public data (only public_fork)
         assert len(res.json['data']) == 1
 
         public_fork.is_deleted = True
         public_fork.save()
+
+        # confirm it's still a fork even after deletion
+        assert len(public_project.forks.all()) == 2
 
         # confirm fork no longer shows on public project's forks list
         res = app.get(public_project_url, auth=user.auth)


### PR DESCRIPTION
## Purpose
`/v2/nodes/<guid>/forks` doesn't hide deleted forks

## Changes
Make sure, like the v1 view, the NodeForksList view excludes deleted forks.

## QA Notes
1. Create a node
2. Fork the node
3. Delete the fork
4. Go to /v2/nodes/<guid>/forks

the deleted fork should not be listed.

## Ticket
https://openscience.atlassian.net/browse/EMB-221
