### PR TITLE
Feature/Meetings Open Same Tab [PLAT-792]

### DIFF
--- a/website/static/js/meetings.js
+++ b/website/static/js/meetings.js
@@ -45,7 +45,7 @@ function Meetings(data) {
                     data : 'name',  // Data field name
                     sortInclude : true,
                     filter : true,
-                    custom : function() { return m('a', { href : item.data.url, target : '_blank' }, item.data.name ); }
+                    custom : function() { return m('a', { href : item.data.url }, item.data.name ); }
 
                 },
                 {

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -53,13 +53,13 @@ function Submissions(data) {
                     sortInclude : true,
                     filter : true,
                     custom : function() {
-                        return m('a', { href : item.data.nodeUrl, target : '_blank' }, item.data.title ); }
+                        return m('a', { href : item.data.nodeUrl }, item.data.title ); }
 
                 },
                 {
                     data: 'author',  // Data field name
                     sortInclude: true,
-                    custom: function() { return m('a', {href: item.data.authorUrl, target : '_blank'}, item.data.author); },
+                    custom: function() { return m('a', { href: item.data.authorUrl }, item.data.author); },
                     filter : true
                 },
                 {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently both meetings and the projects within them open in new tabs when clicked on OSF for Meetings. Would be great for it to all stay in the same browser window.  Internal links aren't usually expected to open in new tabs (confirmed this with Product)

## Changes

- Meeting links open in same browser window.
- Submission links open in same browser window.
- Submission author links open in same browser window (went ahead and added, so links would behave same as above item)

## QA Notes

- Verify changes listed above.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-792