### PR TITLE
[SVCS-812] Disable Institution Login for Ferris State University

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -217,7 +217,7 @@ def main(env):
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
                 'domains': [],
                 'email_domains': [],
-                'delegation_protocol': 'cas-pac4j',
+                'delegation_protocol': '',
             },
             {
                 '_id': 'fsu',
@@ -793,7 +793,7 @@ def main(env):
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
                 'domains': [],
                 'email_domains': [],
-                'delegation_protocol': 'cas-pac4j',
+                'delegation_protocol': '',
             },
             {
                 '_id': 'fsu',


### PR DESCRIPTION
## Purpose

Ferris State University have decided to abandon CAS protocol and use SAML2 for institution login. For now, disable institution login for Ferris until they are ready.

## Changes

Set `delegation_protocol` to the empty string `''` so that CAS no longer pulls Ferris from the database.

## QA Notes

NotQATeam

## Documentation

No

## Side Effects

CAS PR: https://github.com/CenterForOpenScience/cas-overlay/pull/106

## Ticket

https://openscience.atlassian.net/browse/SVCS-812
