### PR TITLE
[PLAT-934][Hotfix] Registrations children list 502s when not logged in

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -262,8 +262,9 @@ class RegistrationChildrenList(JSONAPIBaseView, generics.ListAPIView, ListFilter
 
     def get_queryset(self):
         registration = self.get_node()
+        auth = get_user_auth(self.request)
         registration_pks = registration.node_relations.filter(is_node_link=False).select_related('child').values_list('child__pk', flat=True)
-        return self.get_queryset_from_request().filter(pk__in=registration_pks).can_view(self.request.user).order_by('-modified')
+        return self.get_queryset_from_request().filter(pk__in=registration_pks).can_view(auth.user).order_by('-modified')
 
 
 class RegistrationCitationDetail(NodeCitationDetail, RegistrationMixin):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -262,9 +262,8 @@ class RegistrationChildrenList(JSONAPIBaseView, generics.ListAPIView, ListFilter
 
     def get_queryset(self):
         registration = self.get_node()
-        auth = get_user_auth(self.request)
         registration_pks = registration.node_relations.filter(is_node_link=False).select_related('child').values_list('child__pk', flat=True)
-        return self.get_queryset_from_request().filter(pk__in=registration_pks).can_view(auth.user).order_by('-modified')
+        return self.get_queryset_from_request().filter(pk__in=registration_pks).can_view(self.request.user).order_by('-modified')
 
 
 class RegistrationCitationDetail(NodeCitationDetail, RegistrationMixin):

--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -56,9 +56,7 @@ def registration_with_children_approved_url(registration_with_children_approved)
 class TestRegistrationsChildrenList:
 
     def test_registrations_children_list(self, user, app, registration_with_children, registration_with_children_url):
-
-        component_one = registration_with_children.node_relations.all()[0].child
-        component_two = registration_with_children.node_relations.all()[1].child
+        component_one, component_two = registration_with_children.nodes
 
         res = app.get(registration_with_children_url, auth=user.auth)
         ids = [node['id'] for node in res.json['data']]
@@ -69,8 +67,7 @@ class TestRegistrationsChildrenList:
         assert component_two._id in ids
 
     def test_return_registrations_list_no_auth_approved(self, user, app, registration_with_children_approved, registration_with_children_approved_url):
-        component_one = registration_with_children_approved.node_relations.all()[0].child
-        component_two = registration_with_children_approved.node_relations.all()[1].child
+        component_one, component_two = registration_with_children_approved.nodes
 
         res = app.get(registration_with_children_approved_url)
         ids = [node['id'] for node in res.json['data']]
@@ -91,9 +88,7 @@ class TestRegistrationsChildrenList:
 class TestRegistrationChildrenListFiltering:
 
     def test_registration_child_filtering(self, app, user, registration_with_children):
-
-        component_one = registration_with_children.node_relations.all()[0].child
-        component_two = registration_with_children.node_relations.all()[1].child
+        component_one, component_two = registration_with_children.nodes
 
         url = '/{}registrations/{}/children/?filter[title]={}'.format(
             API_BASE,

--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -1,0 +1,107 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from framework.auth.core import Auth
+from osf_tests.factories import (
+    NodeFactory,
+    ProjectFactory,
+    AuthUserFactory,
+)
+
+from osf.models import MetaSchema
+
+
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
+
+@pytest.fixture()
+def registration_with_children(user):
+    project = ProjectFactory(creator=user)
+    NodeFactory(parent=project, creator=user)
+    NodeFactory(parent=project, creator=user)
+
+    reg = project.register_node(
+        schema=MetaSchema.objects.first(),
+        auth=Auth(user=user),
+        data='B-Dawk',
+    )
+    return reg
+
+@pytest.fixture()
+def registration_with_children_url(registration_with_children):
+    return '/{}registrations/{}/children/'.format(
+        API_BASE,
+        registration_with_children._id,
+    )
+
+
+@pytest.fixture()
+def registration_with_children_approved(user, registration_with_children):
+
+    registration_with_children._initiate_approval(user)
+    approval_token = registration_with_children.registration_approval.approval_state[user._id]['approval_token']
+    registration_with_children.registration_approval.approve(user, approval_token)
+
+    return registration_with_children
+
+@pytest.fixture()
+def registration_with_children_approved_url(registration_with_children_approved):
+    return '/{}registrations/{}/children/'.format(
+        API_BASE,
+        registration_with_children_approved._id,
+    )
+
+@pytest.mark.django_db
+class TestRegistrationsChildrenList:
+
+    def test_registrations_children_list(self, user, app, registration_with_children, registration_with_children_url):
+
+        component_one = registration_with_children.node_relations.all()[0].child
+        component_two = registration_with_children.node_relations.all()[1].child
+
+        res = app.get(registration_with_children_url, auth=user.auth)
+        ids = [node['id'] for node in res.json['data']]
+
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert component_one._id in ids
+        assert component_two._id in ids
+
+    def test_return_registrations_list_no_auth_approved(self, user, app, registration_with_children_approved, registration_with_children_approved_url):
+        component_one = registration_with_children_approved.node_relations.all()[0].child
+        component_two = registration_with_children_approved.node_relations.all()[1].child
+
+        res = app.get(registration_with_children_approved_url)
+        ids = [node['id'] for node in res.json['data']]
+
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert component_one._id in ids
+        assert component_two._id in ids
+
+    def test_registrations_list_no_auth_unapproved(self, user, app, registration_with_children, registration_with_children_url):
+        res = app.get(registration_with_children_url, expect_errors=True)
+
+        assert res.status_code == 401
+        assert res.content_type == 'application/vnd.api+json'
+
+
+@pytest.mark.django_db
+class TestRegistrationChildrenListFiltering:
+
+    def test_registration_child_filtering(self, app, user, registration_with_children):
+
+        component_one = registration_with_children.node_relations.all()[0].child
+        component_two = registration_with_children.node_relations.all()[1].child
+
+        url = '/{}registrations/{}/children/?filter[title]={}'.format(
+            API_BASE,
+            registration_with_children._id,
+            component_one.title
+        )
+        res = app.get(url, auth=user.auth)
+        ids = [node['id'] for node in res.json['data']]
+
+        assert component_one._id in ids
+        assert component_two._id not in ids

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -10,6 +10,7 @@ import bson
 from django.db.models import Q
 from dirtyfields import DirtyFieldsMixin
 from django.apps import apps
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.paginator import Paginator
 from django.core.exceptions import ValidationError
@@ -139,7 +140,7 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
 
             qs |= self.filter(private_links__is_deleted=False, private_links__key=private_link)
 
-        if user is not None:
+        if user is not None and not isinstance(user, AnonymousUser):
             if isinstance(user, OSFUser):
                 user = user.pk
             if not isinstance(user, int):


### PR DESCRIPTION
## Purpose

If you're not logged in (or in incognito mode) and you visit a registration children endpoint, like https://api.osf.io/v2/registrations/5k7hu/children/ the result will 502, that ain't right! This PR fixes that.

## Changes

- Changes the get queryset method for the RegistrationList view to get the auth properly instead of just taking it off the request object.

## QA Notes

Open an incognito window and go to a registrations endpoint, if you get any 200 response you are good to go.

## Documentation

🐞  fix no docs.

## Side Effects

None that I know of.

## Ticket
* https://openscience.atlassian.net/browse/PLAT-934
* Sentry: https://sentry2.cos.io/cos/osf-back-end/issues/213/
