### PR TITLE
[PLAT-755] Wiki drag-and-drop allows users to upload more images while it's loading

### DIFF
--- a/addons/wiki/static/dragNDrop.js
+++ b/addons/wiki/static/dragNDrop.js
@@ -9,10 +9,6 @@ var getExtension = function(filename) {
 var validImgExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp'];
 var imageFolder = 'Wiki images';
 
-// Stop people from dropping files in the gutter while editor is disabled.
-$('.ace_gutter').bind("dragover", function(e) {
-            e.preventDefault();
-});
 
 var autoIncrementFileName = function(name, nameList) {
     var num = 1;
@@ -187,7 +183,7 @@ var addDragNDrop = function(editor, panels, cm, TextareaState) {
      * Also adds a second cursor that follows around the mouse cursor and signifies where the image/link will
      * be inserted
      */
-    element.addEventListener('dragover', function(event) {
+    $(element).find('.ace_scroller')[0].addEventListener('dragover', function(event) {
         event.preventDefault();
         event.stopPropagation();
         if (!editor.marker.active) {


### PR DESCRIPTION
## Purpose

Currently the user can't drop an image while other images are loading because this will tear up the markdown, but there's a small bug where they can drop an image in the "gutter" and this allows them to upload more files and cut up the mardown. This PR stops them from hitting the gutter.

## Changes

- disable dropping in the "gutter"

## QA Notes

Drop files using the wiki drag and drop, then try to drop a file in the "gutter." The green plus sign should not appear.
<img width="1440" alt="screen shot 2018-04-20 at 11 11 08 am" src="https://user-images.githubusercontent.com/9688518/39059470-9461469a-448c-11e8-9070-8263208dc8d1.png">


## Documentation

This is just a bug fix, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-755