### PR TITLE
[IN-231][OSF] Add collected subjects to project overview

### DIFF
--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -4266,6 +4266,10 @@ class TestCollectionProperties:
     def bookmark_collection(self, user):
         return find_bookmark_collection(user)
 
+    @pytest.fixture()
+    def subjects(self):
+        return [[SubjectFactory()._id] for i in xrange(0, 5)]
+
     def test_collection_project_views(
             self, user, node, collection_one, collection_two, collection_public,
             public_non_provided_collection, private_non_provided_collection, bookmark_collection, collector):
@@ -4291,7 +4295,7 @@ class TestCollectionProperties:
         assert ids_actual == ids_expected
 
     def test_permissions_collection_project_views(
-            self, user, node, contrib, collection_one, collection_two,
+            self, user, node, contrib, subjects, collection_one, collection_two,
             collection_public, public_non_provided_collection, private_non_provided_collection,
             bookmark_collection, collector):
 
@@ -4300,10 +4304,16 @@ class TestCollectionProperties:
         public_non_provided_collection.collect_object(node, collector)
         private_non_provided_collection.collect_object(node, collector)
         bookmark_collection.collect_object(node, collector)
-        collection_public.collect_object(node, collector)
+        cgm = collection_public.collect_object(node, collector, status='Complete', collected_type='Dataset')
+        cgm.set_subjects(subjects, Auth(collector))
 
         ## test_not_logged_in_user_only_sees_public_collection_info
         collection_summary = serialize_collections(node.collecting_metadata_list, Auth())
+
+        # test_subjects_are_serialized
+        assert len(collection_summary[0]['subjects'])
+        assert len(collection_summary[0]['subjects']) == len(subjects)
+
         assert len(collection_summary) == 1
         assert collection_public._id == collection_summary[0]['url'].strip('/')
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -875,6 +875,7 @@ def serialize_collections(cgms, auth):
         'url': '/{}/'.format(cgm.collection._id),
         'status': cgm.status,
         'type': cgm.collected_type,
+        'subjects': list(cgm.subjects.values_list('text', flat=True)),
         'is_public': cgm.collection.is_public,
         'logo': cgm.collection.provider.get_asset_url('favicon')
     } for cgm in cgms if cgm.collection.is_public or

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -832,6 +832,36 @@ table.add-links {
     color: #000000;
 }
 
+.subject-preview {
+    display: inline-block;
+    background-color: #F8F8F8;
+    border-radius: 3px;
+    border: 1px solid #EEE;
+    padding: 1px 7px;
+    margin-bottom: 4px;
+    margin-right: 5px;
+}
+
+.dl-subjects dt {
+    width: 10px;
+    overflow: visible;
+    font-weight: normal;
+}
+
+.dl-subjects dd {
+    margin-left: 65px;
+}
+
+@media (max-width: 767px) {
+    .dl-subjects dd {
+        margin-left: 0px;
+    }
+
+    .dl-subjects dt {
+        padding-bottom: 5px;
+    }
+}
+
 /* Override jumbotron to be a bit smaller.
    Used for the updated terms of service banner on all pages. */
 .jumbotron {

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -299,9 +299,8 @@
     <div class="collections-container">
     % for i, collection in enumerate(node['collections'][:5]):
     <div class="row">
-        <div class="col-xs-12 col-md-6">
-            <div style="margin-top: 5px;">
-                Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
+        <div class="col-xs-12">
+            <div style="margin-top: 5px;">Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
                 <img style="margin: 0px 0px 2px 5px;" src="${collection['logo']}">
             % if any([collection['type'], collection['status']]):
               &nbsp;<span id="metadata${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadata${i}"></span>
@@ -318,6 +317,20 @@
                       <li>Status:&nbsp;&nbsp;<b>${collection['status']}</b></li>
                     % endif
 
+                    % if collection['subjects']:
+                      <li>
+                        <dl class="dl-horizontal dl-subjects">
+                          <dt>Subjects:&nbsp;&nbsp;</dt>
+                          <dd>
+                          % for subject in collection['subjects']:
+                            <span class='subject-preview'>
+                              <small> ${subject} </small>
+                            </span>
+                          % endfor
+                          </dd>
+                        </dl>
+                      </li>
+                    % endif
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Purpose

Add collected subjects to project overview

## Changes

- Update tests to make sure subjects show
- Update template to show collected subjects

## QA Notes

- Make sure to have lots of subjects (say 15), test the responsiveness of the subjects list
- Make sure the list only shows if you are the collector, right permissions.

## Documentation
N/A

## After
**Lots of subjects:** See http://recordit.co/IFLgNxIJH7
**Few subjects:**
<img width="1609" alt="screen shot 2018-07-11 at 8 24 54 pm" src="https://user-images.githubusercontent.com/4511563/42607714-5085a6da-8552-11e8-86bf-849beaf71670.png">

## Ticket
[[IN-231]](https://openscience.atlassian.net/browse/IN-231)
