### PR TITLE
[hotfix] Don't call check_spam if user cannot be loaded from request

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -160,7 +160,10 @@ class WikiVersion(ObjectIDMixin, BaseModel):
                 if isinstance(v, basestring)
             }
         user = OSFUser.load(user_id)
-        return self.wiki_page.node.check_spam(user, ['wiki_pages_latest'], request_headers)
+        if user:
+            return self.wiki_page.node.check_spam(user, ['wiki_pages_latest'], request_headers)
+        else:
+            return False
 
     def clone_version(self, wiki_page, user):
         """Clone a node wiki page.


### PR DESCRIPTION

## Purpose

<!-- Describe the purpose of your changes -->
Before 0.138, wiki spam cwas checked in Node.on_update, which
checks `if user` before calling `check_spam`.
WikiVersion.check_spam does NOT check `if user`, so the
`check_spam` call raises an error.

This is preventing some users' submissions to OSF4M.



## Changes

<!-- Briefly describe or list your changes  -->
Don't call `WikiVersion.check_spam` unless a user can be loaded from the request.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

Quick regression test to make sure OSF4M submission still works.


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->
This may not be the best long-term solution, but it's low-risk, and
this will at least allow prod users to submit to OSF4M. In the future, we may want to allow `check_spam` to work without a user.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
Sentry: https://sentry2.cos.io/cos/osf-back-end/issues/2892/
(no JIRA ticket)