### PR TITLE
Disable PLAT-639 (Track Unseen Versions) and PLAT-218 (tally preprint views)

### DIFF
--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -381,7 +381,9 @@ def osfstorage_download(file_node, payload, node_addon, **kwargs):
             raise make_error(httplib.BAD_REQUEST, message_short='Version must be an integer if not specified')
 
     version = file_node.get_version(version_id, required=True)
-
+    # TODO: Update analytics in MFR callback when it is implemented
+    if request.args.get('mode') not in ('render', ):
+        utils.update_analytics(node_addon.owner, file_node._id, int(version.identifier) - 1)
     return {
         'data': {
             'name': file_node.name,

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -317,8 +317,7 @@ class TestAddonLogs(OsfTestCase):
             'github_addon_file_renamed',
         )
 
-    @mock.patch('addons.base.views.mark_file_version_as_seen')
-    def test_action_downloads_contrib(self, mock_mark_version):
+    def test_action_downloads_contrib(self):
         url = self.node.api_url_for('create_waterbutler_log')
         download_actions=('download_file', 'download_zip')
         wb_url = settings.WATERBUTLER_URL + '?version=1'
@@ -338,105 +337,7 @@ class TestAddonLogs(OsfTestCase):
             assert_equal(res.status_code, 200)
 
         self.node.reload()
-        assert_equal(self.file.get_download_count(), 0) # contrib don't count as download
         assert_equal(self.node.logs.count(), nlogs)
-
-    @mock.patch('addons.base.views.mark_file_version_as_seen')
-    def test_action_downloads_non_contrib(self, mock_mark_version):
-        url = self.node.api_url_for('create_waterbutler_log')
-        download_actions=('download_file', 'download_zip')
-        request_url = settings.WATERBUTLER_URL + '/v1/resources/test1/providers/osfstorage/testfile?version=1'
-        for action in download_actions:
-            payload = self.build_payload(metadata={'path': '/testfile',
-                                                   'nid': self.node._id},
-                                         action_meta={'is_mfr_render': False},
-                                         request_meta={'url': request_url},
-                                         action=action,
-                                         auth={'id': self.user_non_contrib._id})
-            nlogs = self.node.logs.count()
-            res = self.app.put_json(
-                url,
-                payload,
-                headers={'Content-Type': 'application/json'},
-                expect_errors=False,
-            )
-            assert_equal(res.status_code, 200)
-
-        self.node.reload()
-        assert_equal(self.file.get_download_count(), 2)
-        assert_equal(self.node.logs.count(), nlogs) # don't log downloads
-
-    @mock.patch('addons.base.views.mark_file_version_as_seen')
-    def test_action_download_mfr_views_contrib(self, mock_mark_version):
-        url = self.node.api_url_for('create_waterbutler_log')
-        request_url = settings.WATERBUTLER_URL + '/v1/resources/test1/providers/osfstorage/testfile?version=1'
-        payload = self.build_payload(metadata={'path': '/testfile',
-                                               'nid': self.node._id},
-                                     action='download_file',
-                                     action_meta={'is_mfr_render': True},
-                                     request_meta={'url': request_url})
-        nlogs = self.node.logs.count()
-        res = self.app.put_json(
-            url,
-            payload,
-            headers={'Content-Type': 'application/json'},
-            expect_errors=False,
-        )
-        assert_equal(res.status_code, 200)
-
-        self.file.reload()
-        assert_equal(self.file.get_view_count(), 0) # contribs don't count as views
-        assert_equal(self.node.logs.count(), nlogs) # don't log views
-
-    @mock.patch('addons.base.views.mark_file_version_as_seen')
-    def test_action_download_mfr_views_non_contrib(self, mock_mark_version):
-        url = self.node.api_url_for('create_waterbutler_log')
-        request_url = settings.WATERBUTLER_URL + '/v1/resources/test1/providers/osfstorage/testfile?version=1'
-        payload = self.build_payload(metadata={'path': '/testfile',
-                                               'nid': self.node._id},
-                                     action='download_file',
-                                     request_meta={'url': request_url},
-                                     action_meta={'is_mfr_render': True},
-                                     auth={'id': self.user_non_contrib._id})
-        nlogs = self.node.logs.count()
-        res = self.app.put_json(
-            url,
-            payload,
-            headers={'Content-Type': 'application/json'},
-            expect_errors=False,
-        )
-        assert_equal(res.status_code, 200)
-
-        self.file.reload()
-        assert_equal(self.file.get_view_count(), 1)
-        assert_equal(self.node.logs.count(), nlogs) # don't log views
-
-    def test_action_downloads_marks_version_as_seen(self):
-        test_file = create_test_file(self.node, self.user)
-        url = self.node.api_url_for('create_waterbutler_log')
-        request_url = settings.WATERBUTLER_URL + '/v1/resources/test1/providers/osfstorage/testfile?version=1'
-        payload = self.build_payload(metadata={'path': test_file._id,
-                                               'nid': self.node._id},
-                                     action='download_file',
-                                     request_meta={'url': request_url},
-                                     action_meta={'is_mfr_render': True},
-                                     auth={'id': self.user_non_contrib._id})
-        res = self.app.put_json(
-            url,
-            payload,
-            headers={'Content-Type': 'application/json'},
-            expect_errors=False,
-        )
-        assert_equal(res.status_code, 200)
-
-        # Add a new version, make sure that does not have a record
-        version = FileVersionFactory()
-        test_file.versions.add(version)
-        test_file.save()
-
-        versions = test_file.versions.order_by('created')
-        assert versions.first().seen_by.filter(guids___id=self.user_non_contrib._id).exists()
-        assert not versions.last().seen_by.filter(guids___id=self.user_non_contrib._id).exists()
 
     def test_add_file_osfstorage_log(self):
         self.configure_osf_addon()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
These were using the WB log callback to mark versions as seen
and tally preprint views, respectively. This approach won't
work outside of local development due to MFR's cached renders.

Fitz is working on adding an MFR callback that we will
use instead. Once that's ready, we can revert this commit.

## Changes

<!-- Briefly describe or list your changes  -->
Remove the code that marks file versions as seen and updates file view analytics in the waterbutler log callback.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/PLAT-639
https://openscience.atlassian.net/browse/PLAT-218
