### PR TITLE
Refactor ember-osf-web asset routing

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -58,6 +58,7 @@ from website.identifiers import views as identifier_views
 from website.ember_osf_web.decorators import ember_flag_is_active
 from website.settings import EXTERNAL_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
+EMBER_ASSET_ROUTE_PREFIXES = ['assets', 'engines-dist', 'fonts', 'img']
 
 def set_status_message(user):
     if user and not user.accepted_terms_of_service:
@@ -226,13 +227,13 @@ def ember_app(path=None):
         if request.path.strip('/').startswith(k):
             ember_app = EXTERNAL_EMBER_APPS[k]
             break
-        if 'asset_prefixes' in EXTERNAL_EMBER_APPS[k]:
-            for asset_prefix in EXTERNAL_EMBER_APPS[k]['asset_prefixes']:
-                if request.path.strip('/').startswith(asset_prefix):
-                    ember_app = EXTERNAL_EMBER_APPS[k]
-                    strip_prefix = False
-                    fp = asset_prefix + '/' + fp
-                    break
+
+    for asset_prefix in EMBER_ASSET_ROUTE_PREFIXES:
+        if request.path.strip('/').startswith(asset_prefix) and EXTERNAL_EMBER_APPS.get('ember_osf_web'):
+            ember_app = EXTERNAL_EMBER_APPS['ember_osf_web']
+            strip_prefix = False
+            fp = asset_prefix + '/' + fp
+            break
 
     if not ember_app:
         raise HTTPError(http.NOT_FOUND)
@@ -364,13 +365,7 @@ def make_url_map(app):
                     notemplate
                 )
             ])
-            EXTERNAL_EMBER_APPS['ember_osf_web']['asset_prefixes'] = [
-                'assets',
-                'fonts',
-                'img',
-                'engines-dist',
-            ]
-            for asset_prefix in EXTERNAL_EMBER_APPS['ember_osf_web']['asset_prefixes']:
+            for asset_prefix in EMBER_ASSET_ROUTE_PREFIXES:
                 process_rules(app, [
                     Rule(
                         '/<path:path>',

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -35,7 +35,11 @@ LIVE_RELOAD_DOMAIN = 'http://{}:4200'.format(EMBER_DOMAIN)  # Change port for th
 EXTERNAL_EMBER_APPS = {
     'ember_osf_web': {
         'server': 'http://{}:4200/'.format(EMBER_DOMAIN),
-        'path': '/ember_osf_web/'
+        'path': '/ember_osf_web/',
+        'routes': [
+            'collections',
+            'handbook',
+        ],
     },
     'preprints': {
         'server': 'http://{}:4201/'.format(EMBER_DOMAIN),


### PR DESCRIPTION
## Purpose

Allow `ember-osf-web` assets to be served from `/assets/` and add simple way to add extra routes.
(assets served from `/ember_osf_web/assets/` will continue to work)

## Changes

* Refactor flask routing to automatically add routes for Ember asset prefixes when `ember_osf_web` external ember app is defined.
* Add optional `routes` config key to list extra routes for `ember_osf_web`.

## QA Notes

Should only affect development environments.

## Documentation

Not at this time.

## Side Effects

n/a

## Ticket

n/a
