### PR TITLE
[hotfix] Allow Meeting submission when user has project with same title [PLAT-927]

### DIFF
--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -8,12 +8,13 @@ from osf.models import MailRecord
 from api.base.utils import waterbutler_api_url_for
 
 
-def record_message(message, nodes_created, users_created):
+def record_message(message, node_created, user_created):
     record = MailRecord.objects.create(
         data=message.raw,
     )
-    record.users_created.add(*users_created),
-    record.nodes_created.add(*nodes_created)
+    if user_created:
+        record.users_created.add(user_created)
+    record.nodes_created.add(node_created)
     record.save()
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Previously, the OSF Meetings hook was looking for a project of the same name and same creator as the submitter - let's update that to always create a new project when making a conference submission from email.

## Changes
- always create a new node when getting a conference email
- add test to ensure that a new project is created when a project with the same name exists

## QA Notes
To test:
- Choose an existing project
- Submit a paper or talk to an existing meeting endpoint with that same project title
- Ensure the submission appears in that conference
- You should now have two projects with that title, one with the conference tag and one without


## Documentation

- Double checked our [help section for creating meeting submissions](http://help.osf.io/m/meetings/l/546443-submit-to-a-meeting), there doesn't seem to be anything there about creating a submission from an existing project, which is what I'm guessing this code was originally intended to allow. This should make the current functionality match the existing documentation!

## Side Effects
None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-927
