### PR TITLE
[IN-214][OSF] Allow superuser to download unpublished preprint

### DIFF
--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -213,6 +213,83 @@ class TestResolveGuid(OsfTestCase):
         assert res.status_code == 302
         assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
+    @mock.patch('website.settings.USE_EXTERNAL_EMBER', True)
+    @mock.patch('website.settings.EXTERNAL_EMBER_APPS', {
+        'preprints': {
+            'server': 'http://localhost:4200',
+            'path': '/preprints/'
+        },
+    })
+    def test_resolve_guid_download_file_from_emberapp_preprints_unpublished(self):
+        # non-branded domains
+        provider = PreprintProviderFactory(_id='sockarxiv', name='Sockarxiv', reviews_workflow='pre-moderation')
+
+        # branded domains
+        branded_provider = PreprintProviderFactory(_id='spot', name='Spotarxiv', reviews_workflow='pre-moderation')
+        branded_provider.allow_submissions = False
+        branded_provider.domain = 'https://www.spotarxiv.com'
+        branded_provider.description = 'spots not dots'
+        branded_provider.domain_redirect_enabled = True
+        branded_provider.share_publish_type = 'Thesis'
+        branded_provider.save()
+
+        # test_provider_submitter_can_download_unpublished
+        submitter = AuthUserFactory()
+        project = NodeFactory(creator=submitter)
+        pp = PreprintFactory(finish=True, provider=provider, is_published=False, project=project)
+        pp.run_submit(submitter)
+        pp_branded = PreprintFactory(finish=True, provider=branded_provider, is_published=False, project=project, filename='preprint_file_two.txt')
+        pp_branded.run_submit(submitter)
+
+        res = self.app.get('{}download'.format(pp.url), auth=submitter.auth)
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        res = self.app.get('{}download'.format(pp_branded.url), auth=submitter.auth)
+        assert res.status_code == 302
+
+        # test_provider_super_user_can_download_unpublished
+        super_user = AuthUserFactory()
+        super_user.is_superuser = True
+        super_user.save()
+
+        res = self.app.get('{}download'.format(pp.url), auth=super_user.auth)
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        res = self.app.get('{}download'.format(pp_branded.url), auth=super_user.auth)
+        assert res.status_code == 302
+
+        # test_provider_moderator_can_download_unpublished
+        moderator = AuthUserFactory()
+        provider.add_to_group(moderator, 'moderator')
+        provider.save()
+
+        res = self.app.get('{}download'.format(pp.url), auth=moderator.auth)
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        branded_provider.add_to_group(moderator, 'moderator')
+        branded_provider.save()
+
+        res = self.app.get('{}download'.format(pp_branded.url), auth=moderator.auth)
+        assert res.status_code == 302
+
+        # test_provider_admin_can_download_unpublished
+        admin = AuthUserFactory()
+        provider.add_to_group(admin, 'admin')
+        provider.save()
+
+        res = self.app.get('{}download'.format(pp.url), auth=admin.auth)
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        branded_provider.add_to_group(admin, 'admin')
+        branded_provider.save()
+
+        res = self.app.get('{}download'.format(pp_branded.url), auth=admin.auth)
+        assert res.status_code == 302
+
     def test_resolve_guid_download_file_export(self):
         pp = PreprintFactory(finish=True)
 

--- a/website/views.py
+++ b/website/views.py
@@ -31,7 +31,6 @@ from website.ember_osf_web.decorators import ember_flag_is_active, MockUser
 from website.ember_osf_web.views import use_ember_app
 from website.project.model import has_anonymous_link
 from osf.utils import permissions
-from api.providers.permissions import GroupHelper
 
 logger = logging.getLogger(__name__)
 preprints_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['preprints']['path']))
@@ -291,12 +290,11 @@ def resolve_guid(guid, suffix=None):
                     # the routing scheme - if a preprint is not published, only
                     # admins and moderators should be able to know it exists.
                     auth = Auth.from_kwargs(request.args.to_dict(), {})
-                    group_helper = GroupHelper(referent.provider)
-                    admin_group = group_helper.get_group('admin')
-                    mod_group = group_helper.get_group('moderator')
-                    # Check if user isn't a nonetype or that the user has admin/moderator permissions
-                    if auth.user is None or not (referent.node.has_permission(auth.user, permissions.ADMIN) or (mod_group.user_set.all() | admin_group.user_set.all()).filter(id=auth.user.id).exists()):
+                    # Check if user isn't a nonetype or that the user has admin/moderator/superuser permissions
+                    if auth.user is None or not (auth.user.has_perm('view_submissions', referent.provider) or
+                            referent.node.has_permission(auth.user, permissions.ADMIN)):
                         raise HTTPError(http.NOT_FOUND)
+
                 file_referent = referent.primary_file
             elif isinstance(referent, BaseFileNode) and referent.is_file:
                 file_referent = referent


### PR DESCRIPTION
## Purpose

Allow superuser to download unpublished preprint

## Changes

Modify permissions check to include superuser perms check.

## QA Notes

Essentially these changes allow superuser to download unpublished
preprints. But it also ensures submitter, moderator, and admin can download unpublished preprints
on branded and non-branded preprint providers.

Please check and make sure users can download their own unpublished preprints from custom domains. https://openscience.atlassian.net/browse/IN-214

## Documentation


## Side Effects

<!-- Any possible side effects? -->

## Ticket

[[IN-214]](https://openscience.atlassian.net/browse/IN-214)