### PR TITLE
Fix/Mock Zotero Data [PLAT-730] 

### DIFF
--- a/addons/zotero/tests/utils.py
+++ b/addons/zotero/tests/utils.py
@@ -269,12 +269,21 @@ mock_responses = {k: dumps(v) for k, v in mock_responses.iteritems()}
 mock_responses_with_filed_and_unfiled = {
     'folders': [
         {
+            'library': {
+                'type': 'user',
+                'id': '56789'
+            },
             'data': {
                 "key": "4901a8f5-9840-49bf-8a17-bdb3d5900417",
                 "name": "subfolder",
+                "parentCollection": False
             },
         },
         {
+            'library': {
+                'type': 'user',
+                'id': '56789'
+            },
             'data': {
                 "key": "a6b12ebf-bd07-4f4e-ad73-f9704555f032",
                 "name": "subfolder2",
@@ -282,6 +291,10 @@ mock_responses_with_filed_and_unfiled = {
             },
         },
         {
+            'library': {
+                'type': 'user',
+                'id': '56789'
+            },
             'data': {
                 "key": "e843da05-8818-47c2-8c37-41eebfc4fe3f",
                 "name": "subfolder3",


### PR DESCRIPTION
## Purpose

An earlier Zotero PR https://github.com/CenterForOpenScience/osf.io/pull/8219 added a test and then a later PR https://github.com/CenterForOpenScience/osf.io/pull/8230 started accessing a different key from data returned from pyzotero.

Mock test data from PR https://github.com/CenterForOpenScience/osf.io/pull/8219 needs to be expanded to include this new key.

## Changes

Fix test failure on release/next-platform.  
https://travis-ci.org/CenterForOpenScience/osf.io/jobs/380280400

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
