### PR TITLE
[IN-242][OSF] Fix weird interactions btn github and zotero dismissible alerts

### DIFF
--- a/website/static/js/alertsManager.js
+++ b/website/static/js/alertsManager.js
@@ -70,7 +70,7 @@ var AlertsViewModel = function() {
             self.loading(false);
         });
         request.fail(function(xhr, status, error){
-            self.loaded(false);
+            self.loading(false);
             $osf.growl('Error', 'Could not fetch alerts for this page. Please refresh page and try again.', 'danger');
             Raven.captureMessage('Error fetching user alerts', {
                 extra: {

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -19,7 +19,7 @@
         </div>
         <div class="col-sm-9">
     % else:
-        <div class="col-sm-12">
+         <div class="col-sm-12">
     % endif
 
     <!-- End left column -->
@@ -101,7 +101,8 @@
             % endif
         % endif  ## End Select Addons
 
-        % if any(addon['enabled'] and not addon['default'] for addon in addon_settings): ## Begin Configure Addons
+        % if any(addon['enabled'] and not addon['default'] for addon in addon_settings):
+            ## Begin Configure Addons
             <div class="panel panel-default" id="configureAddon">
                 <span id="configureAddonsAnchor" class="anchor"></span>
                 <div class="panel-heading clearfix">
@@ -124,32 +125,35 @@
                                         <span aria-hidden="true">&times;</span>
                                     </button>
                                     <div>
-                                        <h4>Don’t see your GitHub Organization repositories?</h4>
+                                        <h4>Don’t see your GitHub organization repositories?</h4>
                                         <p>
                                             You may need to reauthorize your GitHub access token.
                                             Follow the steps in the <a class="alert-link" href="http://help.osf.io/a/850865-reauthorize-github" target="_black">help guide</a> to resolve the issue. <br>
                                         </p>
                                         <p>
-                                            Please contact support <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
+                                            Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
                                         </p>
                                     </div>
                                 </div>
+                            </div>
                         % endif
                         % if addon['addon_short_name'] == 'zotero':
-                            <div id='zotero-group-library-alert' class='scripted dismissible-alerts'>
+                            <div id='zotero-group-library-alert' class='scripted'>
                                 <div class="alert alert-info alert-dismissible" role="alert">
-                                    <button type="button" id="zoteroWarningCancel" class="close" data-dismiss="alert" aria-label="Close"
+                                    <button type="button" id="zoteroWarningCancel" class="close" data-dismiss="alert" aria-label="Close">
                                         <span aria-hidden="true">&times;</span>
                                     </button>
-                                <div>
-                                <h4>Don’t see your Zotero group libraries?</h4>
-                                <p>
-                                    You may need to reauthorize your Zotero access token.
-                                    Follow the steps in the <a class="alert-link" href='http://help.osf.io/a/850167-reauthorize-zotero' target="_black">help guide</a> to resolve the issue.
-                                </p>
-                                <p>
-                                    Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
-                                </p>
+                                    <div>
+                                        <h4>Don’t see your Zotero group libraries?</h4>
+                                        <p>
+                                            You may need to reauthorize your Zotero access token.
+                                            Follow the steps in the <a class="alert-link" href='http://help.osf.io/a/850167-reauthorize-zotero' target="_black">help guide</a> to resolve the issue.
+                                        </p>
+                                        <p>
+                                            Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
                         % endif
                         % if not loop.last:
@@ -158,7 +162,8 @@
                     % endfor
                 </div>
             </div>
-        % endif  ## End Configure Addons
+        % endif
+        ## End Configure Addons
     </div>
 </div>
 


### PR DESCRIPTION
## Purpose

Fix weird UI interactions btn github and zotero dismissible alerts

## Changes
- Fix unclosed divs
- Remove `.dismissible-alerts` from zotero alert to allow
dismissing gh alerts when zotero is enabled.
 
## QA Notes

## Documentation

## Side Effects

## After
http://recordit.co/tyaValuPqD
## Ticket
[IN-242](https://openscience.atlassian.net/browse/IN-242)