### PR TITLE
Feature/Manage Two-Factor Auth in V2 [PLAT-963]

### DIFF
--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     url(r'^(?P<user_id>\w+)/nodes/$', views.UserNodes.as_view(), name=views.UserNodes.view_name),
     url(r'^(?P<user_id>\w+)/preprints/$', views.UserPreprints.as_view(), name=views.UserPreprints.view_name),
     url(r'^(?P<user_id>\w+)/registrations/$', views.UserRegistrations.as_view(), name=views.UserRegistrations.view_name),
+    url(r'^(?P<user_id>\w+)/settings/$', views.UserSettings.as_view(), name=views.UserSettings.view_name),
     url(r'^(?P<user_id>\w+)/quickfiles/$', views.UserQuickFiles.as_view(), name=views.UserQuickFiles.view_name),
     url(r'^(?P<user_id>\w+)/relationships/institutions/$', views.UserInstitutionsRelationship.as_view(), name=views.UserInstitutionsRelationship.view_name),
 ]

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -23,6 +23,8 @@ from api.users.serializers import (UserAddonSettingsSerializer,
                                    UserDetailSerializer,
                                    UserInstitutionsRelationshipSerializer,
                                    UserSerializer,
+                                   UserSettingsSerializer,
+                                   UserSettingsUpdateSerializer,
                                    UserQuickFilesSerializer,
                                    ReadEmailUserDetailSerializer,)
 from django.contrib.auth.models import AnonymousUser
@@ -436,3 +438,31 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
             if val['id'] in current_institutions:
                 user.remove_institution(val['id'])
         user.save()
