### PR TITLE
[IN-352][OSF] Add pseudo anchors for filters on My Projects Page

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -536,11 +536,52 @@ var MyProjects = {
             self.getCurrentLogs();
         };
 
+        self.filterHistoryData = {
+            undefined: {title: 'My Projects', name: ''},
+            1: {title: 'My Registrations', name: '#registrations'},
+            2: {title: 'My Preprints', name: '#preprints'}
+        };
+
+        /**
+         * Sets the url history with filter param when filter is updated
+         * @param index {Number} the filter id - 1 or index of the filter in the collections array
+         */
+        self.setFilterHistory = function(index) {
+            var filter;
+            if (index in self.filterHistoryData) {
+                filter = self.filterHistoryData[index];
+            }   else {
+                filter = self.filterHistoryData[undefined];
+            }
+            // Uses replaceState instead of pushState because back buttons will not reset the filter on back without forcing a page refresh
+            // A bug in history causes titles not to change despite setting them here.
+            window.history.replaceState({setFilter: index}, 'OSF | ' + filter.title, '/myprojects/' + filter.name);
+        };
+
+        /**
+         * Sets the initial filter based on href
+         */
+        self.getFilterIndex = function() {
+            // Cast to string undefined => "undefined" to handle upper/lower case anchors
+            var name = String(window.location.href.split('#')[1]).toLowerCase();
+            switch(name) {
+                case 'registrations':
+                    return 1;
+                case 'preprints':
+                    return 2;
+                default:
+                    return 0;
+            }
+        };
+
         /**
          * Update the currentView
          * @param filter
          */
         self.updateFilter = function _updateFilter(filter) {
+            // index for the filter is id - 1
+            self.setFilterHistory(filter.id - 1);
+
             // if collection, reset currentView otherwise toggle the item in the list of currentview items
             if (['node', 'collection'].indexOf(filter.type) === -1 ) {
                 var filterIndex = self.currentView()[filter.type].indexOf(filter);
@@ -982,7 +1023,7 @@ var MyProjects = {
                 self.loadCollections(collectionsUrl);
             }
             // Add linkObject to the currentView
-            self.updateFilter(self.collections()[0]);
+            self.updateFilter(self.collections()[self.getFilterIndex()]);
         };
 
         self.init();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We need a way to link to the preprints/registrations sections of the my projects page to add a "My Registrations" and "My Preprints" links to the respective apps.
<!-- Describe the purpose of your changes -->

## Changes
Standard anchors aren't a great option here (not just scrolling to a page section), so I added two somewhat hacky functions:
1.  Splits the href and sets the filter on init 
2. Sets the page history to include the pseudo anchor

![myprojectsfilter](https://user-images.githubusercontent.com/1322421/42471244-fccf1314-838a-11e8-999b-e4f3d5dc7ee6.gif)


<!-- Briefly describe or list your changes  -->

## QA Notes
New Things:
1. Going to `myprojects/#preprints` or `myprojects/#registrations` goes to the respective section of the myprojects page. 
2. Going to `myprojects/` will not add an anchor to the url and will load projects.
3. The anchors are case insensitive (`#pRePriNtS` will reset it to `#preprints`)
4. Clicking registrations or preprints will add the appropriate anchor to the url
5. Clicking projects, bookmarks, or custom collections will not add a facet and will clear one if it exists.
6. Pressing the back button does NOT loop through the anchors but will go back to the previous page, whatever that was (e.g., `home` -> `myprojects` click preprints -> `myprojects#preprints` -> back button = home
7. Going to invalid anchors will redirect to `myprojects/#projects`
 
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
N/A
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
None known
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/IN-352
