### PR TITLE
[hotfix] Make synchronous tasks asynchronous [PLAT-857]

### DIFF
--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -3,6 +3,7 @@ import urlparse
 import requests
 import logging
 
+from framework.celery_tasks import app
 from website import settings
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ def get_bannable_urls(instance):
     return bannable_urls, parsed_absolute_url.hostname
 
 
+@app.task(max_retries=5, default_retry_delay=60)
 def ban_url(instance):
     # TODO: Refactor; Pull url generation into postcommit_task handling so we only ban urls once per request
     timeout = 0.3  # 300ms timeout for bans

--- a/api_tests/actions/views/test_action_list.py
+++ b/api_tests/actions/views/test_action_list.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE
@@ -60,9 +59,8 @@ class TestReviewActionCreateRoot(object):
         moderator.groups.add(GroupHelper(provider).get_group('moderator'))
         return moderator
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_create_permissions(
-            self, mock_ezid, app, url, preprint, node_admin, moderator
+            self, app, url, preprint, node_admin, moderator
     ):
         assert preprint.machine_state == 'initial'
 
@@ -136,9 +134,6 @@ class TestReviewActionCreateRoot(object):
         assert preprint.machine_state == 'accepted'
         assert preprint.is_published
 
-        # Check if "get_and_set_preprint_identifiers" is called once.
-        assert mock_ezid.call_count == 1
-
     def test_cannot_create_actions_for_unmoderated_provider(
             self, app, url, preprint, provider, node_admin
     ):
