### PR TITLE
[PLAT-108]  Registration modal gives incorrect instructions about links to other projects

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2834,7 +2834,7 @@ class TestPointerViews(OsfTestCase):
         prompts = [
             prompt
             for prompt in res.json['prompts']
-            if 'Links will be copied into your registration' in prompt
+            if 'These links will be copied into your registration,' in prompt
         ]
         assert_equal(len(prompts), 1)
 

--- a/website/language.py
+++ b/website/language.py
@@ -102,10 +102,11 @@ AFTER_REGISTER_ARCHIVING = (
 )
 
 BEFORE_REGISTER_HAS_POINTERS = (
-    u'This {category} contains links to other projects. Links will be copied '
-    u'into your registration, but the projects that they link to will not be '
-    u'registered. If you wish to register the linked projects, you must fork '
-    u'them from the original project before registering.'
+    u'This {category} contains links to other projects. These links will be '
+    u'copied into your registration, but the projects that they link to will '
+    u'not be registered. If you wish to register the linked projects, they '
+    u'must registered separately. Learn more about <a href="http://help.osf.io'
+    u'/m/links_forks/l/524112-link-to-a-project">links</a>.'
 )
 
 BEFORE_FORK_HAS_POINTERS = (

--- a/website/language.py
+++ b/website/language.py
@@ -105,7 +105,7 @@ BEFORE_REGISTER_HAS_POINTERS = (
     u'This {category} contains links to other projects. These links will be '
     u'copied into your registration, but the projects that they link to will '
     u'not be registered. If you wish to register the linked projects, they '
-    u'must registered separately. Learn more about <a href="http://help.osf.io'
+    u'must be registered separately. Learn more about <a href="http://help.osf.io'
     u'/m/links_forks/l/524112-link-to-a-project">links</a>.'
 )
 

--- a/website/static/templates/registration-modal.html
+++ b/website/static/templates/registration-modal.html
@@ -3,7 +3,7 @@
   <li data-bind="html: $data"></li>
 </ul>
 <div class="form-group">
-  <label class="control-label">Registration Choice</label>
+  <label class="control-label">Registration choice</label>
   <select class="form-control" data-bind="options: registrationOptions,
                                           value: registrationChoice,
                                           optionsText: 'message',


### PR DESCRIPTION
## Purpose

Correct wrong info about private links and  add new link.

## Changes

- Just minor HTML changes

## QA Notes

There's a screenshot of what this should look like attached to the ticket.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-108