### PR TITLE
Make sure migration to add default regions imports models correctly [no ticket]

### DIFF
--- a/osf/migrations/0099_add_default_storage_region.py
+++ b/osf/migrations/0099_add_default_storage_region.py
@@ -8,8 +8,6 @@ from django.db import migrations
 from django.apps import apps
 from django.core.paginator import Paginator
 
-from osf.models import OSFUser
-from addons.osfstorage.models import Region, UserSettings as OsfStorageUserSettings
 from addons.osfstorage.settings import DEFAULT_REGION_NAME, DEFAULT_REGION_ID
 from website.settings import WATERBUTLER_URL
 
@@ -18,7 +16,10 @@ logger = logging.getLogger(__file__)
 osfstorage_config = apps.get_app_config('addons_osfstorage')
 
 
-def add_osfstorage_addon(*args):
+def add_osfstorage_addon(apps, *args):
+    OSFUser = apps.get_model('osf', 'OSFUser')
+    Region = apps.get_model('addons_osfstorage', 'Region')
+    OsfStorageUserSettings = apps.get_model('addons_osfstorage', 'UserSettings')
 
     default_region, created = Region.objects.get_or_create(
         _id=DEFAULT_REGION_ID,
@@ -52,7 +53,9 @@ def add_osfstorage_addon(*args):
     logger.info('Created UserSettings for {} users'.format(total_users))
 
 
-def remove_osfstorage_addon(*args):
+def remove_osfstorage_addon(apps, *args):
+    OSFUser = apps.get_model('osf', 'OSFUser')
+    Region = apps.get_model('addons_osfstorage', 'Region')
     OsfStorageUserSettings = osfstorage_config.user_settings
 
     region = Region.objects.filter(
@@ -68,6 +71,7 @@ def remove_osfstorage_addon(*args):
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('addons_osfstorage', '0004_storage_region_models'),
         ('osf', '0098_merge_20180416_1807'),
     ]
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Directly importing user and osfstorage models was causing some trouble when running migrations locally. Also, make sure to specify the dependency to another app's migrations.

## Changes

- update add_default_storage_region migration to import correctly

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

none necessary!

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->
none needed

## Side Effects

none anticipated
<!-- Any possible side effects? -->

## Ticket
no ticket