### PR TITLE
[IN-281][OSF] Add preprint spam handling in Admin

### DIFF
--- a/admin/preprints/serializers.py
+++ b/admin/preprints/serializers.py
@@ -1,3 +1,5 @@
+import json
+
 from admin.nodes.serializers import serialize_node
 
 
@@ -11,5 +13,8 @@ def serialize_preprint(preprint):
         'node': serialize_node(preprint.node),
         'is_published': preprint.is_published,
         'date_published': preprint.date_published,
-        'subjects': preprint.subjects.all()
+        'subjects': preprint.subjects.all(),
+        'spam_status': preprint.spam_status,
+        'spam_pro_tip': preprint.spam_pro_tip,
+        'spam_data': json.dumps(preprint.spam_data, indent=4),
     }

--- a/admin/preprints/urls.py
+++ b/admin/preprints/urls.py
@@ -8,4 +8,11 @@ urlpatterns = [
     url(r'^(?P<guid>[a-z0-9]+)/$', views.PreprintView.as_view(), name='preprint'),
     url(r'^(?P<guid>[a-z0-9]+)/reindex_share_preprint/$', views.PreprintReindexShare.as_view(),
         name='reindex-share-preprint'),
+    url(r'^(?P<guid>[a-z0-9]+)/confirm_spam/$', views.PreprintConfirmSpamView.as_view(),
+        name='confirm-spam'),
+    url(r'^(?P<guid>[a-z0-9]+)/confirm_ham/$', views.PreprintConfirmHamView.as_view(),
+        name='confirm-ham'),
+    url(r'^flagged_spam$', views.PreprintFlaggedSpamList.as_view(), name='flagged-spam'),
+    url(r'^known_spam$', views.PreprintKnownSpamList.as_view(), name='known-spam'),
+    url(r'^known_ham$', views.PreprintKnownHamList.as_view(), name='known-ham'),
 ]

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -1,13 +1,16 @@
 from __future__ import unicode_literals
 
-from django.views.generic import UpdateView, DeleteView
+from django.views.generic import ListView, UpdateView, DeleteView
 from django.core.urlresolvers import reverse_lazy
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.shortcuts import redirect
+from django.core.exceptions import PermissionDenied
 
+from osf.models import SpamStatus
 from osf.models.preprint_service import PreprintService
-from osf.models.admin_log_entry import update_admin_log, REINDEX_SHARE
+from osf.models.admin_log_entry import update_admin_log, REINDEX_SHARE, CONFIRM_SPAM, CONFIRM_HAM
 from website.preprints.tasks import update_preprint_share
+from website.project.views.register import osf_admin_change_status_identifier
 
 from framework.exceptions import PermissionsError
 from admin.base.views import GuidFormView, GuidView
@@ -58,23 +61,119 @@ class PreprintView(PermissionRequiredMixin, UpdateView, GuidView):
         # TODO - we shouldn't need this serialized_preprint value -- https://openscience.atlassian.net/browse/OSF-7743
         kwargs['serialized_preprint'] = serialize_preprint(preprint)
         kwargs['change_provider_form'] = ChangeProviderForm(instance=preprint)
+        kwargs.update({'SPAM_STATUS': SpamStatus})  # Pass spam status in to check against
+
         return super(PreprintView, self).get_context_data(**kwargs)
 
+class PreprintSpamList(PermissionRequiredMixin, ListView):
+    SPAM_STATE = SpamStatus.UNKNOWN
 
