### PR TITLE
Process names for CrossRef contributors [PLAT-802]

### DIFF
--- a/scripts/remove_after_use/register_preprint_dois_with_crossref.py
+++ b/scripts/remove_after_use/register_preprint_dois_with_crossref.py
@@ -56,17 +56,18 @@ def send_preprints(qs, client):
         n_processed = 0
         for page_num in paginator.page_range:
             page = paginator.page(page_num)
-            # build batch metadata to send to CrossRef
-            bulk_preprint_metadata = client.build_metadata(page.object_list)
-            preprint_ids = [e._id for e in page.object_list]
-            if dry:
-                logger.info('[dry] Sent metadata for preprints: {}'.format(preprint_ids))
-            else:
-                client.bulk_create(metadata=bulk_preprint_metadata, filename='osf_dois_{}'.format(page_num))
-                logger.info('Sent metadata for preprints: {}'.format(preprint_ids))
+            if len(page.object_list):
+                # build batch metadata to send to CrossRef
+                bulk_preprint_metadata = client.build_metadata(page.object_list)
+                preprint_ids = [e._id for e in page.object_list]
+                if dry:
+                    logger.info('[dry] Sent metadata for preprints: {}'.format(preprint_ids))
+                else:
+                    client.bulk_create(metadata=bulk_preprint_metadata, filename='osf_dois_{}'.format(page_num))
+                    logger.info('Sent metadata for preprints: {}'.format(preprint_ids))
 
-            n_processed += len(preprint_ids)
-            progress_bar.update(n_processed)
+                n_processed += len(preprint_ids)
+                progress_bar.update(n_processed)
             if page.has_next():
                 # Throttle requeests
                 if not dry:

--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -200,6 +200,16 @@ class TestCrossRefClient:
         assert meta['given_name'] == long_given[:crossref.CROSSREF_GIVEN_NAME_LIMIT]
         assert meta['surname'] == long_surname[:crossref.CROSSREF_SURNAME_LIMIT]
 
+        # Unparsable given or surname just returns fullname as surname
+        unparsable_fullname = 'Author (name withheld until double-blind peer review completes and this name is also really long)'
+        contributor.given_name = ''
+        contributor.family_name = ''
+        contributor.fullname = unparsable_fullname
+        contributor.save()
+
+        meta = crossref_client._process_crossref_name(contributor)
+        assert meta == {'surname': unparsable_fullname[:crossref.CROSSREF_SURNAME_LIMIT]}
+
     def test_metadata_for_single_name_contributor_only_has_surname(self, crossref_client, preprint):
         contributor = preprint.node.creator
         contributor.fullname = 'Madonna'

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -23,6 +23,9 @@ JATS_NAMESPACE = 'http://www.ncbi.nlm.nih.gov/JATS1'
 XSI = 'http://www.w3.org/2001/XMLSchema-instance'
 CROSSREF_DEPOSITOR_NAME = 'Open Science Framework'
 
+CROSSREF_SUFFIX_LIMIT = 10
+CROSSREF_SURNAME_LIMIT = 60
+CROSSREF_GIVEN_NAME_LIMIT = 60
 
 class CrossRefClient(AbstractIdentifierClient):
 
@@ -164,11 +167,12 @@ class CrossRefClient(AbstractIdentifierClient):
         )
         surname_processed = remove_control_characters(family)
 
-        processed_names = {'surname': surname_processed or given_processed}
+        surname = surname_processed or given_processed
+        processed_names = {'surname': surname[:CROSSREF_SURNAME_LIMIT].strip()}
         if given_processed and surname_processed:
-            processed_names['given_name'] = given_processed
+            processed_names['given_name'] = given_processed[:CROSSREF_GIVEN_NAME_LIMIT].strip()
         if suffix:
-            processed_names['suffix'] = suffix
+            processed_names['suffix'] = suffix[:CROSSREF_SUFFIX_LIMIT].strip()
 
         return processed_names
 

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -167,11 +167,11 @@ class CrossRefClient(AbstractIdentifierClient):
         )
         surname_processed = remove_control_characters(family)
 
-        surname = surname_processed or given_processed
+        surname = surname_processed or given_processed or contributor.fullname
         processed_names = {'surname': surname[:CROSSREF_SURNAME_LIMIT].strip()}
         if given_processed and surname_processed:
             processed_names['given_name'] = given_processed[:CROSSREF_GIVEN_NAME_LIMIT].strip()
-        if suffix:
+        if suffix and (surname_processed or given_processed):
             processed_names['suffix'] = suffix[:CROSSREF_SUFFIX_LIMIT].strip()
 
         return processed_names


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Truncate and process names a bit more so that crossref will accept contributor names for preprints found on production.

## Changes

- Don't build metadata for an empty object list when sending existing preprints to crossref

- Truncate surnames and given_names to 60 chars
- Truncate suffixes to 10 chars
- If a name cannot be parsed as a given_name and surname, return "anonymous"

## QA Notes

This is different than what we had before -- now, names should be actively truncated at 60 chars for Given + middle, 60 for surname, and 10 for suffix.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-802
