### PR TITLE
 [IN-282][OSF] Update crossref status upon preprint withdrawal

### DIFF
--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -63,7 +63,7 @@ class PreprintService(DirtyFieldsMixin, SpamMixin, GuidMixin, IdentifierMixin, R
 
     @property
     def verified_publishable(self):
-        return self.is_published and self.node.is_preprint and not self.node.is_deleted
+        return self.is_published and self.node.is_preprint and not (self.is_retracted or self.node.is_deleted)
 
     @property
     def primary_file(self):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -4,6 +4,7 @@ import mock
 import urlparse
 import pytest
 
+from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 
 from addons.osfstorage.models import OsfStorageFile
@@ -20,15 +21,18 @@ from osf_tests.factories import (
     ProjectFactory,
     SubjectFactory,
     UserFactory,
+    PreprintRequestFactory,
 )
 from osf_tests.utils import MockShareResponse
 from osf.utils import permissions
+from osf.utils.workflows import DefaultStates, RequestTypes
 from tests.utils import assert_logs
 from tests.base import OsfTestCase
 from website import settings, mails
 from website.identifiers.clients import CrossRefClient, ECSArXivCrossRefClient
 from website.preprints.tasks import format_preprint, update_preprint_share, on_preprint_updated, update_or_create_preprint_identifiers, update_or_enqueue_on_preprint_updated
 from website.project.views.contributor import find_preprint_provider
+from website.identifiers.clients import crossref
 from website.util.share import format_user
 
 
@@ -818,46 +822,122 @@ class TestWithdrawnPreprint:
         return AuthUserFactory()
 
     @pytest.fixture()
-    def preprint_pre_mod(self):
+    def unpublished_preprint_pre_mod(self):
         return PreprintFactory(provider__reviews_workflow='pre-moderation', is_published=False)
 
     @pytest.fixture()
-    def preprint_post_mod(self):
+    def preprint_pre_mod(self):
+        return PreprintFactory(provider__reviews_workflow='pre-moderation')
+
+    @pytest.fixture()
+    def unpublished_preprint_post_mod(self):
         return PreprintFactory(provider__reviews_workflow='post-moderation', is_published=False)
+
+    @pytest.fixture()
+    def preprint_post_mod(self):
+        return PreprintFactory(provider__reviews_workflow='post-moderation')
 
     @pytest.fixture()
     def preprint(self):
         return PreprintFactory()
 
-    @mock.patch('website.identifiers.utils.request_identifiers')
-    def test_withdrawn_preprint(self, _, user, preprint, preprint_pre_mod, preprint_post_mod):
+    @pytest.fixture()
+    def admin(self):
+        admin = AuthUserFactory()
+        osf_admin = Group.objects.get(name='osf_admin')
+        admin.groups.add(osf_admin)
+        return admin
+
+    @pytest.fixture()
+    def moderator(self, preprint_pre_mod, preprint_post_mod):
+        moderator = AuthUserFactory()
+        preprint_pre_mod.provider.add_to_group(moderator, 'moderator')
+        preprint_pre_mod.provider.save()
+
+        preprint_post_mod.provider.add_to_group(moderator, 'moderator')
+        preprint_post_mod.provider.save()
+
+        return moderator
+
+    @pytest.fixture()
+    def make_withdrawal_request(self, user):
+        def withdrawal_request(target):
+            request = PreprintRequestFactory(
+                        creator=user,
+                        target=target,
+                        request_type=RequestTypes.WITHDRAWAL.value,
+                        machine_state=DefaultStates.INITIAL.value)
+            request.run_submit(user)
+            return request
+        return withdrawal_request
+
+    @pytest.fixture()
+    def crossref_client(self):
+        return crossref.CrossRefClient(base_url='http://test.osf.crossref.test')
+
+
+    def test_withdrawn_preprint(self, user, preprint, unpublished_preprint_pre_mod, unpublished_preprint_post_mod):
         # test_ever_public
 
         # non-moderated
         assert preprint.ever_public
 
         # pre-mod
-        preprint_pre_mod.run_submit(user)
+        unpublished_preprint_pre_mod.run_submit(user)
 
-        assert not preprint_pre_mod.ever_public
-        preprint_pre_mod.run_reject(user, 'it')
-        preprint_pre_mod.reload()
-        assert not preprint_pre_mod.ever_public
-        preprint_pre_mod.run_accept(user, 'it')
-        preprint_pre_mod.reload()
-        assert preprint_pre_mod.ever_public
+        assert not unpublished_preprint_pre_mod.ever_public
+        unpublished_preprint_pre_mod.run_reject(user, 'it')
+        unpublished_preprint_pre_mod.reload()
+        assert not unpublished_preprint_pre_mod.ever_public
+        unpublished_preprint_pre_mod.run_accept(user, 'it')
+        unpublished_preprint_pre_mod.reload()
+        assert unpublished_preprint_pre_mod.ever_public
 
         # post-mod
-        preprint_post_mod.run_submit(user)
-        assert preprint_post_mod.ever_public
+        unpublished_preprint_post_mod.run_submit(user)
+        assert unpublished_preprint_post_mod.ever_public
 
         # test_cannot_set_ever_public_to_False
-        preprint_pre_mod.ever_public = False
-        preprint_post_mod.ever_public = False
+        unpublished_preprint_pre_mod.ever_public = False
+        unpublished_preprint_post_mod.ever_public = False
         preprint.ever_public = False
         with pytest.raises(ValidationError):
             preprint.save()
         with pytest.raises(ValidationError):
-            preprint_pre_mod.save()
+            unpublished_preprint_pre_mod.save()
         with pytest.raises(ValidationError):
-            preprint_post_mod.save()
+            unpublished_preprint_post_mod.save()
+
+    def test_crossref_status_is_updated(self, make_withdrawal_request, preprint, preprint_post_mod, preprint_pre_mod, moderator, admin, crossref_client):
+        # test_non_moderated_preprint
+        assert preprint.verified_publishable
+        assert crossref_client.get_status(preprint) == 'public'
+
+        withdrawal_request = make_withdrawal_request(preprint)
+        withdrawal_request.run_accept(admin, withdrawal_request.comment)
+
+        assert preprint.is_retracted
+        assert not preprint.verified_publishable
+        assert crossref_client.get_status(preprint) == 'unavailable'
+
+        # test_post_moderated_preprint
+        assert preprint_post_mod.verified_publishable
+        assert crossref_client.get_status(preprint_post_mod) == 'public'
+
+        withdrawal_request = make_withdrawal_request(preprint_post_mod)
+        withdrawal_request.run_accept(moderator, withdrawal_request.comment)
+
+        assert preprint_post_mod.is_retracted
+        assert not preprint_post_mod.verified_publishable
+        assert crossref_client.get_status(preprint_post_mod) == 'unavailable'
+
+        # test_pre_moderated_preprint
+        assert preprint_pre_mod.verified_publishable
+        assert crossref_client.get_status(preprint_pre_mod) == 'public'
+
+        withdrawal_request = make_withdrawal_request(preprint_pre_mod)
+        withdrawal_request.run_accept(moderator, withdrawal_request.comment)
+
+        assert preprint_pre_mod.is_retracted
+        assert not preprint_pre_mod.verified_publishable
+        assert crossref_client.get_status(preprint_pre_mod) == 'unavailable'


### PR DESCRIPTION
## Purpose

Update crossref status from `public` to `unavailable` upon preprint withdrawal

h/t to @erinspace for all the work on crossref and helping out.

## Changes

- Modify `verified_publishable` to return false when preprint is withdrawn.
- Add tests

## QA Notes
- Create a preprint and make sure it gets crossref doi, checking at `test.crossref.org` the status should be 'public'
- Create a withdrawal request  and approve it, make sure that  (may take a while) the status gets updated to `unavailable` at `test.crossref.org`


## Documentation

## Side Effects

## Ticket

[[IN-282]](https://openscience.atlassian.net/browse/IN-282)
