### PR TITLE
[PLAT-875] Incorrect wiki prompt for non-write users

### DIFF
--- a/addons/wiki/static/wikiPage.js
+++ b/addons/wiki/static/wikiPage.js
@@ -86,7 +86,13 @@ function ViewWidget(visible, version, viewText, rendered, contentURL, allowMathj
                 request.done(function (resp) {
                     if(self.visible()) {
                         var $markdownElement = $('#wikiViewRender');
-                        var rawContent = resp.wiki_content || '*Add important information, links, or images here to describe your project.*';
+                        if (resp.wiki_content){
+                            var rawContent = resp.wiki_content
+                        } else if(window.contextVars.currentUser.canEdit) {
+                            var rawContent = '*Add important information, links, or images here to describe your project.*';
+                        } else {
+                            var rawContent = '*No wiki content.*';
+                        }
                         if (resp.rendered_before_update) {
                             // Use old md renderer. Don't mathjaxify
                             self.allowMathjaxification(false);

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -332,7 +332,15 @@ $(document).ready(function () {
             url: ctx.urls.wikiContent
         });
         request.done(function(resp) {
-            var rawText = resp.wiki_content || '*Add important information, links, or images here to describe your project.*';
+            var rawText;
+            if(resp.wiki_content){
+                rawText = resp.wiki_content;
+            } else if(window.contextVars.currentUser.canEdit) {
+                rawText = '*Add important information, links, or images here to describe your project.*';
+            } else {
+                rawText = '*No wiki content.*';
+            }
+
             var renderedText = ctx.renderedBeforeUpdate ? oldMd.render(rawText) : md.render(rawText);
             // don't truncate the text when length = 400
             var truncatedText = $.truncate(renderedText, {length: 401});


### PR DESCRIPTION
## Purpose

Currently a wiki this no content will prompt the user to add content even if they don't have the permissions to add content. This PR changes the language to be appropriate.

## Changes

- Simple fixes to new and old wiki renders.

## QA Notes

The phrase, "No wiki content" should appear for wikis with no content for users that can't edit the wikis, otherwise behavior should be unchanged.

## Documentation

🐞  fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-875