### PR TITLE
[PLAT-802] Make sure suffix is indeed separate from surname

### DIFF
--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -176,7 +176,7 @@ class TestCrossRefClient:
         contributor.family_name = ''
         contributor.save()
         meta = crossref_client._process_crossref_name(contributor)
-        assert meta == {'given_name': 'ScottyHotty Ronald', 'surname': 'Garland II'}
+        assert meta == {'given_name': 'ScottyHotty Ronald', 'surname': 'Garland', 'suffix': 'II'}
 
     def test_metadata_for_single_name_contributor_only_has_surname(self, crossref_client, preprint):
         contributor = preprint.node.creator

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -156,18 +156,18 @@ class CrossRefClient(AbstractIdentifierClient):
             suffix = names.get('suffix')
 
         given_name = ' '.join([given, middle]).strip()
-        surname = ' '.join([family, suffix]).strip()
-
         given_stripped = remove_control_characters(given_name)
         # For crossref, given_name is not allowed to have numbers or question marks
         given_processed = ''.join(
             [char for char in given_stripped if (not char.isdigit() and char != '?')]
         )
-        surname_processed = remove_control_characters(surname)
+        surname_processed = remove_control_characters(family)
 
         processed_names = {'surname': surname_processed or given_processed}
         if given_processed and surname_processed:
             processed_names['given_name'] = given_processed
+        if suffix:
+            processed_names['suffix'] = suffix
 
         return processed_names
 
@@ -183,8 +183,8 @@ class CrossRefClient(AbstractIdentifierClient):
             if name_parts.get('given_name'):
                 person.append(element.given_name(name_parts['given_name']))
             person.append(element.surname(name_parts['surname']))
-            if contributor.suffix:
-                person.append(element.suffix(remove_control_characters(contributor.suffix)))
+            if name_parts.get('suffix'):
+                person.append(element.suffix(remove_control_characters(name_parts['suffix'])))
             if contributor.external_identity.get('ORCID'):
                 orcid = contributor.external_identity['ORCID'].keys()[0]
                 verified = contributor.external_identity['ORCID'].values()[0] == 'VERIFIED'


### PR DESCRIPTION


## Purpose
Don't combine the suffix with the surname, let it be seperate as crossref allows this

## Changes

- undo combining surname and suffix
- test

## QA Notes
- suffix should now appear in its own field and not repeated in surname


        <person_name contributor_role="author" sequence="first">
          <given_name>Erin Leonor</given_name>
          <surname>Braswell</surname>
          <suffix>I</suffix>
        </person_name>


<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-802