-class PreprintReindexShare(PermissionRequiredMixin, DeleteView):
-    template_name = 'preprints/reindex_preprint_share.html'
+    paginate_by = 25
+    paginate_orphans = 1
+    ordering = ('created')
+    context_object_name = 'preprintservice'
+    permission_required = ('osf.view_spam', 'osf.view_preprintservice')
+    raise_exception = True
+
+    def get_queryset(self):
+        return PreprintService.objects.filter(spam_status=self.SPAM_STATE).order_by(self.ordering)
+
+    def get_context_data(self, **kwargs):
+        query_set = kwargs.pop('object_list', self.object_list)
+        page_size = self.get_paginate_by(query_set)
+        paginator, page, query_set, is_paginated = self.paginate_queryset(
+            query_set, page_size)
+        return {
+            'preprints': map(serialize_preprint, query_set),
+            'page': page,
+        }
+
+class PreprintFlaggedSpamList(PreprintSpamList, DeleteView):
+    SPAM_STATE = SpamStatus.FLAGGED
+    template_name = 'preprints/flagged_spam_list.html'
+
+    def delete(self, request, *args, **kwargs):
+        if not request.user.has_perm('auth.mark_spam'):
+            raise PermissionDenied('You do not have permission to update a preprint flagged as spam.')
+        preprint_ids = [
+            pid for pid in request.POST.keys()
+            if pid != 'csrfmiddlewaretoken'
+        ]
+        for pid in preprint_ids:
+            preprint = PreprintService.load(pid)
+            osf_admin_change_status_identifier(preprint, 'unavailable | spam')
+            preprint.confirm_spam(save=True)
+            update_admin_log(
+                user_id=self.request.user.id,
+                object_id=pid,
+                object_repr='PreprintService',
+                message='Confirmed SPAM: {}'.format(pid),
+                action_flag=CONFIRM_SPAM
+            )
+        return redirect('preprints:flagged-spam')
+
+class PreprintKnownSpamList(PreprintSpamList):
+    SPAM_STATE = SpamStatus.SPAM
+    template_name = 'preprints/known_spam_list.html'
+
+class PreprintKnownHamList(PreprintSpamList):
+    SPAM_STATE = SpamStatus.HAM
+    template_name = 'preprints/known_spam_list.html'
+
+class PreprintDeleteBase(DeleteView):
+    template_name = None
     context_object_name = 'preprintservice'
     object = None
-    permission_required = 'osf.view_preprintservice'
-    raise_exception = True
 
     def get_context_data(self, **kwargs):
         context = {}
         context.setdefault('guid', kwargs.get('object')._id)
-        return super(PreprintReindexShare, self).get_context_data(**context)
+        return super(PreprintDeleteBase, self).get_context_data(**context)
 
     def get_object(self, queryset=None):
         return PreprintService.load(self.kwargs.get('guid'))
+
+
+class PreprintConfirmSpamView(PermissionRequiredMixin, PreprintDeleteBase):
+    template_name = 'preprints/confirm_spam.html'
+    permission_required = 'osf.mark_spam'
+    raise_exception = True
+
+    def delete(self, request, *args, **kwargs):
+        preprint = self.get_object()
+        preprint.confirm_spam(save=True)
+        osf_admin_change_status_identifier(preprint, 'unavailable | spam')
+        update_admin_log(
+            user_id=self.request.user.id,
+            object_id=preprint._id,
+            object_repr='PreprintService',
+            message='Confirmed SPAM: {}'.format(preprint._id),
+            action_flag=CONFIRM_SPAM,
+        )
+        return redirect(reverse_preprint(self.kwargs.get('guid')))
+
+class PreprintConfirmHamView(PermissionRequiredMixin, PreprintDeleteBase):
+    template_name = 'preprints/confirm_ham.html'
+    permission_required = 'osf.mark_spam'
+    raise_exception = True
+
+    def delete(self, request, *args, **kwargs):
+        preprint = self.get_object()
+        preprint.confirm_ham(save=True)
+        osf_admin_change_status_identifier(preprint, 'public')
+        update_admin_log(
+            user_id=self.request.user.id,
+            object_id=preprint._id,
+            object_repr='PreprintService',
+            message='Confirmed HAM: {}'.format(preprint._id),
+            action_flag=CONFIRM_HAM
+        )
+        return redirect(reverse_preprint(self.kwargs.get('guid')))
+
+class PreprintReindexShare(PermissionRequiredMixin, PreprintDeleteBase):
+    template_name = 'preprints/reindex_preprint_share.html'
+    permission_required = 'osf.view_preprintservice'
+    raise_exception = True
 
     def delete(self, request, *args, **kwargs):
         preprint = self.get_object()

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -116,9 +116,23 @@
                 </div>
             </li>
             {% endif %}
