### PR TITLE
Fix docker-compose boot order requirement

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -32,6 +32,7 @@ DATABASES = {
 }
 
 DATABASE_ROUTERS = ['osf.db.router.PostgreSQLFailoverRouter', ]
+RETRY_DB_CONNECTION = False
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
     'django.contrib.auth.hashers.BCryptPasswordHasher',

--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -12,6 +12,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 # DEBUG_PROPAGATE_EXCEPTIONS = True
 
 if DEBUG:
+    RETRY_DB_CONNECTION = True
     INSTALLED_APPS += ('debug_toolbar', 'nplusone.ext.django',)
     MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', 'nplusone.ext.django.NPlusOneMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {

--- a/osf/db/router.py
+++ b/osf/db/router.py
@@ -45,6 +45,9 @@ class PostgreSQLFailoverRouter(object):
                     return name
                 cur.close()
                 conn.close()
+
+            if not settings.RETRY_DB_CONNECTION:
+                return None
             logger.error('A writable db wasn\'t found. Trying again in 10 seconds')
             time.sleep(10)
         return None

--- a/osf/db/router.py
+++ b/osf/db/router.py
@@ -1,6 +1,10 @@
+import time
 from django.conf import settings
 import psycopg2
 
+
+import logging
+logger = logging.getLogger(__name__)
 
 class PostgreSQLFailoverRouter(object):
     """
@@ -24,18 +28,27 @@ class PostgreSQLFailoverRouter(object):
         Finds the first database that's writeable and returns the configuration name.
         :return: :str: name of database config or None
         """
-        for name, dsn in self.DSNS.iteritems():
-            conn = self._get_conn(dsn)
-            cur = conn.cursor()
-            cur.execute('SHOW transaction_read_only;')  # 'on' for slaves, 'off' for masters
-            row = cur.fetchone()
-            if row[0] == u'off':
+        conn = False
+        while not conn:
+            for name, dsn in self.DSNS.iteritems():
+                try:
+                    conn = self._get_conn(dsn)
+                except Exception as ex:
+                    conn = False
+                    continue
+                cur = conn.cursor()
+                cur.execute('SHOW transaction_read_only;')  # 'on' for slaves, 'off' for masters
+                row = cur.fetchone()
+                if row[0] == u'off':
+                    cur.close()
+                    conn.close()
+                    return name
                 cur.close()
                 conn.close()
-                return name
-            cur.close()
-            conn.close()
+            logger.error('A writable db wasn\'t found. Trying again in 10 seconds')
+            time.sleep(10)
         return None
+
 
     def _get_dsns(self):
         """
@@ -65,6 +78,7 @@ class PostgreSQLFailoverRouter(object):
         :param hints: hints to help choosing a database (disused)
         :return:
         """
+
         if not self.CACHED_MASTER:
             exit()
         return self.CACHED_MASTER


### PR DESCRIPTION
## Purpose

If the postgres container is not running and accepting connections when
the api container is booting, the api will fail to operate correctly
after crashing when it can't connect to postgres.

## Changes

This change causes a loop when the connection errors in order to provide
time for the database to start up without nerfing the api. It'll try to
get the connection every 10 seconds until it succeeds, and will log the
error that occurred when trying to connect.

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->



<!-- Describe the purpose of your changes -->



<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-892

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
