### PR TITLE
Feature/Account Export and Deactivation Requests in APIv2 [PLAT-929]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -176,6 +176,7 @@ REST_FRAMEWORK = {
         'root-anon-throttle': '1000/hour',
         'test-user': '2/hour',
         'test-anon': '1/hour',
+        'send-email': '2/minute',
     }
 }
 

--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -28,4 +28,5 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'root-anon-throttle': '1000000/second',
     'test-user': '2/hour',
     'test-anon': '1/hour',
+    'send-email': '2/minute',
 }

--- a/api/base/settings/local-travis.py
+++ b/api/base/settings/local-travis.py
@@ -14,6 +14,7 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'root-anon-throttle': '1000000/second',
     'test-user': '2/hour',
     'test-anon': '1/hour',
+    'send-email': '2/minute',
 }
 
 ALLOWED_HOSTS.append('localhost')

--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -95,3 +95,8 @@ class TestUserRateThrottle(BaseThrottle, UserRateThrottle):
 class TestAnonRateThrottle(BaseThrottle, AnonRateThrottle):
 
     scope = 'test-anon'
+
+
+class SendEmailThrottle(BaseThrottle, UserRateThrottle):
+
+    scope = 'send-email'

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -252,3 +252,17 @@ class UserInstitutionsRelationshipSerializer(BaseAPISerializer):
 
     class Meta:
         type_ = 'institutions'
+
+
+class UserAccountExportSerializer(BaseAPISerializer):
+    type = TypeField()
+
+    class Meta:
+        type_ = 'user-account-export-form'
+
+
+class UserAccountDeactivateSerializer(BaseAPISerializer):
+    type = TypeField()
+
+    class Meta:
+        type_ = 'user-account-deactivate-form'

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -16,4 +16,6 @@ urlpatterns = [
     url(r'^(?P<user_id>\w+)/registrations/$', views.UserRegistrations.as_view(), name=views.UserRegistrations.view_name),
     url(r'^(?P<user_id>\w+)/quickfiles/$', views.UserQuickFiles.as_view(), name=views.UserQuickFiles.view_name),
     url(r'^(?P<user_id>\w+)/relationships/institutions/$', views.UserInstitutionsRelationship.as_view(), name=views.UserInstitutionsRelationship.view_name),
+    url(r'^(?P<user_id>\w+)/settings/export/$', views.UserAccountExport.as_view(), name=views.UserAccountExport.view_name),
+    url(r'^(?P<user_id>\w+)/settings/deactivate/$', views.UserAccountDeactivate.as_view(), name=views.UserAccountDeactivate.view_name),
 ]

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -12,6 +12,7 @@ from api.base.utils import (default_node_list_queryset,
                             get_object_or_error,
                             get_user_auth)
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
+from api.base.throttling import SendEmailThrottle
 from api.institutions.serializers import InstitutionSerializer
 from api.nodes.filters import NodesFilterMixin
 from api.nodes.serializers import NodeSerializer
