### PR TITLE
[IN-276][OSF] Allow admins to remove their submissions from collections

### DIFF
--- a/api/collections/permissions.py
+++ b/api/collections/permissions.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import NotFound
 
 from api.base.utils import get_user_auth
 from osf.models import AbstractNode, Collection, CollectedGuidMetadata, CollectionProvider
-from osf.utils.permissions import WRITE
+from osf.utils.permissions import WRITE, ADMIN
 
 class CollectionWriteOrPublic(permissions.BasePermission):
     # Adapted from ContributorOrPublic
@@ -54,8 +54,8 @@ class CanUpdateDeleteCGMOrPublic(permissions.BasePermission):
         elif request.method in ['PUT', 'PATCH']:
             return obj.guid.referent.has_permission(auth.user, WRITE) or auth.user.has_perm('write_collection', collection)
         elif request.method == 'DELETE':
-            # Restricted to collection admins
-            return auth.user.has_perm('admin_collection', collection)
+            # Restricted to collection and project admins.
+            return obj.guid.referent.has_permission(auth.user, ADMIN) or auth.user.has_perm('admin_collection', collection)
         return False
 
 class CollectionWriteOrPublicForPointers(permissions.BasePermission):

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -3819,7 +3819,7 @@ class TestCollectedMetaDetail:
         )
         assert res.status_code == 403
 
-        project_one.add_contributor(user_two, save=True)  # has referent perms
+        project_one.add_contributor(user_two, save=True)  # has referent (read, write) perms
 
         res = app.patch_json_api(
             url,
@@ -3835,6 +3835,13 @@ class TestCollectedMetaDetail:
             expect_errors=True
         )
         assert res.status_code == 403
+
+        project_one.add_contributor(user_two, permissions='admin', save=True)  # has referent admin perms
+        res = app.delete_json_api(
+            url,
+            auth=user_two.auth,
+        )
+        assert res.status_code == 204
 
     def test_with_permissions(self, app, collection, cgm, user_one, user_two, url, payload):
         res = app.get(url, auth=user_one.auth, expect_errors=True)


### PR DESCRIPTION
## Purpose

Allow admins to remove their submissions from collections

## Changes

- Extend `DELETE` update handling with a check for `admin` on referent
- Update test

## QA Notes

Recommend API testing as we wait for the collection frontend.
Endpoint to test : `/{}collections/{}/collected_metadata/{}/'.format(API_BASE, collection._id, cgm._id)`
for instaance.
1) default contributor permissions ('read', 'write'), 
1.1) expect `403` should be returned as the contributor does not have `admin`
2) Try with same steps with same user as admin and make sure the submissions get removed from the collection.

## Documentation

## Side Effects

## Ticket

[[IN-276]](https://openscience.atlassian.net/browse/IN-276)
