### PR TITLE
[PLAT-912][hotfix] Remove Zotero library message

### DIFF
--- a/website/static/js/pages/project-addons-page.js
+++ b/website/static/js/pages/project-addons-page.js
@@ -2,7 +2,6 @@
 var $ = require('jquery');
 var bootbox = require('bootbox');
 var $osf = require('js/osfHelpers');
-var Cookie = require('js-cookie');
 var ctx = window.contextVars;
 
 var changeAddonSettingsSuccess = function () {
@@ -14,19 +13,6 @@ var changeAddonSettingsFailure = function () {
     var msg = 'Sorry, we had trouble saving your settings. If this persists please contact <a href="mailto: support@osf.io">support@osf.io</a>';
     $osf.growl('Failure', msg, 'danger');
 };
-
-$(function(){
-    // Make zotero group library message permanently dismissible
-    var zoteroPersistKey = 'zoteroGroupDismiss';
-    var $zoteroPersist = $('#zoteroWarningCancel').click(function() {
-        Cookie.set(zoteroPersistKey, '1', {path: '/'});
-    });
-    var dismissed = Cookie.get(zoteroPersistKey) === '1';
-    if (!dismissed) {
-        $('#zotero-group-library-alert').show();
-    }
-});
-
 
 $('.addon-container').each(function(ind, elm) {
     elm = $(elm);

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -137,25 +137,6 @@
                                 </div>
                             </div>
                         % endif
-                        % if addon['addon_short_name'] == 'zotero':
-                            <div id='zotero-group-library-alert' class='scripted dismissible-alerts'>
-                                <div class="alert alert-info alert-dismissible" role="alert">
-                                    <button type="button" id="zoteroWarningCancel" class="close" data-dismiss="alert" aria-label="Close">
-                                        <span aria-hidden="true">&times;</span>
-                                    </button>
-                                    <div>
-                                        <h4>Don’t see your Zotero group libraries?</h4>
-                                        <p>
-                                            You may need to reauthorize your Zotero access token.
-                                            Follow the steps in the <a class="alert-link" href='http://help.osf.io/a/850167-reauthorize-zotero' target="_black">help guide</a> to resolve the issue.
-                                        </p>
-                                        <p>
-                                            Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        % endif
                         % if not loop.last:
                             <hr />
                         % endif


### PR DESCRIPTION
## Purpose

The Zotero library message a has served it duty and now it's time for this old soldier to fade away.

## Changes

- Simple HTML and JS changes

## QA Notes

Enable Zotero, there shouldn't be a message, you should try this in an incognito window because old cookies might prevent this message from being displays.

## Documentation

No docs necessary.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-912