### PR TITLE
[PLAT-946][hotfix] Fix Probabistic Travis fail

### DIFF
--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -305,7 +305,7 @@ class TestRegistrationFiltering(ApiTestCase):
         self.project_one.add_tag('caT', Auth(self.user_one))
         self.project_one.add_tag('CAT', Auth(self.user_one))
         self.project_one_reg = RegistrationFactory(
-            creator=self.user_one, project=self.project_one, is_public=True)
+            creator=self.user_one, project=self.project_one, is_public=True, title='No search terms!')
         res = self.app.get(
             '/{}registrations/?filter[tags]=cat'.format(
                 API_BASE


### PR DESCRIPTION
## Purpose

When we search factory made nodes by title we often accidentally through random chance make a title that contains terms we don't want to find. This fixes that issue.

## Changes

- Stops title from being random.

## QA Notes

- No QA for travis issue

## Documentation

Not user facing.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-946