### PR TITLE
Feature/Generalize Metaschemas API [PLAT-816]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -413,7 +413,7 @@ def root(request, format=None, **kwargs):
             'registrations': utils.absolute_reverse('registrations:registration-list', kwargs=kwargs),
             'institutions': utils.absolute_reverse('institutions:institution-list', kwargs=kwargs),
             'licenses': utils.absolute_reverse('licenses:license-list', kwargs=kwargs),
-            'metaschemas': utils.absolute_reverse('metaschemas:metaschema-list', kwargs=kwargs),
+            'metaschemas': utils.absolute_reverse('metaschemas:registration-metaschema-list', kwargs=kwargs),
             'addons': utils.absolute_reverse('addons:addon-list', kwargs=kwargs),
         }
     }

--- a/api/metaschemas/serializers.py
+++ b/api/metaschemas/serializers.py
@@ -21,3 +21,9 @@ class MetaSchemaSerializer(JSONAPISerializer):
 
     class Meta:
         type_ = 'metaschemas'
+
+
+class RegistrationMetaSchemaSerializer(MetaSchemaSerializer):
+
+    class Meta:
+        type_ = 'registration_metaschemas'

--- a/api/metaschemas/urls.py
+++ b/api/metaschemas/urls.py
@@ -5,6 +5,8 @@ from api.metaschemas import views
 app_name = 'osf'
 
 urlpatterns = [
-    url(r'^$', views.MetaSchemasList.as_view(), name=views.MetaSchemasList.view_name),
-    url(r'^(?P<metaschema_id>\w+)/$', views.MetaSchemaDetail.as_view(), name=views.MetaSchemaDetail.view_name)
+    url(r'^$', views.DeprecatedMetaSchemasList.as_view(), name=views.DeprecatedMetaSchemasList.view_name),
+    url(r'^registrations/$', views.RegistrationMetaschemaList.as_view(), name=views.RegistrationMetaschemaList.view_name),
+    url(r'^(?P<metaschema_id>\w+)/$', views.DeprecatedMetaSchemaDetail.as_view(), name=views.DeprecatedMetaSchemaDetail.view_name),
+    url(r'^registrations/(?P<metaschema_id>\w+)/$', views.RegistrationMetaschemaDetail.as_view(), name=views.RegistrationMetaschemaDetail.view_name),
 ]

--- a/api/metaschemas/views.py
+++ b/api/metaschemas/views.py
@@ -8,7 +8,7 @@ from api.base.views import JSONAPIBaseView
 from api.base.utils import get_object_or_error
 
 from osf.models import MetaSchema
-from api.metaschemas.serializers import MetaSchemaSerializer
+from api.metaschemas.serializers import MetaSchemaSerializer, RegistrationMetaSchemaSerializer
 
 
 class RegistrationMetaschemaList(JSONAPIBaseView, generics.ListAPIView):
@@ -23,7 +23,7 @@ class RegistrationMetaschemaList(JSONAPIBaseView, generics.ListAPIView):
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
-    serializer_class = MetaSchemaSerializer
+    serializer_class = RegistrationMetaSchemaSerializer
     view_category = 'registration-metaschemas'
     view_name = 'registration-metaschema-list'
 
@@ -45,7 +45,7 @@ class RegistrationMetaschemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     required_read_scopes = [CoreScopes.METASCHEMA_READ]
     required_write_scopes = [CoreScopes.NULL]
 
-    serializer_class = MetaSchemaSerializer
+    serializer_class = RegistrationMetaSchemaSerializer
     view_category = 'registration-metaschemas'
     view_name = 'registration-metaschema-detail'
 

--- a/api/metaschemas/views.py
+++ b/api/metaschemas/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics, permissions as drf_permissions
-
+from api.base.views import DeprecatedView
 from framework.auth.oauth_scopes import CoreScopes
 
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
@@ -11,7 +11,7 @@ from osf.models import MetaSchema
 from api.metaschemas.serializers import MetaSchemaSerializer
 
 
