### PR TITLE
Cleanup extra call from bad merge

### DIFF
--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -64,17 +64,6 @@ def _async_update_preprint_share(self, preprint_id, old_subjects, share_type):
     data = serialize_share_preprint_data(preprint, share_type, old_subjects)
     resp = send_share_preprint_data(preprint, data)
     try:
-        resp = requests.post('{}api/v2/normalizeddata/'.format(settings.SHARE_URL), json={
-            'data': {
-                'type': 'NormalizedData',
-                'attributes': {
-                    'tasks': [],
-                    'raw': None,
-                    'data': {'@graph': format_preprint(preprint, share_type, old_subjects)}
-                }
-            }
-        }, headers={'Authorization': 'Bearer {}'.format(preprint.provider.access_token), 'Content-Type': 'application/vnd.api+json'})
-        logger.debug(resp.content)
         resp.raise_for_status()
     except Exception as e:
         if resp.status_code >= 500:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
A bad merge conflict fix (my fault) caused calls to share to dupe if the first call raised a 500 error. 
The removed part was moved to a function but got resurrected. 
<!-- Describe the purpose of your changes -->

## Changes
Excise dupe code.
<!-- Briefly describe or list your changes  -->

## QA Notes
Not really testable. If we really want to test it, share needs to raise a 500, then check to make sure the call for that preprint only showed up once. IMHO not worth worrying about.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
No
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
None known
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/IN-296