-            {% if perms.osf.view_preprintservice %}
-            <li><a href="{% url 'preprints:search' %}"><i class='fa fa-link'></i><span>Preprints</span> </a></li>
-            {% endif %}
+          {% if perms.osf.view_preprintservice %}
+              <li>
+                  <a role="button" data-toggle="collapse" href="#collapsePreprints">
+                      <i class='fa fa-caret-down'></i> Preprints
+                  </a>
+              </li>
+              <li>
+                  <div class="collapse" id="collapsePreprints">
+                      <ul class="sidebar-menu sidebar-menu-inner">
+                          <li><a href="{% url 'preprints:search' %}"><i class='fa fa-link'></i><span>Preprints</span> </a></li>
+                          <li><a href="{% url 'preprints:flagged-spam' %}"><i class="fa fa-exclamation-triangle"></i><span> Flagged Spam</span> </a></li>
+                          <li><a href="{% url 'preprints:known-spam' %}"><i class="fa fa-cutlery"></i><span> Known Spam</span> </a></li>
+                          <li><a href="{% url 'preprints:known-ham' %}"><i class="fa fa-star"></i><span> Known Ham</span> </a></li>
+                      </ul>
+                  </div>
+              </li>
+          {% endif %}
           {% if perms.osf.view_osfuser %}
               <li><a role="button" data-toggle="collapse" href="#collapseUsers">
                   <i class='fa fa-caret-down'></i> OSF Users

--- a/admin/templates/preprints/confirm_ham.html
+++ b/admin/templates/preprints/confirm_ham.html
@@ -1,0 +1,13 @@
+<form class="well" method="post" action="{% url 'preprints:confirm-ham' guid=guid %}">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">x</button>
+        <h3>Are you sure this preprint is <strong>not</strong> spam? {{ guid }}</h3>
+    </div>
+    {% csrf_token %}
+    <div class="modal-footer">
+        <input class="btn btn-danger" type="submit" value="Confirm" />
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+            Cancel
+        </button>
+    </div>
+</form>

--- a/admin/templates/preprints/confirm_spam.html
+++ b/admin/templates/preprints/confirm_spam.html
@@ -1,0 +1,13 @@
+<form class="well" method="post" action="{% url 'preprints:confirm-spam' guid=guid %}">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">x</button>
+        <h3>Are you sure this preprint is spam? {{ guid }}</h3>
+    </div>
+    {% csrf_token %}
+    <div class="modal-footer">
+        <input class="btn btn-danger" type="submit" value="Confirm" />
+        <button type="button" class="btn btn-default" data-dismiss="modal">
+            Cancel
+        </button>
+    </div>
+</form>

--- a/admin/templates/preprints/flagged_spam_list.html
+++ b/admin/templates/preprints/flagged_spam_list.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+<title>Flagged Spam Preprints</title>
+{% endblock title %}
+{% block content %}
+  {% url 'preprints:flagged-spam' as form_action %}
+  {% include 'preprints/preprint_list.html' with form_action=form_action%}
+{% endblock content %}

--- a/admin/templates/preprints/known_spam_list.html
+++ b/admin/templates/preprints/known_spam_list.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+<title>Known Spam Preprints</title>
+{% endblock title %}
+{% block content %}
+    {% include 'preprints/preprint_list.html' %}
+{% endblock content %}

--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -38,6 +38,34 @@
                     </span>
                 {% endif %}
                 {% endif %}
