### PR TITLE
[PLAT-155][Hotfix] Embedding primary_file on preprints 502s

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -130,7 +130,6 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     primary_file = PrimaryFileRelationshipField(
         related_view='files:file-detail',
         related_view_kwargs={'file_id': '<primary_file._id>'},
-        lookup_url_kwarg='file_id',
         read_only=False
     )
 


### PR DESCRIPTION
## Purpose

When we embed a `primary_file` in a preprint we 502, this makes us not do that.

## Changes

- remove lookup_url_kwarg we can't actually use lookup

## QA Notes

`v2/preprints/?embed=primary_file` and `v2/preprints/<preprint_guid>/?embed=primary_file` should work and display an embedded primary_file.

## Documentation

🐞 fix, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-155