### PR TITLE
[EMB-277] Registration related_counts, add missing ordering

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -136,11 +136,11 @@ class ShowIfCurrentUser(ConditionalField):
         return request and request.user == instance
 
 
-class ShowIfAdminScope(ConditionalField):
+class ShowIfAdminScopeOrAnonymous(ConditionalField):
 
     def should_show(self, instance):
         request = self.context.get('request')
-        return request and utils.has_admin_scope(request)
+        return request and (request.user.is_anonymous or utils.has_admin_scope(request))
 
 
 class HideIfRegistration(ConditionalField):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -9,7 +9,7 @@ from api.base.serializers import (VersionedDateTimeField, HideIfRegistration, ID
                                   NodeFileHyperLinkField, RelationshipField,
                                   ShowIfVersion, TargetTypeField, TypeField,
                                   WaterbutlerLink, relationship_diff, BaseAPISerializer,
-                                  HideIfWikiDisabled, ShowIfAdminScope)
+                                  HideIfWikiDisabled, ShowIfAdminScopeOrAnonymous)
 from api.base.settings import ADDONS_FOLDER_CONFIGURABLE
 from api.base.utils import (absolute_reverse, get_object_or_error,
                             get_user_auth, is_truthy)
@@ -211,7 +211,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     tags = ValuesListField(attr_name='name', child=ser.CharField(), required=False)
     access_requests_enabled = ser.BooleanField(read_only=False, required=False)
     node_license = NodeLicenseSerializer(required=False, source='license')
-    analytics_key = ShowIfAdminScope(ser.CharField(read_only=True, source='keenio_read_key'))
+    analytics_key = ShowIfAdminScopeOrAnonymous(ser.CharField(read_only=True, source='keenio_read_key'))
     template_from = ser.CharField(required=False, allow_blank=False, allow_null=False,
                                   help_text='Specify a node id for a node you would like to use as a template for the '
                                             'new node. Templating is like forking, except that you do not copy the '

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -930,6 +930,7 @@ class NodeLinkedByNodesList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
 
     view_category = 'nodes'
     view_name = 'node-linked-by-nodes'
+    ordering = ('-modified',)
 
     serializer_class = NodeSerializer
 
@@ -953,6 +954,7 @@ class NodeLinkedByRegistrationsList(JSONAPIBaseView, generics.ListAPIView, NodeM
 
     view_category = 'nodes'
     view_name = 'node-linked-by-registrations'
+    ordering = ('-modified',)
 
     serializer_class = RegistrationSerializer
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -136,7 +136,8 @@ class BaseRegistrationSerializer(NodeSerializer):
 
     forks = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-forks',
-        related_view_kwargs={'node_id': '<_id>'}
+        related_view_kwargs={'node_id': '<_id>'},
+        related_meta={'count': 'get_forks_count'},
     ))
 
     node_links = ShowIfVersion(HideIfWithdrawal(RelationshipField(

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -295,6 +295,9 @@ class BaseRegistrationSerializer(NodeSerializer):
     def get_current_user_permissions(self, obj):
         return NodeSerializer.get_current_user_permissions(self, obj)
 
+    def get_view_only_links_count(self, obj):
+        return obj.private_links.filter(is_deleted=False).count()
+
     def update(self, registration, validated_data):
         auth = Auth(self.context['request'].user)
         # Update tags

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -167,6 +167,16 @@ class RegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, Regist
             raise ValidationError('This is not a registration.')
         return registration
 
+    def get_renderer_context(self):
+        context = super(RegistrationDetail, self).get_renderer_context()
+        show_counts = is_truthy(self.request.query_params.get('related_counts', False))
+        if show_counts:
+            registration = self.get_object()
+            context['meta'] = {
+                'templated_by_count': registration.templated_list.count(),
+            }
+        return context
+
 
 class RegistrationContributorsList(BaseContributorList, RegistrationMixin, UserMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/registrations_contributors_list).

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -144,7 +144,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
                 assert_true(
                     isinstance(reg_field, base_serializers.HideIfWithdrawal) or
                     isinstance(reg_field, base_serializers.ShowIfVersion) or
-                    isinstance(reg_field, base_serializers.ShowIfAdminScope)
+                    isinstance(reg_field, base_serializers.ShowIfAdminScopeOrAnonymous)
                 )
 
     def test_hide_if_registration_fields(self):

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -47,7 +47,7 @@ class TestNodeSerializer:
         assert attributes['registration'] == node.is_registration
         assert attributes['fork'] == node.is_fork
         assert attributes['collection'] == node.is_collection
-        assert 'analytics_key' not in attributes
+        assert attributes['analytics_key'] == node.keenio_read_key
 
         # Relationships
         relationships = data['relationships']

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -128,6 +128,14 @@ class TestRegistrationDetail:
         assert res.status_code == 404
         assert res.json['errors'][0]['detail'] == exceptions.NotFound.default_detail
 
+    #   test_registration_shows_related_counts
+        url = '/{}registrations/{}/?related_counts=True'.format(
+            API_BASE, private_registration._id)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 0
+        assert res.json['data']['relationships']['contributors']['links']['related']['meta']['count'] == 1
+
     #   test_registration_shows_specific_related_counts
         url = '/{}registrations/{}/?related_counts=children'.format(
             API_BASE, private_registration._id)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Support the embosf'd analytics page. Previous changes worked for nodes but not registrations.
<!-- Describe the purpose of your changes -->

## Changes
- Add default ordering to "linked by" relationship views
- Fix 502 error at `/v2/registrations/?related_counts=1` (missing `get_view_only_links_count` method)
- Add count to registrations' `forks` relationship
- Add `templated_by_count` to registration detail meta (to match node detail)
- Replace `ShowIfAdminScope` with `ShowIfAdminScopeOrAnonymous`, so our apps get the same information whether or not the user is logged in.
<!-- Briefly describe or list your changes  -->

## QA Notes
`/v2/registrations/?related_counts=1` should no longer error, and should include counts in each registration's `forks` relationship. 

A registration's detail view (`/v2/registrations/<guid>/?related_counts=1`) should have the `forks` count, plus `templated_by_count` in the root-level `meta`.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/EMB-277
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

extends/replaces #8472