### PR TITLE
[PLAT-844] Modify language on confirmation modal for making registration

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -650,7 +650,7 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
         };
     }
     var preRegisterPrompts = response.prompts || [];
-    preRegisterPrompts.push('Tags on a registration can be modified at any time to enhance discoverability.');
+    preRegisterPrompts.unshift('Registrations cannot be modified or deleted once completed.');
 
     var registrationModal = new RegistrationModal.ViewModel(
         confirm, preRegisterPrompts, validator


### PR DESCRIPTION
## Purpose

This is a language fix that makes it obvious that registrations are immutable when registering a draft. 

## Changes

- adds immutability prompt to modal
- removes "tags" prompt

## QA Notes

create a draft and register it, you should see this:
<img width="1437" alt="screen shot 2018-05-22 at 11 18 48 am" src="https://user-images.githubusercontent.com/9688518/40372449-b90f7702-5db2-11e8-9f1c-7df0b267cbb7.png">

## Documentation

Shouldn't be necessary 

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-844