### PR TITLE
[IN-339][OSF] Properly nullify relationships of withdrawn preprint instead of hiding them.

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -161,9 +161,21 @@ class HideIfDisabled(ConditionalField):
         return not isinstance(self.field, RelationshipField)
 
 
+class NoneIfWithdrawal(ConditionalField):
+    """
+    If preprint is withdrawn, this field (attribute or relationship) should return None instead of hidden.
+    """
+
+    def should_hide(self, instance):
+        return instance.is_retracted
+
+    def should_be_none(self, instance):
+        return True
+
+
 class HideIfWithdrawal(ConditionalField):
     """
-    If registration or preprint is withdrawn, this field will return None.
+    If registration is withdrawn, this field will return None.
     """
 
     def should_hide(self, instance):
@@ -1313,7 +1325,12 @@ class JSONAPISerializer(BaseAPISerializer):
             if attribute is None:
                 # We skip `to_representation` for `None` values so that
                 # fields do not have to explicitly deal with that case.
-                data['attributes'][field.field_name] = None
+                if getattr(field, 'field', None) and isinstance(field.field, RelationshipField):
+                    # if this is a RelationshipField, serialize as a null relationship
+                    data['relationships'][field.field_name] = {"data": None}
+                else:
+                    # otherwise, serialize as an null attribute
+                    data['attributes'][field.field_name] = None
             else:
                 try:
                     if hasattr(field, 'child_relation'):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1327,7 +1327,7 @@ class JSONAPISerializer(BaseAPISerializer):
                 # fields do not have to explicitly deal with that case.
                 if getattr(field, 'field', None) and isinstance(field.field, RelationshipField):
                     # if this is a RelationshipField, serialize as a null relationship
-                    data['relationships'][field.field_name] = {"data": None}
+                    data['relationships'][field.field_name] = {'data': None}
                 else:
                     # otherwise, serialize as an null attribute
                     data['attributes'][field.field_name] = None

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -31,9 +31,9 @@ UPDATE_METHODS = ['PUT', 'PATCH']
 def decompose_field(field):
     from api.base.serializers import (
         HideIfWithdrawal, HideIfRegistration,
-        HideIfDisabled, AllowMissing
+        HideIfDisabled, AllowMissing, NoneIfWithdrawal
     )
-    WRAPPER_FIELDS = (HideIfWithdrawal, HideIfRegistration, HideIfDisabled, AllowMissing)
+    WRAPPER_FIELDS = (HideIfWithdrawal, HideIfRegistration, HideIfDisabled, AllowMissing, NoneIfWithdrawal)
 
     while isinstance(field, WRAPPER_FIELDS):
         try:

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -84,7 +84,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     withdrawal_justification = HideIfNotWithdrawal(ser.CharField(required=False, read_only=True, allow_blank=True))
     is_published = NoneIfWithdrawal(ser.BooleanField(required=False))
     is_preprint_orphan = NoneIfWithdrawal(ser.BooleanField(read_only=True))
-    license_record = NoneIfWithdrawal(NodeLicenseSerializer(required=False, source='license'))
+    license_record = NodeLicenseSerializer(required=False, source='license')
     tags = JSONAPIListField(child=NodeTagField(), required=False, source='node.tags')
     node_is_public = NoneIfWithdrawal(ser.BooleanField(read_only=True, source='node__is_public'))
     preprint_doi_created = NoneIfWithdrawal(VersionedDateTimeField(read_only=True))

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers as ser
 
 from api.base.exceptions import Conflict
 from api.base.serializers import (
-    JSONAPISerializer, IDField, TypeField, HideIfWithdrawal, HideIfNotWithdrawal,
+    JSONAPISerializer, IDField, TypeField, HideIfNotWithdrawal, NoneIfWithdrawal,
     LinksField, RelationshipField, VersionedDateTimeField, JSONAPIListField
 )
 from api.base.utils import absolute_reverse, get_user_auth
@@ -82,31 +82,31 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, source='node.description')
     date_withdrawn = VersionedDateTimeField(read_only=True, allow_null=True)
     withdrawal_justification = HideIfNotWithdrawal(ser.CharField(required=False, read_only=True, allow_blank=True))
