### PR TITLE
[Hotfix][PLAT-822] Stop sending prereg reminder emails on deleted projects

### DIFF
--- a/osf_tests/test_remind_draft_preregistrations.py
+++ b/osf_tests/test_remind_draft_preregistrations.py
@@ -44,6 +44,23 @@ class TestPreregReminder:
 
         assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 1
 
+    def test_dont_trigger_if_node_deleted(self, draft):
+        draft.branched_from.is_deleted = True
+        draft.branched_from.save()
+        main(dry_run=False)
+
+        assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 0
+
+    def test_dequeue_if_node_deleted(self, draft):
+        main(dry_run=False)
+        assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 1
+
+        draft.branched_from.is_deleted = True
+        draft.branched_from.save()
+
+        main(dry_run=False)
+        assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 0
+
     def test_dont_trigger_prereg_reminder_too_new(self, schema):
         DraftRegistrationFactory(registration_schema=schema)
         main(dry_run=False)


### PR DESCRIPTION
## Purpose

Currently if you create a preregistration draft, but don't finish it you get a reminder email prompting you to complete it. The problem is if you delete the project in the mean time, you still get the reminder email. This fix removes the email from the queue if you delete the project.

## Changes

- Dequeues emails from deleted projects
- Adds tests

## QA Notes

The ideal way to test this would be to create a prereg draft, delete it's project and wait 2 week to see if you get a reminder email, but obviously that isn't practical. Devs who want to test this should be able to in the shell or can just run the unit tests.

## Documentation

Bug fix not necessary.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-822