### PR TITLE
Set ASSETS_PREFIX to /ember_osf_web/ in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,6 +252,7 @@ services:
       - web
     environment:
       - BACKEND=local
+      - ASSETS_PREFIX=/ember_osf_web/
     expose:
       - 4200
       - 41953


### PR DESCRIPTION
## Purpose

Allow development docker builds of ember-osf-web to work with osf.io@master

## Changes

Set environment variable `ASSETS_PREFIX=/ember_osf_web/` in docker-compose.yml section for ember_osf_web.

## QA Notes

No QA.

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a
