### PR TITLE
Don't show wiki relationship when wiki is disabled

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -172,6 +172,15 @@ class HideIfWithdrawal(ConditionalField):
         return not isinstance(self.field, RelationshipField)
 
 
+class HideIfWikiDisabled(ConditionalField):
+    """
+    If wiki is disabled, don't show relationship field
+    """
+
+    def should_hide(self, instance):
+        return 'wiki' not in instance.get_addon_names()
+
+
 class HideIfNotNodePointerLog(ConditionalField):
     """
     This field will not be shown if the log is not a pointer log for a node

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -174,11 +174,12 @@ class HideIfWithdrawal(ConditionalField):
 
 class HideIfWikiDisabled(ConditionalField):
     """
-    If wiki is disabled, don't show relationship field
+    If wiki is disabled, don't show relationship field, only available in version 2.8
     """
 
     def should_hide(self, instance):
-        return 'wiki' not in instance.get_addon_names()
+        request = self.context.get('request')
+        return not utils.is_deprecated(request.version, '2.8', '2.8') and 'wiki' not in instance.get_addon_names()
 
 
 class HideIfNotNodePointerLog(ConditionalField):

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -152,6 +152,7 @@ REST_FRAMEWORK = {
         '2.5',
         '2.6',
         '2.7',
+        '2.8',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -8,7 +8,8 @@ from api.base.serializers import (VersionedDateTimeField, HideIfRegistration, ID
                                   JSONAPISerializer, LinksField, ValuesListField,
                                   NodeFileHyperLinkField, RelationshipField,
                                   ShowIfVersion, TargetTypeField, TypeField,
-                                  WaterbutlerLink, relationship_diff, BaseAPISerializer)
+                                  WaterbutlerLink, relationship_diff, BaseAPISerializer,
+                                  HideIfWikiDisabled)
 from api.base.settings import ADDONS_FOLDER_CONFIGURABLE
 from api.base.utils import (absolute_reverse, get_object_or_error,
                             get_user_auth, is_truthy)
@@ -269,10 +270,10 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view_kwargs={'node_id': '<_id>'}
     )
 
-    wikis = RelationshipField(
+    wikis = HideIfWikiDisabled(RelationshipField(
         related_view='nodes:node-wikis',
         related_view_kwargs={'node_id': '<_id>'}
-    )
+    ))
 
     forked_from = RelationshipField(
         related_view=lambda n: 'registrations:registration-detail' if getattr(n, 'is_registration', False) else 'nodes:node-detail',

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -296,14 +296,20 @@ class TestNodeDetail:
         link = res.json['data']['relationships']['identifiers']['links']['related']['href']
         assert '{}identifiers/'.format(url_public) in link
 
-    def test_node_shows_wiki_relationship_based_on_disabled_status(self, app, user, project_public, url_public):
-        res = app.get(url_public, auth=user.auth)
-        url = res.json['data']['relationships'].get('wikis', False)
-        assert url
-        project_public.delete_addon('wiki', auth=Auth(self.user))
-        res = app.get(url_public, auth=user.auth)
-        url = res.json['data']['relationships'].get('wikis', False)
-        assert url is False
+    def test_node_shows_wiki_relationship_based_on_disabled_status_and_version(self, app, user, project_public, url_public):
+        url = url_public + '?version=latest'
+        res = app.get(url, auth=user.auth)
+        rel_link = res.json['data']['relationships'].get('wikis', False)
+        assert rel_link
+        project_public.delete_addon('wiki', auth=Auth(user))
+        project_public.save()
+        res = app.get(url, auth=user.auth)
+        rel_link = res.json['data']['relationships'].get('wikis', False)
+        assert rel_link is False
+        url = url_public + '?version=2.7'
+        res = app.get(url, auth=user.auth)
+        rel_link = res.json['data']['relationships'].get('wikis', False)
+        assert rel_link
 
 
 @pytest.mark.django_db

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -296,6 +296,15 @@ class TestNodeDetail:
         link = res.json['data']['relationships']['identifiers']['links']['related']['href']
         assert '{}identifiers/'.format(url_public) in link
 
+    def test_node_shows_wiki_relationship_based_on_disabled_status(self, app, user, project_public, url_public):
+        res = app.get(url_public, auth=user.auth)
+        url = res.json['data']['relationships'].get('wikis', False)
+        assert url
+        project_public.delete_addon('wiki', auth=Auth(self.user))
+        res = app.get(url_public, auth=user.auth)
+        url = res.json['data']['relationships'].get('wikis', False)
+        assert url is False
+
 
 @pytest.mark.django_db
 class NodeCRUDTestCase:


### PR DESCRIPTION
## Purpose
Ember needs to know when wikis are disabled via the api.

## Changes
As per @brianjgeiger suggestion, do not show the wiki relationship if the wiki is disabled.

## QA Notes
links.relationships.wiki should be present/absent on node list and node details based on whether the wiki is disabled.

## Ticket
No tix
