### PR TITLE
Feature/Anonymize IP's Sent to Keen [PLAT-976]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ kombu==4.1.0
 vine==1.1.4
 httplib2==0.10.3
 itsdangerous==0.24
+ipaddress==1.0.22
 lxml==3.4.1
 mailchimp==2.0.9
 nameparser==0.5.3

--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -180,6 +180,7 @@ var KeenTracker = (function() {
             var _defaultPrivateKeenPayload = function() {
                 var payload = _defaultKeenPayload();
                 var user = window.contextVars.currentUser;
+                var ip = window.contextVars.anonymizedIP;
                 payload.visitor = {
                     id: _getOrCreateKeenId(),
                     session: Cookie.get('keenSessionId'),
@@ -188,7 +189,7 @@ var KeenTracker = (function() {
                 payload.tech = {
                     browser: keenTracking.helpers.getBrowserProfile(),
                     ua: '${keen.user_agent}',
-                    ip: '${keen.ip}',
+                    ip: ip,
                     info: {},
                 };
                 payload.user = {

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -236,6 +236,7 @@
                 maintenance: ${ maintenance | sjson, n},
                 analyticsMeta: {},
                 osfSupportEmail: ${osf_support_email | sjson, n },
+                anonymizedIP: ${ anonymized_ip | sjson, n}
             });
         </script>
 


### PR DESCRIPTION
## Purpose
We need to anonymize the client IP address when sending data to keen.io.

## Changes

Follow Google's implementation to either drop the last octet from the IP (IPv4) or replace the last 80 of the 128 bits (IPv6).
https://support.google.com/analytics/answer/2763052?hl=en

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-976