### PR TITLE
[IN-255][OSF] Use "OSF Preprints" in citations

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -30,7 +30,7 @@ def preprint_csl(preprint, node):
     csl = node.csl
 
     csl['id'] = preprint._id
-    csl['publisher'] = preprint.provider.name
+    csl['publisher'] = 'OSF Preprints' if preprint.provider.name == 'Open Science Framework' else preprint.provider.name
     csl['URL'] = display_absolute_url(preprint)
 
     if preprint.original_publication_date:
@@ -46,7 +46,6 @@ def preprint_csl(preprint, node):
         csl['DOI'] = article_doi
     elif preprint_doi and preprint.is_published and preprint.preprint_doi_created:
         csl['DOI'] = preprint_doi
-
     return csl
 
 
@@ -222,7 +221,7 @@ def remove_extra_period_after_right_quotation(cit):
 
 def chicago_reformat(node, cit):
     cit = remove_extra_period_after_right_quotation(cit)
-    new_csl = cit.split('20')
+    new_csl = cit.split('20', 1)
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
     # throw error if there is no visible contributor

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -190,7 +190,7 @@ class TestPreprintCitationContentMLA(ApiTestCase):
         date = timezone.now().date().strftime('%-d %B %Y')
         assert_equal(citation, u'McGee, Grapes C. B. “{}” {}, {}. Web.'.format(
                 self.node.title,
-                self.published_preprint.provider.name,
+                'OSF Preprints',
                 date)
         )
 

--- a/website/static/bluebook.csl
+++ b/website/static/bluebook.csl
@@ -231,7 +231,8 @@
     <layout>
         <group>
             <names variable="author" suffix=", "/>
-            <text variable="title" font-style="italic" suffix=", Open Science Framework"/>
+            <text variable="title" font-style="italic" suffix=", "/>
+            <text variable="publisher" font-style="italic"/>
             <date variable="issued" prefix=" (" suffix="), ">
                 <date-part name="month" form="short"/>
                 <date-part name="day" suffix=", "/>


### PR DESCRIPTION
## Purpose

Use "OSF Preprints" in citations

## Changes
- Update `bluebook` citation styles
- Update other citations to use "OSF Preprints"


## QA Notes

Please make sure that preprint citations are using the "OSF Preprints" instead of "Open Science Framework". Try bluebook citations as well.

## Documentation

## Side Effects

<!-- Any possible side effects? -->

## Ticket

[[IN-255]](https://openscience.atlassian.net/browse/IN-255)
