### PR TITLE
Show better error message when a user tries to use a blacklisted domain [PLAT-785]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -28,7 +28,7 @@ from osf.models import OSFUser
 from osf.utils.sanitize import strip_html
 from website import settings, mails, language
 from website.util import web_url_for
-from osf.exceptions import ValidationValueError
+from osf.exceptions import ValidationValueError, BlacklistedEmailError
 from osf.models.provider import PreprintProvider
 from osf.utils.requests import check_select_for_update
 
@@ -828,6 +828,11 @@ def register_user(**kwargs):
                     email=markupsafe.escape(request.json['email1'])
                 )
             )
+        )
+    except BlacklistedEmailError as e:
+        raise HTTPError(
+            http.BAD_REQUEST,
+            data=dict(message_long=language.BLACKLISTED_EMAIL)
         )
     except ValidationError as e:
         raise HTTPError(

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -108,3 +108,10 @@ class InvalidTriggerError(Exception):
 class InvalidTransitionError(Exception):
     def __init__(self, machine, transition):
         self.message = 'Machine "{}" received invalid transitions: "{}" expected but not defined'.format(machine, transition)
+
+
+class BlacklistedEmailError(OSFError):
+    """Raised if a user tries to register an email that is included
+    in the blacklisted domains list
+    """
+    pass

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -822,7 +822,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     @classmethod
     def create(cls, username, password, fullname):
-        validate_email(username)  # Raises ValidationError if spam address
+        validate_email(username)  # Raises BlacklistedEmailError if spam address
 
         user = cls(
             username=username,

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -9,7 +9,7 @@ from website.notifications.constants import NOTIFICATION_TYPES
 from website import settings
 
 from osf.utils.sanitize import strip_html
-from osf.exceptions import ValidationError, ValidationValueError, reraise_django_validation_errors
+from osf.exceptions import ValidationError, ValidationValueError, reraise_django_validation_errors, BlacklistedEmailError
 
 
 def validate_history_item(items):
@@ -92,7 +92,8 @@ def validate_email(value):
     with reraise_django_validation_errors():
         django_validate_email(value)
     if value.split('@')[1].lower() in settings.BLACKLISTED_DOMAINS:
-        raise ValidationError('Invalid Email')
+        raise BlacklistedEmailError('Invalid Email')
+
 
 def validate_subject_highlighted_count(provider, is_highlighted_addition):
     if is_highlighted_addition and provider.subjects.filter(highlighted=True).count() >= 10:

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -28,7 +28,7 @@ from website.views import find_bookmark_collection
 from osf.models import AbstractNode, OSFUser, Tag, Contributor, Session
 from framework.auth.core import Auth
 from osf.utils.names import impute_names_model
-from osf.exceptions import ValidationError
+from osf.exceptions import ValidationError, BlacklistedEmailError
 
 from .utils import capture_signals
 from .factories import (
@@ -230,7 +230,7 @@ class TestOSFUser:
             u.save()
 
     def test_add_blacklisted_domain_unconfirmed_email(self, user):
-        with pytest.raises(ValidationError) as e:
+        with pytest.raises(BlacklistedEmailError) as e:
             user.add_unconfirmed_email('kanye@mailinator.com')
         assert e.value.message == 'Invalid Email'
 

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -15,6 +15,7 @@ from framework.auth import get_or_create_user
 from framework.auth.core import Auth
 
 from osf.models import OSFUser, AbstractNode
+from osf.exceptions import BlacklistedEmailError
 from website import settings
 from website.conferences import views
 from website.conferences import utils, message
@@ -92,7 +93,7 @@ class TestConferenceUtils(OsfTestCase):
     def test_get_or_create_user_with_blacklisted_domain(self):
         fullname = 'Kanye West'
         username = 'kanye@mailinator.com'
-        with assert_raises(ValidationError) as e:
+        with assert_raises(BlacklistedEmailError) as e:
             get_or_create_user(fullname, username, is_spam=True)
         assert_equal(e.exception.message, 'Invalid Email')
 

--- a/website/language.py
+++ b/website/language.py
@@ -27,6 +27,8 @@ REGISTRATION_UNAVAILABLE = 'Registration currently unavailable.'
 
 ALREADY_REGISTERED = u'The email {email} has already been registered.'
 
+BLACKLISTED_EMAIL = 'Invalid email address. If this should not have occurred, please report this to {}.'.format(settings.OSF_SUPPORT_EMAIL)
+
 AFTER_SUBMIT_FOR_REVIEW = 'Your submission has been received. You will be notified within two business days regarding the status of your submission. If you have questions you may contact us at prereg@cos.io.'
 
 # Shown if user tries to login with an email that is not yet confirmed

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -23,9 +23,11 @@ from framework.status import push_status_message
 from framework.utils import throttle_period_expired
 
 from osf.models import ApiOAuth2Application, ApiOAuth2PersonalToken, OSFUser, QuickFilesNode
+from osf.exceptions import BlacklistedEmailError
 from website import mails
 from website import mailchimp_utils
 from website import settings
+from website import language
 from website.ember_osf_web.decorators import ember_flag_is_active
 from website.oauth.utils import get_available_scopes
 from website.profile import utils as profile_utils
@@ -142,6 +144,10 @@ def update_user(auth):
             except (ValidationError, ValueError):
                 raise HTTPError(http.BAD_REQUEST, data=dict(
                     message_long='Invalid Email')
+                )
+            except BlacklistedEmailError:
+                raise HTTPError(http.BAD_REQUEST, data=dict(
+                    message_long=language.BLACKLISTED_EMAIL)
                 )
 
             # TODO: This setting is now named incorrectly.


### PR DESCRIPTION

## Purpose
Before, the `validate_email` method would return a `ValidationError`, which made it hard to distinguish from other errors that inhereted from `ValidationError` such as `ValidationValueError`, which would raise the incorrect message with the "already registered" wording in the `register_user` api v1 route.

### On create account page:
<img width="637" alt="screen shot 2018-05-07 at 12 21 28 pm" src="https://user-images.githubusercontent.com/801594/39717550-a71e947c-5201-11e8-872a-428a436e7dfa.png">

### On user settings
<img width="908" alt="screen shot 2018-05-07 at 12 32 08 pm" src="https://user-images.githubusercontent.com/801594/39717553-a90455e2-5201-11e8-8dfa-10a1b496706e.png">


## Changes

- Change the error raised to a specific `BlacklistedEmailError` so that it can be caught uniquely and a full error message shown.
- Also throw/catch this exception when attempting to enter an alternate email on the profile settings page from the blacklisted domains list.
- Update tests to look for this specific exception

## QA Notes

To test this:
1. Try to sign up for the OSF with an email from [any of the blacklisted domains](https://github.com/CenterForOpenScience/osf.io/blob/1bda6e975c466d8cd4eabe25e198664aaa538314/website/settings/defaults.py#L683)
2. Try to add an alternate email on the profile settings page from one of those blacklisted domains.

In both cases, the error message should read: 
"Invalid email address. If this should not have occurred, please report this to <support email>."

## Documentation
none necessary

## Side Effects
None

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-785