### PR TITLE
[PLAT-838] Admin: add ability to remove stuck registrations

### DIFF
--- a/admin/nodes/urls.py
+++ b/admin/nodes/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
         name='reindex-elastic-node'),
     url(r'^(?P<guid>[a-z0-9]+)/restart_stuck_registrations/$', views.RestartStuckRegistrationsView.as_view(),
         name='restart-stuck-registrations'),
+    url(r'^(?P<guid>[a-z0-9]+)/remove_stuck_registrations/$', views.RemoveStuckRegistrationsView.as_view(),
+        name='remove-stuck-registrations'),
     url(r'^(?P<node_id>[a-z0-9]+)/remove_user/(?P<user_id>[a-z0-9]+)/$',
         views.NodeRemoveContributorView.as_view(), name='remove_user'),
 ]

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -442,14 +442,17 @@ class NodeReindexElastic(PermissionRequiredMixin, NodeDeleteBase):
         return redirect(reverse_node(self.kwargs.get('guid')))
 
 
-class RestartStuckRegistrationsView(PermissionRequiredMixin, TemplateView):
-    template_name = 'nodes/restart_registrations_modal.html'
+class StuckRegistrationsView(PermissionRequiredMixin, TemplateView):
     permission_required = ('osf.view_node', 'osf.change_node')
     raise_exception = True
     context_object_name = 'node'
 
     def get_object(self, queryset=None):
         return Registration.load(self.kwargs.get('guid'))
+
+
+class RestartStuckRegistrationsView(StuckRegistrationsView):
+    template_name = 'nodes/restart_registrations_modal.html'
 
     def post(self, request, *args, **kwargs):
         from osf.management.commands.force_archive import archive, verify
@@ -469,14 +472,8 @@ class RestartStuckRegistrationsView(PermissionRequiredMixin, TemplateView):
         return redirect(reverse_node(self.kwargs.get('guid')))
 
 
-class RemoveStuckRegistrationsView(PermissionRequiredMixin, TemplateView):
+class RemoveStuckRegistrationsView(StuckRegistrationsView):
     template_name = 'nodes/remove_registrations_modal.html'
-    permission_required = ('osf.view_node', 'osf.change_node')
-    raise_exception = True
-    context_object_name = 'node'
-
-    def get_object(self, queryset=None):
-        return Registration.load(self.kwargs.get('guid'))
 
     def post(self, request, *args, **kwargs):
         from osf.management.commands.force_archive import verify

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -53,6 +53,11 @@
                                    class="btn btn-warning">
                                     Restart Registration
                                 </a>
+                                <a href="{% url 'nodes:remove-stuck-registrations' guid=node.id %}"
+                                   data-toggle="modal" data-target="#confirmRemoveRegistration"
+                                   class="btn btn-danger">
+                                    Remove Registration
+                                </a>
                             {% endif %}
 
                         {% endif %}
@@ -93,6 +98,12 @@
                         </div>
                     </div>
                     <div class="modal" id="confirmRestartRegistration">
+                        <div class="modal-dialog">
+                            <div class="modal-content"></div>
+                            {# Data from above link #}
+                        </div>
+                    </div>
+                    <div class="modal" id="confirmRemoveRegistration">
                         <div class="modal-dialog">
                             <div class="modal-content"></div>
                             {# Data from above link #}

--- a/admin/templates/nodes/remove_registrations_modal.html
+++ b/admin/templates/nodes/remove_registrations_modal.html
@@ -1,7 +1,7 @@
-<form class="well" method="post" action="{% url 'nodes:restart-stuck-registrations' guid=guid %}">
+<form class="well" method="post" action="{% url 'nodes:remove-stuck-registrations' guid=guid %}">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">x</button>
-        <h3>Are you sure you want to restart the registration process? {{ guid }}</h3>
+        <h3>Are you sure you want to remove this registration? {{ guid }}</h3>
     </div>
     {% csrf_token %}
     <div class="modal-footer">

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -460,7 +460,7 @@ class TestRemoveStuckRegistrationsView(AdminTestCase):
 
         nt.assert_true(self.registration, view.get_object())
 
-    def test_restart_stuck_registration(self):
+    def test_remove_stuck_registration(self):
         view = RemoveStuckRegistrationsView()
         view = setup_log_view(view, self.request, guid=self.registration._id)
         from django.contrib.messages.storage.fallback import FallbackStorage

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -12,7 +12,8 @@ from admin.nodes.views import (
     NodeKnownHamList,
     NodeConfirmHamView,
     AdminNodeLogView,
-    RestartStuckRegistrationsView
+    RestartStuckRegistrationsView,
+    RemoveStuckRegistrationsView
 )
 from admin_tests.utilities import setup_log_view, setup_view
 
@@ -442,3 +443,35 @@ class TestRestartStuckRegistrationsView(AdminTestCase):
         view.post(self.request)
 
         nt.assert_equal(self.registration.archive_job.status, u'SUCCESS')
+
+
+class TestRemoveStuckRegistrationsView(AdminTestCase):
+    def setUp(self):
+        super(TestRemoveStuckRegistrationsView, self).setUp()
+        self.user = AuthUserFactory()
+        self.registration = RegistrationFactory(creator=self.user)
+        self.registration.save()
+        self.view = RemoveStuckRegistrationsView
+        self.request = RequestFactory().post('/fake_path')
+
+    def test_get_object(self):
+        view = RemoveStuckRegistrationsView()
+        view = setup_log_view(view, self.request, guid=self.registration._id)
+
+        nt.assert_true(self.registration, view.get_object())
+
+    def test_restart_stuck_registration(self):
+        view = RemoveStuckRegistrationsView()
+        view = setup_log_view(view, self.request, guid=self.registration._id)
+        from django.contrib.messages.storage.fallback import FallbackStorage
+
+        # django.contrib.messages has a bug which effects unittests
+        # more info here -> https://code.djangoproject.com/ticket/17971
+        setattr(self.request, 'session', 'session')
+        messages = FallbackStorage(self.request)
+        setattr(self.request, '_messages', messages)
+
+        view.post(self.request)
+
+        self.registration.refresh_from_db()
+        nt.assert_true(self.registration.is_deleted)


### PR DESCRIPTION
## Purpose

Admins want to delete stuck registrations via the Admin App, this lets them. This is the spiritual sequel to the "restart stuck registrations" feature.

## Changes

- Button and modal UI to remove stuck registrations.
- Added RemoveStuckRegistrationView
- Added tests

## QA Notes

For info on making stuck registrations check out the QA notes for [restart stuck regs PR](https://github.com/CenterForOpenScience/osf.io/pull/8271) This is a very similar PR except it marks the reg as deleted instead of restarting it.

## Documentation

Admin app issue should be known by all parties.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-838