+            {% if perms.osf.mark_spam %}
+            <span class="col-md-2">
+                <a href="{% url 'preprints:confirm-spam' guid=serialized_preprint.id %}"
+                   data-toggle="modal" data-target="#confirmSpamModal"
+                   class="btn btn-warning">
+                    Confirm Spam
+                </a>
+            </span>
+            <div class="modal" id="confirmSpamModal">
+                <div class="modal-dialog">
+                    <div class="modal-content"></div>
+                    {# Data from above link #}
+                </div>
+            </div>
+            <span class="col-md-2">
+                <a href="{% url 'preprints:confirm-ham' guid=serialized_preprint.id %}"
+                   data-toggle="modal" data-target="#confirmHamModal"
+                   class="btn btn-default">
+                    Confirm <strong>Not</strong> Spam
+                </a>
+            </span>
+            <div class="modal" id="confirmHamModal">
+                <div class="modal-dialog">
+                    <div class="modal-content"></div>
+                    {# Data from above link #}
+                </div>
+            </div>
+            {% endif %}
             <span class="col-md-2">
                 <a href="{% url 'preprints:reindex-share-preprint' guid=serialized_preprint.id %}"
                    data-toggle="modal" data-target="#confirmReindexSharePreprint"
@@ -94,7 +122,7 @@
                             {% if perms.osf.change_preprintservice %}
                             <span class="provider_form_link" style="margin-left: 100px;">
                                 <a class="btn btn-link" role="button" data-toggle="collapse" href="#collapseChangeProvider">
-                                    Change prepint provider
+                                    Change preprint provider
                                 </a>
                                 <div class="collapse" id="collapseChangeProvider">
                                     <div class="well">
@@ -125,7 +153,7 @@
                     </tr>
                     <tr>
                         <td>Date Modified</td>
-                        <td>{{ serialized_preprint.date_created }} UTC</td>
+                        <td>{{ serialized_preprint.modified }} UTC</td>
                     </tr>
                     <tr>
                         <td>Published</td>
@@ -171,6 +199,30 @@
                             {% endfor %}
                             </tbody>
                             </table>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>SPAM Pro Tip</td>
+                        <td>{{ serialized_preprint.spam_pro_tip }}</td>
+                    </tr>
+                    <tr>
+                    <td>SPAM Status</td>
+                    <td>
+                        {% if serialized_preprint.spam_status == SPAM_STATUS.UNKNOWN %}
+                            <span class="label label-default">Unknown</span>
+                        {% elif serialized_preprint.spam_status == SPAM_STATUS.FLAGGED %}
+                            <span class="label label-warning">Flagged</span>
+                        {% elif serialized_preprint.spam_status == SPAM_STATUS.SPAM %}
+                            <span class="label label-danger">Spam</span>
+                        {% elif serialized_preprint.spam_status == SPAM_STATUS.HAM %}
+                            <span class="label label-success">Ham</span>
+                        {% endif %}
+                    </td>
+                    </tr>
+                    <tr>
+                        <td>SPAM Data</td>
+                        <td>
+                            <pre>{{ serialized_preprint.spam_data }}</pre>
                         </td>
                     </tr>
                 </tbody>

--- a/admin/templates/preprints/preprint_list.html
+++ b/admin/templates/preprints/preprint_list.html
@@ -1,0 +1,82 @@
+{% load user_extras %}
+{% load node_extras %}
+{% include "util/pagination.html" with items=page status=status %}
+{% if form_action %}
+<form action={{form_action}} method="POST">
+{% endif %}
+<table class="table table-striped table-hover table-responsive">
+    <thead>
+        <tr>
+            {% if form_action %}
+            <th>
+                <input type="checkbox" onclick="toggle(this)">
+                <script language="javascript">
+                    function toggle(source) {
+                        var checkboxes = document.getElementsByClassName('selection');
+                        for (var i in checkboxes) {
+                            checkboxes[i].checked = source.checked;
+                        }
+                    }
+                </script>
+            </th>
+            {% endif %}
+            <th>GUID</th>
+            <th>Title</th>
+            <th>Public</th>
+            <th>Provider</th>
+            <th>Date Published</th>
+            <th>Date Modified</th>
+            <th>Date Created</th>
+            <th>Creator</th>
+            <th>SPAM Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for preprint in preprints %}
+        <tr>
+            {% if form_action %}
+            <td>
+                <input name="{{preprint.id}}" class="selection" type="checkbox"/>
+            </td>
+            {% endif %}
+            <td>
+                <a href="{%  url 'preprints:preprint' preprint.id %}"
+                   class="btn btn-primary">
+                    {{ preprint.id }}
+                </a>
+            </td>
+            <td> {{ preprint.node.title }} </td>
+            <td> {{ preprint.node.is_public }} </td>
+            <td> {{ preprint.provider.name }} </td>
+            <td> {{ preprint.date_published }} </td>
+            <td> {{ preprint.modified }} </td>
+            <td> {{ preprint.date_created}} </td>
+            <td> {{ preprint.node.creator }} </td>
+            <td> {{ preprint.spam_status }} </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% if form_action and perms.osf.mark_spam %}
+<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
+    Confirm Spam
+</button>
+<div id="confirmSpamListModal" class="modal fade well" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">x</button>
+                <h3>Are you sure the selected preprint(s) are spam?</h3>
+            </div>
+            <div class="modal-footer">
+                <input class="btn btn-danger" type="submit" value="Confirm" />
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+{% csrf_token %}
+</form>
+{% endif %}

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -1,142 +1,253 @@
+import pytest
 import mock
-from nose import tools as nt
+# from nose import tools as nt
 from django.test import RequestFactory
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import Permission
 
-from tests.base import AdminTestCase
+# from tests.base import AdminTestCase
 from osf.models import PreprintService
 from osf_tests.factories import AuthUserFactory, PreprintFactory, PreprintProviderFactory
 from osf.models.admin_log_entry import AdminLogEntry
