### PR TITLE
[Hotfix] never send custom domains to Ember

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -129,7 +129,6 @@ def serialize_node_summary(node, auth, primary=True, show_path=False):
 
     return summary
 
-@ember_flag_is_active('ember_home_page')
 def index():
     try:  # Check if we're on an institution landing page
         #TODO : make this way more robust
@@ -145,6 +144,10 @@ def index():
     except Institution.DoesNotExist:
         pass
 
+    return home()
+
+@ember_flag_is_active('ember_home_page')
+def home():
     user_id = get_current_user_id()
     if user_id:  # Logged in: return either landing page or user home page
         all_institutions = (


### PR DESCRIPTION
## Purpose

`ember-osf-web` does not yet support custom domains (nor even institutions), so we shouldn't send them to it.

## Changes

Separate the custom domain handling from the legacy home page and only decorate the legacy home page func.

## QA Notes

Make sure this works for custom domains, e.g. https://staging-osf-nd.cos.io

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a
