### PR TITLE
Feature/Return User Profile Info in the API [PLAT-817]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -53,6 +53,8 @@ class UserSerializer(JSONAPISerializer):
     timezone = HideIfDisabled(ser.CharField(required=False, help_text="User's timezone, e.g. 'Etc/UTC"))
     locale = HideIfDisabled(ser.CharField(required=False, help_text="User's locale, e.g.  'en_US'"))
     social = ListDictField(required=False)
+    jobs = ser.ListField(child=ser.DictField(), read_only=True)
+    schools = ser.ListField(child=ser.DictField(), read_only=True)
     can_view_reviews = ShowIfCurrentUser(ser.SerializerMethodField(help_text='Whether the current user has the `view_submissions` permission to ANY reviews provider.'))
 
     links = HideIfDisabled(LinksField(

--- a/api_tests/users/serializers/test_serializers.py
+++ b/api_tests/users/serializers/test_serializers.py
@@ -1,0 +1,56 @@
+import pytest
+
+from api.users.serializers import UserSerializer
+from osf_tests.factories import (
+    AuthUserFactory,
+)
+from tests.utils import make_drf_request_with_version
+
+
+@pytest.fixture()
+def user():
+    user = AuthUserFactory()
+    user.jobs = [{
+        'title': 'Veterinarian/Owner',
+        'ongoing': True,
+        'startYear': '2009',
+        'startMonth': 4,
+        'institution': 'Happy Paws Vet'
+    }]
+    user.schools = [{
+        'endYear': '1994',
+        'ongoing': False,
+        'endMonth': 6,
+        'startYear': '1990',
+        'department': 'Veterinary Medicine',
+        'startMonth': 8,
+        'institution': 'UC Davis'
+    }]
+    return user.save()
+
+
+@pytest.mark.django_db
+class TestUserSerializer:
+
+    def test_user_serializer(self, user):
+        req = make_drf_request_with_version(version='2.7')
+        result = UserSerializer(user, context={'request': req}).data
+        data = result['data']
+        assert data['id'] == user._id
+        assert data['type'] == 'users'
+
+        # Attributes
+        attributes = data['attributes']
+        assert attributes['family_name'] == user.family_name
+        assert attributes['given_name'] == user.given_name
+        assert attributes['active'] == user.active
+        assert attributes['jobs'] == user.jobs
+        assert attributes['schools'] == user.schools
+
+        # Relationships
+        relationships = data['relationships']
+        assert 'quickfiles' in relationships
+        assert 'nodes' in relationships
+        assert 'institutions' in relationships
+        assert 'preprints' in relationships
+        assert 'registrations' in relationships


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Embosf needs more user fields to complete the contributors page.
## Changes
- Return jobs and schools when serializing a user in V2
- Adds small user serializer test

<img width="537" alt="screen shot 2018-05-01 at 8 39 44 am" src="https://user-images.githubusercontent.com/9755598/39486090-99827aec-4d40-11e8-91ac-97d61b422cc4.png">


## QA Notes
Add school/employment info to users on settings page, verify these show in the API.

## Documentation

Attributes specifically stated to not need documentation.

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/projects/PLAT/issues/PLAT-817
