### PR TITLE
[PLAT-772][Hotfix] Fix responsive button for forks and request access

### DIFF
--- a/website/static/css/add-project-plugin.css
+++ b/website/static/css/add-project-plugin.css
@@ -17,3 +17,8 @@ select option:first-child {
 .help-text {
     color: grey;
 }
+
+/*  Tiny hack to allow dropdowns to work responsively https://github.com/twbs/bootstrap/issues/7968 */
+.dropdown-backdrop {
+    position: static;
+}


### PR DESCRIPTION
## Purpose

On mobile devices clicking/touching the dropdown menus for forks or request access to projects doesn't work this makes it work

## Changes

- Simple CSS fix for bootstrap bug.

## QA Notes

Using a mobile device or Chrome's responsive mode, click the anything forks dropdown menu to see if it works.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-772