### PR TITLE
Set TIME_ZONE = UTC in settings [PLAT-954]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -228,9 +228,7 @@ WSGI_APPLICATION = 'api.base.wsgi.application'
 
 LANGUAGE_CODE = 'en-us'
 
-# Disabled to make a test work (TestNodeLog.test_formatted_date)
-# TODO Try to understand what's happening to cause the test to break when that line is active.
-# TIME_ZONE = 'UTC'
+TIME_ZONE = 'UTC'
 
 USE_I18N = True
 


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The default for Django is 'America/Chicago'. This should be updated to 'UTC,' as we store all dates and datetimes as UTC anyhow.  This wasn't set in the past to fix a failing test, which no longer seems to be a part of the codebase.

## Changes

- set `TIME_ZONE = UTC`

## QA Notes

No user facing changes, nothing should be different

## Documentation

None necessary

## Side Effects

This may have been causing some strange bugs as this setting will affect any datetime queries. All datetime queries should now be using `UTC`, which should hopefully make things more consistent in general.

## Ticket

https://openscience.atlassian.net/browse/PLAT-954
