### PR TITLE
If we get a crossref error that's caused by double metadata posts, don't email the helpdesk

### DIFF
--- a/api/crossref/views.py
+++ b/api/crossref/views.py
@@ -68,6 +68,9 @@ class ParseCrossRefConfirmation(APIView):
                         logger.warn('Related publication DOI does not exist, sending metadata again without it...')
                         client = preprint.get_doi_client()
                         client.create_identifier(preprint, category='doi', include_relation=False)
+                    # This error occurs when a single preprint is being updated several times in a row with the same metadata [#PLAT-944]
+                    elif 'less or equal to previously submitted version' in record.find('msg').text and record_count == 2:
+                        break
                     else:
                         unexpected_errors = True
             logger.info('Creation success email received from CrossRef for preprints: {}'.format(guids))


### PR DESCRIPTION

## Purpose

It appears that if two metadata updates come too quickly to crossref with duplicate metadata. These errors are expected and mostly caused by how calls to update preprint metadata are triggered, as lots of unrelated node updates will cause a connected preprint to update in crossref.

After the node/preprint divorce, this will get a lot better as updates to things like tags, files, and the wiki won't automatically trigger updates on the connected preprint.

Here's a ticket (also now referenced in the code) that can be used to address this once that happens: https://openscience.atlassian.net/browse/PLAT-944

## Changes

- Ignore expected duplicate metadata errors

## QA Notes

Probably best QAed by Becca -- errors from crossref should virtually disappear!

## Documentation

None anticipated

## Side Effects

none needed

## Ticket
Kind of https://openscience.atlassian.net/browse/PLAT-944