### PR TITLE
If a preprint's provider has pre-moderation, don't return preprint URL [PLAT-821]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -15,6 +15,7 @@ from api.nodes.serializers import (
     NodeTagField
 )
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
+from api.providers import workflows
 from framework.exceptions import PermissionsError
 from website.exceptions import NodeStateError
 from website.project import signals as project_signals
@@ -165,8 +166,10 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         if doi_identifier:
             doi = doi_identifier.value
         else:
-            client = obj.get_doi_client()
-            doi = client.build_doi(preprint=obj) if client else None
+            # if proivider has pre-moderation, don't show the DOI prematurely
+            if obj.provider.reviews_workflow != workflows.Workflows.PRE_MODERATION:
+                client = obj.get_doi_client()
+                doi = client.build_doi(preprint=obj) if client else None
         return 'https://dx.doi.org/{}'.format(doi) if doi else None
 
     def update(self, preprint, validated_data):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Don't show the pre-built DOI if it has't yet been given for pre-moderation preprints

## Changes

- update serializer to check for pre-moderation status if there's no DOI yet.

## QA Notes

- PRe moderation preprints  that haven't been approved shouldn't have that message any longer

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-921
