### PR TITLE
[hotfix] Display currently selected github repo on addons page [PLAT-911]

### DIFF
--- a/addons/github/models.py
+++ b/addons/github/models.py
@@ -231,7 +231,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
                 'node_has_auth': True,
                 'github_user': self.user or '',
                 'github_repo': self.repo or '',
-                'github_repo_full_name': '{0} / {1}'.format(self.user, self.repo) if (self.user and self.repo) else '',
+                'github_repo_full_name': '{0}/{1}'.format(self.user, self.repo) if (self.user and self.repo) else '',
                 'auth_osf_name': owner.fullname,
                 'auth_osf_url': owner.url,
                 'auth_osf_id': owner._id,

--- a/addons/github/templates/github_node_settings.mako
+++ b/addons/github/templates/github_node_settings.mako
@@ -43,13 +43,9 @@
             <div class="col-md-6 m-b-sm">
                 <select id="githubSelectRepo" class="form-control" ${'disabled' if not is_owner or is_registration else ''}>
                     <option>-----</option>
-                        % if is_owner:
-                            % for repo_name in repo_names:
-                                <option value="${repo_name['path']}" ${'selected' if repo_name == github_repo_full_name else ''}>${repo_name['path']}</option>
-                            % endfor
-                        % else:
-                            <option selected>${github_repo_full_name}</option>
-                        % endif
+                    % for repo_name in repo_names:
+                        <option value="${repo_name['path']}" ${'selected' if repo_name['path'] == github_repo_full_name else ''}>${repo_name['path']}</option>
+                    % endfor
                 </select>
             </div>
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
In order for the currently selected github repo to be shown to admins as the selected option in the dropdown, make a change to how `github_repo_full_name` is serialized (removing the spaces between the use and the repo names) to match how the repo name is returned in `repo_name['path']`

<img width="519" alt="screen shot 2018-07-05 at 3 33 22 pm" src="https://user-images.githubusercontent.com/801594/42343960-ce2319c2-8068-11e8-8af1-b7c3a2a8b99f.png">


## Changes

- Remove spaces between username and repo name for `github_repo_full_name` in `to_json` method of github node settings
- Compare `repo_name['path']` to `github_repo_full_name` to determine which option should be selected
- Clean up logic when rendering `<option>` tags

## QA Notes
- Authorize the github addon
- Connect a repo to the project and save
- Refresh the page
- Make sure the previously selected repo name is still selected in the dropdown

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
None necessary
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-911
