### PR TITLE
[IN-313][OSF] Add logos to project overview page for collected projects

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -37,7 +37,7 @@ from website.util.rubeus import collect_addon_js
 from website.project.model import has_anonymous_link, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
 from website.project.metadata.utils import serialize_meta_schemas
-from osf.models import AbstractNode, Collection, Guid, PrivateLink, Contributor, Node, NodeRelation
+from osf.models import AbstractNode, Collection, Guid, PrivateLink, Contributor, Node, NodeRelation, CollectedGuidMetadata
 from osf.models.contributor import get_contributor_permissions
 from osf.models.licenses import serialize_node_license_record
 from osf.utils.sanitize import strip_html
@@ -695,6 +695,7 @@ def _view_project(node, auth, primary=False,
     else:
         in_bookmark_collection = False
         bookmark_collection_id = ''
+
     view_only_link = auth.private_key or request.args.get('view_only', '').strip('/')
     anonymous = has_anonymous_link(node, auth)
     addons = list(node.get_addons())
@@ -875,6 +876,7 @@ def serialize_collections(cgms, auth):
         'status': cgm.status,
         'type': cgm.collected_type,
         'is_public': cgm.collection.is_public,
+        'logo': cgm.collection.provider.asset_files.get(name='favicon-16x16').file.url
     } for cgm in cgms if cgm.collection.is_public or
         (auth.user and auth.user.has_perm('read_collection', cgm.collection))]
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -37,7 +37,7 @@ from website.util.rubeus import collect_addon_js
 from website.project.model import has_anonymous_link, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
 from website.project.metadata.utils import serialize_meta_schemas
-from osf.models import AbstractNode, Collection, Guid, PrivateLink, Contributor, Node, NodeRelation, CollectedGuidMetadata
+from osf.models import AbstractNode, Collection, Guid, PrivateLink, Contributor, Node, NodeRelation
 from osf.models.contributor import get_contributor_permissions
 from osf.models.licenses import serialize_node_license_record
 from osf.utils.sanitize import strip_html

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -298,8 +298,9 @@
     % for i, collection in enumerate(node['collections'][:5]):
     <div class="row">
         <div class="col-xs-12 col-md-6">
-            <div style="margin-top: 5px;">Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
-                <img src="${collection['logo']}">
+            <div style="margin-top: 5px;">
+                Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
+                <img style="margin: 0px 0px 2px 5px;" src="${collection['logo']}">
             % if any([collection['type'], collection['status']]):
               &nbsp;<span id="metadata${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadata${i}"></span>
             % endif

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -299,6 +299,7 @@
     <div class="row">
         <div class="col-xs-12 col-md-6">
             <div style="margin-top: 5px;">Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
+                <img src="${collection['logo']}">
             % if any([collection['type'], collection['status']]):
               &nbsp;<span id="metadata${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadata${i}"></span>
             % endif


### PR DESCRIPTION
## Purpose

Add logos to project overview page for collected projects.

## Changes

Add new entry to the dict returned by `serialize_collections`.

## Screenshot

<img width="666" alt="screen shot 2018-06-15 at 11 21 55 am" src="https://user-images.githubusercontent.com/1566880/41476063-7006ea2e-708e-11e8-92dd-71c5eb9ee2d5.png">

## QA Notes

There is currently no UI to add stuff to collections. So there are two ways to go about this ticket. The first is to defer until collection fronted UI is there. The second is to use osf shell on staging to add project to collections.


## Side Effects

None.

## Ticket

https://openscience.atlassian.net/browse/IN-313
