### PR TITLE
[EMB-281] Fix node-based waffle flags

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -21,13 +21,13 @@ from framework.exceptions import HTTPError
 from framework.flask import redirect  # VOL-aware redirect
 from framework.forms import utils as form_utils
 from framework.routing import proxy_url
-from framework.auth.core import get_current_user_id
+from framework.auth.core import get_current_user_id, _get_current_user
 from website import settings
 from website.institutions.views import serialize_institution
 
 from osf.models import BaseFileNode, Guid, Institution, PreprintService, AbstractNode, Node
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT, INSTITUTION_DISPLAY_NODE_THRESHOLD, DOMAIN
-from website.ember_osf_web.decorators import ember_flag_is_active
+from website.ember_osf_web.decorators import ember_flag_is_active, MockUser
 from website.ember_osf_web.views import use_ember_app
 from website.project.model import has_anonymous_link
 from osf.utils import permissions
@@ -36,6 +36,7 @@ from api.preprint_providers.permissions import GroupHelper
 logger = logging.getLogger(__name__)
 preprints_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['preprints']['path']))
 ember_osf_web_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['ember_osf_web']['path']))
+
 
 def serialize_contributors_for_summary(node, max_count=3):
     # # TODO: Use .filter(visible=True) when chaining is fixed in django-include
@@ -332,7 +333,10 @@ def resolve_guid(guid, suffix=None):
 
         if isinstance(referent, Node) and not referent.is_registration and suffix:
             page = suffix.strip('/').split('/')[0]
-            if waffle.flag_is_active(request, 'ember_project_{}_page'.format(page)):
+            flag_name = 'ember_project_{}_page'.format(page)
+            request.user = _get_current_user() or MockUser()
+
+            if waffle.flag_is_active(request, flag_name):
                 use_ember_app()
 
         url = _build_guid_url(urllib.unquote(referent.deep_url), suffix)


### PR DESCRIPTION
## Purpose

We fixed waffle flags for non-project pages, but that didn't transfer to projects. This applies that fix to project pages.

## Changes

Update the website view to get the current user or a mock user and inject that onto the request object.

## QA Notes

If the project_forks flag works with everybody turned to unknown, then this should be good.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

No more than we'll have for other flags, which is to say that I'm pretty sure that other Waffle features won't work on these pages (like waffling for different languages or anything like that). Any new waffle features we might want to try, which currently we have no plans for, will need to be tested before we can expect them to work.

## Ticket

https://openscience.atlassian.net/browse/EMB-281