### PR TITLE
[no ticket] [hotfix] Handle wikis with non-sequential version numbers

### DIFF
--- a/addons/wiki/tests/test_models.py
+++ b/addons/wiki/tests/test_models.py
@@ -3,10 +3,10 @@ import pytz
 import datetime
 from addons.wiki.exceptions import NameMaximumLengthError
 
-from addons.wiki.models import WikiPage
+from addons.wiki.models import WikiPage, WikiVersion
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 from osf_tests.factories import NodeFactory, UserFactory, ProjectFactory
-from tests.base import OsfTestCase
+from tests.base import OsfTestCase, fake
 
 pytestmark = pytest.mark.django_db
 
@@ -83,3 +83,22 @@ class TestWikiPage(OsfTestCase):
         wiki.save()
         url = '{}wiki/{}/'.format(self.project.url, wiki.page_name)
         assert wiki.url == url
+
+    # Regression test for an issue on prod:
+    #   https://www.flowdock.com/app/cos/archiver/threads/I09794CXgkkFK22_2kpEQfeIws2
+    # We can't assume that WikiVersion.identifier follows a contiguous
+    # sequence. There was a WikiPage that had versions (ordered by creation):
+    #   1, 2, 3, 4, 5, 6, 7, 8, 2, 3, 4, 5
+    # This test reproduces that state and makes sure that
+    # WikiPage.current_version_number, WikiPage.get_version, and WikiVersion.is_current
+    # behave as expected
+    def test_current_version_number_with_non_contiguous_version_numbers(self):
+        wiki = WikiFactory()
+        for i in range(1, 9):
+            WikiVersion(wiki_page=wiki, identifier=i, content=fake.sentence()).save()
+        for i in range(2, 6):
+            WikiVersion(wiki_page=wiki, identifier=i, content=fake.sentence()).save()
+        assert wiki.current_version_number == 5
+        latest_version = wiki.versions.order_by('-created')[0]
+        assert latest_version.is_current
+        assert wiki.get_version(5) == latest_version


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Visiting some older projects, such as https://osf.io/b6m4w results in a 500 error: https://sentry2.cos.io/cos/osf-back-end/issues/2777/.

We can't assume that WikiVersion.identifier follows a contiguous
sequence. There was a WikiPage that had versions (ordered by creation):
  1, 2, 3, 4, 5, 6, 7, 8, 2, 3, 4, 5

`get_version` was returning an error, causing a 500 when visiting
https://osf.io/b6m4w/

## Changes

<!-- Briefly describe or list your changes  -->

This updates the code so that
WikiPage.current_version_number, WikiPage.get_version,
and WikiVersion.is_current behave as expected even when
we come across bad data like this.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
No ticket, see https://www.flowdock.com/app/cos/archiver/threads/I09794CXgkkFK22_2kpEQfeIws2
