### PR TITLE
[PLAT-915] Fix corner case for adding a contributor with a registered, secondary email

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1332,19 +1332,18 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             contributor, _ = self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
                                  permissions=permissions, send_email=send_email, save=True)
         else:
-
-            try:
+            contributor = get_user(email=email)
+            if contributor:
+                if self.contributor_set.filter(user=contributor).exists():
+                    raise ValidationValueError('{} is already a contributor.'.format(contributor.fullname))
+                self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
+                                    send_email=send_email, permissions=permissions, save=True)
+            else:
                 contributor = self.add_unregistered_contributor(
                     fullname=full_name, email=email, auth=auth,
                     send_email=send_email, permissions=permissions,
                     visible=bibliographic, save=True
                 )
-            except ValidationError:
-                contributor = get_user(email=email)
-                if self.contributor_set.filter(user=contributor).exists():
-                    raise ValidationValueError('{} is already a contributor.'.format(contributor.fullname))
-                self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
-                                     send_email=send_email, permissions=permissions, save=True)
 
         auth.user.email_last_sent = timezone.now()
         auth.user.save()

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -25,6 +25,7 @@ from osf.utils.permissions import READ, WRITE, ADMIN, expand_permissions, DEFAUL
 
 from osf.models import (
     AbstractNode,
+    Email,
     Node,
     Tag,
     NodeLog,
@@ -1154,6 +1155,16 @@ class TestNodeAddContributorRegisteredOrNot:
         registered_user = UserFactory()
         contributor_obj = node.add_contributor_registered_or_not(auth=Auth(user), full_name='F Mercury', email=registered_user.username)
         contributor = contributor_obj.user
+        assert contributor in node.contributors
+        assert contributor.is_registered is True
+
+    def test_add_contributor_fullname_email_exists_as_secondary(self, user, node):
+        registered_user = UserFactory()
+        secondary_email = 'secondary@test.test'
+        Email.objects.create(address=secondary_email, user=registered_user)
+        contributor_obj = node.add_contributor_registered_or_not(auth=Auth(user), full_name='F Mercury', email=secondary_email)
+        contributor = contributor_obj.user
+        assert contributor == registered_user
         assert contributor in node.contributors
         assert contributor.is_registered is True
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -56,6 +56,7 @@ from website.views import index
 from osf.utils import permissions
 from osf.models import Comment
 from osf.models import OSFUser
+from osf.models import Email
 from tests.base import (
     assert_is_redirect,
     capture_signals,


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

See: https://www.flowdock.com/app/cos/archiver/threads/6Az9BWQBQPlk_HELqquwhMwEJ9b

User is unable to add an unregistered contributor whose email address is associated with a registered user.

## Changes

<!-- Briefly describe or list your changes  -->

The get_user call was not correctly handling when a user tries to
add an unregistered user using an email that's a secondary email address
of a registered user. With this change, we get the registered user associated
with the email address rather than using `get_user`.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Steps:

* Register email A
* Add email B as a confirmed, secondary email
* Create a preprint, inviting email B as an unregistered contributor

Expected:

The registered user (with username A) is added as a contributor to the
preprint/node.

Actual:

There is an unregistered contributor with email B as the username, even
though email B is a secondary email for a registered user. This
prevents them from adding new contributors to the project.

## Ticket

https://openscience.atlassian.net/browse/PLAT-915

Also see https://www.flowdock.com/app/cos/archiver/threads/6Az9BWQBQPlk_HELqquwhMwEJ9b
