### PR TITLE
[PLAT-977] move file upload limits to settings

### DIFF
--- a/addons/box/apps.py
+++ b/addons/box/apps.py
@@ -1,4 +1,6 @@
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.box.settings import MAX_UPLOAD_SIZE
+
 
 box_root_folder = generic_root_folder('box')
 
@@ -12,7 +14,7 @@ class BoxAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 250  # MB
+    max_file_size = MAX_UPLOAD_SIZE
 
     @property
     def get_hgrid_data(self):

--- a/addons/box/settings/defaults.py
+++ b/addons/box/settings/defaults.py
@@ -9,3 +9,6 @@ REFRESH_TIME = 5 * 60  # 5 minutes
 BOX_OAUTH_TOKEN_ENDPOINT = 'https://www.box.com/api/oauth2/token'
 BOX_OAUTH_AUTH_ENDPOINT = 'https://www.box.com/api/oauth2/authorize'
 BOX_OAUTH_REVOKE_ENDPOINT = 'https://api.box.com/oauth2/revoke'
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 250

--- a/addons/dropbox/apps.py
+++ b/addons/dropbox/apps.py
@@ -1,4 +1,5 @@
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.dropbox.settings import MAX_UPLOAD_SIZE
 
 
 dropbox_root_folder = generic_root_folder('dropbox')
@@ -11,7 +12,7 @@ class DropboxAddonAppConfig(BaseAddonAppConfig):
     short_name = 'dropbox'
     configs = ['accounts', 'node']
     has_hgrid_files = True
-    max_file_size = 150  # MB
+    max_file_size = MAX_UPLOAD_SIZE
     owners = ['user', 'node']
     categories = ['storage']
 

--- a/addons/dropbox/settings/defaults.py
+++ b/addons/dropbox/settings/defaults.py
@@ -3,3 +3,6 @@ DROPBOX_KEY = None
 DROPBOX_SECRET = None
 
 DROPBOX_AUTH_CSRF_TOKEN = 'dropbox-auth-csrf-token'
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 150

--- a/addons/figshare/apps.py
+++ b/addons/figshare/apps.py
@@ -1,4 +1,5 @@
 from addons.base.apps import BaseAddonAppConfig
+from addons.figshare.settings import MAX_UPLOAD_SIZE
 
 from website.util import rubeus
 
@@ -33,7 +34,7 @@ class FigshareAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 50  # MB
+    max_file_size = MAX_UPLOAD_SIZE
 
     @property
     def get_hgrid_data(self):

--- a/addons/figshare/settings/defaults.py
+++ b/addons/figshare/settings/defaults.py
@@ -5,6 +5,9 @@ API_BASE_URL = 'https://api.figshare.com/v2/'
 
 MAX_RENDER_SIZE = 1000
 
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 50
+
 FIGSHARE_OAUTH_TOKEN_ENDPOINT = '{}{}'.format(API_BASE_URL, 'token')
 FIGSHARE_OAUTH_AUTH_ENDPOINT = 'https://figshare.com/account/applications/authorize'
 

--- a/addons/github/apps.py
+++ b/addons/github/apps.py
@@ -4,6 +4,7 @@ import os
 from addons.base.apps import BaseAddonAppConfig
 from addons.github.api import GitHubClient, ref_to_params
 from addons.github.exceptions import NotFoundError, GitHubError
+from addons.github.settings import MAX_UPLOAD_SIZE
 from addons.github.utils import get_refs, check_permissions
 from website.util import rubeus
 
@@ -106,7 +107,7 @@ class GitHubAddonConfig(BaseAddonAppConfig):
     categories = ['storage']
     owners = ['user', 'node']
     has_hgrid_files = True
-    max_file_size = 100  # MB
+    max_file_size = MAX_UPLOAD_SIZE
     node_settings_template = NODE_SETTINGS_TEMPLATE
 
     @property

--- a/addons/github/settings/defaults.py
+++ b/addons/github/settings/defaults.py
@@ -17,4 +17,7 @@ OAUTH_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
 # Max render size in bytes; no max if None
 MAX_RENDER_SIZE = None
 
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 100
+
 CACHE = False

--- a/addons/gitlab/apps.py
+++ b/addons/gitlab/apps.py
@@ -84,7 +84,6 @@ class GitLabAddonConfig(BaseAddonAppConfig):
     categories = ['storage']
     owners = ['user', 'node']
     has_hgrid_files = True
-    max_file_size = 100  # MB
     node_settings_template = NODE_SETTINGS_TEMPLATE
     user_settings_template = USER_SETTINGS_TEMPLATE
 

--- a/addons/onedrive/apps.py
+++ b/addons/onedrive/apps.py
@@ -12,7 +12,6 @@ class OneDriveAddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 250  # MB
 
     @property
     def get_hgrid_data(self):

--- a/addons/osfstorage/apps.py
+++ b/addons/osfstorage/apps.py
@@ -37,8 +37,8 @@ class OSFStorageAddonAppConfig(BaseAddonAppConfig):
 
     get_hgrid_data = osf_storage_root
 
-    max_file_size = 5 * 1024  # 5 GB
-    high_max_file_size = 5 * 1024  # 5 GB
+    max_file_size = addon_settings.MAX_UPLOAD_SIZE
+    high_max_file_size = addon_settings.HIGH_MAX_UPLOAD_SIZE
 
     owners = ['node']
 

--- a/addons/osfstorage/settings/defaults.py
+++ b/addons/osfstorage/settings/defaults.py
@@ -31,3 +31,9 @@ try:
     globals().update({k: getattr(mod, k) for k in dir(mod)})
 except Exception as ex:
     logger.warn('No migration settings loaded for OSFStorage, falling back to local dev. {}'.format(ex))
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 5 * 1024  # 5 GB
+
+# Max file size permitted by frontend in megabytes for verified users
+HIGH_MAX_UPLOAD_SIZE = 5 * 1024  # 5 GB

--- a/addons/s3/apps.py
+++ b/addons/s3/apps.py
@@ -1,5 +1,6 @@
 import os
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.s3.settings import MAX_UPLOAD_SIZE
 
 s3_root_folder = generic_root_folder('s3')
 
@@ -19,7 +20,7 @@ class S3AddonAppConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
-    max_file_size = 128  # MB
+    max_file_size = MAX_UPLOAD_SIZE
     node_settings_template = os.path.join(TEMPLATE_PATH, 's3_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 's3_user_settings.mako')
 

--- a/addons/s3/settings/defaults.py
+++ b/addons/s3/settings/defaults.py
@@ -9,6 +9,9 @@ STATIC_PATH = os.path.join(parent_dir(HERE), 'static')
 
 MAX_RENDER_SIZE = (1024 ** 2) * 3
 
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 128
+
 ALLOWED_ORIGIN = '*'
 
 BUCKET_LOCATIONS = {}


### PR DESCRIPTION
## Purpose

Make  file size upload limits configurable.

## Changes

Move file size upload limits from hardcoded values in `apps.py` to `settings/defaults.py`.
.
## QA Notes

@felliott will test

No changes have been made to the current limits.  For each applicable addon:

1. Upload a file smaller than the limit.  This should succeed.
2. Upload a file larger than the limit.  This should fail with an error message.

## Documentation

No changes needed.

## Side Effects

None expected.

## Ticket

https://openscience.atlassian.net/browse/PLAT-977