### PR TITLE
[PLAT-783] Prevent accessing a deactivated users quickfiles

### DIFF
--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -44,6 +44,14 @@ class TestUserQuickFiles:
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
 
+    def test_deactivated_gets_410(self, app, url):
+        user = AuthUserFactory(is_disabled=True)
+        QuickFilesNode.objects.get(creator=user).save()
+        url = '/{}users/{}/quickfiles/'.format(API_BASE, user._id)
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 410
+        assert res.content_type == 'application/vnd.api+json'
+
     def test_get_files_logged_in(self, app, user, url):
         res = app.get(url, auth=user.auth)
         node_json = res.json['data']


### PR DESCRIPTION
## Purpose

When a user is deactivated their quickfiles remain public and open, this shuts that down on the back-end.

## Changes

- Adds check if user is active and calls it from the UserQuickfiles view.
- Adds tests.

## QA Notes

Deactivate a user through the admin app or shell and try to access their quickfiles. You should get something like the following via the API. 
<img width="1439" alt="screen shot 2018-05-07 at 5 37 54 pm" src="https://user-images.githubusercontent.com/9688518/39726556-6ae14c72-521d-11e8-96b9-a47b8bc56db1.png">

~The front end aspects will be covered by the Embosf team.~
Edit: the quickfiles page and files page (for a quickfile from a disabled user) show the appropriate "Page Not Found" template
![screen shot 2018-05-24 at 11 39 19 am](https://user-images.githubusercontent.com/7913604/40496208-3b864f40-5f47-11e8-8680-7348a5a6b292.png)


## Documentation

Doesn't really need any docs I can see.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-783