### PR TITLE
[IN-260] Include comment in "edit-comment" email

### DIFF
--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -141,6 +141,7 @@ class ReviewsMachine(BaseMachine):
                                            action=self.action)
     def notify_edit_comment(self, ev):
         context = self.get_context()
+        context['comment'] = self.action.comment
         if not self.machineable.provider.reviews_comments_private and self.action.comment:
             reviews_signals.reviews_email.send(creator=ev.kwargs.get('user'), context=context,
                                                template='reviews_update_comment',

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import time
-import random
 
 import datetime
 import mock

--- a/website/templates/emails/reviews_update_comment.html.mako
+++ b/website/templates/emails/reviews_update_comment.html.mako
@@ -2,8 +2,8 @@
 <div style="margin: 40px;">
     <p>Hello ${recipient.fullname},</p>
     <p>
-        Your ${reviewable.provider.preprint_word} "${reviewable.node.title}" has an updated comment by the moderator.
-        To view the comment, go to your <a href="${reviewable.absolute_url}">${reviewable.provider.preprint_word}</a>.
+        Your ${reviewable.provider.preprint_word} "<a href="${reviewable.absolute_url}">${reviewable.node.title}</a>" has an updated comment by the moderator:<br/>
+        ${comment}
     </p>
     <p>
         You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails


### PR DESCRIPTION
## Purpose
Include comment in "edit-comment" email

## Changes
* Include comment in "edit-comment" email
* Fix flake upstream

## QA Notes
Ensure comment included in "edit-comment" email

## Side Effects
None expected

## Ticket
[[IN-260]](https://openscience.atlassian.net/browse/IN-260)