@@ -208,9 +203,8 @@ class TestReviewActionCreateRoot(object):
         )
         assert res.status_code == 400
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_valid_transitions(
-            self, mock_ezid, app, url, preprint, provider, moderator
+            self, app, url, preprint, provider, moderator
     ):
         valid_transitions = {
             'post-moderation': [
@@ -257,12 +251,9 @@ class TestReviewActionCreateRoot(object):
                 if preprint.in_public_reviews_state:
                     assert preprint.is_published
                     assert preprint.date_published == action.created
-                    assert mock_ezid.called
-                    mock_ezid.reset_mock()
                 else:
                     assert not preprint.is_published
                     assert preprint.date_published is None
-                    assert not mock_ezid.called
 
                 if trigger == 'edit_comment':
                     assert preprint.date_last_transitioned is None

--- a/api_tests/preprint_providers/views/test_preprint_provider_preprints_list.py
+++ b/api_tests/preprint_providers/views/test_preprint_provider_preprints_list.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE
@@ -121,24 +122,25 @@ class TestPreprintProviderPreprintListFilteringByReviewableFields(
 
     @pytest.fixture()
     def expected_reviewables(self, provider, user):
-        preprints = [
-            PreprintFactory(
-                is_published=False,
-                provider=provider,
-                project=ProjectFactory(is_public=True)),
-            PreprintFactory(
-                is_published=False,
-                provider=provider,
-                project=ProjectFactory(is_public=True)),
-            PreprintFactory(
-                is_published=False,
-                provider=provider,
-                project=ProjectFactory(is_public=True)), ]
-        preprints[0].run_submit(user)
-        preprints[0].run_accept(user, 'comment')
-        preprints[1].run_submit(user)
-        preprints[2].run_submit(user)
-        return preprints
+        with mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers'):
+            preprints = [
+                PreprintFactory(
+                    is_published=False,
+                    provider=provider,
+                    project=ProjectFactory(is_public=True)),
+                PreprintFactory(
+                    is_published=False,
+                    provider=provider,
+                    project=ProjectFactory(is_public=True)),
+                PreprintFactory(
+                    is_published=False,
+                    provider=provider,
+                    project=ProjectFactory(is_public=True)), ]
+            preprints[0].run_submit(user)
+            preprints[0].run_accept(user, 'comment')
+            preprints[1].run_submit(user)
+            preprints[2].run_submit(user)
+            return preprints
 
     @pytest.fixture
     def user(self):

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -560,8 +560,7 @@ class TestPreprintUpdate:
 
         assert not preprint.subjects.filter(_id=subject._id).exists()
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
-    def test_update_published(self, mock_get_identifiers, app, user):
+    def test_update_published(self, app, user):
         unpublished = PreprintFactory(creator=user, is_published=False)
         url = '/{}preprints/{}/'.format(API_BASE, unpublished._id)
         payload = build_preprint_update_payload(
@@ -569,11 +568,9 @@ class TestPreprintUpdate:
         app.patch_json_api(url, payload, auth=user.auth)
         unpublished.reload()
         assert unpublished.is_published
-        assert mock_get_identifiers.called
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_update_published_makes_node_public(
-            self, mock_get_identifiers, app, user):
+            self, app, user):
         unpublished = PreprintFactory(creator=user, is_published=False)
         assert not unpublished.node.is_public
         url = '/{}preprints/{}/'.format(API_BASE, unpublished._id)

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -223,20 +223,21 @@ class TestPreprintListFilteringByReviewableFields(ReviewableFilterMixin):
 
     @pytest.fixture()
     def expected_reviewables(self, user):
-        preprints = [
-            PreprintFactory(
-                is_published=False, project=ProjectFactory(
-                    is_public=True)), PreprintFactory(
-                is_published=False, project=ProjectFactory(
-                    is_public=True)), PreprintFactory(
-                        is_published=False, project=ProjectFactory(
-                            is_public=True)), ]
-        preprints[0].run_submit(user)
-        preprints[0].run_accept(user, 'comment')
-        preprints[1].run_submit(user)
-        preprints[1].run_reject(user, 'comment')
-        preprints[2].run_submit(user)
-        return preprints
+        with mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers'):
+            preprints = [
+                PreprintFactory(
+                    is_published=False, project=ProjectFactory(
+                        is_public=True)), PreprintFactory(
+                    is_published=False, project=ProjectFactory(
+                        is_public=True)), PreprintFactory(
+                            is_published=False, project=ProjectFactory(
+                                is_public=True)), ]
+            preprints[0].run_submit(user)
+            preprints[0].run_accept(user, 'comment')
+            preprints[1].run_submit(user)
+            preprints[1].run_reject(user, 'comment')
+            preprints[2].run_submit(user)
+            return preprints
 
     @pytest.fixture
     def user(self):
@@ -277,9 +278,7 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 201)
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
-    def test_create_preprint_from_private_project(
-            self, mock_create_identifiers):
+    def test_create_preprint_from_private_project(self):
         private_project_payload = build_preprint_create_payload(
             self.private_project._id,
             self.provider._id,
@@ -375,9 +374,7 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 403)
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
-    def test_publish_preprint_fails_with_no_primary_file(
-            self, mock_get_identifiers):
+    def test_publish_preprint_fails_with_no_primary_file(self):
         no_file_payload = build_preprint_create_payload(
             node_id=self.public_project._id,
             provider_id=self.provider._id,
@@ -398,9 +395,7 @@ class TestPreprintCreate(ApiTestCase):
             res.json['errors'][0]['detail'],
             'A valid primary_file must be set before publishing a preprint.')
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
-    def test_publish_preprint_fails_with_invalid_primary_file(
-            self, mock_get_identifiers):
+    def test_publish_preprint_fails_with_invalid_primary_file(self):
         no_file_payload = build_preprint_create_payload(
             node_id=self.public_project._id,
             provider_id=self.provider._id,
@@ -508,8 +503,7 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'],
                      'Cannot create a preprint from a deleted node.')
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
-    def test_create_preprint_adds_log_if_published(self, mock_get_identifiers):
+    def test_create_preprint_adds_log_if_published(self):
         public_project_payload = build_preprint_create_payload(
             self.public_project._id,
             self.provider._id,
@@ -530,10 +524,9 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(log.action, 'preprint_initiated')
         assert_equal(log.params.get('preprint'), preprint_id)
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_create_preprint_from_project_published_hits_update(
-            self, mock_on_preprint_updated, mock_get_identifiers):
+            self, mock_on_preprint_updated):
         private_project_payload = build_preprint_create_payload(
             self.private_project._id,
             self.provider._id,
@@ -567,10 +560,9 @@ class TestPreprintCreate(ApiTestCase):
             auth=self.user.auth)
         assert not mock_on_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_setting_is_published_with_moderated_provider_fails(
-            self, mock_get_identifiers, mock_on_preprint_updated):
+            self, mock_on_preprint_updated):
         self.provider.reviews_workflow = 'pre-moderation'
         self.provider.save()
         public_project_payload = build_preprint_create_payload(
@@ -588,7 +580,6 @@ class TestPreprintCreate(ApiTestCase):
             auth=self.user.auth,
             expect_errors=True)
         assert res.status_code == 409
-        assert not mock_get_identifiers.called
         assert not mock_on_preprint_updated.called
 
 

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -1,5 +1,4 @@
 import pytest
-import mock
 
 from api.base.settings.defaults import API_BASE
 from api.preprint_providers.permissions import GroupHelper
@@ -83,9 +82,8 @@ class TestReviewActionCreateRelated(object):
         moderator.groups.add(GroupHelper(provider).get_group('moderator'))
         return moderator
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_create_permissions(
-            self, mock_ezid, app, url, preprint, node_admin, moderator):
+            self, app, url, preprint, node_admin, moderator):
         assert preprint.machine_state == 'initial'
 
         submit_payload = self.create_payload(preprint._id, trigger='submit')
