### PR TITLE
Account for new duplicate success message about possible pairs in crossref [PLAT-802]

### DIFF
--- a/api/crossref/views.py
+++ b/api/crossref/views.py
@@ -50,7 +50,8 @@ class ParseCrossRefConfirmation(APIView):
                     if created or legacy_doi:
                         # Sets preprint_doi_created and saves the preprint
                         preprint.set_identifier_values(doi=doi, save=True)
-                    else:
+                    # Double records returned when possible matching DOI is found in crossref
+                    elif 'possible preprint/vor pair' not in msg.lower():
                         # Directly updates the identifier
                         preprint.set_identifier_value(category='doi', value=doi)
 


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
On Crossref's latest test server, minting a DOI that has a possible match with a title and first author of a preprint already on their server now returns 2 success messages, which looks something like:

```
   <record_diagnostic status="Success">
      <doi>10.31235/osf.io/bemhx</doi>
      <msg>Possible preprint/VoR pair, Vor DOI: 10.1017/S0140525X17001893</msg>
   </record_diagnostic>
   <record_diagnostic status="Success">
      <doi>10.31235/osf.io/bemhx</doi>
      <msg>Successfully added</msg>
   </record_diagnostic>
```



## Changes
- Don't update the DOI for those successes, but still count it when deciding how many DOIs were processed successfully

## QA Notes
Should not have any impact on the way things are currently working!

## Documentation
None needed

## Side Effects
None anticipated 

## Ticket
https://openscience.atlassian.net/browse/PLAT-802
