### PR TITLE
[IN-208] Order "Other" subjects last

### DIFF
--- a/api/taxonomies/utils.py
+++ b/api/taxonomies/utils.py
@@ -1,7 +1,14 @@
-from django.db.models import Count
+from django.db.models import BooleanField, Case, Count, When
 
 def optimize_subject_query(subject_queryset):
     """
     Optimize subject queryset for TaxonomySerializer
     """
-    return subject_queryset.prefetch_related('parent', 'provider').annotate(children_count=Count('children'))
+    return subject_queryset.prefetch_related('parent', 'provider').annotate(
+        children_count=Count('children'),
+        is_other=Case(
+            When(text__startswith='Other', then=True),
+            default=False,
+            output_field=BooleanField()
+        )
+    ).order_by('is_other', 'text')

--- a/api_tests/providers/preprints/views/test_preprint_provider_subjects_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_subjects_list.py
@@ -11,12 +11,12 @@ class TestPreprintProviderSubjectsForDeprecatedEndpoint(ProviderSubjectsMixin):
 
     @pytest.fixture()
     def lawless_url(self, lawless_provider):
-        return '/{}preprint_providers/{}/taxonomies/?page[size]=15&'.format(
+        return '/{}preprint_providers/{}/taxonomies/?page[size]=20&'.format(
             API_BASE, lawless_provider._id)
 
     @pytest.fixture()
     def ruled_url(self, ruled_provider):
-        return '/{}preprint_providers/{}/taxonomies/?page[size]=15&'.format(
+        return '/{}preprint_providers/{}/taxonomies/?page[size]=20&'.format(
             API_BASE, ruled_provider._id)
 
     @pytest.fixture()
@@ -30,12 +30,12 @@ class TestPreprintProviderSubjects(ProviderSubjectsMixin):
 
     @pytest.fixture()
     def lawless_url(self, lawless_provider):
-        return '/{}providers/preprints/{}/taxonomies/?page[size]=15&'.format(
+        return '/{}providers/preprints/{}/taxonomies/?page[size]=20&'.format(
             API_BASE, lawless_provider._id)
 
     @pytest.fixture()
     def ruled_url(self, ruled_provider):
-        return '/{}providers/preprints/{}/taxonomies/?page[size]=15&'.format(
+        return '/{}providers/preprints/{}/taxonomies/?page[size]=20&'.format(
             API_BASE, ruled_provider._id)
 
     @pytest.fixture()
@@ -84,12 +84,27 @@ class TestPreprintProviderHighlightedSubjects:
         return SubjectFactory(provider=provider, text='AA', parent=subj_a, highlighted=True)
 
     @pytest.fixture()
+    def other_subj(self, provider):
+        return SubjectFactory(text='Other Text', provider=provider, highlighted=True)
+
+    @pytest.fixture()
+    def z_subj(self, provider):
+        return SubjectFactory(text='Zzz Text', provider=provider, highlighted=True)
+
+    @pytest.fixture()
     def url_deprecated(self, provider):
         return '/{}preprint_providers/{}/taxonomies/highlighted/'.format(API_BASE, provider._id)
 
     @pytest.fixture()
     def url(self, provider):
         return '/{}providers/preprints/{}/taxonomies/highlighted/'.format(API_BASE, provider._id)
+
+    def test_taxonomy_other_ordering(self, app, url, provider, subj_a, subj_aa, other_subj, z_subj):
+        res = app.get(url)
+        assert len(res.json['data']) == 3
+        assert res.json['data'][0]['id'] == subj_aa._id
+        assert res.json['data'][1]['id'] == z_subj._id
+        assert res.json['data'][2]['id'] == other_subj._id
 
     def test_mapped_subjects_filter_wrong_provider(self, app, url_deprecated, url, subj_aa):
         res = app.get(url_deprecated)
@@ -121,8 +136,16 @@ class TestCustomTaxonomy:
         return SubjectFactory(text='BePress Text', provider=osf_provider)
 
     @pytest.fixture()
+    def a_subj(self, bepress_subj, asdf_provider):
+        return SubjectFactory(text='Aaa Text', bepress_subject=bepress_subj, provider=asdf_provider)
+
+    @pytest.fixture()
     def other_subj(self, bepress_subj, asdf_provider):
         return SubjectFactory(text='Other Text', bepress_subject=bepress_subj, provider=asdf_provider)
+
+    @pytest.fixture()
+    def z_subj(self, bepress_subj, asdf_provider):
+        return SubjectFactory(text='Zzz Text', bepress_subject=bepress_subj, provider=asdf_provider)
 
     @pytest.fixture()
     def url_deprecated(self):
@@ -131,6 +154,13 @@ class TestCustomTaxonomy:
     @pytest.fixture()
     def url(self):
         return '/{}providers/preprints/{}/taxonomies/'
+
+    def test_taxonomy_other_ordering(self, app, url, asdf_provider, a_subj, other_subj, z_subj):
+        res = app.get(url.format(API_BASE, asdf_provider._id))
+        assert len(res.json['data']) == 3
+        assert res.json['data'][0]['id'] == a_subj._id
+        assert res.json['data'][1]['id'] == z_subj._id
+        assert res.json['data'][2]['id'] == other_subj._id
 
     def test_taxonomy_share_title(self, app, url_deprecated, url, osf_provider, asdf_provider, bepress_subj, other_subj):
         bepress_res = app.get(


### PR DESCRIPTION
## Purpose
Show subjects starting with "Other" at the end of all lists. This sort could be done on the front-end, but it's less costly to do so on the backend.

## Changes
* Annotate and sort `optimize_subject_queryset`
* Add tests

## QA Notes
Ensure "Other" subjects are at the end of lists in the front-end

## Side Effects
None expected, at present.
`startswith` (uses a bitmap heap scan) was used over `istartswith` (sequence scan) for optimization purposes. Currently, all subjects starting with `r'[oO]ther'` are capitalized, but this may become a problem if any start with a lowercase `'other'` (unlikely).

## Ticket
[[IN-208]](https://openscience.atlassian.net/browse/IN-208)
