### PR TITLE
More Request Access Improvements! [PLAT-462]

### DIFF
--- a/api_tests/requests/views/test_request_list_create.py
+++ b/api_tests/requests/views/test_request_list_create.py
@@ -96,3 +96,13 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
         assert component.admin_contributors.count() == 2
         assert component.contributors.count() == 1
         assert mock_mail.call_count == 1
+
+    def test_request_followed_by_added_as_contrib(elf, app, project, noncontrib, admin, url, create_payload):
+        res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
+        assert res.status_code == 201
+        assert project.requests.filter(creator=noncontrib, machine_state='pending').exists()
+
+        project.add_contributor(noncontrib, save=True)
+        assert project.is_contributor(noncontrib)
+        assert not project.requests.filter(creator=noncontrib, machine_state='pending').exists()
+        assert project.requests.filter(creator=noncontrib, machine_state='accepted').exists()

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -194,10 +194,12 @@ class ComposedScopes(object):
 
     # Privileges relating to who can access a node (via contributors or registrations)
     NODE_ACCESS_READ = (CoreScopes.NODE_CONTRIBUTORS_READ, CoreScopes.NODE_REGISTRATIONS_READ,
-                        CoreScopes.NODE_VIEW_ONLY_LINKS_READ, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_READ)
+                        CoreScopes.NODE_VIEW_ONLY_LINKS_READ, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_READ,
+                        CoreScopes.NODE_REQUESTS_READ)
     NODE_ACCESS_WRITE = NODE_ACCESS_READ + \
                             (CoreScopes.NODE_CONTRIBUTORS_WRITE, CoreScopes.NODE_REGISTRATIONS_WRITE,
-                             CoreScopes.NODE_VIEW_ONLY_LINKS_WRITE, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_WRITE)
+                             CoreScopes.NODE_VIEW_ONLY_LINKS_WRITE, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_WRITE,
+                             CoreScopes.NODE_REQUESTS_WRITE)
 
     # Combine all sets of node permissions into one convenience level
     NODE_ALL_READ = NODE_METADATA_READ + NODE_DATA_READ + NODE_ACCESS_READ

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1184,6 +1184,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     difference = count - MAX_RECENT_LENGTH
                     for each in user.recentlyaddedcontributor_set.order_by('date_added')[:difference]:
                         each.delete()
