### PR TITLE
[IN-148][OSF] Fix reviews status update emails

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1478,7 +1478,7 @@ class TestSendEmails(NotificationTestCase):
         emails.notify_mentions('global_mentions', user=user, node=node, timestamp=time_now, new_mentions=[user._id])
         assert_true(mock_store.called)
         mock_store.assert_called_with([node.creator._id], 'email_transactional', 'global_mentions', user,
-                                      node, time_now, None, new_mentions=[node.creator._id], is_creator=(user == node.creator))
+                                      node, time_now, template=None, new_mentions=[node.creator._id], is_creator=(user == node.creator))
 
     @mock.patch('website.notifications.emails.store_emails')
     def test_notify_sends_comment_reply_event_if_comment_is_direct_reply(self, mock_store):

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -66,7 +66,7 @@ def notify_global_event(event, sender_user, node, timestamp, recipients, templat
         context['is_creator'] = recipient == node.creator
         for notification_type in subscriptions:
             if (notification_type != 'none' and subscriptions[notification_type] and recipient._id in subscriptions[notification_type]):
-                store_emails([recipient._id], notification_type, event, sender_user, node, timestamp, template, **context)
+                store_emails([recipient._id], notification_type, event, sender_user, node, timestamp, template=template, **context)
                 sent_users.append(recipient._id)
 
     return sent_users

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -8,7 +8,7 @@
                 <p>Hello ${recipient.fullname},</p>
                 <p>
                 % if workflow == 'pre-moderation':
-                    Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has
+                    Your submission <a href="${reviewable.absolute_url}">${reviewable.node.title}</a>, submitted to ${reviewable.provider.name} has
                     % if is_rejected:
                         not been accepted. Contributors with admin permissions may edit the ${reviewable.provider.preprint_word} and
                         resubmit, at which time it will return to a pending state and be reviewed by a moderator.


### PR DESCRIPTION
## Purpose

Fix reviews status update emails

## Changes

- Make template a keyword arguments.
- Use preprint/submission url.

## QA Notes

## Documentation

## Side Effects

## Ticket

[[IN-48]](https://openscience.atlassian.net/browse/IN-48)