### PR TITLE
Hotfix/Chicago Citation Splitting [PLAT-827]

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -222,7 +222,7 @@ def remove_extra_period_after_right_quotation(cit):
 
 def chicago_reformat(node, cit):
     cit = remove_extra_period_after_right_quotation(cit)
-    new_csl = cit.split('20')
+    new_csl = cit.split(str(node.csl['issued']['date-parts'][0][0]))
     contributors_list = list(node.visible_contributors)
     contributors_list_length = len(contributors_list)
     # throw error if there is no visible contributor
@@ -255,7 +255,7 @@ def chicago_reformat(node, cit):
         new_chi += '.'
     cit = new_chi
     for x in new_csl[1:]:
-        cit += ' 20' + x
+        cit += ' ' + str(node.csl['issued']['date-parts'][0][0]) + x
     return cit
 
 def mla_name(name, initial=False):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
I thought it was a good idea to split chicago citations on the number 20. It is July 20 and preprints chicago citations tests are failing.

## Changes
Try to split chicago preprints citation on date issued instead of the number 20?

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
