### PR TITLE
[IN-243][OSF] Fix handling enter keypress on editable html input

### DIFF
--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -474,6 +474,11 @@ ko.bindingHandlers.editableHTML = {
         $element.on('change input paste keyup blur', function() {
             options.observable($element.html());
         });
+        $element.on('keypress', function(e){
+            if (e.keyCode === 13){
+                e.preventDefault();
+            }
+        });
     },
     update: function(element, valueAccessor, allBindings, viewModel) {
         var $element = $(element);
@@ -481,7 +486,7 @@ ko.bindingHandlers.editableHTML = {
         var initialValue = options.observable();
         options.onUpdate.call(viewModel, element);
         if (initialValue === '') {
-            $(element).html(initialValue);
+            $element.html(initialValue);
         }
     }
 };


### PR DESCRIPTION
## Purpose

Fix issue where enter keypress on input field result in new line.
This change should not affect enter keypress on `textarea` inputs using
the `editableHtml` ko helper.

## Changes

`preventDefault` on enter keypress.

## QA Notes
Make sure the pressing enter while confirming the delete does not do anything.

These changes modifies a helper also used in comments, but it should modify the behavior on enter keypress. Check and see if comments still work just fine.

## Documentation
## Side Effects
## Ticket

[IN-243](https://openscience.atlassian.net/browse/IN-243)