### PR TITLE
[EMB-299] Active waffle flags in /v2/ root

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -33,7 +33,8 @@ from api.nodes.permissions import ReadOnlyIfRegistration
 from api.users.serializers import UserSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Contributor, MaintenanceState, BaseFileNode
-
+from waffle.models import Flag
+from waffle import flag_is_active
 
 class JSONAPIBaseView(generics.GenericAPIView):
 
@@ -393,18 +394,21 @@ class LinkedRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDe
 def root(request, format=None, **kwargs):
     """
     The documentation for the Open Science Framework API can be found at [developer.osf.io](https://developer.osf.io).
+    The contents of this endpoint are variable and subject to change without notification.
     """
     if request.user and not request.user.is_anonymous:
         user = request.user
         current_user = UserSerializer(user, context={'request': request}).data
     else:
         current_user = None
+    flags = [item.name for item in Flag.objects.all() if flag_is_active(request, item.name)]
     kwargs = request.parser_context['kwargs']
     return_val = {
         'meta': {
             'message': 'Welcome to the OSF API.',
             'version': request.version,
             'current_user': current_user,
+            'active_flags': flags,
         },
         'links': {
             'nodes': utils.absolute_reverse('nodes:node-list', kwargs=kwargs),

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -401,7 +401,7 @@ def root(request, format=None, **kwargs):
         current_user = UserSerializer(user, context={'request': request}).data
     else:
         current_user = None
-    flags = [item.name for item in Flag.objects.all() if flag_is_active(request, item.name)]
+    flags = [name for name in Flag.objects.values_list('name', flat=True) if flag_is_active(request, name)]
     kwargs = request.parser_context['kwargs']
     return_val = {
         'meta': {


### PR DESCRIPTION
## Purpose

Eliminate the need to also do a request to `/v2/_waffle/` every time someone launches an embosfed page

## Changes

Add a meta attribute to the root endpoint to include active waffle flag names. See `meta.active_flags` below:

```
{
    "meta": {
        "version": "2.8",
        "current_user": {
            "data": {
                "relationships": {
                    "quickfiles": {
                        "links": {
                            "download": {
                                "href": "http://localhost:7777/v1/resources/cw6uj4b279/providers/osfstorage/?zip=",
                                "meta": {}
                            },
                            "upload": {
                                "href": "http://localhost:7777/v1/resources/cw6uj4b279/providers/osfstorage/",
                                "meta": {}
                            },
                            "related": {
                                "href": "http://localhost:8000/v2/users/g3mq5/quickfiles/",
                                "meta": {}
                            }
                        }
                    },
                    "nodes": {
                        "links": {
                            "related": {
                                "href": "http://localhost:8000/v2/users/g3mq5/nodes/",
                                "meta": {}
                            }
                        }
                    },
                    "institutions": {
                        "links": {
                            "self": {
                                "href": "http://localhost:8000/v2/users/g3mq5/relationships/institutions/",
                                "meta": {}
                            },
                            "related": {
                                "href": "http://localhost:8000/v2/users/g3mq5/institutions/",
                                "meta": {}
                            }
                        }
                    },
                    "preprints": {
                        "links": {
                            "related": {
                                "href": "http://localhost:8000/v2/users/g3mq5/preprints/",
                                "meta": {}
                            }
                        }
                    },
                    "registrations": {
                        "links": {
                            "related": {
                                "href": "http://localhost:8000/v2/users/g3mq5/registrations/",
                                "meta": {}
                            }
                        }
                    }
                },
                "links": {
                    "self": "http://localhost:8000/v2/users/g3mq5/",
                    "html": "http://localhost:5000/g3mq5/",
                    "profile_image": "https://secure.gravatar.com/avatar/8516344ae435f2516087523734bc8056?d=identicon"
                },
                "attributes": {
                    "family_name": "Geiger",
                    "suffix": "",
                    "locale": "en_US",
                    "can_view_reviews": [],
                    "date_registered": "2018-04-05T21:08:16.959554Z",
                    "middle_names": "J.",
                    "given_name": "Brian",
                    "full_name": "Brian J. Geiger",
                    "social": {},
                    "active": true,
                    "timezone": "Etc/UTC"
                },
                "type": "users",
                "id": "g3mq5"
            }
        },
        "admin": true,
        "message": "Welcome to the OSF API.",
        "active_flags": [
            "ember_home_page",
            "ember_dashboard_page",
            "ember_project_forks_page",
            "ember_support_page"
        ]
    },
    "links": {
        "collections": "http://localhost:8000/v2/collections/",
        "users": "http://localhost:8000/v2/users/",
        "licenses": "http://localhost:8000/v2/licenses/",
        "nodes": "http://localhost:8000/v2/nodes/",
        "addons": "http://localhost:8000/v2/addons/",
        "institutions": "http://localhost:8000/v2/institutions/",
        "metaschemas": "http://localhost:8000/v2/metaschemas/",
        "registrations": "http://localhost:8000/v2/registrations/"
    }
}
```

## QA Notes

Should not need QA

## Documentation

I mentioned explicitly on the root endpoint that people shouldn't rely on it.

## Side Effects

No, it's only additional information. The root route might take a bit longer to load.

## Ticket

https://openscience.atlassian.net/browse/EMB-299