### PR TITLE
[No Ticket] Update ES mapping for collectionSubmission docs

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -689,45 +689,57 @@ def create_index(index=None):
 
     client().indices.create(index, ignore=[400])  # HTTP 400 if index already exists
     for type_ in document_types:
-        mapping = {
-            'properties': {
-                'tags': NOT_ANALYZED_PROPERTY,
-                'license': {
-                    'properties': {
-                        'id': NOT_ANALYZED_PROPERTY,
-                        'name': NOT_ANALYZED_PROPERTY,
-                        # Elasticsearch automatically infers mappings from content-type. `year` needs to
-                        # be explicitly mapped as a string to allow date ranges, which break on the inferred type
-                        'year': {'type': 'string'},
+        if type_ == 'collectionSubmission':
+            mapping = {
+                'properties': {
+                    'collectedType': NOT_ANALYZED_PROPERTY,
+                    'subjects': NOT_ANALYZED_PROPERTY,
+                    'status': NOT_ANALYZED_PROPERTY,
+                    'provider': NOT_ANALYZED_PROPERTY,
+                    'title': ENGLISH_ANALYZER_PROPERTY,
+                    'abstract': ENGLISH_ANALYZER_PROPERTY
+                }
+            }
+        else:
+            mapping = {
+                'properties': {
+                    'tags': NOT_ANALYZED_PROPERTY,
+                    'license': {
+                        'properties': {
+                            'id': NOT_ANALYZED_PROPERTY,
+                            'name': NOT_ANALYZED_PROPERTY,
+                            # Elasticsearch automatically infers mappings from content-type. `year` needs to
+                            # be explicitly mapped as a string to allow date ranges, which break on the inferred type
+                            'year': {'type': 'string'},
+                        }
                     }
                 }
             }
-        }
-        if type_ in project_like_types:
-            analyzers = {field: ENGLISH_ANALYZER_PROPERTY
-                         for field in analyzed_fields}
-            mapping['properties'].update(analyzers)
+            if type_ in project_like_types:
+                analyzers = {field: ENGLISH_ANALYZER_PROPERTY
+                             for field in analyzed_fields}
+                mapping['properties'].update(analyzers)
 
-        if type_ == 'user':
-            fields = {
-                'job': {
-                    'type': 'string',
-                    'boost': '1',
-                },
-                'all_jobs': {
-                    'type': 'string',
-                    'boost': '0.01',
-                },
-                'school': {
-                    'type': 'string',
-                    'boost': '1',
-                },
-                'all_schools': {
-                    'type': 'string',
-                    'boost': '0.01'
-                },
-            }
-            mapping['properties'].update(fields)
+            if type_ == 'user':
+                fields = {
+                    'job': {
+                        'type': 'string',
+                        'boost': '1',
+                    },
+                    'all_jobs': {
+                        'type': 'string',
+                        'boost': '0.01',
+                    },
+                    'school': {
+                        'type': 'string',
+                        'boost': '1',
+                    },
+                    'all_schools': {
+                        'type': 'string',
+                        'boost': '0.01'
+                    },
+                }
+                mapping['properties'].update(fields)
         client().indices.put_mapping(index=index, doc_type=type_, body=mapping, ignore=[400, 404])
 
 @requires_search


### PR DESCRIPTION
## Purpose
Allow searching by direct matching controlled server-side language

## Changes
* Update mapping

## QA Notes
No UI yet

## Side Effects
None expected.

## Deployment Notes
Requires `invoke migrate_search --no-delete` to be ran before [mappings will be updated](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping.html#_updating_existing_mappings). Tested locally, worked with a production-sized dataset in ~16 minutes. 
Shouldn't require downtime, as it's only making `SELECT`s, but would certainly run faster with it.

Additionally, if it's not ran, nothing will be any more broken than it currently is. Search will just continue not behaving as required for `collectionSubmission` docs

## Ticket
None