### PR TITLE
[PLAT-783] Prevent accessing a deactivated users quickfiles ...again

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -44,6 +44,9 @@ class FileMixin(object):
             if not isinstance(obj, BaseFileNode):
                 raise NotFound
 
+        if obj.node.is_quickfiles and not obj.node.creator.is_active:
+            raise Gone(detail='This user has been deactivated and their quickfiles are no longer available.')
+
         if check_permissions:
             # May raise a permission denied
             self.check_object_permissions(self.request, obj)
@@ -87,8 +90,6 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     def get_object(self):
         user = utils.get_user_auth(self.request).user
         file = self.get_file()
-        if file.node.is_quickfiles and not file.node.creator.is_active:
-            raise Gone()
 
         if self.request.GET.get('create_guid', False):
             # allows quickfiles to be given guids when another user wants a permanent link to it

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -44,7 +44,7 @@ class FileMixin(object):
             if not isinstance(obj, BaseFileNode):
                 raise NotFound
 
-        if obj.node.is_quickfiles and not obj.node.creator.is_active:
+        if obj.node.is_quickfiles and obj.node.creator.is_disabled:
             raise Gone(detail='This user has been deactivated and their quickfiles are no longer available.')
 
         if check_permissions:

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -87,6 +87,9 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     def get_object(self):
         user = utils.get_user_auth(self.request).user
         file = self.get_file()
+        if file.node.is_quickfiles and not file.node.creator.is_active:
+            raise Gone()
+
         if self.request.GET.get('create_guid', False):
             # allows quickfiles to be given guids when another user wants a permanent link to it
             if (self.get_node().has_permission(user, 'admin') and utils.has_admin_scope(self.request)) or file.node.is_quickfiles:

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -94,7 +94,7 @@ class TestFileView:
         )
         url_with_id = '/{}files/{}/'.format(API_BASE, file_node._id)
 
-        res = app.get(url_with_id, expect_errors=True)
+        res = app.get(url_with_id)
         assert res.status_code == 200
 
         res = app.get(url_with_guid, auth=user.auth)
@@ -104,9 +104,13 @@ class TestFileView:
         user.save()
 
         res = app.get(url_with_id, expect_errors=True)
+        assert res.json['errors'][0]['detail'] == 'This user has been deactivated and their' \
+                                                  ' quickfiles are no longer available.'
         assert res.status_code == 410
 
         res = app.get(url_with_guid, expect_errors=True)
+        assert res.json['errors'][0]['detail'] == 'This user has been deactivated and their' \
+                                                  ' quickfiles are no longer available.'
         assert res.status_code == 410
 
     def test_file_guid_guid_status(self, app, user, file, file_url):

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -130,3 +130,11 @@ class TestUserQuickFiles:
 
         assert 'upload' in file_detail_json['links']
         assert file_detail_json['links']['upload'] == waterbutler_url
+
+    def test_disabled_users_quickfiles_gets_410(self, app, url):
+        user = AuthUserFactory(is_disabled=True)
+        QuickFilesNode.objects.get(creator=user).save()
+        url = '/{}users/{}/quickfiles/'.format(API_BASE, user._id)
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 410
+        assert res.content_type == 'application/vnd.api+json'

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -131,10 +131,9 @@ class TestUserQuickFiles:
         assert 'upload' in file_detail_json['links']
         assert file_detail_json['links']['upload'] == waterbutler_url
 
-    def test_disabled_users_quickfiles_gets_410(self, app, url):
-        user = AuthUserFactory(is_disabled=True)
-        QuickFilesNode.objects.get(creator=user).save()
-        url = '/{}users/{}/quickfiles/'.format(API_BASE, user._id)
+    def test_disabled_users_quickfiles_gets_410(self, app, user, quickfiles, url):
+        user.is_disabled = True
+        user.save()
         res = app.get(url, expect_errors=True)
         assert res.status_code == 410
         assert res.content_type == 'application/vnd.api+json'


### PR DESCRIPTION
## Purpose

Stop users from being able to access a disabled users quickfiles from the file detail page.

## Changes

- adds check for FileDetail class and two new tests

## QA Notes

1. create a user
2. upload files to their quickfiles node.
3. save the file detail urls for those files
4. disable/deactivate the user (you can do this via the admin or shell).
5. visit the urls again, you should see this:
<img width="1440" alt="screen shot 2018-05-24 at 5 30 18 pm" src="https://user-images.githubusercontent.com/9688518/40514703-3051ffa8-5f78-11e8-9694-f491c9e9def1.png">

## Documentation

Bug fix, no docs necessary. 

# Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-783