### PR TITLE
Prevent pending to accept transition from happening twice when adding a contributor

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1188,7 +1188,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             # If there are pending access requests for this user, mark them as accepted
             pending_access_requests_for_user = self.requests.filter(creator=contrib_to_add, machine_state='pending')
             if pending_access_requests_for_user.exists():
-                pending_access_requests_for_user.get().run_accept(contrib_to_add, comment='')
+                pending_access_requests_for_user.get().run_accept(contrib_to_add, comment='', permissions=reduce_permissions(permissions))
 
             if log:
                 self.add_log(


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Before, two things were wonky. One was that permissions werent being set when adding a contributor with  a pending acccess request. Second, seince add_contributor was being called in the transition from pending to accepted, add_contributor was called twice. This was remedied by both checking if the user was a contributor in the accept request transition, and by calling add_contributor after the transition is complete.


## Changes

- Call add_contributor after the transition from pending to accepted is complete
- Add a check in that transition to make sure the user isn't already a contributor
- Make sure to pass along correct permissions when accepting a request from a user that has already been added as a contributor

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
- Accepting an access request should have the right permissions that you specify in the menu
- Request access from a user,  then add as a contributor should remove that user from the request access list

## Documentation

nope

## Side Effects

hopefully not 🤞 

## Ticket
https://openscience.atlassian.net/browse/PLAT-462