+
+
+class UserSettings(JSONAPIBaseView, generics.RetrieveUpdateAPIView, UserMixin):
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        CurrentUser,
+    )
+
+    required_read_scopes = [CoreScopes.USER_SETTINGS_READ]
+    required_write_scopes = [CoreScopes.USER_SETTINGS_WRITE]
+
+    view_category = 'users'
+    view_name = 'user-settings'
+
+    serializer_class = UserSettingsSerializer
+    # overrides RetrieveUpdateAPIView
+    def get_serializer_class(self):
+        """
+        Use NodeDetailSerializer which requires 'id'
+        """
+        if self.request.method in ('PUT', 'PATCH'):
+            return UserSettingsUpdateSerializer
+        return UserSettingsSerializer
+
+    # overrides RetrieveUpdateAPIView
+    def get_object(self):
+        return self.get_user()

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+import pytest
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    AuthUserFactory,
+)
+from addons.twofactor.tests.utils import _valid_code
+
+
+@pytest.fixture()
+def user_one():
+    return AuthUserFactory()
+
+@pytest.fixture()
+def user_two():
+    return AuthUserFactory()
+
+
+@pytest.mark.django_db
+class TestUserSettingsGet:
+
+    @pytest.fixture()
+    def url(self, user_one):
+        return '/{}users/{}/settings/'.format(API_BASE, user_one._id)
+
+    def test_get(self, app, user_one, user_two, url):
+        # User unauthenticated
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 401
+
+        # User accessing another user's settings
+        res = app.get(url, auth=user_two.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # User authenticated
+        res = app.get(url, auth=user_one.auth)
+        assert res.status_code == 200
+
+
+@pytest.mark.django_db
+class TestUserSettingsUpdate:
+
+    @pytest.fixture()
+    def url(self, user_one):
+        return '/{}users/{}/settings/'.format(API_BASE, user_one._id)
+
+    @pytest.fixture()
+    def payload(self, user_one):
+        return {
+            'data': {
+                'type': 'user-settings',
+                'id': user_one._id,
+                'attributes': {}
+            }
+        }
+
+    def test_user_settings_type(self, app, user_one, url, payload):
+        payload['data']['type'] = 'Invalid type'
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 409
+
+    def test_update_two_factor_permissions(self, app, user_one, user_two, url, payload):
+        payload['data']['attributes']['two_factor_enabled'] = False
+        # Unauthenticated
+        res = app.patch_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 401
+        # User modifying someone else's settings
+        res = app.patch_json_api(url, payload, auth=user_two.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    def test_update_two_factor_enabled(self, app, user_one, url, payload):
+        # Invalid data type
+        payload['data']['attributes']['two_factor_enabled'] = 'Yes'
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == '"Yes" is not a valid boolean.'
+
+        # Already disabled - nothing happens, still disabled
+        payload['data']['attributes']['two_factor_enabled'] = False
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['two_factor_enabled'] is False
+
+        # Test enabling two factor
+        payload['data']['attributes']['two_factor_enabled'] = True
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['two_factor_enabled'] is True
+        user_one.reload()
+        addon = user_one.get_addon('twofactor')
+        assert addon.deleted is False
+        assert addon.is_confirmed is False
+
+        # Test already enabled - nothing happens, still enabled
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['two_factor_enabled'] is True
+
+        # Test disabling two factor
+        payload['data']['attributes']['two_factor_enabled'] = False
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['two_factor_enabled'] is False
+        user_one.reload()
+        addon = user_one.get_addon('twofactor')
+        assert addon is None
+
+    def test_update_two_factor_verification(self, app, user_one, url, payload):
+        TOTP_SECRET = 'b8f85986068f8079aa9d'
+        # Two factor not enabled
+        payload['data']['attributes']['two_factor_verification'] = 123456
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Two-factor authentication is not enabled.'
+
+        # Two factor invalid code
+        payload['data']['attributes']['two_factor_enabled'] = True
+        payload['data']['attributes']['two_factor_verification'] = 123456
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'The two-factor verification code you provided is invalid.'
+
+        # Test invalid data type
+        payload['data']['attributes']['two_factor_verification'] = 'abcd123'
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'A valid integer is required.'
+
+        # Test two factor valid code
+        del payload['data']['attributes']['two_factor_verification']
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        addon = user_one.get_addon('twofactor')
+        addon.totp_secret = TOTP_SECRET
+        addon.save()
+        payload['data']['attributes']['two_factor_verification'] = _valid_code(TOTP_SECRET)
+        res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.json['data']['attributes']['two_factor_enabled'] is True
+        assert res.status_code == 200
+        user_one.reload()
+        addon = user_one.get_addon('twofactor')
+        assert addon.deleted is False
+        assert addon.is_confirmed is True

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -31,6 +31,9 @@ class CoreScopes(object):
     USERS_WRITE = 'users_write'
     USERS_CREATE = 'users_create'
 
+    USER_SETTINGS_READ = 'user.settings_read'
+    USER_SETTINGS_WRITE = 'user.settings_write'
+
     USER_EMAIL_READ = 'users.email_read'
 
     USER_ADDON_READ = 'users.addon_read'
@@ -147,8 +150,8 @@ class ComposedScopes(object):
     # All views should be based on selections from CoreScopes, above
 
     # Users collection
-    USERS_READ = (CoreScopes.USERS_READ, CoreScopes.SUBSCRIPTIONS_READ, CoreScopes.ALERTS_READ)
-    USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE, CoreScopes.SUBSCRIPTIONS_WRITE, CoreScopes.ALERTS_WRITE)
+    USERS_READ = (CoreScopes.USERS_READ, CoreScopes.SUBSCRIPTIONS_READ, CoreScopes.ALERTS_READ, CoreScopes.USER_SETTINGS_READ)
+    USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE, CoreScopes.SUBSCRIPTIONS_WRITE, CoreScopes.ALERTS_WRITE, CoreScopes.USER_SETTINGS_WRITE)
     USERS_CREATE = USERS_READ + (CoreScopes.USERS_CREATE, )
 
     # User extensions


### PR DESCRIPTION
## Purpose

Needed for Embosf User Account Settings Page

## Changes

Added a `/v2/users/<uid>/settings/` endpoint, GET/PATCH only
- `two_factor_enabled`, writeable boolean, turns two factor on/off
- `two_factor_verification` (write-only int field), enter 2f code
- attempting to update two_factor_verification if two_factor_enabled is false should error

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
Located here: https://github.com/CenterForOpenScience/developer.osf.io/pull/24

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-963