### PR TITLE
[hotfix] [PLAT-806] Allow disabling EZID DOI creation/updates via a waffle switch

### DIFF
--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -4,6 +4,7 @@ import responses
 from nose.tools import *  # noqa
 
 from django.db import IntegrityError
+from waffle.testutils import override_switch
 
 from tests.base import OsfTestCase
 from osf_tests.factories import AuthUserFactory
@@ -208,6 +209,7 @@ class TestIdentifierViews(OsfTestCase):
         self.node = RegistrationFactory(creator=self.user, is_public=True)
 
     @responses.activate
+    @override_switch('ezid', active=True)
     @mock.patch('website.settings.EZID_USERNAME', 'testfortravisnotreal')
     @mock.patch('website.settings.EZID_PASSWORD', 'testfortravisnotreal')
     def test_create_identifiers_not_exists(self):
@@ -241,6 +243,7 @@ class TestIdentifierViews(OsfTestCase):
         assert_equal(res.status_code, 201)
 
     @responses.activate
+    @override_switch('ezid', active=True)
     @mock.patch('website.settings.EZID_USERNAME', 'testfortravisnotreal')
     @mock.patch('website.settings.EZID_PASSWORD', 'testfortravisnotreal')
     def test_create_identifiers_exists(self):

--- a/website/identifiers/client.py
+++ b/website/identifiers/client.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import furl
+import logging
 
+import furl
+import waffle
 from website.util.client import BaseClient
 
 from . import utils
+logger = logging.getLogger(__name__)
 
+EZID_SWITCH = 'ezid'
 
 class EzidClient(BaseClient):
 
@@ -38,6 +42,9 @@ class EzidClient(BaseClient):
         return utils.from_anvl(resp.content.strip('\n'))
 
     def create_identifier(self, identifier, metadata=None):
+        if not waffle.switch_is_active(EZID_SWITCH):
+            logger.info('ezid waffle switch is off. Doing nothing...')
+            return None
         resp = self._make_request(
             'PUT',
             self._build_url('id', identifier),
@@ -47,6 +54,9 @@ class EzidClient(BaseClient):
         return utils.from_anvl(resp.content)
 
     def mint_identifier(self, shoulder, metadata=None):
+        if not waffle.switch_is_active(EZID_SWITCH):
+            logger.info('ezid waffle switch is off. Doing nothing...')
+            return None
         resp = self._make_request(
             'POST',
             self._build_url('shoulder', shoulder),
@@ -56,6 +66,9 @@ class EzidClient(BaseClient):
         return utils.from_anvl(resp.content)
 
     def change_status_identifier(self, status, identifier, metadata=None):
+        if not waffle.switch_is_active(EZID_SWITCH):
+            logger.info('ezid waffle switch is off. Doing nothing...')
+            return None
         metadata['_status'] = status
         resp = self._make_request(
             'POST',

--- a/website/routes.py
+++ b/website/routes.py
@@ -149,6 +149,7 @@ def get_globals():
         'osf_contact_email': settings.OSF_CONTACT_EMAIL,
         'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=reverse('wafflejs')),
         'footer_links': settings.FOOTER_LINKS,
+        'waffle': waffle,
     }
 
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -213,6 +213,7 @@
                       <span data-bind="if: hasArk()" class="scripted">| ARK <span data-bind="text: ark"></span></span>
                   </p>
                 </span>
+                % if waffle.switch_is_active('ezid'):
                 <span data-bind="if: canCreateIdentifiers()" class="scripted">
                   <!-- ko if: idCreationInProgress() -->
                     <p>
@@ -227,6 +228,7 @@
                   </p>
                   <!-- /ko -->
                 </span>
+                % endif
                 <p>
                     Category: <span data-bind="css: icon"></span>
                     <span id="nodeCategoryEditable">${node['category']}</span>


### PR DESCRIPTION
because we need to disable DOI creation/updates while
the EZID prefix is being migrated to Datacite

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

Allow us to disable EZID DOI creation/updates while our prefix is changed over to Datacite's prefix.

## Changes

<!-- Briefly describe or list your changes  -->
Put EZID requests behind a waffle switch.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/PLAT-806
