### PR TITLE
Access Request Adjustments [PLAT-462]

### DIFF
--- a/api_tests/requests/views/test_request_list_create.py
+++ b/api_tests/requests/views/test_request_list_create.py
@@ -3,6 +3,7 @@ import pytest
 
 from api.base.settings.defaults import API_BASE
 from api_tests.requests.mixins import NodeRequestTestMixin
+from osf_tests.factories import NodeFactory
 
 @pytest.mark.django_db
 class TestNodeRequestListCreate(NodeRequestTestMixin):
@@ -83,3 +84,15 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
         res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
         assert res.status_code == 201
         assert mock_mail.call_count == 2
+
+    @mock.patch('website.mails.mails.send_mail')
+    def test_email_not_sent_to_parent_admins_on_submit(self, mock_mail, app, project, noncontrib, url, create_payload, second_admin):
+        component = NodeFactory(parent=project, creator=second_admin)
+        component.is_public = True
+        project.save()
+        url = '/{}nodes/{}/requests/'.format(API_BASE, component._id)
+        res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
+        assert res.status_code == 201
+        assert component.admin_contributors.count() == 2
+        assert component.contributors.count() == 1
+        assert mock_mail.call_count == 1

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -173,7 +173,7 @@ class RequestMachine(BaseMachine):
         context = self.get_context()
         context['contributors_url'] = '{}contributors/'.format(self.machineable.target.absolute_url)
         context['project_settings_url'] = '{}settings/'.format(self.machineable.target.absolute_url)
-        for admin in self.machineable.target.admin_contributors:
+        for admin in self.machineable.target.contributors.filter(contributor__admin=True, contributor__node=self.machineable.target):
             mails.send_mail(
                 admin.username,
                 mails.ACCESS_REQUEST_SUBMITTED,

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -232,7 +232,7 @@ MODERATOR_ADDED = lambda provider: Mail(
 )
 CONTRIBUTOR_ADDED_ACCESS_REQUEST = Mail(
     'contributor_added_access_request',
-    subject='Your access request to an OSF project has been approved.'
+    subject='Your access request to an OSF project has been approved'
 )
 PREPRINT_CONFIRMATION_DEFAULT = Mail(
     'preprint_confirmation_default',
@@ -424,5 +424,5 @@ ACCESS_REQUEST_SUBMITTED = Mail(
 
 ACCESS_REQUEST_DENIED = Mail(
     'access_request_rejected',
-    subject='Your access request to an OSF project has been declined.'
+    subject='Your access request to an OSF project has been declined'
 )

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -200,7 +200,8 @@ def check_can_access(node, user, key=None, api_node=None):
             access_request = node.requests.filter(creator=user).exclude(machine_state='accepted')
             data = {
                 'node': {
-                    'id': node._id
+                    'id': node._id,
+                    'url': node.url
                 },
                 'user': {
                     'access_request_state': access_request.get().machine_state if access_request else None

--- a/website/templates/emails/access_request_submitted.html.mako
+++ b/website/templates/emails/access_request_submitted.html.mako
@@ -8,11 +8,11 @@
     %>
     Hello ${admin.fullname},<br>
     <br>
-    ${requester.fullname} (${requester.absolute_url}) has requested access to your ${node.project_or_component} "${node.title}" (${node.absolute_url}).<br>
+    <a href="${requester.absolute_url}">${requester.fullname}</a> has requested access to your ${node.project_or_component} "<a href="${node.absolute_url}">${node.title}</a>".<br>
     <br>
-    To review the request, click here ${contributors_url} to allow or deny access and configure permissions.<br>
+    To review the request, click <a href="${contributors_url}">here</a> to allow or deny access and configure permissions.<br>
     <br>
-    This request is being sent to you because your project has the 'Request Access' feature enabled. This allows potential collaborators to request to be added to your project. To disable this feature, click here ${project_settings_url}<br>
+    This request is being sent to you because your project has the 'Request Access' feature enabled. This allows potential collaborators to request to be added to your project. To disable this feature, click <a href="${project_settings_url}">here</a>.<br>
     <br>
     Sincerely,<br>
     <br>

--- a/website/templates/emails/contributor_added_access_request.html.mako
+++ b/website/templates/emails/contributor_added_access_request.html.mako
@@ -8,9 +8,9 @@
     %>
     Hello ${user.fullname},<br>
     <br>
-    ${referrer_name + ' has approved your access request and added you' if referrer_name else 'Your access request has been approved, and you have been added'} as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}<br>
+    ${referrer_name + ' has approved your access request and added you' if referrer_name else 'Your access request has been approved, and you have been added'} as a contributor to the project "<a href="${node.absolute_url}">${node.title}</a>" on the Open Science Framework.<br>
     <br>
-    You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '} notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}<br>
+    You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '} notification emails for this project. To change your email notification preferences, visit your project or your <a href="${settings.DOMAIN + "settings/notifications/"}">user settings</a>.<br>
     <br>
     Sincerely,<br>
     <br>

--- a/website/templates/request_access.mako
+++ b/website/templates/request_access.mako
@@ -20,7 +20,7 @@
                                        css: {'disabled': accessRequestPendingOrDenied()},
                                        tooltip: {title: accessRequestTooltip(),'disabled': true, 'placement': 'top'}">
                     </button>
-                    <a type="button" class="btn btn-default" href="${reauth_url}" >Switch account</a>
+                    <a type="button" class="btn btn-default" href="${web_url_for('auth_logout', next=node['url'])}" >Switch account</a>
                 </div>
                 <div>
                     <p style="margin-top: 10px;" data-bind="html: supportMessage"></p>


### PR DESCRIPTION
## Purpose
A round of pre-official-QA adjustments to the request access feature!

## Changes

- Remove periods from request access email subject lines
- Add inline links to HTML emails for request access notifications
- Ensure that emails are only sent to project admins, not admins on parent projects
- Use `auth_logout` with `?next=<node_url>` instead of reauth, which was re-logging back in right away!

## QA Notes

QA notes are included in original frontend PR #8192

## Documentation
see above!

## Side Effects
none anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-462