### PR TITLE
Fix/More Preprints API Citations [PLAT-827]

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -99,6 +99,7 @@ def render_citation(node, style='apa'):
     cit = unicode(bib[0] if len(bib) else '')
 
     title = csl['title'] if csl else node.csl['title']
+    title = title.rstrip('.')
     if cit.count(title) == 1:
         i = cit.index(title)
         prefix = clean_up_common_errors(cit[0:i])
@@ -121,7 +122,6 @@ def render_citation(node, style='apa'):
 
     return cit
 
-
 def apa_reformat(node, cit):
     new_csl = cit.split('(')
     contributors_list = list(node.visible_contributors)
@@ -142,8 +142,8 @@ def apa_reformat(node, cit):
         new_apa += ' & ' + last_one
     # handle 8 or more contributors
     else:
-        name_list = [apa_name(process_name(node, x)) for x in contributors_list[:5]]
-        new_apa = ' '.join(name_list) + '... ' + apa_name(process_name(node, contributors_list[-1]))
+        name_list = [apa_name(process_name(node, x)) for x in contributors_list[:6]]
+        new_apa = ' '.join(name_list) + ' \xe2\x80\xa6 '.decode('utf-8') + apa_name(process_name(node, contributors_list[-1]))
 
     cit = new_apa.rstrip(', ') + ' '
     for x in new_csl[1:]:
@@ -158,7 +158,7 @@ def apa_name(name):
     if name['given_name']:
         apa += ' ' + name['given_name'][0] + '.'
         if name['middle_names']:
-            apa += ' ' + name['middle_names'][0] + '.'
+            apa += middle_name_splitter(name['middle_names'], add_periods=True)
         apa += ','
     if name['suffix']:
         apa += ' ' + name['suffix'] + ','
@@ -168,8 +168,7 @@ def apa_name(name):
 def mla_reformat(node, cit):
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
-    # Remove extra period after right-side quotation
-    cit = cit.encode('utf-8').replace('\xe2\x80\x9d.', '\xe2\x80\x9d').decode('utf-8')
+    cit = remove_extra_period_after_right_quotation(cit)
     cit_minus_authors = cit.split('.', 1)[1]
 
     # throw error if there is no visible contributor
@@ -178,7 +177,7 @@ def mla_reformat(node, cit):
     # handle only one contributor
     elif contributors_list_length == 1:
         name = process_name(node, contributors_list[0])
-        new_mla = mla_name(name, initial=True).rstrip(' ')[:-1] + '.'
+        new_mla = mla_name(name, initial=True).rstrip(' ')[:-1]
     # handle more than one contributor but less than 5 contributors
     elif contributors_list_length in range(1, 5):
         first_one = mla_name(process_name(node, contributors_list[0]), initial=True)
@@ -186,18 +185,23 @@ def mla_reformat(node, cit):
         last_one = mla_name(process_name(node, contributors_list[-1]))
         if rest_ones:
             rest_part = ', '.join(rest_ones)
-            new_mla = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one + '.'
+            new_mla = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one
         else:
-            new_mla = first_one + 'and ' + last_one
+            new_mla = first_one + ' and ' + last_one
     # handle 5 or more contributors
     else:
         name = process_name(node, contributors_list[0])
-        new_mla = mla_name(name, initial=True) + ' et al.'
+        new_mla = mla_name(name, initial=True)[:-1] + ' et al.'
 
+    if new_mla[-1] != '.':
+        new_mla = new_mla + '.'
     return new_mla + cit_minus_authors
 
+def remove_extra_period_after_right_quotation(cit):
+    return cit.encode('utf-8').replace('\xe2\x80\x9d.', '\xe2\x80\x9d').decode('utf-8')
 
 def chicago_reformat(node, cit):
+    cit = remove_extra_period_after_right_quotation(cit)
     new_csl = cit.split('20')
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
@@ -208,7 +212,7 @@ def chicago_reformat(node, cit):
     # handle only one contributor
     elif contributors_list_length == 1:
         name = process_name(node, contributors_list[0])
