### PR TITLE
[IN-260] Add Comments to Reviews Emails

### DIFF
--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -121,6 +121,7 @@ class ReviewsMachine(BaseMachine):
     def notify_accept_reject(self, ev):
         context = self.get_context()
         context['notify_comment'] = not self.machineable.provider.reviews_comments_private and self.action.comment
+        context['comment'] = self.action.comment
         context['is_rejected'] = self.action.to_state == DefaultStates.REJECTED.value
         context['was_pending'] = self.action.from_state == DefaultStates.PENDING.value
         reviews_signals.reviews_email.send(creator=ev.kwargs.get('user'), context=context,

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -24,7 +24,8 @@
 
     % if notify_comment:
         The moderator has also provided a comment that is only visible to contributors
-        of the ${reviewable.provider.preprint_word}, and not to others.
+        of the ${reviewable.provider.preprint_word}, and not to others:</br>
+        ${comment}
     % endif
     </p>
 


### PR DESCRIPTION
## Purpose
Some providers report that users aren't reading their comments after submission -- including them in emails may lead to increased user involvement.

## Changes
* Add comments to reviews emails when appropriate

## QA Notes
1. Submit preprint to a moderated service that doesn't have `reviews_comments_private` set to `True`
2. Moderate it and include a comment.
3. Ensure submitting user gets the comment in their notification email.

## Side Effects
None expected

## Ticket
[[IN-260]](https://openscience.atlassian.net/browse/IN-260)
