### PR TITLE
[hotfix] Fix node bulk delete with linked node [PLAT-889]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -276,7 +276,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
         if NodeRelation.objects.filter(
             parent__in=resource_object_list,
             child__is_deleted=False
-        ).exclude(child__in=resource_object_list, is_node_link=False).exists():
+        ).exclude(Q(child__in=resource_object_list) | Q(is_node_link=True)).exists():
             raise ValidationError('Any child components must be deleted prior to deleting this project.')
 
         remove_addons(auth, resource_object_list)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -3002,6 +3002,24 @@ class TestNodeBulkDelete:
             url, new_payload, auth=user_one.auth, bulk=True)
         assert res.status_code == 204
 
+    # Regression test for PLAT-889
+    def test_bulk_delete_project_with_linked_node(
+            self, app, user_one,
+            public_project_parent,
+            public_component, url):
+
+        node_link = NodeFactory(is_public=True, creator=user_one)
+        public_project_parent.add_pointer(node_link, auth=Auth(user_one))
+
+        new_payload = {'data': [
+            {'id': public_project_parent._id, 'type': 'nodes'},
+            {'id': public_component._id, 'type': 'nodes'}
+        ]}
+
+        res = app.delete_json_api(
+            url, new_payload, auth=user_one.auth, bulk=True)
+        assert res.status_code == 204
+
 
 @pytest.mark.django_db
 class TestNodeBulkDeleteSkipUneditable:


### PR DESCRIPTION
#### Purpose
* Allow projects with linked nodes to be bulk deleted. 

#### Changes
* Properly exclude linked nodes from bulk delete check.

#### QA Notes
* Steps to reproduce in ticket.

#### Side Effects
* None expected.

#### Ticket
* https://openscience.atlassian.net/browse/PLAT-889

#### TDD
```
(osf)~/d/osf.io ❯❯❯ py.test api_tests/nodes/views/test_node_list.py -k test_bulk_delete_project_with_linked_node
=================================================================== test session starts ====================================================================
platform darwin -- Python 2.7.13, pytest-3.0.3, py-1.5.3, pluggy-0.4.0
Django settings: api.base.settings (from environment variable)
rootdir: /Users/caseyrollins/develop/osf.io, inifile: pytest.ini
plugins: xdist-1.15.0, django-3.2.1, celery-4.2.0rc2
collected 78 items

api_tests/nodes/views/test_node_list.py F

========================================================================= FAILURES =========================================================================
_______________________________________________ TestNodeBulkDelete.test_bulk_delete_project_with_linked_node _______________________________________________
api_tests/nodes/views/test_node_list.py:3020: in test_bulk_delete_project_with_linked_node
    url, new_payload, auth=user_one.auth, bulk=True)
tests/json_api_test_app.py:118: in wrapper
    return JSONAPIWrapper.make_wrapper(self, url, method, content_type, params, **kw)
tests/json_api_test_app.py:33: in make_wrapper
    wrapper = self._gen_request(method, url, **kw)
../../miniconda/envs/osf/lib/python2.7/site-packages/webtest_plus/app.py:177: in _gen_request
    **kwargs)
../../miniconda/envs/osf/lib/python2.7/site-packages/webtest/app.py:755: in _gen_request
    expect_errors=expect_errors)
tests/json_api_test_app.py:82: in do_request
    expect_errors)
../../miniconda/envs/osf/lib/python2.7/site-packages/webtest/app.py:651: in do_request
    self._check_status(status, res)
../../miniconda/envs/osf/lib/python2.7/site-packages/webtest/app.py:683: in _check_status
    res)
E   AppError: Bad response: 400 Bad Request (not 200 OK or 3xx redirect for http://localhost/v2/nodes/)
E   '{"errors":[{"detail":"Any child components must be deleted prior to deleting this project."}],"meta":{"version":"2.0"}}'
=================================================================== 77 tests deselected ====================================================================
========================================================= 1 failed, 77 deselected in 32.38 seconds =========================================================



(osf)~/d/osf.io ❯❯❯ py.test api_tests/nodes/views/test_node_list.py -k test_bulk_delete_project_with_linked_node
=================================================================== test session starts ====================================================================
platform darwin -- Python 2.7.13, pytest-3.0.3, py-1.5.3, pluggy-0.4.0
Django settings: api.base.settings (from environment variable)
rootdir: /Users/caseyrollins/develop/osf.io, inifile: pytest.ini
plugins: xdist-1.15.0, django-3.2.1, celery-4.2.0rc2
collected 78 items

api_tests/nodes/views/test_node_list.py .

=================================================================== 77 tests deselected ====================================================================
========================================================= 1 passed, 77 deselected in 21.80 seconds =========================================================
```
