### PR TITLE
Preprint DOI improvements to metadata and DOI setting [PLAT-802] [PLAT-921]

### DIFF
--- a/api/crossref/permissions.py
+++ b/api/crossref/permissions.py
@@ -21,6 +21,8 @@ class RequestComesFromMailgun(permissions.BasePermission):
         data = request.data
         if not data:
             raise exceptions.ParseError('Request body is empty')
+        if not settings.MAILGUN_API_KEY:
+            return False
         signature = hmac.new(
             key=settings.MAILGUN_API_KEY,
             msg='{}{}'.format(

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -163,7 +163,11 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     def get_preprint_doi_url(self, obj):
         doi_identifier = obj.get_identifier('doi')
         if doi_identifier:
-            return 'https://dx.doi.org/{}'.format(doi_identifier.value)
+            doi = doi_identifier.value
+        else:
+            client = obj.get_doi_client()
+            doi = client.build_doi(preprint=obj) if client else None
+        return 'https://dx.doi.org/{}'.format(doi) if doi else None
 
     def update(self, preprint, validated_data):
         assert isinstance(preprint, PreprintService), 'You must specify a valid preprint to be updated'

--- a/api_tests/crossref/views/test_crossref_email_response.py
+++ b/api_tests/crossref/views/test_crossref_email_response.py
@@ -189,7 +189,7 @@ class TestCrossRefEmailResponse:
         assert not mock_send_mail.called
         assert preprint.get_identifier_value(category='doi') != initial_value
 
-    def test_update_success_does_not_set_prerprint_doi_created(self, app, preprint, url, update_success_xml):
+    def test_update_success_does_not_set_preprint_doi_created(self, app, preprint, url, update_success_xml):
         preprint.set_identifier_value(category='doi', value='test')
         preprint.preprint_doi_created = timezone.now()
         preprint.save()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -994,7 +994,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         mock_update_doi_metadata.assert_called_with(
             project_public._id, status='unavailable')
 
-    @mock.patch('website.preprints.tasks.update_doi_metadata_on_change')
+    @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')
     def test_set_node_with_preprint_private_updates_doi(
             self, mock_update_doi_metadata, app, user,
             project_public, url_public, make_node_payload):
@@ -1009,8 +1009,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert res.status_code == 200
         project_public.reload()
         assert not project_public.is_public
-        mock_update_doi_metadata.assert_called_with(
-            target_object._id, status='unavailable')
+        mock_update_doi_metadata.assert_called_with(target_object._id)
 
     def test_permissions_to_set_subjects(self, app, user, project_public, subject, url_public, make_node_payload):
         # test_write_contrib_cannot_set_subjects

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -398,7 +398,7 @@ class TestPreprintUpdate:
         assert preprint_detail['links']['doi'] == 'https://dx.doi.org/{}'.format(
             new_doi)
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')
     def test_update_description_and_title(
             self, mock_preprint_updated, app, user, preprint, url):
         new_title = 'Brother Nero'
@@ -424,7 +424,7 @@ class TestPreprintUpdate:
         assert preprint.node.title == new_title
         assert mock_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.update_doi_metadata_on_change')
+    @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')
     def test_update_tags(self, mock_update_doi_metadata, app, user, preprint, url):
         new_tags = ['hey', 'sup']
 
@@ -450,7 +450,7 @@ class TestPreprintUpdate:
         ) == new_tags
         assert mock_update_doi_metadata.called
 
-    @mock.patch('website.preprints.tasks.update_doi_metadata_on_change')
+    @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')
     def test_update_contributors(
             self, mock_update_doi_metadata, app, user, preprint, url):
         new_user = AuthUserFactory()
@@ -605,7 +605,7 @@ class TestPreprintUpdate:
 
         assert unpublished.node.is_public
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')
     def test_update_preprint_task_called_on_api_update(
             self, mock_on_preprint_updated, app, user, preprint, url):
         update_doi_payload = build_preprint_update_payload(

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -223,7 +223,7 @@ class TestPreprintListFilteringByReviewableFields(ReviewableFilterMixin):
 
     @pytest.fixture()
     def expected_reviewables(self, user):
-        with mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers'):
+        with mock.patch('website.identifiers.utils.request_identifiers'):
             preprints = [
                 PreprintFactory(
                     is_published=False, project=ProjectFactory(

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -307,7 +307,7 @@ class PreprintIsValidListMixin:
         res = app.get(url, auth=user_admin_contrib.auth)
         assert len(res.json['data']) == 0
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
+    @mock.patch('osf.models.preprint_service.update_or_enqueue_on_preprint_updated')
     def test_preprint_node_null_invisible(
             self, mock_preprint_updated, app,
             user_admin_contrib, user_write_contrib,

--- a/api_tests/providers/preprints/views/test_preprint_provider_preprints_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_preprints_list.py
@@ -124,7 +124,7 @@ class TestPreprintProviderPreprintListFilteringByReviewableFields(
 
     @pytest.fixture()
     def expected_reviewables(self, provider, user):
-        with mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers'):
+        with mock.patch('website.identifiers.utils.request_identifiers'):
             preprints = [
                 PreprintFactory(
                     is_published=False,

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -58,6 +58,14 @@ def postcommit_after_request(response, base_status_error_code=500):
             logger.error('Post commit task queue not initialized: {}'.format(ex))
     return response
 
+def get_task_from_postcommit_queue(name, predicate):
+    matches = [task for key, task in postcommit_celery_queue().iteritems() if task.type.name == name and predicate(task)]
+    if len(matches) == 1:
+        return matches[0]
+    elif len(matches) > 1:
+        raise ValueError()
+    return False
+
 def enqueue_postcommit_task(fn, args, kwargs, celery=False, once_per_request=True):
     '''
     Any task queued with this function where celery=True will be run asynchronously.

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -58,8 +58,9 @@ def postcommit_after_request(response, base_status_error_code=500):
             logger.error('Post commit task queue not initialized: {}'.format(ex))
     return response
 
-def get_task_from_postcommit_queue(name, predicate):
-    matches = [task for key, task in postcommit_celery_queue().iteritems() if task.type.name == name and predicate(task)]
+def get_task_from_postcommit_queue(name, predicate, celery=True):
+    queue = postcommit_celery_queue() if celery else postcommit_queue()
+    matches = [task for key, task in queue.iteritems() if task.type.name == name and predicate(task)]
     if len(matches) == 1:
         return matches[0]
     elif len(matches) > 1:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2431,11 +2431,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         if self.preprint_file:
             # avoid circular imports
-            from website.preprints.tasks import on_preprint_updated
+            from website.preprints.tasks import update_or_enqueue_on_preprint_updated
             PreprintService = apps.get_model('osf.PreprintService')
             # .preprints wouldn't return a single deleted preprint
             for preprint in PreprintService.objects.filter(node_id=self.id, is_published=True):
-                enqueue_task(on_preprint_updated.s(preprint._id))
+                update_or_enqueue_on_preprint_updated(preprint._id)
 
         user = User.load(user_id)
         if user and self.check_spam(user, saved_fields, request_headers):

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -245,7 +245,7 @@ class PreprintService(DirtyFieldsMixin, SpamMixin, GuidMixin, IdentifierMixin, R
         ret = super(PreprintService, self).save(*args, **kwargs)
 
         if (not first_save and 'is_published' in saved_fields) or self.is_published:
-            update_or_enqueue_on_preprint_updated(preprint_id=self._id, old_subjects=old_subjects)
+            update_or_enqueue_on_preprint_updated(preprint_id=self._id, old_subjects=old_subjects, saved_fields=saved_fields)
         return ret
 
     def _get_spam_content(self, saved_fields):

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 
-from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from framework.exceptions import PermissionsError
 from osf.models.mixins import ReviewableMixin
 from osf.models import NodeLog, OSFUser
@@ -18,7 +17,7 @@ from osf.utils.permissions import ADMIN
 from osf.utils.requests import DummyRequest, get_request_and_user_id, get_headers_from_request
 from website.notifications.emails import get_user_subscriptions
 from website.notifications import utils
-from website.preprints.tasks import on_preprint_updated
+from website.preprints.tasks import update_or_enqueue_on_preprint_updated
 from website.project.licenses import set_license
 from website.util import api_v2_url
 from website.identifiers.clients import CrossRefClient, ECSArXivCrossRefClient
@@ -246,7 +245,7 @@ class PreprintService(DirtyFieldsMixin, SpamMixin, GuidMixin, IdentifierMixin, R
         ret = super(PreprintService, self).save(*args, **kwargs)
 
         if (not first_save and 'is_published' in saved_fields) or self.is_published:
-            enqueue_postcommit_task(on_preprint_updated, (self._id,), {'old_subjects': old_subjects}, celery=True)
+            update_or_enqueue_on_preprint_updated(preprint_id=self._id, old_subjects=old_subjects)
         return ret
 
     def _get_spam_content(self, saved_fields):

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -653,7 +653,7 @@ class PreprintFactory(DjangoModelFactory):
             if license_details:
                 instance.set_preprint_license(license_details, auth=auth)
 
-            create_task_patcher = mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers')
+            create_task_patcher = mock.patch('website.identifiers.utils.request_identifiers')
             mock_create_identifier = create_task_patcher.start()
             if is_published and set_doi:
                 mock_create_identifier.side_effect = sync_set_identifiers(instance)

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -644,6 +644,7 @@ class PreprintFactory(DjangoModelFactory):
             'size': 1337,
             'contentType': 'img/png'
         }).save()
+        update_task_patcher.stop()
 
         if finish:
             auth = Auth(user)

--- a/osf_tests/test_reviewable.py
+++ b/osf_tests/test_reviewable.py
@@ -8,7 +8,7 @@ from osf_tests.factories import PreprintFactory, AuthUserFactory
 @pytest.mark.django_db
 class TestReviewable:
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers')
+    @mock.patch('website.identifiers.utils.request_identifiers')
     def test_state_changes(self, _):
         user = AuthUserFactory()
         preprint = PreprintFactory(provider__reviews_workflow='pre-moderation', is_published=False)


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Updating a preprint's metadata was causing lots of POSTs to crossref, as the call to update metadata is triggered from preprint's save method. Combine calls to the task on_preprint_updated to ensure it's just called once if that task is already in the postcommit queue. 

Also, make sure to set the DOI for real only when we receive confirmation from crossref.  Set the doi URL from the client's build_doi method if it doesn't have a real identifier set yet.

Fix the tests to look for this change in the way `on_preprint_updated` is called.

<!-- Describe the purpose of your changes -->

## Changes

- add update_or_enqueue_on_preprint_updated method that uses new get_task_from_postcommit_queue to check for the task in the postcommit queue
- also call this in the preprint save method
- Remove the `get_and_set_preprint_identifiers` method as that's necessary now. Instead, call the methods it was calling from the crossref confirmation view.
- If the preprint serializer can't yet find a real DOI, pull the DOI url from the client and display the message that the DOI is still being minted from the 3rd party.


## QA Notes
- Updates to a preprint's metadata should no longer trigger random failures after successes caused by rapid unecessary updates -- minimizing excess emails to the helpdesk. 
- Immediately after creating a preprint, the DOI splash page should now show the unlinked DOI with the "DOIs are minted by a 3rd party" message. This should go away pretty quickly tho, maybe in 10 seconds, if everything is working properly. You'll need to refresh the page to make it turn into a link!

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->
Nope

## Side Effects
none anticipated
<!-- Any possible side effects? -->

## Ticket
general crossref stuff:
https://openscience.atlassian.net/browse/PLAT-802
not linking the DOI right away:
https://openscience.atlassian.net/browse/PLAT-921