-        new_chi = mla_name(name, initial=True) + ' '
+        new_chi = mla_name(name, initial=True)[:-1] + '. '
     # handle more than one contributor  but less than 11 contributors
     elif contributors_list_length in range(1, 11):
         first_one = mla_name(process_name(node, contributors_list[0]), initial=True)
@@ -216,9 +220,10 @@ def chicago_reformat(node, cit):
         last_one = mla_name(process_name(node, contributors_list[-1]))
         if rest_ones:
             rest_part = ', '.join(rest_ones)
-            new_chi = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one + ' '
+            new_chi = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one + '. '
         else:
-            new_chi = first_one + 'and ' + last_one + ' '
+
+            new_chi = first_one[:-1] + ', and ' + last_one + '. '
     # handle 11 or more contributors
     else:
         new_chi = mla_name(process_name(node, contributors_list[0]), initial=True).rstrip(', ')
@@ -241,7 +246,7 @@ def mla_name(name, initial=False):
         if name['given_name']:
             mla += ' ' + name['given_name']
             if name['middle_names']:
-                mla += ' ' + name['middle_names'][0] + '.'
+                mla += middle_name_splitter(name['middle_names'])
             mla += ','
         if name['suffix']:
             mla += ' ' + name['suffix']
@@ -250,9 +255,18 @@ def mla_name(name, initial=False):
         if name['given_name']:
             mla += name['given_name']
             if name['middle_names']:
-                mla += ' ' + name['middle_names'][0]
+                mla += middle_name_splitter(name['middle_names'])
         if name['family_name']:
             mla += ' ' + name['family_name']
         if name['suffix']:
             mla += ' ' + name['suffix']
     return mla
+
+def middle_name_splitter(middle_names, add_periods=False):
+    initials = ''
+    middle_names_arr = middle_names.split(' ')
+    for name in middle_names_arr:
+        initials += ' ' + name[0]
+        if add_periods:
+            initials += '.'
+    return initials

--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -168,7 +168,9 @@ def apa_name(name):
 def mla_reformat(node, cit):
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
-    retrive_from = cit.split('Open')[-1]
+    # Remove extra period after right-side quotation
+    cit = cit.encode('utf-8').replace('\xe2\x80\x9d.', '\xe2\x80\x9d').decode('utf-8')
+    cit_minus_authors = cit.split('.', 1)[1]
 
     # throw error if there is no visible contributor
     if contributors_list_length == 0:
@@ -176,25 +178,23 @@ def mla_reformat(node, cit):
     # handle only one contributor
     elif contributors_list_length == 1:
         name = process_name(node, contributors_list[0])
-        new_mla = mla_name(name, initial=True).rstrip(' ')
-    # handle more than one contributor  but less than 5 contributors
+        new_mla = mla_name(name, initial=True).rstrip(' ')[:-1] + '.'
+    # handle more than one contributor but less than 5 contributors
     elif contributors_list_length in range(1, 5):
         first_one = mla_name(process_name(node, contributors_list[0]), initial=True)
         rest_ones = [mla_name(process_name(node, x)) for x in contributors_list[1:-1]]
         last_one = mla_name(process_name(node, contributors_list[-1]))
         if rest_ones:
             rest_part = ', '.join(rest_ones)
-            new_mla = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one
+            new_mla = first_one.rstrip(',') + ', ' + rest_part + ', and ' + last_one + '.'
         else:
             new_mla = first_one + 'and ' + last_one
     # handle 5 or more contributors
     else:
         name = process_name(node, contributors_list[0])
-        new_mla = mla_name(name, initial=True) + ' et al. '
+        new_mla = mla_name(name, initial=True) + ' et al.'
 
-    cit = new_mla
-    cit += u' \u201c' + node.title.title() + u'.\u201d Open' + retrive_from
-    return cit
+    return new_mla + cit_minus_authors
 
 
 def chicago_reformat(node, cit):

--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -264,6 +264,8 @@ def mla_name(name, initial=False):
 
 def middle_name_splitter(middle_names, add_periods=False):
     initials = ''
