### PR TITLE
[feature fix] Fix branded preprint logos in emails [PLAT-338]

### DIFF
--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -215,7 +215,7 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMi
             logo = settings.OSF_PREPRINTS_LOGO
         else:
             email_template = getattr(mails, 'PREPRINT_CONFIRMATION_BRANDED')(self.provider)
-            logo = self.provider.name
+            logo = self.provider._id
 
         mails.send_mail(
             auth.user.username,

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -464,7 +464,7 @@ def send_claim_email(email, unclaimed_user, node, notify=True, throttle=24 * 360
             if preprint_provider._id == 'osf':
                 logo = settings.OSF_PREPRINTS_LOGO
             else:
-                logo = 'preprints_assets/{}/wide_white'.format(preprint_provider._id)
+                logo = preprint_provider._id
         else:
             mail_tpl = getattr(mails, 'INVITE_DEFAULT'.format(email_template.upper()))
 
@@ -549,7 +549,7 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
             if preprint_provider._id == 'osf':
                 logo = settings.OSF_PREPRINTS_LOGO
             else:
-                logo = 'preprints_assets/{}/wide_white'.format(preprint_provider._id)
+                logo = preprint_provider._id
         elif email_template == 'access_request':
             mimetype = 'html'
             email_template = getattr(mails, 'CONTRIBUTOR_ADDED_ACCESS_REQUEST'.format(email_template.upper()))

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1897,9 +1897,6 @@ OSF_PREREG_LOGO = 'osf_prereg'
 OSF_REGISTRIES_LOGO = 'osf_registries'
 OSF_LOGO_LIST = [OSF_LOGO, OSF_PREPRINTS_LOGO, OSF_MEETINGS_LOGO, OSF_PREREG_LOGO, OSF_REGISTRIES_LOGO]
 
-#osf-assets-hash
-OSF_ASSETS_COMMIT_HASH = 'b4f8acda9d0667360528ccc77815034c26a6d382'
-
 FOOTER_LINKS = {
     'terms': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md',
     'privacyPolicy': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md',

--- a/website/templates/emails/file_operation_failed.html.mako
+++ b/website/templates/emails/file_operation_failed.html.mako
@@ -23,7 +23,7 @@
                                 <tr>
                                     <td style="border-collapse: collapse;">
                                         % if context.get('logo', settings.OSF_LOGO) not in settings.OSF_LOGO_LIST:
-                                            <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/${settings.OSF_ASSETS_COMMIT_HASH}/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
+                                            <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/master/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                         %else:
                                             <img src="https://osf.io/static/img/${context.get('logo', settings.OSF_LOGO)}.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                         % endif

--- a/website/templates/emails/file_operation_success.html.mako
+++ b/website/templates/emails/file_operation_success.html.mako
@@ -23,7 +23,7 @@
                                 <tr>
                                     <td style="border-collapse: collapse;">
                                         % if context.get('logo', settings.OSF_LOGO) not in settings.OSF_LOGO_LIST:
-                                            <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/${settings.OSF_ASSETS_COMMIT_HASH}/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
+                                            <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/master/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                         %else:
                                             <img src="https://osf.io/static/img/${context.get('logo', settings.OSF_LOGO)}.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                         % endif

--- a/website/templates/emails/notify_base.mako
+++ b/website/templates/emails/notify_base.mako
@@ -22,7 +22,7 @@
                                     <tr>
                                         <td style="border-collapse: collapse;">
                                             % if context.get('logo', settings.OSF_LOGO) not in settings.OSF_LOGO_LIST:
-                                                <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/${settings.OSF_ASSETS_COMMIT_HASH}/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
+                                                <img src="https://raw.githubusercontent.com/CenterForOpenScience/osf-assets/master/files/preprints-assets/${context.get('logo')}/wide_white.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                             %else:
                                                 <img src="https://osf.io/static/img/${context.get('logo', settings.OSF_LOGO)}.png" alt="OSF logo" style="border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
                                             % endif


### PR DESCRIPTION
#### Purpose
- Follow-up fixes to #8187 
- Fix branded preprint provider logos not appearing in HTML emails. 

#### Changes
- Retrieve assets from the master branch of osf-assets instead of a specific commit. 

#### Ticket
- https://openscience.atlassian.net/browse/PLAT-338
