### PR TITLE
Remove ember-osf-web assets routes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -252,7 +252,6 @@ services:
       - web
     environment:
       - BACKEND=local
-      - ASSETS_PREFIX=/ember_osf_web/
     expose:
       - 4200
       - 41953

--- a/website/routes.py
+++ b/website/routes.py
@@ -58,8 +58,6 @@ from website.identifiers import views as identifier_views
 from website.ember_osf_web.decorators import ember_flag_is_active
 from website.settings import EXTERNAL_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
-EMBER_ASSET_ROUTE_PREFIXES = ['assets', 'engines-dist', 'fonts', 'img']
-
 def set_status_message(user):
     if user and not user.accepted_terms_of_service:
         status.push_status_message(
@@ -221,28 +219,17 @@ def ember_app(path=None):
     fp = path or 'index.html'
 
     ember_app = None
-    strip_prefix = True
 
     for k in EXTERNAL_EMBER_APPS.keys():
         if request.path.strip('/').startswith(k):
             ember_app = EXTERNAL_EMBER_APPS[k]
             break
 
-    for asset_prefix in EMBER_ASSET_ROUTE_PREFIXES:
-        if request.path.strip('/').startswith(asset_prefix) and EXTERNAL_EMBER_APPS.get('ember_osf_web'):
-            ember_app = EXTERNAL_EMBER_APPS['ember_osf_web']
-            strip_prefix = False
-            fp = asset_prefix + '/' + fp
-            break
-
     if not ember_app:
         raise HTTPError(http.NOT_FOUND)
 
     if settings.PROXY_EMBER_APPS:
-        if strip_prefix:
-            path = request.path[len(ember_app['path']):]
-        else:
-            path = request.path
+        path = request.path[len(ember_app['path']):]
         url = urlparse.urljoin(ember_app['server'], path)
         resp = requests.get(url, stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT, headers={'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'})
         excluded_headers = ['content-encoding', 'content-length', 'transfer-encoding', 'connection']
@@ -365,16 +352,6 @@ def make_url_map(app):
                     notemplate
                 )
             ])
-            for asset_prefix in EMBER_ASSET_ROUTE_PREFIXES:
-                process_rules(app, [
-                    Rule(
-                        '/<path:path>',
-                        'get',
-                        ember_app,
-                        json_renderer,
-                        endpoint_suffix='__' + asset_prefix
-                    )
-                ], prefix='/' + asset_prefix)
             if 'routes' in EXTERNAL_EMBER_APPS['ember_osf_web']:
                 for route in EXTERNAL_EMBER_APPS['ember_osf_web']['routes']:
                     process_rules(app, [


### PR DESCRIPTION
## Purpose

https://github.com/CenterForOpenScience/osf.io/pull/8371/files#diff-758f58f82207e3674b3105d2b3d4ce7aR1679 created a route conflict so serving ember-osf-web assets from `/assets` is no longer an option. Instead, we have set up the ember app so that its assets can always be served from `/ember_osf_web`, regardless of whether served through flask or directly from the ember-cli express server. This PR removes the special assets routes for ember-osf-web and the setting of ASSETS_PREFIX=/ember_osf_web/, which is no longer necessary, as this is now the default.

## Changes

* Remove ember-osf-web asset routing
* Remove setting of ASSETS_PREFIX for ember_osf_web

## QA Notes

No QA needed. This only affects local development.

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a
