### PR TITLE
[PLAT-735] Make wiki tables scrollable

### DIFF
--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -340,3 +340,8 @@ select.form-control {
     top:50%;
     z-index: 1;
 }
+
+#wikiViewRender > .table {
+    display: inherit;
+    overflow-y: scroll;
+}


### PR DESCRIPTION
## Purpose

Very wide Wiki tables get cut off in the view pane, this fix allows them to scroll.

## Changes

- Simple CSS fix

## QA Notes

This fix only pertains the Wiki page when the view pane is the only one visible. Markdown for adding a table is view able here.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-735