### PR TITLE
Hotfix/JS Errors Registration Wikis [PLAT-825]

### DIFF
--- a/website/static/vendor/ace-plugins/spellcheck_ace.js
+++ b/website/static/vendor/ace-plugins/spellcheck_ace.js
@@ -54,51 +54,54 @@ var markers_present = [];
 // Spell check the Ace editor contents.
 function spell_check(check_right_click) {
     // Wait for the dictionary to be loaded.
-    if (dictionary == null) {
-        return;
-    }
-    if (currently_spellchecking) {
-    	return;
-    }
-
-    if (!contents_modified) {
-    	return;
-    }
-    currently_spellchecking = true;
-    var session = ace.edit(editor).getSession();
-
-    // Clear the markers.
-    for (var i in markers_present) {
-        session.removeMarker(markers_present[i]);
-    }
-    markers_present = [];
-    try {
-	    var Range = ace.require('ace/range').Range;
-	    var lines = session.getDocument().getAllLines();
-	    for (var i in lines) {
-	    	// Clear the gutter.
-	        session.removeGutterDecoration(i, 'misspelled');
-	        // Check spelling of this line.
-	        var misspellings = misspelled(lines[i]);
-	        // Add markers and gutter markings.
-	        if (misspellings.length > 0) {
-	            session.addGutterDecoration(i, 'misspelled');
-	        }
-	        for (var j in misspellings) {
-	            var range = new Range(i, misspellings[j][0], i, misspellings[j][1]);
-	            markers_present[markers_present.length] = session.addMarker(range, 'misspelled', 'typo', true);
-	        }
+	if ($('#' + editor).length) {
+		if (dictionary == null) {
+	        return;
 	    }
-	} finally {
-		currently_spellchecking = false;
-		contents_modified = false;
+	    if (currently_spellchecking) {
+	    	return;
+	    }
+
+	    if (!contents_modified) {
+	    	return;
+	    }
+	    currently_spellchecking = true;
+	    var session = ace.edit(editor).getSession();
+
+	    // Clear the markers.
+	    for (var i in markers_present) {
+	        session.removeMarker(markers_present[i]);
+	    }
+	    markers_present = [];
+	    try {
+		    var Range = ace.require('ace/range').Range;
+		    var lines = session.getDocument().getAllLines();
+		    for (var i in lines) {
+		    	// Clear the gutter.
+		        session.removeGutterDecoration(i, 'misspelled');
+		        // Check spelling of this line.
+		        var misspellings = misspelled(lines[i]);
+		        // Add markers and gutter markings.
+		        if (misspellings.length > 0) {
+		            session.addGutterDecoration(i, 'misspelled');
+		        }
+		        for (var j in misspellings) {
+		            var range = new Range(i, misspellings[j][0], i, misspellings[j][1]);
+		            markers_present[markers_present.length] = session.addMarker(range, 'misspelled', 'typo', true);
+		        }
+		    }
+		} finally {
+			currently_spellchecking = false;
+			contents_modified = false;
+		}
 	}
 }
 
 function enable_spellcheck() {
-    ace.edit(editor).getSession().on('change', function(e) {
-    	contents_modified = true;
-	});
-
-	setInterval(spell_check, 500);
+	if ($('#' + editor).length) {
+		ace.edit(editor).getSession().on('change', function(e) {
+	    	contents_modified = true;
+		});
+		setInterval(spell_check, 500);
+	}
 }


### PR DESCRIPTION
## Purpose

There are JS errors `"ace.edit can't find div #editor"` when visiting a Registration's wiki.

## Changes

It looks like where `('../../vendor/ace-plugins/spellcheck_ace.js');` is being required on the `wiki-edit-page`, *ace.edit('editor')* is being called to spell check Ace editor contents.    Using jquery in both the enable_spellcheck() and spell_check functions, check if `#editor` exists on the page before attempting to call ace.edit('editor').

## QA Notes
1. Create a registration
2. Visit its wiki
3. Confirm there are no longer JS errors in the console regarding the ace editor.  Also visit the registration's project and confirm spellcheck is still enabled.  Type jibberish in the wiki editor and confirm it is underlined with red dots.


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-825