### PR TITLE
Increase The Max File Size Limit For Box With Chunked Upload

### DIFF
--- a/addons/box/apps.py
+++ b/addons/box/apps.py
@@ -12,7 +12,7 @@ class BoxAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 250  # MB
+    max_file_size = 65536  # MB
 
     @property
     def get_hgrid_data(self):


### PR DESCRIPTION
## Purpose

Increase the max file size limit for box with chunked upload.

@felliott 
- [ ] Decide the max file size we allow users to upload when chunked uploads is ready
- [ ] Optional: should we make this a configurable OSF settings

@sloria 
- [ ] Must be merged and deployed at the same time with the [WB PR](https://github.com/CenterForOpenScience/waterbutler/pull/348)

## Changes

Increase the max upload size from 250 MB to 65536 MB.

## QA Notes

This is a supporting PR. Please see the notes in the [WB PR](https://github.com/CenterForOpenScience/waterbutler/pull/348) or the [ticket](https://openscience.atlassian.net/browse/SVCS-545) itself.

## Documentation

TBD

## Side Effects

TBD

## Ticket

https://openscience.atlassian.net/browse/SVCS-545
