### PR TITLE
Hotfix/Bulk Delete Nodes APIV2 - Previously Deleted Components [PLAT-859]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -275,7 +275,8 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
         id_list = [x.id for x in resource_object_list]
 
         if NodeRelation.objects.filter(
-            parent__in=resource_object_list
+            parent__in=resource_object_list,
+            child__is_deleted=False
         ).exclude(child__in=resource_object_list, is_node_link=False).exists():
             raise ValidationError('Any child components must be deleted prior to deleting this project.')
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -2983,6 +2983,25 @@ class TestNodeBulkDelete:
             url, new_payload, auth=user_one.auth, bulk=True)
         assert res.status_code == 204
 
+    # Regression test for PLAT-859
+    def test_bulk_delete_project_with_already_deleted_component(
+            self, app, user_one,
+            public_project_parent,
+            public_project_one,
+            public_component, url):
+
+        public_component.is_deleted = True
+        public_component.save()
+
+        new_payload = {'data': [
+            {'id': public_project_parent._id, 'type': 'nodes'},
+            {'id': public_project_one._id, 'type': 'nodes'}
+        ]}
+
+        res = app.delete_json_api(
+            url, new_payload, auth=user_one.auth, bulk=True)
+        assert res.status_code == 204
+
 
 @pytest.mark.django_db
 class TestNodeBulkDeleteSkipUneditable:


### PR DESCRIPTION
## Purpose

When attempting to delete a project with child components a user will select all of the components, usually by clicking the "select all" button, and then proceed to the deletion confirmation screen. After correctly entering the challenge name the user will then receive the error message that all child components need to be deleted before the project can be deleted. Screenshots attached to show the project structure with all components selected and the resulting error message.

## Changes

Changes to NodeRelation query where bulk deleting nodes in APIv2.  Make sure previously deleted NodeRelations don't appear in query.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-859