### PR TITLE
[hotfix] Remove google plus from the footer [PLAT-909]

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1913,5 +1913,4 @@ FOOTER_LINKS = {
     'facebook': 'https://www.facebook.com/CenterForOpenScience/',
     'googleGroup': 'https://groups.google.com/forum/#!forum/openscienceframework',
     'github': 'https://www.github.com/centerforopenscience',
-    'googlePlus': 'https://plus.google.com/b/104751442909573665859',
 }

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -56,7 +56,6 @@
                     <a href="${footer_links['facebook']}" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
                     <a href="${footer_links['googleGroup']}" aria-label="Google Group"><i class="fa fa-group fa-2x"></i></a>
                     <a href="${footer_links['github']}" aria-label="GitHub"><i class="fa fa-github fa-2x"></i></a>
-                    <a href="${footer_links['googlePlus']}" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
#### Purpose
* Remove google plus link/icon from the footer. 

#### After
![screen shot 2018-06-13 at 3 16 30 pm](https://user-images.githubusercontent.com/7913604/41372943-cabc13ae-6f1c-11e8-88c3-2461cb8fcdb6.png)

#### Ticket
* https://openscience.atlassian.net/browse/PLAT-909
