### PR TITLE
Make sure updating contributors and licenses trigger changes in datacite metadata

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1562,6 +1562,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 auth=auth,
                 save=False,
             )
+            self.update_or_enqueue_on_node_updated(auth.user._id, first_save=False, saved_fields={'node_license'})
 
         if save:
             self.save()

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3408,9 +3408,22 @@ class TestOnNodeUpdate:
         new_person = UserFactory()
         node.add_contributor(new_person)
 
-        # Make sure there's just one on_node_updated task, and that is has contributors in the kwargs
+        # so will updating a license
+        new_license = NodeLicenseRecordFactory()
+        node.set_node_license(
+            {
+                'id': new_license.license_id,
+                'year': '2018',
+                'copyrightHolders': ['LeBron', 'Ladron']
+            },
+            Auth(node.creator),
+        )
+        node.save()
+
+        # Make sure there's just one on_node_updated task, and that is has contributors and node_license in the kwargs
         task = handlers.get_task_from_queue('website.project.tasks.on_node_updated', predicate=lambda task: task.kwargs['node_id'] == node._id)
         assert 'contributors' in task.kwargs['saved_fields']
+        assert 'node_license' in task.kwargs['saved_fields']
         mock_request_update.assert_called_once()
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -35,6 +35,9 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
         update_node_share(node)
         update_collecting_metadata(node, saved_fields)
 
+    if node.get_identifier_value('doi') and bool(node.IDENTIFIER_UPDATE_FIELDS.intersection(saved_fields)):
+        node.request_identifier_update(category='doi')
+
 def update_collecting_metadata(node, saved_fields):
     from website.search.search import update_collected_metadata
     if node.is_collected:
@@ -43,9 +46,6 @@ def update_collecting_metadata(node, saved_fields):
         else:
             if 'is_public' in saved_fields:
                 update_collected_metadata(node._id, op='delete')
-
-    if node.get_identifier_value('doi') and bool(node.IDENTIFIER_UPDATE_FIELDS.intersection(saved_fields)):
-        node.request_identifier_update(category='doi')
 
 def update_node_share(node):
     # Wrapper that ensures share_url and token exist


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Updating contributors or licenses on a project should trigger changes to the datacite metadata

## Changes

- move a call to on_node_updated that got nested incorrectly on merging 
- add call to update on_node_updated task when a license is changed
- test to make sure that call is created correctly when a license is changed

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Now, changing a license or contributors should trigger a version change. Changing two contributors should create just one new version!

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-806