### PR TITLE
[PLAT-947] Script to get hosts for all GitLab instances

### DIFF
--- a/scripts/count_gitlab_hosts.py
+++ b/scripts/count_gitlab_hosts.py
@@ -1,0 +1,31 @@
+"""
+Meant to count the frequency of gitlab host names, so we can create a whitelist or do a better migration.
+"""
+
+import logging
+
+import django
+from django.utils import timezone
+from django.db import transaction
+django.setup()
+
+from osf.models import ExternalAccount
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+
+    hosts = list(ExternalAccount.objects.filter(provider='gitlab').values_list('oauth_secret', flat=True))
+    hosts_keys = set(hosts)
+
+    hosts_dict = {}
+    for key in hosts_keys:
+        logger.info("{} | Host name: {} ".format(hosts.count(key), key))
+
+    return hosts_dict
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

We need to make some changes to the way our host names for gitlab instances are stored in our database in order to accommodate our new gitlab client. To best know how to do that we first need have some data on what those host names are. This script counts our host names.

## Changes

- adds script that counts host names

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-947