### PR TITLE
Fix/Optimize N+1 subject queries [PLAT-707]

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -687,9 +687,12 @@ class TaxonomizableMixin(models.Model):
 
     @cached_property
     def subject_hierarchy(self):
-        return [
-            s.object_hierarchy for s in self.subjects.exclude(children__in=self.subjects.all())
-        ]
+        subjects = self.subjects.all()
+        if subjects.count():
+            return [
+                s.object_hierarchy for s in self.subjects.exclude(children__in=subjects).select_related('parent')
+            ]
+        return []
 
     def set_subjects(self, new_subjects, auth, add_log=True):
         """ Helper for setting M2M subjects field from list of hierarchies received from UI.


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Nplusone picked up on a bunch of possibly suboptimal queries (i.e. requests that generated a linear instead of constant number of queries).  Look into `subject_hierarchy` method - hit when accessing `v2/nodes` or `v2/preprints`.  It builds the subject hierarchy:
<img width="345" alt="screen shot 2018-04-17 at 3 44 09 pm" src="https://user-images.githubusercontent.com/9755598/38895654-3646623a-4256-11e8-97e8-6d72bf47b834.png">


## Changes

- Added a `select_related('parent')` to the subject query, fixes error for preprints (Potential n+1 query detected on `Subject.parent`)
- Checked to see if subjects exist before making a more intensive query. Fixes error for NodesListEndpoint (Potential n+1 query detected on `Node.subjects`).
## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-707