-    is_published = HideIfWithdrawal(ser.BooleanField(required=False))
-    is_preprint_orphan = HideIfWithdrawal(ser.BooleanField(read_only=True))
-    license_record = HideIfWithdrawal(NodeLicenseSerializer(required=False, source='license'))
+    is_published = NoneIfWithdrawal(ser.BooleanField(required=False))
+    is_preprint_orphan = NoneIfWithdrawal(ser.BooleanField(read_only=True))
+    license_record = NoneIfWithdrawal(NodeLicenseSerializer(required=False, source='license'))
     tags = JSONAPIListField(child=NodeTagField(), required=False, source='node.tags')
-    node_is_public = HideIfWithdrawal(ser.BooleanField(read_only=True, source='node__is_public'))
-    preprint_doi_created = HideIfWithdrawal(VersionedDateTimeField(read_only=True))
+    node_is_public = NoneIfWithdrawal(ser.BooleanField(read_only=True, source='node__is_public'))
+    preprint_doi_created = NoneIfWithdrawal(VersionedDateTimeField(read_only=True))
 
     contributors = RelationshipField(
         related_view='nodes:node-contributors',
         related_view_kwargs={'node_id': '<node._id>'},
     )
-    reviews_state = HideIfWithdrawal(ser.CharField(source='machine_state', read_only=True, max_length=15))
-    date_last_transitioned = HideIfWithdrawal(VersionedDateTimeField(read_only=True))
+    reviews_state = NoneIfWithdrawal(ser.CharField(source='machine_state', read_only=True, max_length=15))
+    date_last_transitioned = NoneIfWithdrawal(VersionedDateTimeField(read_only=True))
 
-    citation = HideIfWithdrawal(RelationshipField(
+    citation = NoneIfWithdrawal(RelationshipField(
         related_view='preprints:preprint-citation',
         related_view_kwargs={'preprint_id': '<_id>'}
     ))
 
-    identifiers = HideIfWithdrawal(RelationshipField(
+    identifiers = NoneIfWithdrawal(RelationshipField(
         related_view='preprints:identifier-list',
         related_view_kwargs={'preprint_id': '<_id>'}
     ))
 
-    node = HideIfWithdrawal(NodeRelationshipField(
+    node = NoneIfWithdrawal(NodeRelationshipField(
         related_view='nodes:node-detail',
         related_view_kwargs={'node_id': '<node._id>'},
         read_only=False
@@ -118,24 +118,24 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         read_only=False
     )
 
-    provider = HideIfWithdrawal(PreprintProviderRelationshipField(
+    provider = NoneIfWithdrawal(PreprintProviderRelationshipField(
         related_view='providers:preprint-providers:preprint-provider-detail',
         related_view_kwargs={'provider_id': '<provider._id>'},
         read_only=False
     ))
 
-    files = HideIfWithdrawal(RelationshipField(
+    files = NoneIfWithdrawal(RelationshipField(
         related_view='nodes:node-providers',
         related_view_kwargs={'node_id': '<_id>'}
     ))
 
-    primary_file = HideIfWithdrawal(PrimaryFileRelationshipField(
+    primary_file = NoneIfWithdrawal(PrimaryFileRelationshipField(
         related_view='files:file-detail',
         related_view_kwargs={'file_id': '<primary_file._id>'},
         read_only=False
     ))
 
-    review_actions = HideIfWithdrawal(RelationshipField(
+    review_actions = NoneIfWithdrawal(RelationshipField(
         related_view='preprints:preprint-review-action-list',
         related_view_kwargs={'preprint_id': '<_id>'}
     ))


### PR DESCRIPTION
## Purpose

Currently, for withdrawn preprints, API V2 would hide some of its relationship fields, creating problems for the frontend app to properly update such relationships. This PR fix the problems by serializing a `null` relationship instead of simply hiding them.

## Changes

- A new `NoneIfWithdrawal` class (subclassing `ConditionalField`) is implemented to determine whether a certain field should be serialized.
- Change preprint serializers to make use of the newly added class for the fields that previously used `HideIfWithdrawal`.
- Modify the `JSONAPISerializer` class so that we will serialize a `null` relationship for RelationshipField. (Currently, `JSONAPISerializer` would serialize a null RelatioshipField as a null attribute, which, needless to say, is not good.)
- Modify `decompose_field()` to add `NoneIfWithdrawal` to `WRAPPER_FIELDS`, so that API filters know how to decompose the field properly.

## QA Notes

Make sure that relationship fields for withdrawn preprints are now `null` instead of hidden. Other behaviors of the API endpoint should not change. (For example, attributes that were previously serialized as `null` should remain the same.)

## Ticket

https://openscience.atlassian.net/browse/IN-339