+from osf.models.spam import SpamStatus
 
 from admin_tests.utilities import setup_view, setup_log_view
 
 from admin.preprints import views
 from admin.preprints.forms import ChangeProviderForm
 
+pytestmark = pytest.mark.django_db
 
-class TestPreprintView(AdminTestCase):
+@pytest.fixture()
+def preprint():
+    return PreprintFactory()
 
-    def setUp(self):
-        super(TestPreprintView, self).setUp()
-        self.preprint = PreprintFactory()
-        self.view = views.PreprintView
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
 
-    def test_no_guid(self):
-        request = RequestFactory().get('/fake_path')
-        view = setup_view(self.view(), request)
+@pytest.fixture()
+def req(user):
+    req = RequestFactory().get('/fake_path')
+    req.user = user
+    return req
+
+@pytest.mark.urls('admin.base.urls')
+class TestPreprintView:
+
+    @pytest.fixture()
+    def plain_view(self):
+        return views.PreprintView
+
+    @pytest.fixture()
+    def view(self, req, plain_view):
+        view = plain_view()
+        setup_view(view, req)
+        return view
+
+    @pytest.fixture()
+    def ham_preprint(self):
+        ham_preprint = PreprintFactory()
+        ham_preprint.spam_status = SpamStatus.HAM
+        ham_preprint.save()
+        return ham_preprint
+
+    @pytest.fixture()
+    def spam_preprint(self):
+        spam_preprint = PreprintFactory()
+        spam_preprint.spam_status = SpamStatus.SPAM
+        spam_preprint.save()
+        return spam_preprint
+
+    @pytest.fixture()
+    def flagged_preprint(self):
+        flagged_preprint = PreprintFactory()
+        flagged_preprint.spam_status = SpamStatus.FLAGGED
+        flagged_preprint.save()
+        return flagged_preprint
+
+    @pytest.fixture()
+    def superuser(self):
+        superuser = AuthUserFactory()
+        superuser.is_superuser = True
+        superuser.save()
+        return superuser
+
+    def test_no_guid(self, view):
         preprint = view.get_object()
-        nt.assert_is_none(preprint)
+        assert preprint is None
 
-    def test_get_object(self):
-        request = RequestFactory().get('/fake_path')
-        view = setup_view(self.view(), request, guid=self.preprint._id)
+    def test_get_object(self, req, preprint, plain_view):
+        view = setup_view(plain_view(), req, guid=preprint._id)
         res = view.get_object()
-        nt.assert_is_instance(res, PreprintService)
+        assert isinstance(res, PreprintService)
 
-    def test_no_user_permissions_raises_error(self):
-        user = AuthUserFactory()
-        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+    def test_no_user_permissions_raises_error(self, user, preprint, plain_view):
+        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': preprint._id}))
         request.user = user
 
-        with nt.assert_raises(PermissionDenied):
-            self.view.as_view()(request, guid=self.preprint._id)
+        with pytest.raises(PermissionDenied):
+            plain_view.as_view()(request, guid=preprint._id)
 
-    def test_correct_view_permissions(self):
-        user = AuthUserFactory()
+    def test_get_flagged_spam(self, superuser, preprint, ham_preprint, spam_preprint, flagged_preprint):
+        request = RequestFactory().get(reverse('preprints:flagged-spam'))
+        request.user = superuser
+        response = views.PreprintFlaggedSpamList.as_view()(request)
+        assert response.status_code == 200
 
