### PR TITLE
[PLAT-836] Partial Registrations backend

### DIFF
--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -134,7 +134,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'preprint',
             'subjects']
         # fields that do not appear on registrations
-        non_registration_fields = ['registrations', 'draft_registrations']
+        non_registration_fields = ['registrations', 'draft_registrations', 'children']
 
         for field in NodeSerializer._declared_fields:
             assert_in(field, RegistrationSerializer._declared_fields)

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -373,6 +373,7 @@ class TestRegistrationUpdate:
             'draft_registration',
             'registration_choice',
             'lift_embargo',
+            'children',
             'tags']
         for field in RegistrationSerializer._declared_fields:
             reg_field = RegistrationSerializer._declared_fields[field]
@@ -386,6 +387,7 @@ class TestRegistrationUpdate:
             'draft_registration',
             'registration_choice',
             'lift_embargo',
+            'children',
             'tags']
 
         for field in RegistrationDetailSerializer._declared_fields:

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -520,6 +520,18 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
             schema_version=LATEST_SCHEMA_VERSION)
 
     @pytest.fixture()
+    def project_public_child(self, project_public):
+        return ProjectFactory(parent=project_public)
+
+    @pytest.fixture()
+    def project_public_grandchild(self, project_public_child):
+        return ProjectFactory(parent=project_public_child)
+
+    @pytest.fixture()
+    def project_public_excluded_sibling(self, project_public):
+        return ProjectFactory(parent=project_public)
+
+    @pytest.fixture()
     def draft_registration(self, user, project_public, schema):
         return DraftRegistrationFactory(
             initiator=user,
@@ -548,6 +560,48 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
             }
         }
 
+    @pytest.fixture()
+    def payload_with_children(self, draft_registration, project_public_child, project_public_grandchild):
+        return {
+            'data': {
+                'type': 'registrations',
+                'attributes': {
+                    'draft_registration': draft_registration._id,
+                    'children': [project_public_child._id, project_public_grandchild._id],
+                    'registration_choice': 'immediate'
+
+                }
+            }
+        }
+
+    @pytest.fixture()
+    def payload_with_grandchildren_but_no_children(self, draft_registration, project_public_child, project_public_grandchild):
+        return {
+            'data': {
+                'type': 'registrations',
+                'attributes': {
+                    'draft_registration': draft_registration._id,
+                    'children': [project_public_grandchild._id],
+                    'registration_choice': 'immediate'
+
+                }
+            }
+        }
+
+    @pytest.fixture()
+    def payload_with_bad_child_node_guid(self, draft_registration):
+        return {
+            'data': {
+                'type': 'registrations',
+                'attributes': {
+                    'draft_registration': draft_registration._id,
+                    'children': ['fake0', 'fake3'],
+                    'registration_choice': 'immediate'
+
+                }
+            }
+        }
+
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_admin_can_create_registration(
             self, mock_enqueue, app, user, payload, url_registrations):
@@ -557,6 +611,42 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
         assert data['registration'] is True
         assert data['pending_registration_approval'] is True
         assert data['public'] is False
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_admin_can_create_registration_with_specific_children(
+            self, mock_enqueue, app, user, payload_with_children, project_public,  project_public_child, project_public_excluded_sibling, project_public_grandchild, url_registrations):
+        res = app.post_json_api(url_registrations, payload_with_children, auth=user.auth)
+        data = res.json['data']['attributes']
+        assert res.status_code == 201
+        assert data['registration'] is True
+        assert data['pending_registration_approval'] is True
+        assert data['public'] is False
+
+        assert project_public.registrations.all().count() == 1
+        assert project_public_child.registrations.all().count() == 1
+        assert project_public_grandchild.registrations.all().count() == 1
+        assert project_public_excluded_sibling.registrations.all().count() == 0
+
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_admin_400_with_bad_child_node_guid(
+            self, mock_enqueue, app, user, payload_with_bad_child_node_guid, url_registrations):
+        res = app.post_json_api(url_registrations, payload_with_bad_child_node_guid, auth=user.auth, expect_errors=True)
+
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Some child nodes could not be found.'
+
+
+    @mock.patch('framework.celery_tasks.handlers.enqueue_task')
+    def test_admin_cant_register_grandchildren_without_children(
+            self, mock_enqueue, app, user, payload_with_grandchildren_but_no_children, url_registrations):
+        res = app.post_json_api(url_registrations, payload_with_grandchildren_but_no_children, auth=user.auth, expect_errors=True)
+
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Some child nodes could not be found. All nodes ' \
+                                                  'must be have parents that are being registered ' \
+                                                  'or be the root.'
+
 
     def test_cannot_create_registration(
             self, app, user_write_contrib, user_read_contrib,

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1674,7 +1674,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             contribs.append(contrib)
         Contributor.objects.bulk_create(contribs)
 
-    def register_node(self, schema, auth, data, parent=None):
+    def register_node(self, schema, auth, data, parent=None, excluded_node_ids=None):
         """Make a frozen copy of a node.
 
         :param schema: Schema object
@@ -1696,6 +1696,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         # and point them towards the registration
         if original.is_deleted:
             raise NodeStateError('Cannot register deleted node.')
+
+        excluded_node_ids = excluded_node_ids or []
 
         registered = original.clone()
         registered.recast('osf.registration')
@@ -1742,12 +1744,13 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         for node_relation in original.node_relations.filter(child__is_deleted=False):
             node_contained = node_relation.child
             # Register child nodes
-            if not node_relation.is_node_link:
+            if not node_relation.is_node_link and node_contained._id not in excluded_node_ids:
                 node_contained.register_node(
                     schema=schema,
                     auth=auth,
                     data=data,
                     parent=registered,
+                    excluded_node_ids=excluded_node_ids
                 )
             else:
                 # Copy linked nodes

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -584,14 +584,15 @@ class DraftRegistration(ObjectIDMixin, BaseModel):
         if save:
             self.save()
 
-    def register(self, auth, save=False):
+    def register(self, auth, save=False, excluded_node_ids=None):
         node = self.branched_from
 
         # Create the registration
         register = node.register_node(
             schema=self.registration_schema,
             auth=auth,
-            data=self.registration_metadata
+            data=self.registration_metadata,
+            excluded_node_ids=excluded_node_ids
         )
         self.registered_node = register
         self.add_status_log(auth.user, DraftRegistrationLog.REGISTERED)


### PR DESCRIPTION
## Purpose 

Allow people to register a selection of components instead of an entire project.

## Changes 

- Adds optional attribute `children` to payload with list of guids to be registered
- Validates so those components contain no orphaned grandchildren. 
- Add tests

## QA Notes

Make a POST request to  `/nodes/{node_id}/registrations/` with a payload of JSON data like:
```json
{
    "data": 
{
    "type": "registrations",
    "attributes": 
{
    "draft_registration": "{draft_registration_id}",
    "registration_choice": "embargo",
    "lift_embargo": "2017-05-10T20:44:03.185000",
    "children": 
            [
                "fsd2s",
                "dwsa2"
            ]
        }
    }
}
```
Only the `{node_id}` node  and children whose's guids are listed should be registered. Sending invalid guids should cause descriptive 400s.

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/18

## Ticket 

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-836