### PR TITLE
[OSF][IN-457] Unhide `review_actions` relationship for withdrawn preprints. 

### DIFF
--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -12,6 +12,7 @@ from api.base.serializers import LinksField
 from api.base.serializers import RelationshipField
 from api.base.serializers import HideIfProviderCommentsAnonymous
 from api.base.serializers import HideIfProviderCommentsPrivate
+from api.requests.serializers import PreprintRequestSerializer
 from osf.exceptions import InvalidTriggerError
 from osf.models import PreprintService, NodeRequest, PreprintRequest
 from osf.utils.workflows import DefaultStates, DefaultTriggers, ReviewStates, ReviewTriggers
@@ -68,6 +69,12 @@ class TargetRelationshipField(RelationshipField):
         target = self.get_object(data)
         return {'target': target}
 
+
+class PreprintRequestTargetRelationshipField(TargetRelationshipField):
+    def to_representation(self, value):
+        ret = super(TargetRelationshipField, self).to_representation(value)
+        ret['data']['type'] = PreprintRequestSerializer.Meta.type_
+        return ret
 
 class BaseActionSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
@@ -219,7 +226,7 @@ class PreprintRequestActionSerializer(BaseActionSerializer):
     class Meta:
         type_ = 'preprint-request-actions'
 
-    target = TargetRelationshipField(
+    target = PreprintRequestTargetRelationshipField(
         target_class=PreprintRequest,
         read_only=False,
         required=True,

--- a/api/requests/views.py
+++ b/api/requests/views.py
@@ -114,7 +114,7 @@ class PreprintRequestDetail(JSONAPIBaseView, generics.RetrieveAPIView, PreprintR
     required_read_scopes = [CoreScopes.PREPRINT_REQUESTS_READ]
     required_write_scopes = [CoreScopes.NULL]
 
-    serializer_class = NodeRequestSerializer
+    serializer_class = PreprintRequestSerializer
 
     view_category = 'requests'
     view_name = 'preprint-request-detail'

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -681,6 +681,18 @@ class ReviewProviderMixin(GuardianMixin):
         counts.update({row['machine_state']: row['count'] for row in qs if row['machine_state'] in counts})
         return counts
 
+    def get_request_state_counts(self):
+        # import stuff here to get around circular imports
+        from osf.models import PreprintRequest
+        qs = PreprintRequest.objects.filter(target__provider__id=self.id,
+                                            target__node__isnull=False,
+                                            target__node__is_deleted=False,
+                                            target__node__is_public=True)
+        qs = qs.values('machine_state').annotate(count=models.Count('*'))
+        counts = {state.value: 0 for state in DefaultStates}
+        counts.update({row['machine_state']: row['count'] for row in qs if row['machine_state'] in counts})
+        return counts
+
     def add_to_group(self, user, group):
         # Add default notification subscription
         notification = self.notification_subscriptions.get(_id='{}_new_pending_submissions'.format(self._id))

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -275,7 +275,7 @@ class PreprintRequestMachine(BaseMachine):
                 self.machineable.run_accept(user=self.machineable.creator, comment=self.action.comment, auto=True)
         elif ev.event.name == DefaultTriggers.ACCEPT.value:
             # If moderator accepts the withdrawal request
-            self.machineable.target.run_withdraw(user=self.machineable.creator, comment=self.action.comment)
+            self.machineable.target.run_withdraw(user=self.action.creator, comment=self.action.comment)
         self.machineable.save()
 
     def auto_approval_allowed(self):

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -272,7 +272,7 @@ class PreprintRequestMachine(BaseMachine):
         elif ev.event.name == DefaultTriggers.SUBMIT.value:
             # If the provider is pre-moderated and target has not been through moderation, auto approve withdrawal
             if self.auto_approval_allowed():
-                self.machineable.run_accept(user=self.machineable.creator, comment=self.action.comment, auto=True)
+                self.machineable.run_accept(user=self.machineable.creator, comment=self.machineable.comment, auto=True)
         elif ev.event.name == DefaultTriggers.ACCEPT.value:
             # If moderator accepts the withdrawal request
             self.machineable.target.run_withdraw(user=self.action.creator, comment=self.action.comment)


### PR DESCRIPTION
## Purpose

- Currently, `review_actions` relationship of a withdrawn preprint is hidden. Therefore, ember cannot conveniently get the list of review actions by simply accessing them through preprint model's `hasMany` relationship. This PR unhide the relationship field for withdrawn preprints.
- Request status counts are added to the `meta` of the `withdraw_request` endpoint so that the front end may get the current status count without having to query/filter the endpoint multiple times by different parameters.
- The `PreprintRequestMachine` is also modified so that the creator of the `withdraw` action (`trigger=withdraw`), which is created as a result of approving a pending withdrawal request, would be the moderator who approves the request, instead of the user who submits the request. This is important because the reviews app can only tell who approves the withdrawal request by looking at the `creator` field of the `withdraw` action. There is no such information for the `request` instance, as it only has information on the **creato**r of the request, not the **approver** of the request.
- Currently, when viewing from the API the detail of a `PreprintRequestAction`, the `target` relationship would have a type of `requests` instead of `preprint-requests`, causing Ember to get the wrong relationship. Therefore, the newly created `PreprintRequestTargetRelationshipField` is used for the relationship.

## Changes

The following changes are made, respectively:

- `NoneIfWithdrawal` is removed for `review_actions` relationship field of `PreprintSerializer`
- `get_request_state_counts()` is added to `ReviewProviderMixin` to get a dictionary of state counts for the provider.
    - `get_renderer_context()` is overridden for `PreprintProviderWithdrawRequestList ` view to serialize state counts for the endpoint when `?[meta]=requests_state_count` is included as a query parameter.
- In `save_changes()` hook of `PreprintRequestMachine`,  `run_withdraw()` is now called with the action creator as the parameter.
- `PreprintRequestTargetRelationshipField` is created to override the `to_representation()` of the field so that the `type` is serialized correctly.

## QA Notes

None so far.

## Ticket

https://openscience.atlassian.net/browse/IN-457