+        response_ids = map(lambda res: res['id'], response.context_data['preprints'])
+        assert preprint._id not in response.context_data['preprints'][0]['id']
+        assert len(response.context_data['preprints']) == 1
+        assert flagged_preprint._id in response_ids
+        assert ham_preprint._id not in response_ids
+        assert spam_preprint._id not in response_ids
+        assert preprint._id not in response_ids
+
+    def test_get_known_spam(self, superuser, preprint, ham_preprint, spam_preprint, flagged_preprint):
+        request = RequestFactory().get(reverse('preprints:known-spam'))
+        request.user = superuser
+        response = views.PreprintKnownSpamList.as_view()(request)
+        assert response.status_code == 200
+
+        response_ids = map(lambda res: res['id'], response.context_data['preprints'])
+        assert preprint._id not in response.context_data['preprints'][0]['id']
+        assert len(response.context_data['preprints']) == 1
+        assert flagged_preprint._id not in response_ids
+        assert ham_preprint._id not in response_ids
+        assert spam_preprint._id in response_ids
+        assert preprint._id not in response_ids
+
+    def test_get_known_ham(self, superuser, preprint, ham_preprint, spam_preprint, flagged_preprint):
+        request = RequestFactory().get(reverse('preprints:known-ham'))
+        request.user = superuser
+        response = views.PreprintKnownHamList.as_view()(request)
+        assert response.status_code == 200
+
+        response_ids = map(lambda res: res['id'], response.context_data['preprints'])
+        assert preprint._id not in response.context_data['preprints'][0]['id']
+        assert len(response.context_data['preprints']) == 1
+        assert flagged_preprint._id not in response_ids
+        assert ham_preprint._id in response_ids
+        assert spam_preprint._id not in response_ids
+        assert preprint._id not in response_ids
+
+    def test_confirm_spam(self, flagged_preprint, superuser):
+        request = RequestFactory().post('/fake_path')
+        request.user = superuser
+
+        view = views.PreprintConfirmSpamView()
+        view = setup_view(view, request, guid=flagged_preprint._id)
+        view.delete(request)
+
+        assert flagged_preprint.node.is_public
+
+        flagged_preprint.refresh_from_db()
+        flagged_preprint.node.refresh_from_db()
+
+        assert flagged_preprint.is_spam
+        assert flagged_preprint.node.is_spam
+        assert not flagged_preprint.node.is_public
+
+    def test_confirm_ham(self, preprint, superuser):
+        request = RequestFactory().post('/fake_path')
+        request.user = superuser
+
+        view = views.PreprintConfirmHamView()
+        view = setup_view(view, request, guid=preprint._id)
+        view.delete(request)
+
+        preprint.refresh_from_db()
+        preprint.node.refresh_from_db()
+
+        assert preprint.spam_status == SpamStatus.HAM
+        assert preprint.node.spam_status == SpamStatus.HAM
+        assert preprint.node.is_public
+
+    def test_correct_view_permissions(self, user, preprint, plain_view):
         view_permission = Permission.objects.get(codename='view_preprintservice')
         user.user_permissions.add(view_permission)
         user.save()
 
-        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': preprint._id}))
         request.user = user
 
-        response = self.view.as_view()(request, guid=self.preprint._id)
-        nt.assert_equal(response.status_code, 200)
+        response = plain_view.as_view()(request, guid=preprint._id)
+        assert response.status_code == 200
 
-    def test_change_preprint_provider_no_permission(self):
-        user = AuthUserFactory()
-        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+    def test_change_preprint_provider_no_permission(self, user, preprint, plain_view):
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}))
         request.user = user
 
-        with nt.assert_raises(PermissionDenied):
-            self.view.as_view()(request, guid=self.preprint._id)
+        with pytest.raises(PermissionDenied):
+            plain_view.as_view()(request, guid=preprint._id)
 
-    def test_change_preprint_provider_correct_permission(self):
-        user = AuthUserFactory()
-
+    def test_change_preprint_provider_correct_permission(self, user, preprint, plain_view):
         change_permission = Permission.objects.get(codename='change_preprintservice')
         view_permission = Permission.objects.get(codename='view_preprintservice')
         user.user_permissions.add(change_permission)
         user.user_permissions.add(view_permission)
         user.save()
 
-        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}))
         request.user = user
 
-        response = self.view.as_view()(request, guid=self.preprint._id)
-        nt.assert_equal(response.status_code, 302)
+        response = plain_view.as_view()(request, guid=preprint._id)
+        assert response.status_code == 302
 
-    def test_change_preprint_provider_form(self):
+    def test_change_preprint_provider_form(self, plain_view, preprint):
         new_provider = PreprintProviderFactory()
-        self.view.kwargs = {'guid': self.preprint._id}
+        plain_view.kwargs = {'guid': preprint._id}
         form_data = {
             'provider': new_provider.id
         }
-        form = ChangeProviderForm(data=form_data, instance=self.preprint)
-        self.view().form_valid(form)
+        form = ChangeProviderForm(data=form_data, instance=preprint)
+        plain_view().form_valid(form)
 
-        nt.assert_equal(self.preprint.provider, new_provider)
+        assert preprint.provider == new_provider
 
+@pytest.mark.urls('admin.base.urls')
+class TestPreprintFormView:
 