@@ -152,9 +150,6 @@ class TestReviewActionCreateRelated(object):
         assert preprint.machine_state == 'accepted'
         assert preprint.is_published
 
-        # Check if "get_and_set_preprint_identifiers" is called once.
-        assert mock_ezid.call_count == 1
-
     def test_cannot_create_actions_for_unmoderated_provider(
             self, app, url, preprint, provider, node_admin):
         provider.reviews_workflow = None
@@ -216,9 +211,8 @@ class TestReviewActionCreateRelated(object):
             expect_errors=True)
         assert res.status_code == 400
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_valid_transitions(
-            self, mock_ezid, app, url, preprint, provider, moderator):
+            self, app, url, preprint, provider, moderator):
         valid_transitions = {
             'post-moderation': [
                 ('accepted', 'edit_comment', 'accepted'),
@@ -264,12 +258,9 @@ class TestReviewActionCreateRelated(object):
                 if preprint.in_public_reviews_state:
                     assert preprint.is_published
                     assert preprint.date_published == action.created
-                    assert mock_ezid.called
-                    mock_ezid.reset_mock()
                 else:
                     assert not preprint.is_published
                     assert preprint.date_published is None
-                    assert not mock_ezid.called
 
                 if trigger == 'edit_comment':
                     assert preprint.date_last_transitioned is None

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -8,9 +8,7 @@ import binascii
 from collections import OrderedDict
 import os
 
-from celery import chain
 from celery.canvas import Signature
-from framework.celery_tasks import app
 from celery.local import PromiseProxy
 from gevent.pool import Pool
 
@@ -33,14 +31,6 @@ def postcommit_before_request():
     _local.postcommit_queue = OrderedDict()
     _local.postcommit_celery_queue = OrderedDict()
 
-@app.task(max_retries=5, default_retry_delay=60)
-def postcommit_celery_task_wrapper(queue):
-    # chain.apply calls the tasks synchronously without re-enqueuing each one
-    # http://stackoverflow.com/questions/34177131/how-to-solve-python-celery-error-when-using-chain-encodeerrorruntimeerrormaxi?answertab=votes#tab-top
-    # celery serialized signatures into dictionaries, so we need to deserialize here
-    # https://sentry.cos.io/sentry/osf-iy/issues/289209/
-    chain([Signature.from_dict(task_dict) for task_dict in queue.values()]).apply()
-
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
         _local.postcommit_queue = OrderedDict()
@@ -56,8 +46,9 @@ def postcommit_after_request(response, base_status_error_code=500):
 
         if postcommit_celery_queue():
             if settings.USE_CELERY:
-                # delay pushes the wrapper task into celery
-                postcommit_celery_task_wrapper.delay(postcommit_celery_queue())
+                for task_dict in postcommit_celery_queue().values():
+                    task = Signature.from_dict(task_dict)
+                    task.apply_async()
             else:
                 for task in postcommit_celery_queue().values():
                     task()
@@ -68,6 +59,9 @@ def postcommit_after_request(response, base_status_error_code=500):
     return response
 
 def enqueue_postcommit_task(fn, args, kwargs, celery=False, once_per_request=True):
+    '''
+    Any task queued with this function where celery=True will be run asynchronously.
+    '''
     # make a hash of the pertinent data
     raw = [fn.__name__, fn.__module__, args, kwargs]
     m = hashlib.md5()
@@ -93,6 +87,7 @@ def run_postcommit(once_per_request=True, celery=False):
     Delays function execution until after the request's transaction has been committed.
     If you set the celery kwarg to True args and kwargs must be JSON serializable
     Tasks will only be run if the response's status code is < 500.
+    Any task queued with this function where celery=True will be run asynchronously.
     :return:
     '''
     def wrapper(func):

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -13,7 +13,7 @@ from osf.models import NodeLog
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.workflows import DefaultStates
 from osf.utils.permissions import ADMIN
-from website.preprints.tasks import on_preprint_updated, get_and_set_preprint_identifiers
+from website.preprints.tasks import on_preprint_updated
 from website.project.licenses import set_license
 from website.util import api_v2_url
 from website import settings, mails
@@ -164,9 +164,6 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMi
                     auth=None,
                     log=True
                 )
-
-            # This should be called after all fields for EZID metadta have been set
-            enqueue_postcommit_task(get_and_set_preprint_identifiers, (), {'preprint_id': self._id}, celery=True)
 
             self._send_preprint_confirmation(auth)
 

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -3,14 +3,12 @@ from transitions import Machine
 
 from api.preprint_providers.workflows import Workflows
 from framework.auth import Auth
-from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from osf.exceptions import InvalidTransitionError
 from osf.models.action import ReviewAction, NodeRequestAction
 from osf.models.nodelog import NodeLog
 from osf.utils import permissions
 from osf.utils.workflows import DefaultStates, DefaultTriggers, DEFAULT_TRANSITIONS
 from website.mails import mails
-from website.preprints.tasks import get_and_set_preprint_identifiers
 from website.reviews import signals as reviews_signals
 from website.settings import DOMAIN, OSF_SUPPORT_EMAIL, OSF_CONTACT_EMAIL
 
@@ -89,7 +87,6 @@ class ReviewsMachine(BaseMachine):
                 raise ValueError('Preprint must have at least one subject to be published.')
             self.machineable.date_published = now
             self.machineable.is_published = True
-            enqueue_postcommit_task(get_and_set_preprint_identifiers, (), {'preprint_id': self.machineable._id}, celery=True)
         elif not should_publish and self.machineable.is_published:
             self.machineable.is_published = False
         self.machineable.save()

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -628,7 +628,7 @@ class PreprintFactory(DjangoModelFactory):
             if license_details:
                 instance.set_preprint_license(license_details, auth=auth)
 
-            create_task_patcher = mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+            create_task_patcher = mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers')
             mock_create_identifier = create_task_patcher.start()
             if is_published:
                 mock_create_identifier.side_effect = sync_set_identifiers(instance)

--- a/osf_tests/test_reviewable.py
+++ b/osf_tests/test_reviewable.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from osf.models import PreprintService
@@ -7,7 +8,8 @@ from osf_tests.factories import PreprintFactory, AuthUserFactory
 @pytest.mark.django_db
 class TestReviewable:
 
-    def test_state_changes(self):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers')
+    def test_state_changes(self, _):
         user = AuthUserFactory()
         preprint = PreprintFactory(provider__reviews_workflow='pre-moderation', is_published=False)
         assert preprint.machine_state == DefaultStates.INITIAL.value

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -17,7 +17,7 @@ from website.identifiers.utils import request_identifiers_from_ezid, parse_ident
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task(ignore_results=True)
+@celery_app.task(ignore_results=True, max_retries=5, default_retry_delay=60)
 def on_preprint_updated(preprint_id, update_share=True, share_type=None, old_subjects=None):
     # WARNING: Only perform Read-Only operations in an asynchronous task, until Repeatable Read/Serializable
     # transactions are implemented in View and Task application layers.
@@ -177,7 +177,7 @@ def format_preprint(preprint, share_type, old_subjects=None):
     return [node.serialize() for node in visited]
 
 
-@celery_app.task(ignore_results=True)
+@celery_app.task(ignore_results=True, max_retries=5, default_retry_delay=60)
 def get_and_set_preprint_identifiers(preprint_id):
     PreprintService = apps.get_model('osf.PreprintService')
     preprint = PreprintService.load(preprint_id)

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -26,14 +26,20 @@ def on_preprint_updated(preprint_id, update_share=True, share_type=None, old_sub
     if old_subjects is None:
         old_subjects = []
     if preprint.node:
-        status = 'public' if preprint.verified_publishable else 'unavailable'
+        update_or_create_preprint_identifiers(preprint)
+    if update_share:
+        update_preprint_share(preprint, old_subjects, share_type)
+
+def update_or_create_preprint_identifiers(preprint):
+    status = 'public' if preprint.verified_publishable else 'unavailable'
+    if preprint.is_published and not preprint.get_identifier('doi'):
+        get_and_set_preprint_identifiers(preprint)
+    else:
         try:
             update_ezid_metadata_on_change(preprint._id, status=status)
         except HTTPError as err:
             sentry.log_exception()
             sentry.log_message(err.args[0])
-    if update_share:
-        update_preprint_share(preprint, old_subjects, share_type)
 
 def update_preprint_share(preprint, old_subjects=None, share_type=None):
     if settings.SHARE_URL:
@@ -177,10 +183,7 @@ def format_preprint(preprint, share_type, old_subjects=None):
     return [node.serialize() for node in visited]
 
 
-@celery_app.task(ignore_results=True, max_retries=5, default_retry_delay=60)
-def get_and_set_preprint_identifiers(preprint_id):
-    PreprintService = apps.get_model('osf.PreprintService')
-    preprint = PreprintService.load(preprint_id)
+def get_and_set_preprint_identifiers(preprint):
     ezid_response = request_identifiers_from_ezid(preprint)
     if ezid_response is None:
         return


### PR DESCRIPTION
#### Purpose
* Upgrading to celery v4.2.0rc2 in 7081d5d7b2e09cc9084c392a9be2aaeb09111c2e resulted in some tasks failing due to a `RuntimeError` (see https://sentry2.cos.io/cos/osf-back-end/issues/3147/#). 
  * `RuntimeError` raised by celery: https://github.com/celery/celery/blob/d02d260a192f8923dfa331ae2b503af57534654a/celery/result.py#L41
  * Addition in v4.2.0rc2 that results in the above `RuntimeError` being raised for synchronous subtasks: https://github.com/celery/celery/blob/d02d260a192f8923dfa331ae2b503af57534654a/celery/result.py#L940

#### Changes
* Remove synchronous subtask calls in `postcommit_celery_task_wrapper` in favor of asynchronous calls in `postcommit_after_request`.
* Directly call `get_and_set_preprint_identifiers` in `on_preprint_updated` (instead of as a synchronous task). 

#### Ticket
- https://openscience.atlassian.net/browse/PLAT-857
