### PR TITLE
Enforce CSRF on OSFSessionAuthentication [PLAT-986]

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -2,6 +2,7 @@ import itsdangerous
 
 from django.utils.translation import ugettext_lazy as _
 
+import waffle
 from rest_framework import authentication
 from rest_framework.authentication import BasicAuthentication, CSRFCheck
 from rest_framework import exceptions
@@ -100,8 +101,9 @@ class OSFSessionAuthentication(authentication.BaseAuthentication):
         user_id = session.data.get('auth_user_id')
         user = OSFUser.load(user_id)
         if user:
-            self.enforce_csrf(request)
-            # CSRF passed with authenticated user
+            if waffle.switch_is_active('enforce_csrf'):
+                self.enforce_csrf(request)
+                # CSRF passed with authenticated user
             check_user(user)
             return user, None
         return None

--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -3,7 +3,7 @@ import itsdangerous
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import authentication
-from rest_framework.authentication import BasicAuthentication
+from rest_framework.authentication import BasicAuthentication, CSRFCheck
 from rest_framework import exceptions
 
 from addons.twofactor.models import UserSettings as TwoFactorUserSettings
@@ -100,9 +100,21 @@ class OSFSessionAuthentication(authentication.BaseAuthentication):
         user_id = session.data.get('auth_user_id')
         user = OSFUser.load(user_id)
         if user:
+            self.enforce_csrf(request)
+            # CSRF passed with authenticated user
             check_user(user)
             return user, None
         return None
+
+    def enforce_csrf(self, request):
+        """
+        Same implementation as django-rest-framework's SessionAuthentication.
+        Enforce CSRF validation for session based authentication.
+        """
+        reason = CSRFCheck().process_view(request, None, (), {})
+        if reason:
+            # CSRF failed, bail with explicit error message
+            raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
 
 
 class OSFBasicAuthentication(BasicAuthentication):

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -3,19 +3,22 @@ Tests related to authenticating API requests
 """
 
 import mock
+import itsdangerous
 
 import pytest
 from nose.tools import *  # flake8: noqa
+from django.middleware import csrf
 
 from framework.auth import cas, core, oauth_scopes
 from website.util import api_v2_url
 from addons.twofactor.tests import _valid_code
-from website.settings import API_DOMAIN
+from website.settings import API_DOMAIN, COOKIE_NAME
 
 from tests.base import ApiTestCase
 from osf_tests.factories import AuthUserFactory, ProjectFactory, UserFactory
 
-from api.base.settings import API_BASE
+from api.base.settings import API_BASE, SECRET_KEY, CSRF_COOKIE_NAME
+from osf.models import Session
 
 
 class TestBasicAuthenticationValidation(ApiTestCase):
@@ -457,3 +460,67 @@ class TestOAuthScopedAccess(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_not_in('email', res.json['data']['attributes'])
         assert_not_in(self.user2.username, res.json)
+
+
+@pytest.mark.django_db
+class TestCSRFValidation:
+
+    @pytest.fixture
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture
+    def url(self):
+        return '/{}nodes/'.format(API_BASE)
+
+    @pytest.fixture
+    def csrf_token(self):
+        return str(csrf._get_new_csrf_token())
+
+    @pytest.fixture
+    def payload(self):
+        return {
+            'data': {
+                'type': 'nodes',
+                'attributes': {
+                    'title': 'Test',
+                    'description': 'Test',
+                    'category': 'data'
+                }
+            }
+        }
+
+    @pytest.fixture(autouse=True)
+    def set_session_cookie(self, user, app):
+        session = Session.objects.create(data={'auth_user_id': user._id})
+        session_cookie = itsdangerous.Signer(SECRET_KEY).sign(session._id)
+        app.set_cookie(COOKIE_NAME, str(session_cookie))
+
+    def test_post_no_csrf_cookie(self, app, url, payload):
+        res = app.post_json_api(
+            url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 403
+        assert csrf.REASON_NO_CSRF_COOKIE in res.json['errors'][0]['detail']
+
+    def test_post_without_csrf_in_headers(self, app, csrf_token, url, payload):
+        app.set_cookie(CSRF_COOKIE_NAME, csrf_token)
+        res = app.post_json_api(
+            url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 403
+        assert csrf.REASON_BAD_TOKEN in res.json['errors'][0]['detail']
+
+    def test_send_csrf_cookie_and_headers(self, app, csrf_token, url, payload):
+        app.set_cookie(CSRF_COOKIE_NAME, csrf_token)
+        res = app.post_json_api(
+            url,
+            payload,
+            headers={'X-CSRFToken': csrf_token},
+            expect_errors=True
+        )
+        assert res.status_code == 201

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -3,7 +3,6 @@ Tests related to authenticating API requests
 """
 
 import mock
-import itsdangerous
 
 import pytest
 from nose.tools import *  # flake8: noqa
@@ -18,7 +17,6 @@ from tests.base import ApiTestCase
 from osf_tests.factories import AuthUserFactory, ProjectFactory, UserFactory
 
 from api.base.settings import API_BASE, SECRET_KEY, CSRF_COOKIE_NAME
-from osf.models import Session
 
 
 class TestBasicAuthenticationValidation(ApiTestCase):
@@ -467,7 +465,7 @@ class TestCSRFValidation:
 
     @pytest.fixture
     def user(self):
-        return AuthUserFactory()
+        return UserFactory()
 
     @pytest.fixture
     def url(self):
@@ -492,8 +490,7 @@ class TestCSRFValidation:
 
     @pytest.fixture(autouse=True)
     def set_session_cookie(self, user, app):
-        session = Session.objects.create(data={'auth_user_id': user._id})
-        session_cookie = itsdangerous.Signer(SECRET_KEY).sign(session._id)
+        session_cookie = user.get_or_create_cookie()
         app.set_cookie(COOKIE_NAME, str(session_cookie))
 
     def test_post_no_csrf_cookie(self, app, url, payload):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Since we're using a custom `OSFSessionAuthentication` class, we need to add in some csrf checks that are similar to [django's SessionAuthentication class](https://github.com/encode/django-rest-framework/blob/master/rest_framework/authentication.py#L111), while still doing our same session cookie processing.

## Changes

- add `enforce_csrf` method to session authentication
- tests to make sure requests made with session auth also have the proper CSRF tokens set to succeed

## QA Notes

No QA necessary!

## Documentation

Session auth doesn't seem to be mentioned in our docs, so no updates necessary there. 

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
Any API requests currently being made with session auth that don't include CSRF validation either in the POST body or in the headers as `X-CSRFToken` will be rejected. I don't think this applies to any of our services, and I don't think that any external user will be using session auth, so as far as I can tell shouldn't effect anything.


## Ticket
https://openscience.atlassian.net/browse/PLAT-986