@@ -24,11 +25,16 @@ from api.users.serializers import (UserAddonSettingsSerializer,
                                    UserInstitutionsRelationshipSerializer,
                                    UserSerializer,
                                    UserQuickFilesSerializer,
+                                   UserAccountExportSerializer,
+                                   UserAccountDeactivateSerializer,
                                    ReadEmailUserDetailSerializer,)
 from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
 from framework.auth.oauth_scopes import CoreScopes, normalize_scopes
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
+from rest_framework import status
+from rest_framework.response import Response
 from rest_framework.exceptions import NotAuthenticated, NotFound
 from osf.models import (Contributor,
                         ExternalAccount,
@@ -38,6 +44,7 @@ from osf.models import (Contributor,
                         Node,
                         Registration,
                         OSFUser)
+from website import mails, settings
 
 
 class UserMixin(object):
@@ -436,3 +443,66 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
             if val['id'] in current_institutions:
                 user.remove_institution(val['id'])
         user.save()
+
+
+class UserAccountExport(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        CurrentUser,
+    )
+
+    required_read_scopes = [CoreScopes.USERS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    view_category = 'users'
+    view_name = 'user-account-export'
+
+    serializer_class = UserAccountExportSerializer
+    throttle_classes = (SendEmailThrottle, )
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = self.get_user()
+        mails.send_mail(
+            to_addr=settings.OSF_SUPPORT_EMAIL,
+            mail=mails.REQUEST_EXPORT,
+            user=user,
+            can_change_preferences=False,
+        )
+        user.email_last_sent = timezone.now()
+        user.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class UserAccountDeactivate(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        CurrentUser,
+    )
+
+    required_read_scopes = [CoreScopes.USERS_READ]
+    required_write_scopes = [CoreScopes.USERS_WRITE]
+
+    view_category = 'users'
+    view_name = 'user-account-deactivate'
+
+    serializer_class = UserAccountDeactivateSerializer
+    throttle_classes = (SendEmailThrottle, )
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = self.get_user()
+        mails.send_mail(
+            to_addr=settings.OSF_SUPPORT_EMAIL,
+            mail=mails.REQUEST_DEACTIVATION,
+            user=user,
+            can_change_preferences=False,
+        )
+        user.email_last_sent = timezone.now()
+        user.requested_deactivation = True
+        user.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -452,8 +452,8 @@ class UserAccountExport(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         CurrentUser,
     )
 
-    required_read_scopes = [CoreScopes.USER_SETTINGS_READ]
-    required_write_scopes = [CoreScopes.NULL]
+    required_read_scopes = [CoreScopes.NULL]
+    required_write_scopes = [CoreScopes.USER_SETTINGS_WRITE]
 
     view_category = 'users'
     view_name = 'user-account-export'
@@ -483,7 +483,7 @@ class UserAccountDeactivate(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         CurrentUser,
     )
 
-    required_read_scopes = [CoreScopes.USER_SETTINGS_READ]
+    required_read_scopes = [CoreScopes.NULL]
     required_write_scopes = [CoreScopes.USER_SETTINGS_WRITE]
 
     view_category = 'users'

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -452,7 +452,7 @@ class UserAccountExport(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         CurrentUser,
     )
 
-    required_read_scopes = [CoreScopes.USERS_READ]
+    required_read_scopes = [CoreScopes.USER_SETTINGS_READ]
     required_write_scopes = [CoreScopes.NULL]
 
     view_category = 'users'
@@ -483,8 +483,8 @@ class UserAccountDeactivate(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         CurrentUser,
     )
 
-    required_read_scopes = [CoreScopes.USERS_READ]
-    required_write_scopes = [CoreScopes.USERS_WRITE]
+    required_read_scopes = [CoreScopes.USER_SETTINGS_READ]
+    required_write_scopes = [CoreScopes.USER_SETTINGS_WRITE]
 
     view_category = 'users'
     view_name = 'user-account-deactivate'

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    AuthUserFactory,
+)
+
+
+@pytest.mark.django_db
+class TestUserRequestExport:
+
+    @pytest.fixture()
+    def user_one(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def user_two(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def url(self, user_one):
+        return '/{}users/{}/settings/export/'.format(API_BASE, user_one._id)
+
+    @pytest.fixture()
+    def payload(self):
+        return {
+            'data': {
+                'type': 'user-account-export-form',
+                'attributes': {}
+            }
+        }
+
+    def test_get(self, app, user_one, url):
+        res = app.get(url, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 405
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_post(self, mock_mail, app, user_one, user_two, url, payload):
+        # Logged out
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 401
+
+        # Logged in, requesting export for another user
+        res = app.post_json_api(url, payload, auth=user_two.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Logged in
+        assert user_one.email_last_sent is None
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+        user_one.reload()
+        assert user_one.email_last_sent is not None
+        assert mock_mail.call_count == 1
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_post_invalid_type(self, mock_mail, app, user_one, url, payload):
+        assert user_one.email_last_sent is None
+        payload['data']['type'] = 'Invalid Type'
+        res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 409
+        user_one.reload()
+        assert user_one.email_last_sent is None
+        assert mock_mail.call_count == 0
+
+    def test_exceed_throttle(self, app, user_one, url, payload):
+        assert user_one.email_last_sent is None
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+
+        res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 429
+
+
+@pytest.mark.django_db
+class TestUserRequestDeactivate:
+
+    @pytest.fixture()
+    def user_one(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def user_two(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def url(self, user_one):
+        return '/{}users/{}/settings/deactivate/'.format(API_BASE, user_one._id)
+
+    @pytest.fixture()
+    def payload(self):
+        return {
+            'data': {
+                'type': 'user-account-deactivate-form',
+                'attributes': {}
+            }
+        }
+
+    def test_get(self, app, user_one, url):
+        res = app.get(url, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 405
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_post(self, mock_mail, app, user_one, user_two, url, payload):
+        # Logged out
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 401
+
+        # Logged in, requesting export for another user
+        res = app.post_json_api(url, payload, auth=user_two.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Logged in
+        assert user_one.email_last_sent is None
+        assert user_one.requested_deactivation is False
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+        user_one.reload()
+        assert user_one.email_last_sent is not None
+        assert user_one.requested_deactivation is True
+        assert mock_mail.call_count == 1
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_post_invalid_type(self, mock_mail, app, user_one, url, payload):
+        assert user_one.email_last_sent is None
+        payload['data']['type'] = 'Invalid Type'
+        res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 409
+        user_one.reload()
+        assert user_one.email_last_sent is None
+        assert mock_mail.call_count == 0
+
+    def test_exceed_throttle(self, app, user_one, url, payload):
+        assert user_one.email_last_sent is None
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+
+        res = app.post_json_api(url, payload, auth=user_one.auth)
+        assert res.status_code == 204
+
+        res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 429

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -6,17 +6,17 @@ from osf_tests.factories import (
     AuthUserFactory,
 )
 
+@pytest.fixture()
+def user_one():
+    return AuthUserFactory()
+
+@pytest.fixture()
+def user_two():
+    return AuthUserFactory()
+
 
 @pytest.mark.django_db
 class TestUserRequestExport:
-
-    @pytest.fixture()
-    def user_one(self):
-        return AuthUserFactory()
-
-    @pytest.fixture()
-    def user_two(self):
-        return AuthUserFactory()
 
     @pytest.fixture()
     def url(self, user_one):
@@ -63,7 +63,8 @@ class TestUserRequestExport:
         assert user_one.email_last_sent is None
         assert mock_mail.call_count == 0
 
-    def test_exceed_throttle(self, app, user_one, url, payload):
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_exceed_throttle(self, mock_mail, app, user_one, url, payload):
         assert user_one.email_last_sent is None
         res = app.post_json_api(url, payload, auth=user_one.auth)
         assert res.status_code == 204
@@ -77,14 +78,6 @@ class TestUserRequestExport:
 
 @pytest.mark.django_db
 class TestUserRequestDeactivate:
-
-    @pytest.fixture()
-    def user_one(self):
-        return AuthUserFactory()
-
-    @pytest.fixture()
-    def user_two(self):
-        return AuthUserFactory()
 
     @pytest.fixture()
     def url(self, user_one):
@@ -133,7 +126,8 @@ class TestUserRequestDeactivate:
         assert user_one.email_last_sent is None
         assert mock_mail.call_count == 0
 
-    def test_exceed_throttle(self, app, user_one, url, payload):
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_exceed_throttle(self, mock_mail, app, user_one, url, payload):
         assert user_one.email_last_sent is None
         res = app.post_json_api(url, payload, auth=user_one.auth)
         assert res.status_code == 204

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -31,6 +31,9 @@ class CoreScopes(object):
     USERS_WRITE = 'users_write'
     USERS_CREATE = 'users_create'
 
+    USER_SETTINGS_READ = 'user.settings_read'
+    USER_SETTINGS_WRITE = 'user.settings_write'
+
     USER_EMAIL_READ = 'users.email_read'
 
     USER_ADDON_READ = 'users.addon_read'
@@ -147,8 +150,8 @@ class ComposedScopes(object):
     # All views should be based on selections from CoreScopes, above
 
     # Users collection
-    USERS_READ = (CoreScopes.USERS_READ, CoreScopes.SUBSCRIPTIONS_READ, CoreScopes.ALERTS_READ)
-    USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE, CoreScopes.SUBSCRIPTIONS_WRITE, CoreScopes.ALERTS_WRITE)
+    USERS_READ = (CoreScopes.USERS_READ, CoreScopes.SUBSCRIPTIONS_READ, CoreScopes.ALERTS_READ, CoreScopes.USER_SETTINGS_READ)
+    USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE, CoreScopes.SUBSCRIPTIONS_WRITE, CoreScopes.ALERTS_WRITE, CoreScopes.USER_SETTINGS_WRITE)
     USERS_CREATE = USERS_READ + (CoreScopes.USERS_CREATE, )
 
     # User extensions


### PR DESCRIPTION
## Purpose

Embosf will need this functionality to implement the account settings page.

## Changes

- Add a /v2/users/<uid>/settings/export/ endpoint.
Type is `user-account-export-form`
POST to this endpoint should email the help desk (as clicking the button currently does)
Reponse should be `204 No Content`
- Add a /v2/users/<uid>/settings/deactivate/ endpoint.
Type is `user-account-deactivate-form`
POST to this endpoint should email the help desk (as clicking the button currently does)
Reponse should be `204 No Content`

## QA Notes

None needed, can be tested on front end when finished.

## Documentation
None needed. Don't need excessive help desk emails.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-929
