### PR TITLE
[PLAT-850] Ask Users for Name if ORCID Doesn't Provide It

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -293,8 +293,6 @@ def make_response_from_ticket(ticket, service_url):
             from website.util import web_url_for
             # orcid attributes can be marked private and not shared, default to orcid otherwise
             fullname = u'{} {}'.format(cas_resp.attributes.get('given-names', ''), cas_resp.attributes.get('family-name', '')).strip()
-            if not fullname:
-                fullname = external_credential['id']
             # TODO [CAS-27]: Remove Access Token From Service Validation
             user = {
                 'external_id_provider': external_credential['provider'],

--- a/framework/auth/forms.py
+++ b/framework/auth/forms.py
@@ -64,6 +64,15 @@ name_field = TextField(
     widget=BootstrapTextInput(),
 )
 
+name_field_not_required = TextField(
+    'Full Name',
+    [
+        NoHtmlCharacters(),
+    ],
+    filters=[stripped],
+    widget=BootstrapTextInput(),
+)
+
 email_field = TextField('Email Address',
     [
         validators.Required(message=u'Email address is required'),
@@ -159,6 +168,7 @@ class SignInForm(Form):
 
 
 class ResendConfirmationForm(Form):
+    name = name_field_not_required  # If the user's auth already has a fullname this won't appear.
     email = email_field
     accepted_terms_of_service = BooleanField(
         [

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -1045,7 +1045,7 @@ def external_login_email_post():
     return {
         'form': form,
         'external_id_provider': external_id_provider,
-        'auth_user_fullname': session.data.get('auth_user_fullname')
+        'auth_user_fullname': fullname
     }
 
 

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -943,7 +943,7 @@ def external_login_email_post():
 
     external_id_provider = session.data['auth_user_external_id_provider']
     external_id = session.data['auth_user_external_id']
-    fullname = session.data.get('auth_user_fullname', form.name.data)
+    fullname = session.data.get('auth_user_fullname') or form.name.data
     service_url = session.data['service_url']
 
     # TODO: @cslzchen use user tags instead of destination

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -921,10 +921,12 @@ def external_login_email_get():
         raise HTTPError(http.UNAUTHORIZED)
 
     external_id_provider = session.data['auth_user_external_id_provider']
+    auth_user_fullname = session.data.get('auth_user_fullname')
 
     return {
         'form': form,
-        'external_id_provider': external_id_provider
+        'external_id_provider': external_id_provider,
+        'auth_user_fullname': auth_user_fullname,
     }
 
 
@@ -941,7 +943,7 @@ def external_login_email_post():
 
     external_id_provider = session.data['auth_user_external_id_provider']
     external_id = session.data['auth_user_external_id']
-    fullname = session.data['auth_user_fullname']
+    fullname = session.data.get('auth_user_fullname', form.name.data)
     service_url = session.data['service_url']
 
     # TODO: @cslzchen use user tags instead of destination
@@ -1042,7 +1044,8 @@ def external_login_email_post():
     # Don't go anywhere
     return {
         'form': form,
-        'external_id_provider': external_id_provider
+        'external_id_provider': external_id_provider,
+        'auth_user_fullname': session.data.get('auth_user_fullname')
     }
 
 

--- a/tests/test_cas_authentication.py
+++ b/tests/test_cas_authentication.py
@@ -68,7 +68,7 @@ def generate_external_user_with_resp(service_url, user=True, release=True):
         user = {
             'external_id_provider': validated_credentials['provider'],
             'external_id': validated_credentials['id'],
-            'fullname': validated_credentials['id'],
+            'fullname': '',
             'access_token': cas_resp.attributes['accessToken'],
             'service_url': service_url,
         }

--- a/website/templates/external_login_email.mako
+++ b/website/templates/external_login_email.mako
@@ -16,6 +16,11 @@
             <div class='form-group'>
                 ${form.email(placeholder='Email address', autofocus=True, required=True) | unicode, n }
             </div>
+            % if not auth_user_fullname:
+                <div class='form-group'>
+                    ${form.name(placeholder='Full name', autofocus=True, required='required') | unicode, n }
+                </div>
+            % endif
             <div class='form-group'>
                 ${form.accepted_terms_of_service(required='required') | unicode, n }
                 <label>I have read and agree to the <a target="_blank" href='https://github.com/CenterForOpenScience/cos.io/blob/master/TERMS_OF_USE.md'>Terms of Use</a> and <a target="_blank" href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md'>Privacy Policy</a>.</label>


### PR DESCRIPTION
## Purpose

If ORCID doesn't provide us with a name, we still want one to use and display when people log in via ORCID. This provides a form field so we can collect it.

## Changes

- adds name field is only required if you don't provide a name.

## QA Notes

It shouldn't be difficult to test this for QA using a live ORCID service on staging, but for a dev using fakecas it's very difficult to test.

I choose to simulate a ORCID response by fudging the Session object so it would appear to come from ORCID.
in the framework/sessions/__init__.py file I modified the `get_session` method to the following:
```python
def get_session():
    Session = apps.get_model('osf.Session')
    user_session = sessions.get(request._get_current_object())
    if not user_session:
        user_session = Session()
        user_session.data['auth_user_external_first_login'] = True
        import random
        user_session.data['auth_user_external_id'] = 'mock external id{}'.format(random.randint(0,10000000000))
        user_session.data['auth_user_external_id_provider'] = 'ORCID'
        user_session.data['auth_user_fullname'] = 'fake name'
        user_session.data['service_url'] = 'mock service url'
        set_session(user_session)
    return user_session
``` 
and just removed `user_session.data['auth_user_fullname'] = 'fake name'` to simulate an unnamed user. I'm sure this is not the best way to do it.

## Documentation

Bug fix 

## Side Effects

None that I know of.

## Ticket
https://openscience.atlassian.net/browse/PLAT-850