### PR TITLE
[EMB-239] Proxy ember apps by default, remove unused url from dicts, set server…

### DIFF
--- a/.docker-compose.env
+++ b/.docker-compose.env
@@ -14,7 +14,7 @@ CAS_SERVER_URL=http://192.168.168.167:8080
 MFR_SERVER_URL=http://localhost:7778
 #SHARE_URL=http://192.168.168.167:8000/
 BROKER_URL=amqp://guest:guest@192.168.168.167:5672/
-LIVE_RELOAD_DOMAIN=http://192.168.168.167:4200
 REDIS_URL=redis://192.168.168.167:6379/1
+EMBER_DOMAIN=192.168.168.167
 
 #PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -196,7 +196,6 @@ class TestResolveGuid(OsfTestCase):
     @mock.patch('website.settings.USE_EXTERNAL_EMBER', True)
     @mock.patch('website.settings.EXTERNAL_EMBER_APPS', {
         'preprints': {
-            'url': '/preprints/',
             'server': 'http://localhost:4200',
             'path': '/preprints/'
         },

--- a/website/routes.py
+++ b/website/routes.py
@@ -2,9 +2,13 @@
 from __future__ import absolute_import
 import os
 import httplib as http
+import requests
+import urlparse
 
 from flask import request
 from flask import send_from_directory
+from flask import Response
+from flask import stream_with_context
 from django.core.urlresolvers import reverse
 
 from geoip import geolite2
@@ -51,6 +55,7 @@ from website.ember_osf_web import views as ember_osf_web_views
 from website.closed_challenges import views as closed_challenges_views
 from website.identifiers import views as identifier_views
 from website.ember_osf_web.decorators import ember_flag_is_active
+from website.settings import EXTERNAL_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
 
 def get_globals():
@@ -197,10 +202,25 @@ def ember_app(path=None):
     """Serve the contents of the ember application"""
     ember_app_folder = None
     fp = path or 'index.html'
-    for k in settings.EXTERNAL_EMBER_APPS.keys():
+
+    ember_app = None
+
+    for k in EXTERNAL_EMBER_APPS.keys():
         if request.path.strip('/').startswith(k):
-            ember_app_folder = os.path.abspath(os.path.join(os.getcwd(), settings.EXTERNAL_EMBER_APPS[k]['path']))
+            ember_app = EXTERNAL_EMBER_APPS[k]
             break
+
+    if not ember_app:
+        raise HTTPError(http.NOT_FOUND)
+
+    if settings.PROXY_EMBER_APPS:
+        url = urlparse.urljoin(ember_app['server'], request.path[len(ember_app['path']):])
+        resp = requests.get(url, stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT, headers={'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'})
+        excluded_headers = ['content-encoding', 'content-length', 'transfer-encoding', 'connection']
+        headers = [(name, value) for (name, value) in resp.raw.headers.items() if name.lower() not in excluded_headers]
+        return Response(resp.content, resp.status_code, headers)
+
+    ember_app_folder = os.path.abspath(os.path.join(os.getcwd(), ember_app['path']))
 
     if not ember_app_folder:
         raise HTTPError(http.NOT_FOUND)
@@ -280,7 +300,7 @@ def make_url_map(app):
     # Ember Applications
     if settings.USE_EXTERNAL_EMBER:
         # Routes that serve up the Ember application. Hide behind feature flag.
-        for prefix in settings.EXTERNAL_EMBER_APPS.keys():
+        for prefix in EXTERNAL_EMBER_APPS.keys():
             process_rules(app, [
                 Rule(
                     [
@@ -307,7 +327,7 @@ def make_url_map(app):
                 ),
             ], prefix='/' + prefix)
 
-        if settings.EXTERNAL_EMBER_APPS.get('ember_osf_web'):
+        if EXTERNAL_EMBER_APPS.get('ember_osf_web'):
             process_rules(app, [
                 Rule(
                     ember_osf_web_views.routes,
@@ -1660,9 +1680,6 @@ def make_url_map(app):
     # NOTE: We use nginx to serve static addon assets in production
     addon_base_path = os.path.abspath('addons')
     if settings.DEV_MODE:
-        from flask import stream_with_context, Response
-        import requests
-
         @app.route('/static/addons/<addon>/<path:filename>')
         def addon_static(addon, filename):
             addon_path = os.path.join(addon_base_path, addon, 'static')

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -6,6 +6,7 @@ NOTE: local.py will not be added to source control.
 '''
 
 from . import defaults
+from os import environ
 
 DEV_MODE = True
 DEBUG_MODE = True  # Sets app to debug mode, turns off template caching, etc.
@@ -22,40 +23,32 @@ API_DOMAIN = PROTOCOL + 'localhost:8000/'
 #WATERBUTLER_URL = 'http://localhost:7777'
 #WATERBUTLER_INTERNAL_URL = WATERBUTLER_URL
 
-LIVE_RELOAD_DOMAIN = 'http://localhost:4200'
 PREPRINT_PROVIDER_DOMAINS = {
     'enabled': False,
     'prefix': 'http://local.',
     'suffix': ':4201/'
 }
 USE_EXTERNAL_EMBER = True
-PROXY_EMBER_APPS = False
+PROXY_EMBER_APPS = True
+EMBER_DOMAIN = environ.get('EMBER_DOMAIN', 'localhost')
+LIVE_RELOAD_DOMAIN = 'http://{}:4200'.format(EMBER_DOMAIN)  # Change port for the current app
 EXTERNAL_EMBER_APPS = {
     'ember_osf_web': {
-        'url': '/ember_osf_web/',
-        'server': 'http://localhost:4200',
+        'server': 'http://{}:4200/'.format(EMBER_DOMAIN),
         'path': '/ember_osf_web/'
     },
     'preprints': {
-        'url': '/preprints/',
-        'server': 'http://192.168.168.167:4201/',
+        'server': 'http://{}:4201/'.format(EMBER_DOMAIN),
         'path': '/preprints/'
     },
     'registries': {
-        'url': '/registries/',
-        'server': 'http://192.168.168.167:4202',
+        'server': 'http://{}:4202/'.format(EMBER_DOMAIN),
         'path': '/registries/'
     },
     'reviews': {
-        'url': '/reviews/',
-        'server': 'http://localhost:4203',
+        'server': 'http://{}:4203/'.format(EMBER_DOMAIN),
         'path': '/reviews/'
-    }
-    # 'meetings': {
-    #     'url': '/meetings/',
-    #     'server': 'http://localhost:4201',
-    #     'path': '../osf-meetings/dist/'
-    # },
+    },
 }
 
 SEARCH_ENGINE = 'elastic'

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -29,12 +29,10 @@ PREPRINT_PROVIDER_DOMAINS = {
 USE_EXTERNAL_EMBER = True
 EXTERNAL_EMBER_APPS = {
     'ember_osf_web': {
-        'url': '/ember_osf_web/',
         'server': 'http://localhost:4200',
         'path': os.environ.get('HOME') + '/ember_osf_web/'
     },
     'preprints': {
-        'url': '/preprints/',
         'server': 'http://localhost:4201',
         'path': os.environ.get('HOME') + '/preprints/'
     }


### PR DESCRIPTION
… urls to 192.168.168.167 default

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

* Proxy ember apps by default (vs `send_from_directory`),
* Allows Proxying to docker or non-docker ember server
* docker-sync doesn't always sync well, so restarting the container and hoping is a pain point
* After sufficient time has passed for people to switch, we can remove `send_from_directory`

## Changes

* Removes unused `url` dict key
* Adds `EMBER_DOMAIN`, defaults to localhost, and `192.168.168.167` for dockerized OSF.

## QA Notes

N/A

## Documentation

`local.py` changes are recommended, but not required.

For the ember apps running outside of docker, the port and live reload port must be set with the `yarn start` command via cli arg e.g. 

```sh
yarn start --port 4201 --live-reload-port 41954
```

or by environment variables e.g.

```sh
export PORT=4201
export EMBER_CLI_INJECT_LIVE_RELOAD_PORT=41954
yarn start --live-reload-port 41954
```

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/EMB-239