+    if middle_names:
+        middle_names = middle_names.strip()
     middle_names_arr = middle_names.split(' ')
     for name in middle_names_arr:
         initials += ' ' + name[0]

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from api.base.settings.defaults import API_BASE
+from django.utils import timezone
 from api.citations.utils import display_absolute_url
 from nose.tools import *  # flake8: noqa
 from osf_tests.factories import AuthUserFactory, PreprintFactory
@@ -93,3 +94,125 @@ class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
             '%Y, %B %-d')
         assert_true(
             expected_date in res.json['data']['attributes']['citation'])
+
+
+class TestPreprintCitationContentMLA(ApiTestCase):
+
+    def setUp(self):
+        super(TestPreprintCitationContentMLA, self).setUp()
+        self.admin_contributor = AuthUserFactory()
+        self.published_preprint = PreprintFactory(
+            creator=self.admin_contributor)
+        self.node = self.published_preprint.node
+        self.node.title = "My Preprint"
+        self.node.save()
+
+        self.admin_contributor.given_name = 'Grapes'
+        self.admin_contributor.middle_names = ' Coffee Beans '
+        self.admin_contributor.family_name = 'McGee'
+        self.admin_contributor.save()
+        self.published_preprint_url = '/{}preprints/{}/citation/modern-language-association/'.format(
+                     API_BASE, self.published_preprint._id)
+
+    def test_citation_contains_correctly_formats_middle_names(self):
+        res = self.app.get(self.published_preprint_url)
+        assert_equal(res.status_code, 200)
+        citation = res.json['data']['attributes']['citation']
+        date = timezone.now().date().strftime('%d %b %Y')
+        assert_equal(citation, u'McGee, Grapes C B. “{}” {}, {}. Web.'.format(
+                self.node.title,
+                self.published_preprint.provider.name,
+                date)
+        )
+
+    def test_citation_no_repeated_periods(self):
+        self.node.title = 'A Study of Coffee.'
+        self.node.save()
+        res = self.app.get(self.published_preprint_url)
+        assert_equal(res.status_code, 200)
+        citation = res.json['data']['attributes']['citation']
+        date = timezone.now().date().strftime('%d %b %Y')
+        assert_equal(citation, u'McGee, Grapes C B. “{}” {}, {}. Web.'.format(
+                self.node.title,
+                self.published_preprint.provider.name,
+                date)
+        )
+
+    def test_citation_osf_provider(self):
+        self.node.title = 'A Study of Coffee.'
+        self.node.save()
+        self.published_preprint.provider.name = 'Open Science Framework'
+        self.published_preprint.provider.save()
+        res = self.app.get(self.published_preprint_url)
+        assert_equal(res.status_code, 200)
+        citation = res.json['data']['attributes']['citation']
+        date = timezone.now().date().strftime('%d %b %Y')
+        assert_equal(citation, u'McGee, Grapes C B. “{}” {}, {}. Web.'.format(
+                self.node.title,
+                self.published_preprint.provider.name,
+                date)
+        )
+
+
+class TestPreprintCitationContentAPA(ApiTestCase):
+
+    def setUp(self):
+        super(TestPreprintCitationContentAPA, self).setUp()
+        self.admin_contributor = AuthUserFactory()
+        self.published_preprint = PreprintFactory(
+            creator=self.admin_contributor)
+        self.node = self.published_preprint.node
+
+        self.admin_contributor.given_name = 'Grapes'
+        self.admin_contributor.middle_names = ' Coffee Beans '
+        self.admin_contributor.family_name = 'McGee'
+        self.admin_contributor.save()
+        self.published_preprint_url = '/{}preprints/{}/citation/apa/'.format(
+                     API_BASE, self.published_preprint._id)
+
+    def test_api_citation_particulars(self):
+        self.node.title = 'A Study of Coffee.'
+        self.node.save()
+        res = self.app.get(self.published_preprint_url)
+        assert_equal(res.status_code, 200)
+        citation = res.json['data']['attributes']['citation']
+        date = timezone.now().date().strftime('%Y, %B %d')
+        assert_equal(citation, u'McGee, G. C. B. ({}). {} {}'.format(
+                date,
+                self.node.title,
+                'http://doi.org/' + self.published_preprint.article_doi
+                )
+        )
+
+
+class TestPreprintCitationContentChicago(ApiTestCase):
+
+    def setUp(self):
+        super(TestPreprintCitationContentChicago, self).setUp()
+        self.admin_contributor = AuthUserFactory()
+        self.published_preprint = PreprintFactory(
+            creator=self.admin_contributor)
+        self.node = self.published_preprint.node
+
+        self.admin_contributor.given_name = 'Grapes'
+        self.admin_contributor.middle_names = ' Coffee Beans '
+        self.admin_contributor.family_name = 'McGee'
+        self.admin_contributor.save()
+        self.published_preprint_url = '/{}preprints/{}/citation/chicago-author-date/'.format(
+                     API_BASE, self.published_preprint._id)
+
+    def test_api_citation_particulars(self):
+        self.node.title = 'A Study of Coffee.'
+        self.node.save()
+        res = self.app.get(self.published_preprint_url)
+        assert_equal(res.status_code, 200)
+        citation = res.json['data']['attributes']['citation']
+        date = timezone.now().date()
+        assert_equal(citation, u'McGee, Grapes C B. {}. “{}” {}. {}. {}.'.format(
+                date.strftime('%Y'),
+                self.node.title,
+                self.published_preprint.provider.name,
+                date.strftime('%B %d'),
+                'doi:' + self.published_preprint.article_doi
+                )
+        )

