### PR TITLE
[no ticket] Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV GOSU_VERSION=1.10 \
 RUN set -ex \
     && mkdir -p /var/www \
     && chown www-data:www-data /var/www \
+    && apt-get update \
+    && apt-get install -y gnupg2 \
     # GOSU
     && gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && for key in \
@@ -31,7 +33,6 @@ RUN set -ex \
       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
     done \
     # Install dependancies
-    && apt-get update \
     && apt-get install -y \
         git \
         libev4 \


### PR DESCRIPTION



<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Docker builds are currently failing because the python2.7-slim
no longer has gnupg2 installed

## Changes

<!-- Briefly describe or list your changes  -->
Install gnupg2 in the docker image.
