### PR TITLE
[EMB-283] Allow PATCHing of VOL information

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1758,7 +1758,7 @@ class NodeViewOnlyLinkDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIV
     view_name = 'node-view-only-link-detail'
 
     def get_serializer_class(self):
-        if self.request.method == 'PUT':
+        if self.request.method == 'PUT' or self.request.method == 'PATCH':
             return NodeViewOnlyLinkUpdateSerializer
         return NodeViewOnlyLinkSerializer
 

--- a/api_tests/nodes/views/test_node_view_only_links_detail.py
+++ b/api_tests/nodes/views/test_node_view_only_links_detail.py
@@ -126,7 +126,7 @@ class TestViewOnlyLinksUpdate:
                 'name': 'updated vol name'
             }
         }
-        res = app.put_json_api(url, {'data': payload}, auth=user.auth)
+        res = app.patch_json_api(url, {'data': payload}, auth=user.auth)
 
         assert res.status_code == 200
         assert res.json['data']['attributes']['name'] == 'updated vol name'


### PR DESCRIPTION
## Purpose

View only links could only be changed with a PUT method but we mostly use PATCHing. This corrects that.

## Changes

1. Modify test to use PATCH instead of PUT
2. Check for PUT or PATCH methods when determining which serializer to use

## QA Notes

This should not require any additional testing.

## Documentation

No documentation needed.

## Side Effects

None that I can imagine.

## Ticket

https://openscience.atlassian.net/browse/EMB-283
