### PR TITLE
[PLAT-880] Integrate django-silk for profiling

### DIFF
--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -13,11 +13,17 @@ CORS_ORIGIN_ALLOW_ALL = True
 
 if DEBUG:
     INSTALLED_APPS += ('debug_toolbar', 'nplusone.ext.django',)
-    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', 'nplusone.ext.django.NPlusOneMiddleware',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',
+                           'nplusone.ext.django.NPlusOneMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda(_): True
     }
     ALLOWED_HOSTS.append('localhost')
+
+    # django-silk
+    INSTALLED_APPS += ('silk',)
+    MIDDLEWARE_CLASSES += ('django.contrib.sessions.middleware.SessionMiddleware',
+                           'silk.middleware.SilkyMiddleware',)
 
 
 REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -62,4 +62,10 @@ urlpatterns = [
     url(r'^$', RedirectView.as_view(pattern_name=views.root), name='redirect-to-root', kwargs={'version': default_version})
 ]
 
+# Add django-silk URLs if it's in INSTALLED_APPS
+if 'silk' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^silk/', include('silk.urls', namespace='silk'))
+    ]
+
 handler404 = views.error_404

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,3 +38,6 @@ pydevd==0.0.6
 
 # n+1 query detection
 nplusone==0.8.2
+
+# Profiling
+django-silk==2.0.0  # pyup: <3.0 # Remove this when we're using MIDDLEWARE


### PR DESCRIPTION
Paired with: @pattisdr 

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Integrate [django-silk](https://github.com/jazzband/django-silk) for profiling requests and code blocks.

## Changes

<!-- Briefly describe or list your changes  -->
* Add django-silk settings to local-dist.py
* Add route for accessing the Silk GUI `http://localhost:8000/silk/`

## QA Notes

None

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

https://www.notion.so/cos/Using-django-silk-for-Profiling-ab212fe4017b484783fb878e344c1b1f

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/PLAT-880

