### PR TITLE
[IN-354] POST v2/search to search

### DIFF
--- a/api/search/permissions.py
+++ b/api/search/permissions.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+class IsAuthenticatedOrReadOnlyForSearch(IsAuthenticatedOrReadOnly):
+    def has_permission(self, request, view):
+        from api.search.views import BaseSearchView
+        if not isinstance(view, BaseSearchView):
+            return False
+        return request.method == 'POST' or super(IsAuthenticatedOrReadOnlyForSearch, self).has_permission(request, view)

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 
-from rest_framework import generics, permissions as drf_permissions
+from rest_framework import generics
 from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
 
 from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
 from api.base.pagination import SearchPagination
+from api.base.parsers import SearchParser
 from api.base.settings import REST_FRAMEWORK, MAX_PAGE_SIZE
 from api.files.serializers import FileSerializer
 from api.nodes.serializers import NodeSerializer
 from api.registrations.serializers import RegistrationSerializer
+from api.search.permissions import IsAuthenticatedOrReadOnlyForSearch
 from api.search.serializers import SearchSerializer
 from api.users.serializers import UserSerializer
 from api.institutions.serializers import InstitutionSerializer
@@ -23,29 +26,45 @@ from website.search.exceptions import MalformedQueryError
 from website.search.util import build_query
 
 
-class BaseSearchView(JSONAPIBaseView, generics.ListAPIView):
+class BaseSearchView(JSONAPIBaseView, generics.ListCreateAPIView):
 
     required_read_scopes = [CoreScopes.SEARCH]
     required_write_scopes = [CoreScopes.NULL]
 
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
+        IsAuthenticatedOrReadOnlyForSearch,
         base_permissions.TokenHasScope,
     )
 
     pagination_class = SearchPagination
 
+    @property
+    def search_fields(self):
+        # Should be overridden in subclasses to provide a list of keys found
+        # in the relevant elastic doc.
+        raise NotImplementedError
+
     def __init__(self):
         super(BaseSearchView, self).__init__()
         self.doc_type = getattr(self, 'doc_type', None)
 
-    def get_queryset(self):
-        query = self.request.query_params.get('q', '*')
+    def get_parsers(self):
+        if self.request.method == 'POST':
+            return (SearchParser(), )
+        return super(BaseSearchView, self).get_parsers()
+
+    def get_queryset(self, query=None):
         page = int(self.request.query_params.get('page', '1'))
         page_size = min(int(self.request.query_params.get('page[size]', REST_FRAMEWORK['PAGE_SIZE'])), MAX_PAGE_SIZE)
         start = (page - 1) * page_size
+        if query:
+            # Parser has built query, but needs paging info
+            query['from'] = start
+            query['size'] = page_size
+        else:
+            query = build_query(self.request.query_params.get('q', '*'), start=start, size=page_size)
         try:
-            results = search.search(build_query(query, start=start, size=page_size), doc_type=self.doc_type, raw=True)
+            results = search.search(query, doc_type=self.doc_type, raw=True)
         except MalformedQueryError as e:
             raise ValidationError(e.message)
         return results
@@ -637,3 +656,24 @@ class SearchCollections(BaseSearchView):
     doc_type = 'collectionSubmission'
     view_category = 'search'
     view_name = 'search-collected-metadata'
+
+    @property
+    def search_fields(self):
+        return [
+            'abstract',
+            'collectedType',
+            'contributors',
+            'status',
+            'subjects',
+            'title'
+        ]
+
+    def create(self, request, *args, **kwargs):
+        # Override POST methods to behave like list, with header query parsing
+        queryset = self.filter_queryset(self.get_queryset(request.data))
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -13,6 +13,7 @@ from osf_tests import factories
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.settings.defaults import API_BASE
+from api.search.permissions import IsAuthenticatedOrReadOnlyForSearch
 from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from api.crossref.views import ParseCrossRefConfirmation
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
@@ -73,7 +74,7 @@ class TestApiBaseViews(ApiTestCase):
     def test_view_classes_have_minimal_set_of_permissions_classes(self):
         base_permissions = [
             TokenHasScope,
-            (IsAuthenticated, IsAuthenticatedOrReadOnly)
+            (IsAuthenticated, IsAuthenticatedOrReadOnly, IsAuthenticatedOrReadOnlyForSearch)
         ]
         for view in VIEW_CLASSES:
             if view in self.EXCLUDED_VIEWS:

--- a/api_tests/search/views/test_views.py
+++ b/api_tests/search/views/test_views.py
@@ -771,6 +771,14 @@ class TestSearchInstitutions(ApiSearchTestCase):
 
 class TestSearchCollections(ApiSearchTestCase):
 
+    def post_payload(self, *args, **kwargs):
+        return {
+            'data': {
+                'attributes': kwargs
+            },
+            'type': 'search'
+        }
+
     @pytest.fixture()
     def url_collection_search(self):
         return '/{}search/collections/'.format(API_BASE)
@@ -845,3 +853,61 @@ class TestSearchCollections(ApiSearchTestCase):
         assert res.status_code == 200
         total = res.json['links']['meta']['total']
         assert total == 0
+
+    def test_POST_search_collections(
+            self, app, url_collection_search, user, node_one, node_two, collection_public,
+            node_with_abstract, node_private):
+        collection_public.collect_object(node_one, user, status='asdf')
+        collection_public.collect_object(node_two, user, collected_type='asdf', status='lkjh')
+        collection_public.collect_object(node_with_abstract, user, status='asdf')
+        collection_public.collect_object(node_private, user, status='asdf', collected_type='asdf')
+
+        # test_search_empty
+        payload = self.post_payload()
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 3
+        assert len(res.json['data']) == 3
+
+        # test_search_title_keyword
+        payload = self.post_payload(q='Ismael')
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 1
+        assert len(res.json['data']) == 1
+
+        # test_search_abstract_keyword
+        payload = self.post_payload(q='Khadja')
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 1
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == node_with_abstract._id
+
+        # test_search_filter
+        payload = self.post_payload(status='asdf')
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 2
+        assert len(res.json['data']) == 2
+
+        payload = self.post_payload(status=['asdf', 'lkjh'])
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 3
+        assert len(res.json['data']) == 3
+
+        payload = self.post_payload(collectedType='asdf')
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 1
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == node_two._id
+
+        # test_search_abstract_keyword_and_filter
+        payload = self.post_payload(q='Khadja', status='asdf')
+        res = app.post_json_api(url_collection_search, payload)
+        assert res.status_code == 200
+        assert res.json['links']['meta']['total'] == 1
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == node_with_abstract._id


### PR DESCRIPTION
## Purpose
Improve consistency with other search paradigms, simplify things for the front-end.

## Changes
* Add `SearchParser` to parse an ES query out of `POST` bodies
* Tweak permissions to treat `POST`s as `SAFE_METHODS` for search views
* Make `POST` behave like a `GET` for search views
* Add test

## QA Notes
Nothing front-end yet. If desired, could use PostMan to test filtering behavior, but that's duplicative of TCI

## Side Effects
This only works for `v2/search/collections`. POSTing to a non-collection search endpoint (e.g. `v2/search/nodes`) will now raise a `501 Not Implemented` rather than a `405 Method Not Allowed`.

## Ticket
[[IN-354]](https://openscience.atlassian.net/browse/IN-354)
