### PR TITLE
[IN-297][OSF] Allow unregistered moderators to set password from invite email

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1284,7 +1284,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         # Create a new user record if you weren't passed an existing user
         contributor = existing_user if existing_user else OSFUser.create_unregistered(fullname=fullname, email=email)
 
-        contributor.add_unclaimed_record(node=self, referrer=auth.user,
+        contributor.add_unclaimed_record(self, referrer=auth.user,
                                          given_name=fullname, email=email)
         try:
             contributor.save()
@@ -1296,7 +1296,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 raise
 
             contributor.add_unclaimed_record(
-                node=self, referrer=auth.user, given_name=fullname, email=email
+                self, referrer=auth.user, given_name=fullname, email=email
             )
 
             contributor.save()

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -146,7 +146,7 @@ class PreprintProvider(AbstractProvider):
 
     @property
     def landing_url(self):
-        return self.domain if self.domain else '{}preprints/{}'.format(settings.DOMAIN, self.name.lower())
+        return self.domain if self.domain else '{}preprints/{}'.format(settings.DOMAIN, self._id)
 
     def get_absolute_url(self):
         return '{}preprint_providers/{}'.format(self.absolute_api_v2_url, self._id)

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -9,6 +9,7 @@ from os.path import splitext
 
 from flask import Request as FlaskRequest
 from framework import analytics
+from guardian.shortcuts import get_perms
 
 # OSF imports
 import itsdangerous
@@ -1333,20 +1334,29 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         """Returns number of "shared projects" (projects that both users are contributors for)"""
         return self._projects_in_common_query(other_user).count()
 
-    def add_unclaimed_record(self, node, referrer, given_name, email=None):
+    def add_unclaimed_record(self, claim_origin, referrer, given_name, email=None):
         """Add a new project entry in the unclaimed records dictionary.
 
-        :param Node node: Node this unclaimed user was added to.
+        :param object claim_origin: Object this unclaimed user was added to. currently `Node` or `Provider`
         :param User referrer: User who referred this user.
         :param str given_name: The full name that the referrer gave for this user.
         :param str email: The given email address.
         :returns: The added record
         """
-        if not node.can_edit(user=referrer):
-            raise PermissionsError(
-                'Referrer does not have permission to add a contributor to project {0}'.format(node._primary_key)
-            )
-        project_id = str(node._id)
+
+        from osf.models.provider import AbstractProvider
+        if isinstance(claim_origin, AbstractProvider):
+            if not bool(get_perms(referrer, claim_origin)):
+                raise PermissionsError(
+                    'Referrer does not have permission to add a moderator to provider {0}'.format(claim_origin._id)
+                )
+        else:
+            if not claim_origin.can_edit(user=referrer):
+                raise PermissionsError(
+                    'Referrer does not have permission to add a contributor to project {0}'.format(claim_origin._primary_key)
+                )
+
+        pid = str(claim_origin._id)
         referrer_id = str(referrer._id)
         if email:
             clean_email = email.lower().strip()
@@ -1354,7 +1364,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             clean_email = None
         verification_key = generate_verification_key(verification_type='claim')
         try:
-            record = self.unclaimed_records[node._id]
+            record = self.unclaimed_records[claim_origin._id]
         except KeyError:
             record = None
         if record:
@@ -1366,7 +1376,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             'expires': verification_key['expires'],
             'email': clean_email,
         }
