### PR TITLE
[IN-334][OSF] Center banner image

### DIFF
--- a/admin/static/css/banners.css
+++ b/admin/static/css/banners.css
@@ -6,4 +6,5 @@
 
 .banner-image {
     max-height: 300px;
+    margin: auto;
 }

--- a/website/static/css/scheduled-banner.css
+++ b/website/static/css/scheduled-banner.css
@@ -1,3 +1,4 @@
 .banner-image {
     max-height: 300px;
+    margin: auto;
 }


### PR DESCRIPTION
## Purpose

Center banner image in admin (banner preview) and legacy frontends

## Changes

- Fix banner styles
- Center the banner image

## Side Effects / Testing Notes

Make sure the banner is centered.
Please try different sizes heights to make sure larger banners display right.

## Documentation

## Side Effects

## Ticket

[IN-334](https://openscience.atlassian.net/browse/IN-334)

## After
**Meetings**
<img width="1677" alt="screen shot 2018-06-14 at 2 26 52 pm" src="https://user-images.githubusercontent.com/4511563/41430984-89ba758a-6fdf-11e8-8831-1621e64d4059.png">

**Admin**
<img width="1678" alt="screen shot 2018-06-14 at 2 26 03 pm" src="https://user-images.githubusercontent.com/4511563/41430994-8fe3626e-6fdf-11e8-9fb1-09b76b89b993.png">
