### PR TITLE
[PLAT-804] Consistent branding on project citations: Open Science Framework -> OSF

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -687,7 +687,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 contributor.csl_name(self._id)  # method in auth/model.py which parses the names of authors
                 for contributor in self.visible_contributors
             ],
-            'publisher': 'Open Science Framework',
+            'publisher': 'OSF',
             'type': 'webpage',
             'URL': self.display_absolute_url,
         }

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3157,7 +3157,7 @@ class TestCitationsProperties:
         assert (
             node.csl ==
             {
-                'publisher': 'Open Science Framework',
+                'publisher': 'OSF',
                 'author': [{
                     'given': node.creator.given_name,
                     'family': node.creator.family_name,
@@ -3179,7 +3179,7 @@ class TestCitationsProperties:
         assert (
             node.csl ==
             {
-                'publisher': 'Open Science Framework',
+                'publisher': 'OSF',
                 'author': [
                     {
                         'given': node.creator.given_name,

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -46,7 +46,7 @@ class CitationsNodeTestCase(OsfTestCase):
         assert_equal(
             self.node.csl,
             {
-                'publisher': 'Open Science Framework',
+                'publisher': 'OSF',
                 'author': [{
                     'given': self.node.creator.given_name,
                     'family': self.node.creator.family_name,
@@ -68,7 +68,7 @@ class CitationsNodeTestCase(OsfTestCase):
         assert_equal(
             self.node.csl,
             {
-                'publisher': 'Open Science Framework',
+                'publisher': 'OSF',
                 'author': [
                     {
                         'given': self.node.creator.given_name,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Citations for projects should be consistent with our branding, so let's change project citations to be for "OSF" rather than "Open Science Framework."

<img width="563" alt="screen shot 2018-06-11 at 11 32 01 am" src="https://user-images.githubusercontent.com/801594/41242824-8afbb044-6d6e-11e8-99e0-65c544eecf05.png">


<!-- Describe the purpose of your changes -->

## Changes
- Update node citation to read "OSF" instead of "Open Science Framework"
- Update tests checking for that wording in node citations

## QA Notes

- make sure that project citations now read "OSF" instead of "Open Science Framework"
- As preprint citations are generated from the name of the preprint provider, those should all still read "Open Science Framework" after this change


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->
https://github.com/CenterForOpenScience/developer.osf.io/pull/20

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-804
