### PR TITLE
Add ordering to linked-by views, fix related_counts for registrations

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -930,6 +930,7 @@ class NodeLinkedByNodesList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
 
     view_category = 'nodes'
     view_name = 'node-linked-by-nodes'
+    ordering = ('-modified',)
 
     serializer_class = NodeSerializer
 
@@ -953,6 +954,7 @@ class NodeLinkedByRegistrationsList(JSONAPIBaseView, generics.ListAPIView, NodeM
 
     view_category = 'nodes'
     view_name = 'node-linked-by-registrations'
+    ordering = ('-modified',)
 
     serializer_class = RegistrationSerializer
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -295,6 +295,9 @@ class BaseRegistrationSerializer(NodeSerializer):
     def get_current_user_permissions(self, obj):
         return NodeSerializer.get_current_user_permissions(self, obj)
 
+    def get_view_only_links_count(self, obj):
+        return obj.private_links.filter(is_deleted=False).count()
+
     def update(self, registration, validated_data):
         auth = Auth(self.context['request'].user)
         # Update tags


### PR DESCRIPTION


## Purpose
Small fixes to allow emberized analytics pages for registrations and nodes.

## Changes
Add get_view_only_links_count function to RegistrationDetail serializer, add ordering to linked-by views

## QA Notes
Hit `/v2/registrations/<id>/?related_counts=True`, and make sure that doesnt fail.
