### PR TITLE
[PLAT-923][Hotfix] Attempting to delete a VOL 502s

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -49,7 +49,6 @@ from api.base.views import (
     LinkedRegistrationsRelationship,
     WaterButlerMixin
 )
-from api.caching.tasks import ban_url
 from api.citations.utils import render_citation
 from api.comments.permissions import CanCommentOrPublic
 from api.comments.serializers import (CommentCreateSerializer,
@@ -101,7 +100,6 @@ from api.users.views import UserMixin
 from api.users.serializers import UserSerializer
 from api.wikis.serializers import NodeWikiSerializer
 from framework.auth.oauth_scopes import CoreScopes
-from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from osf.models import AbstractNode
 from osf.models import (Node, PrivateLink, Institution, Comment, DraftRegistration, Registration, )
 from osf.models import OSFUser
@@ -1817,8 +1815,8 @@ class NodeViewOnlyLinkDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIV
         assert isinstance(link, PrivateLink), 'link must be a PrivateLink'
         link.is_deleted = True
         link.save()
-        enqueue_postcommit_task(ban_url, (self.get_node(),), {}, celery=True, once_per_request=True)
-
+        # FIXME: Doesn't work because instance isn't JSON-serializable
+        # enqueue_postcommit_task(ban_url, (self.get_node(),), {}, celery=False, once_per_request=True)
 
 class NodeIdentifierList(NodeMixin, IdentifierList):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_identifiers_list).

--- a/api_tests/nodes/views/test_node_view_only_links_detail.py
+++ b/api_tests/nodes/views/test_node_view_only_links_detail.py
@@ -93,6 +93,16 @@ class TestViewOnlyLinksDetail:
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
 
+    def test_vol_detail_delete(
+            self, app, user, url, view_only_link):
+
+        #   test_admin_can_view_vol_detail
+        res = app.delete_json_api(url, auth=user.auth)
+        view_only_link.reload()
+
+        assert res.status_code == 204
+        assert view_only_link.is_deleted
+
 
 @pytest.mark.django_db
 class TestViewOnlyLinksUpdate:

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -183,7 +183,9 @@ def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task(ban_url, (guid_obj.referent, ), {}, celery=False, once_per_request=True)
+                # FIXME: Doesn't work because we're not using Vanish anymore
+                # enqueue_postcommit_task(ban_url, (self.get_node(),), {}, celery=False, once_per_request=True)
+                pass
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
## Purpose

if you try to delete a view only link through our v2 API it crashes, this fixes that.

## Changes

- Comments out unused code that was causing problems

## QA Notes

Issue a delete request to v2/<node_id>/view_only_links/<link_id>/, if you receive a 204 with deleted link  you're good.

## Documentation

🐞 fix no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-923