-class MetaSchemasList(JSONAPIBaseView, generics.ListAPIView):
+class RegistrationMetaschemaList(JSONAPIBaseView, generics.ListAPIView):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/metaschemas_list).
 
     """
@@ -24,8 +24,8 @@ class MetaSchemasList(JSONAPIBaseView, generics.ListAPIView):
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
     serializer_class = MetaSchemaSerializer
-    view_category = 'metaschemas'
-    view_name = 'metaschema-list'
+    view_category = 'registration-metaschemas'
+    view_name = 'registration-metaschema-list'
 
     ordering = ('-id',)
 
@@ -34,9 +34,8 @@ class MetaSchemasList(JSONAPIBaseView, generics.ListAPIView):
         return MetaSchema.objects.filter(schema_version=LATEST_SCHEMA_VERSION, active=True)
 
 
-class MetaSchemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
+class RegistrationMetaschemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/metaschemas_read).
-
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
@@ -47,10 +46,28 @@ class MetaSchemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     required_write_scopes = [CoreScopes.NULL]
 
     serializer_class = MetaSchemaSerializer
-    view_category = 'metaschemas'
-    view_name = 'metaschema-detail'
+    view_category = 'registration-metaschemas'
+    view_name = 'registration-metaschema-detail'
 
     # overrides RetrieveAPIView
     def get_object(self):
         schema_id = self.kwargs['metaschema_id']
         return get_object_or_error(MetaSchema, schema_id, self.request)
+
+
+class DeprecatedMetaSchemasList(DeprecatedView, RegistrationMetaschemaList):
+    """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/metaschemas_list).
+    """
+    max_version = '2.7'
+    view_category = 'metaschemas'
+    view_name = 'metaschema-list'
+    serializer_class = MetaSchemaSerializer
+
+
+class DeprecatedMetaSchemaDetail(DeprecatedView, RegistrationMetaschemaDetail):
+    """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/metaschemas_read).
+    """
+    max_version = '2.7'
+    view_category = 'metaschemas'
+    view_name = 'metaschema-detail'
+    serializer_class = MetaSchemaSerializer

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1134,7 +1134,7 @@ class DraftRegistrationSerializer(JSONAPISerializer):
     )
 
     registration_schema = RelationshipField(
-        related_view='metaschemas:metaschema-detail',
+        related_view='metaschemas:registration-metaschema-detail',
         related_view_kwargs={'metaschema_id': '<registration_schema._id>'}
     )
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -163,7 +163,7 @@ class BaseRegistrationSerializer(NodeSerializer):
     ))
 
     registration_schema = RelationshipField(
-        related_view='metaschemas:metaschema-detail',
+        related_view='metaschemas:registration-metaschema-detail',
         related_view_kwargs={'metaschema_id': '<registered_schema_id>'}
     )
 

--- a/api_tests/metaschemas/views/test_registration_metaschemas_detail.py
+++ b/api_tests/metaschemas/views/test_registration_metaschemas_detail.py
@@ -19,7 +19,7 @@ class TestMetaSchemaDetail:
             schema_version=LATEST_SCHEMA_VERSION).first()
 
         # test_pass_authenticated_user_can_retrieve_schema
-        url = '/{}metaschemas/{}/'.format(API_BASE, schema._id)
+        url = '/{}metaschemas/registrations/{}/'.format(API_BASE, schema._id)
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
         data = res.json['data']['attributes']
@@ -35,7 +35,7 @@ class TestMetaSchemaDetail:
         # test_inactive_metaschema_returned
         inactive_schema = MetaSchema.objects.get(
             name='Election Research Preacceptance Competition', active=False)
-        url = '/{}metaschemas/{}/'.format(API_BASE, inactive_schema._id)
+        url = '/{}metaschemas/registrations/{}/'.format(API_BASE, inactive_schema._id)
         res = app.get(url)
         assert res.status_code == 200
         assert res.json['data']['attributes']['name'] == 'Election Research Preacceptance Competition'
@@ -45,13 +45,13 @@ class TestMetaSchemaDetail:
         old_schema = MetaSchema.objects.get(
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=1)
-        url = '/{}metaschemas/{}/'.format(API_BASE, old_schema._id)
+        url = '/{}metaschemas/registrations/{}/'.format(API_BASE, old_schema._id)
         res = app.get(url)
         assert res.status_code == 200
         assert res.json['data']['attributes']['name'] == 'OSF-Standard Pre-Data Collection Registration'
         assert res.json['data']['attributes']['schema_version'] == 1
 
         # test_invalid_metaschema_not_found
-        url = '/{}metaschemas/garbage/'.format(API_BASE)
+        url = '/{}metaschemas/registrations/garbage/'.format(API_BASE)
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 404

--- a/api_tests/metaschemas/views/test_registration_metaschemas_list.py
+++ b/api_tests/metaschemas/views/test_registration_metaschemas_list.py
@@ -14,7 +14,7 @@ class TestMetaSchemaList:
     def test_metaschemas_list_crud(self, app):
 
         user = AuthUserFactory()
-        url = '/{}metaschemas/'.format(API_BASE)
+        url = '/{}metaschemas/registrations/'.format(API_BASE)
 
         # test_pass_authenticated_user_can_view_schemas
         res = app.get(url, auth=user.auth)

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -52,7 +52,7 @@ class MetaSchema(ObjectIDMixin, BaseModel):
 
     @property
     def absolute_api_v2_url(self):
-        path = '/metaschemas/{}/'.format(self._id)
+        path = '/metaschemas/registrations/{}/'.format(self._id)
         return api_v2_url(path)
 
     @classmethod


### PR DESCRIPTION
## Purpose

To allow for `metaschemas/files`, metaschemas endpoint needs to be generalized for different types of metaschemas. Move /v2/metaschemas/ to /v2/metaschemas/registrations/.


❗️ Relies on feature in release/next-interfaces, so pointed to this branch for now.

## Changes

- ADD /v2/metaschemas/registrations/
- ADD /v2/metaschemas/registrations/<metaschema_id>
- DEPRECATE /v2/metaschemas/<metaschema_id>/ (Behaves exactly the same as before, except the response includes a warning in /meta/warnings/)
- DEPRECATE /v2/metaschemas/ ( Behaves exactly the same as before, except the response includes a warning in /meta/warnings)
- Update relationship links that point to metaschemas

## QA Notes
Don't know if there are any automated tests that need to be updated... `/metaschemas` has moved to `/metaschemas/registrations`, and `metaschemas/metaschema_id` has moved to `metaschemas/registrations/<metaschema_id>`.  Old endpoints have deprecation warnings.

## Documentation

PR added here: https://github.com/CenterForOpenScience/developer.osf.io/pull/17

## Side Effects

None, deprecated endpoints still work for now, just shows warnings.

## Ticket

https://openscience.atlassian.net/browse/PLAT-816
