### PR TITLE
[hotfix][OSF] Fix chicago citation reformat

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -222,7 +222,7 @@ def remove_extra_period_after_right_quotation(cit):
 
 def chicago_reformat(node, cit):
     cit = remove_extra_period_after_right_quotation(cit)
-    new_csl = cit.split('20')
+    new_csl = cit.split('20', 1)
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
     # throw error if there is no visible contributor


### PR DESCRIPTION
## Purpose

As things stand, tests for chicago citation would fail on travis the 20th of every month.

## Changes

Update reformat method to split on first occurrence of `20`. The `20` is part of the year, so this test should work till year 3000 😆 😆  

## QA Notes

Please check the chicago citation on preprints and make sure there is no extra space between month and day.

## Documentation

## Side Effects

## Ticket

No ticket.