### PR TITLE
[no ticket] Make sure request access button does not show on registrations

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -125,7 +125,7 @@
                                         </a>
                                     </li>
                                 %endif
-                                % if node['access_requests_enabled'] and not user['is_contributor']:
+                                % if node['access_requests_enabled'] and not user['is_contributor'] and not node['is_registration']:
                                     <li data-bind="css: {'keep-open': user.username}">
                                         <a role="button" href="#" data-bind="
                                                         visible: user.username,


### PR DESCRIPTION

## Purpose
When looking on staging3, noticed that the "Request Access" option was appearing on registrations. 

## Changes

Make sure that "Request Access" does not appear on registrations frontend

## QA Notes

Ensure that Request Access isn't in the dropdown [...] button on registrations! Goes along with request access QA in general!

The strangest thing is this isn't happening locally, but in particular saw it on this registration:
https://staging3.osf.io/kjm4r/

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
None