### PR TITLE
[hotfix] Reindex files in quickfiles nodes so their project links are correct [PLAT-932]

### DIFF
--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1193,6 +1193,7 @@ class TestSearchFiles(OsfTestCase):
         quickfiles_root.append_file('GreenLight.mp3')
         find = query_file('GreenLight.mp3')['results']
         assert_equal(len(find), 1)
+        assert find[0]['node_url'] == '/{}/quickfiles/'.format(quickfiles.creator._id)
 
     def test_qatest_quickfiles_files_not_appear_in_search(self):
         quickfiles = QuickFilesNode.objects.get(creator=self.node.creator)

--- a/scripts/remove_after_use/reindex_quickfiles.py
+++ b/scripts/remove_after_use/reindex_quickfiles.py
@@ -7,12 +7,12 @@ from website.app import setup_django
 setup_django()
 
 from website.search.search import update_file
-from osf.models import QuickFilesNode
+from addons.osfstorage.models import OsfStorageFile
 
-PAGE_SIZE = 50
+PAGE_SIZE = 100
 
 def reindex_quickfiles(dry):
-    qs = QuickFilesNode.objects.all().order_by('id')
+    qs = OsfStorageFile.objects.filter(node__type='osf.quickfilesnode').order_by('id')
     count = qs.count()
     paginator = Paginator(qs, PAGE_SIZE)
 
@@ -20,10 +20,9 @@ def reindex_quickfiles(dry):
     n_processed = 0
     for page_num in paginator.page_range:
         page = paginator.page(page_num)
-        for quickfiles in page.object_list:
-            for file_ in quickfiles.files.all():
-                if not dry:
-                    update_file(file_)
+        for quickfile in page.object_list:
+            if not dry:
+                update_file(quickfile)
         n_processed += len(page.object_list)
         progress_bar.update(n_processed)
 

--- a/scripts/remove_after_use/reindex_quickfiles.py
+++ b/scripts/remove_after_use/reindex_quickfiles.py
@@ -1,0 +1,32 @@
+import sys
+
+import progressbar
+from django.core.paginator import Paginator
+
+from website.app import setup_django
+setup_django()
+
+from website.search.search import update_file
+from osf.models import QuickFilesNode
+
+PAGE_SIZE = 50
+
+def reindex_quickfiles(dry):
+    qs = QuickFilesNode.objects.all().order_by('id')
+    count = qs.count()
+    paginator = Paginator(qs, PAGE_SIZE)
+
+    progress_bar = progressbar.ProgressBar(maxval=count).start()
+    n_processed = 0
+    for page_num in paginator.page_range:
+        page = paginator.page(page_num)
+        for quickfiles in page.object_list:
+            for file_ in quickfiles.files.all():
+                if not dry:
+                    update_file(file_)
+        n_processed += len(page.object_list)
+        progress_bar.update(n_processed)
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    reindex_quickfiles(dry=dry)

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -574,7 +574,10 @@ def update_file(file_, index=None, delete=False):
         provider=file_.provider,
         path=file_.path,
     )
-    node_url = '/{node_id}/'.format(node_id=file_.node._id)
+    if file_.node.is_quickfiles:
+        node_url = '/{user_id}/quickfiles/'.format(user_id=file_.node.creator._id)
+    else:
+        node_url = '/{node_id}/'.format(node_id=file_.node._id)
 
     guid_url = None
     file_guid = file_.get_guid(create=False)


### PR DESCRIPTION

## Purpose

Links to a user's quickfiles node in search were incorrect, using the quickfiles guid instead of `/<user_id>/quickfiles`

<img width="666" alt="screen shot 2018-07-05 at 12 26 50 pm" src="https://user-images.githubusercontent.com/801594/42335604-e07bc016-804e-11e8-80c1-6df81caebc1d.png">


## Changes

- update `node_url` if the search result file is in a quickfiles node
- script to reindex all quickfiles

## QA Notes

After the script is run, all search results for files in quickfiles nodes should link directly to that user's quickfiles page at `/<user_id>/quickfiles/`
- Search for a quickfile on the search page
- Click the link for "User Name's QuickFiles" under the file result

## Documentation

None required

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-932
