### PR TITLE
[hotfix] Add cookie banner to legacy OSF frontend [PLAT-902]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -67,7 +67,7 @@ a {
     bottom:0;
     margin-bottom: 0px;
     left:0;
-    background-color:#204762;
+    background-color: #263947;
     color:white;
     text-align: left;
     border: 0px;

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -89,6 +89,14 @@ a {
     text-decoration: underline;
 }
 
+#cookieBanner a:hover {
+    color: #ADCCE6;
+}
+
+#cookieBanner a:visited {
+    color: #ADCCE6;
+}
+
 /* Footer slide-in */
 #footerSlideIn {
     position:fixed;

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -85,7 +85,8 @@ a {
 }
 
 #cookieBanner a {
-    color:#5BC0DE;
+    color: white;
+    text-decoration: underline;
 }
 
 /* Footer slide-in */

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -59,6 +59,35 @@ a {
     list-style-type: none;
 }
 
+/* Cookie Banner */
+#cookieBanner {
+    position:fixed;
+    width: 100%;
+    z-index: 10;
+    bottom:0;
+    margin-bottom: 0px;
+    left:0;
+    background-color:#204762;
+    color:white;
+    text-align: left;
+    border: 0px;
+    display: none;
+    align-items: center;
+}
+
+#cookieText {
+    margin-left: 10%;
+    margin-right: 75px;
+}
+
+#cookieAccept {
+   margin-right: 10%
+}
+
+#cookieBanner a {
+    color:#5BC0DE;
+}
+
 /* Footer slide-in */
 #footerSlideIn {
     position:fixed;

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -39,6 +39,24 @@ if (String.prototype.endsWith === undefined) {
 
 $('[rel="tooltip"]').tooltip();
 
+// Cookie banner notice for logged out users
+var cookieBannerSelector = '#cookieBanner';
+var CookieBannerViewModel = function(){
+    var self = this;
+    self.elem = $(cookieBannerSelector);
+    var cookieConsentKey = 'osf_cookieconsent';
+
+    self.accept = function() {
+        Cookie.set(cookieConsentKey, '0', { expires: 30, path: '/'});
+    };
+
+    var accepted = Cookie.get(cookieConsentKey) === '0';
+    if (!accepted) {
+        self.elem.css({'display': 'flex'});
+        self.elem.show();
+    }
+};
+
 // If there isn't a user logged in, show the footer slide-in
 var sliderSelector = '#footerSlideIn';
 var SlideInViewModel = function (){
@@ -204,6 +222,10 @@ $(function() {
         window.contextVars.node
     ) {
         $osf.applyBindings(new SlideInViewModel(), sliderSelector);
+    }
+
+    if ($(cookieBannerSelector).length) {
+        $osf.applyBindings(new CookieBannerViewModel(), cookieBannerSelector);
     }
 
     var affix = $('.osf-affix');

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -47,10 +47,10 @@ var CookieBannerViewModel = function(){
     var cookieConsentKey = 'osf_cookieconsent';
 
     self.accept = function() {
-        Cookie.set(cookieConsentKey, '0', { expires: 30, path: '/'});
+        Cookie.set(cookieConsentKey, '1', { expires: 30, path: '/'});
     };
 
-    var accepted = Cookie.get(cookieConsentKey) === '0';
+    var accepted = Cookie.get(cookieConsentKey) === '1';
     if (!accepted) {
         self.elem.css({'display': 'flex'});
         self.elem.show();

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -140,6 +140,16 @@
     ${self.content_wrap()}
 
 % if not user_id:
+<div id="cookieBanner" class="alert">
+    <div id="cookieText">
+        This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information,
+        see our <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md'>Privacy Policy</a>
+        and information on <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect'>cookie use</a>.
+    </div>
+    <div id="cookieAccept">
+        <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
+    </div>
+</div>
 <div id="footerSlideIn">
     <div class="container">
         <div class="row">


### PR DESCRIPTION

## Purpose

Add a banner to alert non-logged in users that the OSF uses cookies. This is dismissible and shouldn't show up for logged-in users.

![cookie-banner](https://user-images.githubusercontent.com/801594/42461073-9d315830-836d-11e8-9fe7-2910e6a768f6.gif)


Note: Appears over the slide-in banner that asks non-logged in users to join the OSF.

<img width="1174" alt="screen shot 2018-07-09 at 11 45 22 am" src="https://user-images.githubusercontent.com/801594/42461079-a01a7ab8-836d-11e8-8395-a156e1ce1ba0.png">


## Changes
- add HTML and CSS for banner
- javascript that adds a cookie when accepted and hides the banner

## QA Notes

This banner:
- Is for legacy OSF frontend
- Should only appear for non-logged-in users who haven't previously clicked Accept
- Clicking Accept sets a cookie that will hide the banner as long as that cookie is set
- The cookie banner should appear over the pre-existing "Join the OSF" banner that slides in
	- both alerts are separately dismissible.


## Documentation

None necessary

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-902
