### PR TITLE
Crossref name parsing plus a bit of email [PLAT-802]

### DIFF
--- a/website/templates/emails/crossref_doi_error.html.mako
+++ b/website/templates/emails/crossref_doi_error.html.mako
@@ -1,19 +1,19 @@
-Hello OSF Support,
-
-There has been some trouble in registering a DOI or updating the metadata for the preprint ${preprint.absolute_url} with CrossRef.
-
-preprint guid: ${preprint._id}
-doi: ${doi}
-
-Here is the original content of the error message:
-
+Hello OSF Support,<br>
+<br>
+There has been some trouble in registering a DOI or updating the metadata for the preprint ${preprint.absolute_url} with CrossRef.<br>
+<br>
+preprint guid: ${preprint._id}<br>
+doi: ${doi}<br>
+<br>
+Here is the original content of the error message:<br>
+<pre>
 ...
 
 ${email_content}
 
 ...
-
-
-Sincerely,
-
+</pre>
+<br>
+Sincerely,<br>
+<br>
 Open Science Framework Robot


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Crossref has some rules with names that I didn't anticipate until actual testing began! Namely (hahah get it):

- If there is just one name, has to be a family name
- There can't be numbers or ? in a given name

Also make the error emails easier to read while we're at it.

## Changes

- Use close to the same logic to figure out how to use the name as the API citation util
- Get rid of numbers and ? in a given name
- Tests for these things
- Make the helpdesk error email better formatted and not just a blob

## QA Notes
- Should now not completely freak out and refuse to mint a DOI if you have a number in your first name
- Should now be able to make DOIs with just a firstname set

## Documentation

Not for this no but I did add a few docstrings!!

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-802
