### PR TITLE
[feature] Send ORCIDs and update licenses in CrossRef metadata [PLAT-802]

### DIFF
--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -17,6 +17,7 @@ from osf_tests.factories import (
     AuthUserFactory
 )
 from framework.flask import rm_handlers
+from framework.auth.core import Auth
 from framework.auth.utils import impute_names
 
 
@@ -190,3 +191,25 @@ class TestCrossRefClient:
 
         assert contributors.find('.//{%s}surname' % crossref.CROSSREF_NAMESPACE).text == 'Madonna'
         assert not contributors.find('.//{%s}given_name' % crossref.CROSSREF_NAMESPACE)
+
+
+    def test_metadata_none_license_update(self, crossref_client, preprint):
+        crossref_xml = crossref_client.build_metadata(preprint, pretty_print=True)
+        root = lxml.etree.fromstring(crossref_xml)
+
+        assert root.find('.//{%s}license_ref' % crossref.CROSSREF_ACCESS_INDICATORS).text == 'https://creativecommons.org/licenses/by/4.0/legalcode'
+        assert root.find('.//{%s}license_ref' % crossref.CROSSREF_ACCESS_INDICATORS).get('start_date') == preprint.date_published.strftime('%Y-%m-%d')
+
+        license_detail = {
+            'copyrightHolders': ['The Carters'],
+            'id': 'NONE',
+            'year': '2018'
+        }
+
+        preprint.set_preprint_license(license_detail, Auth(preprint.node.creator), save=True)
+
+        crossref_xml = crossref_client.build_metadata(preprint, pretty_print=True)
+        root = lxml.etree.fromstring(crossref_xml)
+
+        assert root.find('.//{%s}license_ref' % crossref.CROSSREF_ACCESS_INDICATORS) is None
+        assert root.find('.//{%s}program' % crossref.CROSSREF_ACCESS_INDICATORS).getchildren() == []

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -185,7 +185,13 @@ class CrossRefClient(AbstractIdentifierClient):
             person.append(element.surname(name_parts['surname']))
             if contributor.suffix:
                 person.append(element.suffix(remove_control_characters(contributor.suffix)))
-
+            if contributor.external_identity.get('ORCID'):
+                orcid = contributor.external_identity['ORCID'].keys()[0]
+                verified = contributor.external_identity['ORCID'].values()[0] == 'VERIFIED'
+                if orcid and verified:
+                    person.append(
+                        element.ORCID('https://orcid.org/{}'.format(orcid), authenticated='true')
+                    )
             contributors.append(person)
 
         return contributors

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -114,6 +114,10 @@ class CrossRefClient(AbstractIdentifierClient):
                         xmlns=CROSSREF_ACCESS_INDICATORS
                     )
                 )
+            else:
+                posted_content.append(
+                    element.program(xmlns=CROSSREF_ACCESS_INDICATORS)
+                )
 
             if preprint.node.preprint_article_doi:
                 posted_content.append(


### PR DESCRIPTION
#### Purpose
* Adds user ORCIDs (when verified) to the metadata we send to CrossRef for preprint DOIs.
  * See https://support.crossref.org/hc/en-us/articles/214567746-Authors-and-editors
* Explicitly delete license information from CrossRef metadata when a preprint license is changed to "None"
  * See https://support.crossref.org/hc/en-us/articles/115003564483

#### Changes
* See above.

#### QA Notes
* When a preprint license is updated to "None", license information should be cleared from the DOI metadata.
* If a preprint contributor has a **verified** ORCID (i.e., they've logged in to the OSF via ORCID, not just added it to their profile), their ORCID should be part of the DOI metadata. 

#### Ticket
* https://openscience.atlassian.net/browse/PLAT-802