--- a/framework/auth/utils.py
+++ b/framework/auth/utils.py
@@ -131,6 +131,7 @@ def validate_recaptcha(response, remote_ip=None):
 def generate_csl_given_name(given_name, middle_names='', suffix=''):
     parts = [given_name]
     if middle_names:
+        middle_names = middle_names.strip()
         parts.extend(each[0] for each in re.split(r'\s+', middle_names))
     given = ' '.join(parts)
     if suffix:


### PR DESCRIPTION
## Purpose

We use cite-proc.py to format our citations for APIv2 which are used in preprints.  We use a different library for formatting citations on projects.  Cite-proc is missing some things, so we do some post-processing, and sometimes our overrides need more tweaking.


## Changes
- MLA was looking for the word "Open" in the citation to split it, but this doesn't exist for other preprint providers.  Don't split the citation on the word open to get rid of the duplicated citation.
- When someone has two middle names, both initials need to show up in all three citations
- Extra periods stripped from the end of preprint titles.
- Extra period after the right quotation mark dropped.
- With two authors for MLA/Chicago, no space between authors and no period at the end.
- APA citations more than 8 contributors, showing one less contributor before truncating.  Use ellipsis instead of three dots 
-

###  One author with two middle names (Texas Toast :) and the preprint title has a period on the end "This is a test preprint."
![screen shot 2018-04-27 at 3 18 05 pm](https://user-images.githubusercontent.com/9755598/39384017-fb5e0a82-4a30-11e8-964e-87ca72cb3748.png)

![screen shot 2018-04-27 at 3 34 02 pm](https://user-images.githubusercontent.com/9755598/39383996-ee8761be-4a30-11e8-99d8-1427163e60b1.png)

![screen shot 2018-04-27 at 3 38 52 pm](https://user-images.githubusercontent.com/9755598/39384081-38d29b44-4a31-11e8-8205-6bee897864f6.png)

### Two authors
![screen shot 2018-04-27 at 3 43 56 pm](https://user-images.githubusercontent.com/9755598/39384557-d3870c8c-4a32-11e8-8f4e-c0fd26eb8ff6.png)

![screen shot 2018-04-27 at 3 49 30 pm](https://user-images.githubusercontent.com/9755598/39384516-b392ac06-4a32-11e8-8af2-3ca28ef69bcf.png)

#### Project for comparison
![screen shot 2018-04-27 at 3 50 33 pm](https://user-images.githubusercontent.com/9755598/39384538-c16eab68-4a32-11e8-88c7-ce3e9651ee1c.png)


## QA Notes

Compare citations to citation on project.  With exception of URL and provider, citations should be the same.  Test preprints from 1-9 authors, and compare preprint citation to project citation, you can use an online diff-checker to quickly spot differences.   

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-827