-        self.unclaimed_records[project_id] = record
+        self.unclaimed_records[pid] = record
         return record
 
     def get_unclaimed_record(self, project_id):

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -39,6 +39,7 @@ from .factories import (
     ExternalAccountFactory,
     InstitutionFactory,
     NodeFactory,
+    PreprintProviderFactory,
     ProjectFactory,
     SessionFactory,
     TagFactory,
@@ -849,7 +850,24 @@ class TestUnregisteredUser:
     def unreg_user(self, referrer, project, email):
         user = UnregUserFactory()
         given_name = 'Fredd Merkury'
-        user.add_unclaimed_record(node=project,
+        user.add_unclaimed_record(project,
+            given_name=given_name, referrer=referrer,
+            email=email)
+        user.save()
+        return user
+
+    @pytest.fixture()
+    def provider(self, referrer):
+        provider = PreprintProviderFactory()
+        provider.add_to_group(referrer, 'moderator')
+        provider.save()
+        return provider
+
+    @pytest.fixture()
+    def unreg_moderator(self, referrer, provider, email):
+        user = UnregUserFactory()
+        given_name = 'Freddie Merkkury'
+        user.add_unclaimed_record(provider,
             given_name=given_name, referrer=referrer,
             email=email)
         user.save()
@@ -873,7 +891,8 @@ class TestUnregisteredUser:
         assert bool(u.password) is True
         assert len(u.email_verifications.keys()) == 1
 
-    def test_add_unclaimed_record(self, unreg_user, email, referrer, project):
+    def test_add_unclaimed_record(self, unreg_user, unreg_moderator, email, referrer, provider, project):
+        # test_unreg_contrib
         data = unreg_user.unclaimed_records[project._primary_key]
         assert data['name'] == 'Fredd Merkury'
         assert data['referrer_id'] == referrer._id
@@ -881,7 +900,16 @@ class TestUnregisteredUser:
         assert data['email'] == email
         assert data == unreg_user.get_unclaimed_record(project._primary_key)
 
-    def test_get_claim_url(self, unreg_user, project):
+        # test_unreg_moderator
+        data = unreg_moderator.unclaimed_records[provider._id]
+        assert data['name'] == 'Freddie Merkkury'
+        assert data['referrer_id'] == referrer._id
+        assert 'token' in data
+        assert data['email'] == email
+        assert data == unreg_moderator.get_unclaimed_record(provider._id)
+
+    def test_get_claim_url(self, unreg_user, unreg_moderator, project, provider):
+        # test_unreg_contrib
         uid = unreg_user._primary_key
         pid = project._primary_key
         token = unreg_user.get_unclaimed_record(pid)['token']
@@ -891,16 +919,37 @@ class TestUnregisteredUser:
             '{domain}user/{uid}/{pid}/claim/?token={token}'.format(**locals())
         )
 
-    def test_get_claim_url_raises_value_error_if_not_valid_pid(self, unreg_user):
+        # test_unreg_moderator
+        uid = unreg_moderator._id
+        pid = provider._id
+        token = unreg_moderator.get_unclaimed_record(pid)['token']
+        domain = settings.DOMAIN
+        assert (
+            unreg_moderator.get_claim_url(pid, external=True) ==
+            '{domain}user/{uid}/{pid}/claim/?token={token}'.format(**locals())
+        )
+
+    def test_get_claim_url_raises_value_error_if_not_valid_pid(self, unreg_user, unreg_moderator):
         with pytest.raises(ValueError):
             unreg_user.get_claim_url('invalidinput')
+            unreg_moderator.get_claim_url('invalidinput')
 
-    def test_cant_add_unclaimed_record_if_referrer_isnt_contributor(self, referrer, unreg_user):
-        project = NodeFactory()  # referrer isn't a contributor to this project
-        with pytest.raises(PermissionsError):
-            unreg_user.add_unclaimed_record(node=project,
+    def test_cant_add_unclaimed_record_if_referrer_has_no_permissions(self, referrer, unreg_moderator, unreg_user, provider):
+        # test_referrer_is_not_contrib
+        project = NodeFactory()
+        with pytest.raises(PermissionsError) as e:
+            unreg_user.add_unclaimed_record(project,
                 given_name='fred m', referrer=referrer)
             unreg_user.save()
+        assert e.value.message == 'Referrer does not have permission to add a contributor to project {}'.format(project._primary_key)
+
+        # test_referrer_is_not_admin_or_moderator
+        referrer = UserFactory()
+        with pytest.raises(PermissionsError) as e:
+            unreg_moderator.add_unclaimed_record(provider,
+                given_name='hodor', referrer=referrer)
+            unreg_user.save()
+        assert e.value.message == 'Referrer does not have permission to add a moderator to provider {}'.format(provider._id)
 
     @mock.patch('osf.models.OSFUser.update_search_nodes')
     @mock.patch('osf.models.OSFUser.update_search')
@@ -925,10 +974,16 @@ class TestUnregisteredUser:
         user.register(username=email, password='killerqueen')
         assert user.emails.filter(address=email).exists()
 
-    def test_verify_claim_token(self, unreg_user, project):
+    def test_verify_claim_token(self, unreg_user, unreg_moderator, project, provider):
+        # test_unreg_contrib
         valid = unreg_user.get_unclaimed_record(project._primary_key)['token']
         assert bool(unreg_user.verify_claim_token(valid, project_id=project._primary_key)) is True
         assert bool(unreg_user.verify_claim_token('invalidtoken', project_id=project._primary_key)) is False
+
+        # test_unreg_moderator
+        valid = unreg_moderator.get_unclaimed_record(provider._id)['token']
+        assert bool(unreg_moderator.verify_claim_token(valid, project_id=provider._id)) is True
+        assert bool(unreg_moderator.verify_claim_token('invalidtoken', project_id=provider._id)) is False
 
     def test_verify_claim_token_with_no_expiration_date(self, unreg_user, project):
         # Legacy records may not have an 'expires' key
@@ -1047,7 +1102,7 @@ class TestCitationProperties:
     @pytest.fixture()
     def unreg_user(self, referrer, project, email):
         user = UnregUserFactory()
-        user.add_unclaimed_record(node=project,
+        user.add_unclaimed_record(project,
             given_name=user.fullname, referrer=referrer,
             email=email)
         user.save()

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -122,7 +122,7 @@ class CitationsUserTestCase(OsfTestCase):
         referrer = UserFactory()
         project = NodeFactory(creator=referrer)
         user = UnregUserFactory()
-        user.add_unclaimed_record(node=project,
+        user.add_unclaimed_record(project,
             given_name=user.fullname, referrer=referrer,
             email=fake_email())
         user.save()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2434,7 +2434,7 @@ class TestClaimViews(OsfTestCase):
     def test_posting_to_claim_form_removes_all_unclaimed_data(self, mock_update_search_nodes):
         # user has multiple unclaimed records
         p2 = ProjectFactory(creator=self.referrer)
-        self.user.add_unclaimed_record(node=p2, referrer=self.referrer,
+        self.user.add_unclaimed_record(p2, referrer=self.referrer,
                                        given_name=fake.name())
         self.user.save()
         assert_true(len(self.user.unclaimed_records.keys()) > 1)  # sanity check

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -17,7 +17,7 @@ from framework.flask import redirect  # VOL-aware redirect
 from framework.sessions import session
 from framework.transactions.handlers import no_auto_transaction
 from framework.utils import get_timestamp, throttle_period_expired
-from osf.models import AbstractNode, OSFUser, PreprintService
+from osf.models import AbstractNode, OSFUser, PreprintService, PreprintProvider
 from osf.utils import sanitize
 from osf.utils.permissions import expand_permissions, ADMIN
 from website import mails, language, settings
@@ -183,7 +183,7 @@ def deserialize_contributors(node, user_dicts, auth, validate=False):
 
         # Add unclaimed record if necessary
         if not contributor.is_registered:
-            contributor.add_unclaimed_record(node=node, referrer=auth.user,
+            contributor.add_unclaimed_record(node, referrer=auth.user,
                 given_name=fullname,
                 email=email)
             contributor.save()
@@ -752,8 +752,8 @@ def claim_user_form(auth, **kwargs):
             # Authenticate user and redirect to project page
             status.push_status_message(language.CLAIMED_CONTRIBUTOR, kind='success', trust=True)
             # Redirect to CAS and authenticate the user with a verification key.
-            redirect_url = (web_url_for('resolve_guid', guid=pid, _absolute=True) if not pid.isalpha()
-                            else '{domain}reviews/preprints/{pid}'.format(domain=settings.DOMAIN, pid=pid))
+            provider = PreprintProvider.load(pid)
+            redirect_url = web_url_for('resolve_guid', guid=pid, _absolute=True) if provider is None else provider.landing_url
             return redirect(cas.get_login_url(
                 redirect_url,
                 username=user.username,

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -752,8 +752,10 @@ def claim_user_form(auth, **kwargs):
             # Authenticate user and redirect to project page
             status.push_status_message(language.CLAIMED_CONTRIBUTOR, kind='success', trust=True)
             # Redirect to CAS and authenticate the user with a verification key.
+            redirect_url = (web_url_for('resolve_guid', guid=pid, _absolute=True) if not pid.isalpha()
+                            else '{domain}reviews/preprints/{pid}'.format(domain=settings.DOMAIN, pid=pid))
             return redirect(cas.get_login_url(
-                web_url_for('resolve_guid', guid=pid, _absolute=True),
+                redirect_url,
                 username=user.username,
                 verification_key=user.verification_key
             ))

--- a/website/templates/emails/confirm_moderation.html.mako
+++ b/website/templates/emails/confirm_moderation.html.mako
@@ -7,7 +7,7 @@
     <br>
     You have been added by ${referrer.fullname}, as ${role} to ${provider.name}, powered by OSF. To set a password for your account, visit:<br>
     <br>
-    ${confirmation_url}<br>
+    ${claim_url}<br>
     <br>
     Once you have set a password you will be able to moderate submissions and create your own ${provider.preprint_word}. You will automatically be subscribed to notification emails for new ${provider.preprint_word} submissions to ${provider.name}. To change your email notification preferences, visit your notification settings: ${notification_url}<br>
     <br>


### PR DESCRIPTION
## Purpose

Allow unregistered moderators to set password from invite email

## Changes

- Generalize `add_unclaimed_record` method to handle both unregistered `contributor` and `moderator`
- Generalize `claim_user_form` to allow/handle redirects to provider's reviews or node pages.

## QA Notes

## Documentation

## Side Effects

## Ticket

[[IN-297]](https://openscience.atlassian.net/browse/IN-297)
