### PR TITLE
[hotfix] Notify preprint contributors of DOI platform change [PLAT-938]

### DIFF
--- a/scripts/remove_after_use/send_preprint_user_email.py
+++ b/scripts/remove_after_use/send_preprint_user_email.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+import sys
+import logging
+
+import progressbar
+from django.core.paginator import Paginator
+
+from website.app import setup_django
+setup_django()
+
+from website import mails
+from osf.models import PreprintService
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+PAGE_SIZE = 100
+
+
+def main(dry=True):
+    qs = PreprintService.objects.filter(
+        is_published=True,
+        node__is_deleted=False
+    ).select_related('node').prefetch_related('node___contributors').order_by('pk')
+    count = qs.count()
+    pbar = progressbar.ProgressBar(maxval=count).start()
+    contributors_emailed = set()
+    logger.info('Sending emails to users for {} published preprints...'.format(count))
+    paginator = Paginator(qs, PAGE_SIZE)
+    n_processed = 0
+    for page_num in paginator.page_range:
+        page = paginator.page(page_num)
+        for preprint in page.object_list:
+            users = preprint.node.contributors.filter(is_active=True)
+            for user in users:
+                if user._id not in contributors_emailed:
+                    if not dry:
+                        mails.send_mail(
+                            mail=mails.PREPRINT_DOI_CHANGE,
+                            to_addr=user.username,
+                            can_change_preferences=False,
+                            user=user
+                        )
+                    contributors_emailed.add(user._id)
+        n_processed += len(page.object_list)
+        pbar.update(n_processed)
+
+    logger.info('Sent email to {} users from {} preprints'.format(len(contributors_emailed), count))
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    main(dry=dry)

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -416,3 +416,8 @@ ACCESS_REQUEST_DENIED = Mail(
     'access_request_rejected',
     subject='Your access request to an OSF project has been declined'
 )
+
+PREPRINT_DOI_CHANGE = Mail(
+    'preprint_doi_change',
+    subject='Improvements to OSF Preprints DOIs'
+)

--- a/website/templates/emails/preprint_doi_change.html.mako
+++ b/website/templates/emails/preprint_doi_change.html.mako
@@ -2,7 +2,7 @@
 
 <%def name="content()">
 <tr>
-  <td style="border-collapse: collapse;">
+  <td style="border-collapse: collapse; line-height: 1.5;">
     Dear ${user.fullname},<br>
     <br>
     We're writing to let you know about an improvement to the OSF Preprints family of preprint services.

--- a/website/templates/emails/preprint_doi_change.html.mako
+++ b/website/templates/emails/preprint_doi_change.html.mako
@@ -1,0 +1,29 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    Dear ${user.fullname},<br>
+    <br>
+    We're writing to let you know about an improvement to the OSF Preprints family of preprint services.
+    Soon, OSF Preprints and the branded community preprint services it supports will begin registering DOIs with Crossref.
+    We're making this change to take advantage of Crossref's preprints-specific metadata schema, linking of published articles with preprints,
+    and auto-updating of ORCID profiles (if you've verified your account by logging into the OSF via ORCID).<br>
+    <br>
+    In the coming days, we'll register your existing preprints with Crossref and they'll be given new DOIs, displayed on your preprint page.
+    The current DOIs on your preprints will be aliased and will always resolve to your preprint; however, we recommend that in future citations you use the new DOIs.
+    For a period of time during the re-registering process, your preprint may have 2 distinct DOI records.<br>
+    <br>
+    DOIs for projects and registrations on the OSF will continue to be registered with DataCite and you will not see any changes to these.<br>
+    <br>
+    Please email <a href="mailto:support@osf.io">support@osf.io</a> if you have questions or concerns.<br>
+    <br>
+    Sincerely,<br>
+    <br>
+    The OSF Team<br>
+    <br>
+    <br>
+    You are receiving this service message from OSF because you are an author on a preprint.<br>
+
+</tr>
+</%def>


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Email all users who are active and a contributor of a published preprint that a change is happening. 

Note: updated line-height to 1.5:

<img width="611" alt="screen shot 2018-06-28 at 3 37 32 pm" src="https://user-images.githubusercontent.com/801594/42056799-6bdaaf20-7ae9-11e8-8f0e-57877e352106.png">



## Changes
- One-time use script to email all active users on published preprints once
- The email to send

## QA Notes
- If your user has more than one published preprint, they should only get one email
- A user who only has an unpublished preprint (never completed or not approved by a moderator) should not receive an email
- A user who *only* has a preprint that was since "made private" by making the node private should **still** get an email
- A user who *only* has a preprint that has a node that was deleted should **not** get an email


<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
None required
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
none anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-938
