### PR TITLE
[PLAT-752] Fix dnd load order and + encoding issue

### DIFF
--- a/addons/wiki/static/dragNDrop.js
+++ b/addons/wiki/static/dragNDrop.js
@@ -53,8 +53,8 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
                 return file.attributes.name;
             });
             if (path) {
-                var newName;
                 $.each(files, function (i, file) {
+                    var newName = null;
                     if (fileNames.indexOf(file.name) !== -1) {
                         newName = autoIncrementFileName(file.name, fileNames);
                     }
@@ -63,7 +63,7 @@ var localFileHandler = function(files, cm, init, fixupInputArea) {
                     if (validImgExtensions.indexOf(ext.toLowerCase()) <= -1) {
                         $osf.growl('Error', 'This file type cannot be embedded  (' + file.name + ')', 'danger');
                     } else {
-                        var waterbutlerURL = ctx.waterbutlerURL + 'v1/resources/' + ctx.node.id + '/providers/osfstorage' + encodeURI(path) + '?name=' + encodeURI(name) + '&type=file';
+                        var waterbutlerURL = ctx.waterbutlerURL + 'v1/resources/' + ctx.node.id + '/providers/osfstorage' + encodeURI(path) + '?name=' + encodeURIComponent(name) + '&type=file';
                         $osf.trackClick('wiki', 'dropped-image', ctx.node.id);
                         promises.push(
                             $.ajax({


### PR DESCRIPTION
## Purpose

While trying to fix the load order issue for DnD I discovered a bug which has apparently been in Dnd since Pierce originally wrote it, if you upload a file with a '+' in the name it will appear as a space. This PR addressed both those issues.

## Changes

- Changes name var to refresh on each loop iteration
- encodes filenames properly.

## QA Notes

There are two bugs you are testing for:
1. Load order must be preserved regardless of how big the file is, or how many files there are.
2. You should be able to upload a file with a '+' or other special character, then drag and drop that file again without it breaking. Also check the file name in the Wiki images folder, so a file with the name '1+1.png' appears in the folder as '1+1.png'  and not '1 1.png'.  

## Side Effects

This fixes two bugs one not in the orginal ticket

## Ticket

https://openscience.atlassian.net/browse/PLAT-752