+
+            # If there are pending access requests for this user, mark them as accepted
+            pending_access_requests_for_user = self.requests.filter(creator=contrib_to_add, machine_state='pending')
+            if pending_access_requests_for_user.exists():
+                pending_access_requests_for_user.get().run_accept(contrib_to_add, comment='')
+
             if log:
                 self.add_log(
                     action=NodeLog.CONTRIB_ADDED,

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -141,16 +141,16 @@ var subscribeViewModel = function(viewModel, options) {
         $osf.postJSON(ctx.node.urls.api + options.updateUrl, payload
         ).done(function(response) {
             if (newValue) {
-                viewModel[options.messageObservable](options.name + ' Enabled');
+                viewModel[options.messageObservable](options.name + ' enabled');
             }
             else {
-                viewModel[options.messageObservable](options.name + ' Disabled');
+                viewModel[options.messageObservable](options.name + ' disabled');
             }
             //Give user time to see message before reload.
             setTimeout(function(){window.location.reload();}, 1500);
         }).fail(function(xhr, status, error) {
-            $osf.growl('Error', 'Unable to update wiki');
-            Raven.captureMessage('Could not update wiki.', {
+            $osf.growl('Error', 'Unable to update settings');
+            Raven.captureMessage('Could not update settings.', {
                 extra: {
                     url: ctx.node.urls.api + options.updateUrl, status: status, error: error
                 }
@@ -185,7 +185,7 @@ var RequestAccessSettingsViewModel = {
 
 subscribeViewModel(RequestAccessSettingsViewModel, {
     messageObservable: 'requestAccessMessage',
-    name: 'Request Access',
+    name: 'Request access',
     updateUrl: 'settings/requests/',
     objectToUpdate: 'accessRequestsEnabled'
 });

--- a/website/templates/emails/access_request_rejected.html.mako
+++ b/website/templates/emails/access_request_rejected.html.mako
@@ -14,7 +14,7 @@
     <br>
     The OSF Team<br>
     <br>
-    Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
+    Want more information? Visit https://osf.io/ to learn about OSF, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
     <br>
     Questions? Email contact@osf.io<br>
 </tr>

--- a/website/templates/emails/access_request_submitted.html.mako
+++ b/website/templates/emails/access_request_submitted.html.mako
@@ -8,7 +8,7 @@
     %>
     Hello ${admin.fullname},<br>
     <br>
-    <a href="${requester.absolute_url}">${requester.fullname}</a> has requested access to your ${node.project_or_component} "<a href="${node.absolute_url}">${node.title}</a>".<br>
+    <a href="${requester.absolute_url}">${requester.fullname}</a> has requested access to your ${node.project_or_component} "<a href="${node.absolute_url}">${node.title}</a>."<br>
     <br>
     To review the request, click <a href="${contributors_url}">here</a> to allow or deny access and configure permissions.<br>
     <br>
@@ -18,7 +18,7 @@
     <br>
     The OSF Team<br>
     <br>
-    Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
+    Want more information? Visit https://osf.io/ to learn about OSF, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
     <br>
     Questions? Email contact@osf.io<br>
 </tr>

--- a/website/templates/emails/contributor_added_access_request.html.mako
+++ b/website/templates/emails/contributor_added_access_request.html.mako
@@ -8,7 +8,7 @@
     %>
     Hello ${user.fullname},<br>
     <br>
-    ${referrer_name + ' has approved your access request and added you' if referrer_name else 'Your access request has been approved, and you have been added'} as a contributor to the project "<a href="${node.absolute_url}">${node.title}</a>" on the Open Science Framework.<br>
+    ${referrer_name + ' has approved your access request and added you' if referrer_name else 'Your access request has been approved, and you have been added'} as a contributor to the project "<a href="${node.absolute_url}">${node.title}</a>" on OSF.<br>
     <br>
     You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '} notification emails for this project. To change your email notification preferences, visit your project or your <a href="${settings.DOMAIN + "settings/notifications/"}">user settings</a>.<br>
     <br>
@@ -16,7 +16,7 @@
     <br>
     The OSF Team<br>
     <br>
-    Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
+    Want more information? Visit https://osf.io/ to learn about OSF, or https://cos.io/ for information about its supporting organization, the Center for Open Science.<br>
     <br>
     Questions? Email contact@osf.io<br>
 </tr>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -138,9 +138,9 @@
         ${buttonGroup()}
     </div>
 
-    % if 'admin' in user['permissions'] and access_requests:
+    % if 'admin' in user['permissions'] and access_requests and node['access_requests_enabled']:
     <div id="manageAccessRequests">
-        <h3> Requests for access</h3>
+        <h3> Requests for Access</h3>
         <p class="m-b-xs">The following users have requested access to this project.</p>
         <table  id="manageAccessRequestsTable"
         class="table responsive-table responsive-table-xxs"

--- a/website/templates/project/private_links_table.mako
+++ b/website/templates/project/private_links_table.mako
@@ -47,7 +47,7 @@
         <td>
             <div class="td-content" data-bind="visible: expanded() || !$root.collapsed()">
                 <span data-bind="click: $root.removeLink, visible: !$root.collapsed()"><i class="fa fa-times fa-2x remove-or-reject"></i></span>
-                <button class="btn btn-default btn-sm m-l-md" data-bind="click: $root.removeLink, visible: $root.collapsed()"><i class="fa fa-minus"></i> Remove</button>
+                <button class="btn btn-default btn-sm m-l-md" data-bind="click: $root.removeLink, visible: $root.collapsed()"><i class="fa fa-times"></i> Remove</button>
             </div>
         </td>
     </tr>


### PR DESCRIPTION


## Purpose
Fixing up some things caught by the extremely thorough and wonderful QA team!

## Changes

### Contributors page:
- Change "Wiki enabled/disabled" and "Access requests enabled/disabled" to sentence case
- Change [x Remove] button icon on View Only Link in mobile mode to x instead of -
- If requests are disabled on the project, former requests for access are no longer shown
    - they come back if requests are re-enabled on the node
- If a user requests access and then is added as a contributor, they should no longer show up on the requests for access list
- Access capitalized for consistency with other headers

### Emails
- Instances of "the Open Science Framework" changed to "OSF" in 3 emails
- A period inside the " for the email to the admin about a user requesting access

### Other
- `NODE_REQUESTS_READ`, `NODE_REQUESTS_READ` added to `NODE_ACCESS_READ`/`NODE_ACCESS_WRITE` respectively


## QA Notes
Please see above for enumerated changes! I *think* I covered everything in the comments on [the ticket](https://openscience.atlassian.net/browse/PLAT-462) but plz tell me if I missed something.

## Documentation

nope!

## Side Effects

Nope!

## Ticket
https://openscience.atlassian.net/browse/PLAT-462