### PR TITLE
[hotfix] Update filterable_fields on NodeRequestSerializer for machine_state [PLAT-854]

### DIFF
--- a/api/requests/serializers.py
+++ b/api/requests/serializers.py
@@ -16,7 +16,7 @@ class NodeRequestSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'creator',
         'request_type',
-        'current_state',
+        'machine_state',
         'created',
         'id'
     ])


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Filter field on NodeRequestSerializer was out of date, change it to match fields on the `NodeRequest` model and allow filtering on `machine_state`

## Changes

- Update name in `filterable_fields`
- Add test for `?filter[machine_state]=pending`

## QA Notes
- This change is API only, and so most likely won't need any QA testing. As it's a hotfix and specifically for a feature that's being worked on, I imagine that'll be the testing!

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
Doesn't seem as though the requests part of the API is documented on developer.osf.io yet, so no doc changes needed

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

none anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-854