-class TestPreprintFormView(AdminTestCase):
+    @pytest.fixture()
+    def view(self):
+        return views.PreprintFormView
 
-    def setUp(self):
-        super(TestPreprintFormView, self).setUp()
-        self.preprint = PreprintFactory()
-        self.view = views.PreprintFormView
-        self.user = AuthUserFactory()
-        self.url = reverse('preprints:search')
+    @pytest.fixture()
+    def url(self):
+        return reverse('preprints:search')
 
-    def test_no_user_permissions_raises_error(self):
-        request = RequestFactory().get(self.url)
-        request.user = self.user
-        with nt.assert_raises(PermissionDenied):
-            self.view.as_view()(request)
+    def test_no_user_permissions_raises_error(self, url, user, view):
+        request = RequestFactory().get(url)
+        request.user = user
+        with pytest.raises(PermissionDenied):
+            view.as_view()(request)
 
-    def test_correct_view_permissions(self):
+    def test_correct_view_permissions(self, url, user, view):
 
         view_permission = Permission.objects.get(codename='view_preprintservice')
-        self.user.user_permissions.add(view_permission)
-        self.user.save()
+        user.user_permissions.add(view_permission)
+        user.save()
 
-        request = RequestFactory().get(self.url)
-        request.user = self.user
+        request = RequestFactory().get(url)
+        request.user = user
 
-        response = self.view.as_view()(request)
-        nt.assert_equal(response.status_code, 200)
+        response = view.as_view()(request)
+        assert response.status_code == 200
 
-
-class TestPreprintReindex(AdminTestCase):
-    def setUp(self):
-        super(TestPreprintReindex, self).setUp()
-        self.request = RequestFactory().post('/fake_path')
-
-        self.user = AuthUserFactory()
-        self.preprint = PreprintFactory(creator=self.user)
+@pytest.mark.urls('admin.base.urls')
+class TestPreprintReindex:
 
     @mock.patch('website.preprints.tasks.send_share_preprint_data')
     @mock.patch('website.settings.SHARE_URL', 'ima_real_website')
-    def test_reindex_preprint_share(self, mock_reindex_preprint):
-        self.preprint.provider.access_token = 'totally real access token I bought from a guy wearing a trenchcoat in the summer'
-        self.preprint.provider.save()
+    def test_reindex_preprint_share(self, mock_reindex_preprint, preprint, req):
+        preprint.provider.access_token = 'totally real access token I bought from a guy wearing a trenchcoat in the summer'
+        preprint.provider.save()
 
         count = AdminLogEntry.objects.count()
         view = views.PreprintReindexShare()
-        view = setup_log_view(view, self.request, guid=self.preprint._id)
-        view.delete(self.request)
+        view = setup_log_view(view, req, guid=preprint._id)
+        view.delete(req)
 
-        nt.assert_true(mock_reindex_preprint.called)
-        nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
+        assert mock_reindex_preprint.called
+        assert AdminLogEntry.objects.count() == count + 1

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -280,6 +280,10 @@ class PreprintService(DirtyFieldsMixin, SpamMixin, GuidMixin, IdentifierMixin, R
         super(PreprintService, self).confirm_spam(save=save)
         self.node.confirm_spam(save=save)
 
+    def confirm_ham(self, save=False):
+        super(PreprintService, self).confirm_ham(save=save)
+        self.node.confirm_ham(save=save)
+
     def _send_preprint_confirmation(self, auth):
         # Send creator confirmation email
         recipient = self.node.creator


### PR DESCRIPTION
## Purpose

Add preprint spam handling in Admin

## Changes

- Add `known-spam`, `known-ham`, `confirm-ham`, `confirm-spam` views
- Add spam fields to preprint detail view
- Add tests

## QA Notes
In preparation for testing: it would help to have some flagged preprints.
In Admin, preprints, go to flagged preprints. Make sure you see ll flagged preprints.
Select a few flagged preprints and confirm them as spam.

Go to known spam and make sure all of them are listed.
Go spam preprint node pages and make sure the associated node are now private.

Go to detail page of confirmed spam preprint:
With the 'confirm not spam' button, make some spammy preprints 'HAM'.
Go to the known HAM and make sure the new changed preprints are listed.

Make sure that spam fields show up in the preprint detail page.
## Documentation

## Side Effects

## Ticket

[IN_281](https://openscience.atlassian.net/browse/IN-281)
