### PR TITLE
[PLAT-913][Hotfix] Update API endpoints for GitLab

### DIFF
--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -129,9 +129,9 @@ class TestGitLabViews(OsfTestCase):
         self.node_settings = self.project.get_addon('gitlab')
         self.node_settings.user_settings = self.project.creator.get_addon('gitlab')
         # Set the node addon settings to correspond to the values of the mock repo
-        self.node_settings.user = self.gitlab.repo.return_value['owner']['name']
-        self.node_settings.repo = self.gitlab.repo.return_value['name']
-        self.node_settings.repo_id = self.gitlab.repo.return_value['id']
+        self.node_settings.user = self.gitlab.repo.return_value.owner.name
+        self.node_settings.repo = self.gitlab.repo.return_value.name
+        self.node_settings.repo_id = self.gitlab.repo.return_value.id
         self.node_settings.save()
 
     def _get_sha_for_branch(self, branch=None, mock_branches=None):
@@ -139,7 +139,7 @@ class TestGitLabViews(OsfTestCase):
         if mock_branches is None:
             mock_branches = gitlab_mock.branches
         if branch is None:  # Get default branch name
-            branch = self.gitlab.repo.attributes['default_branch']
+            branch = self.gitlab.repo.default_branch
         for each in mock_branches:
             if each.name == branch:
                 branch_sha = each.commit['id']
@@ -155,7 +155,7 @@ class TestGitLabViews(OsfTestCase):
         branch, sha, branches = utils.get_refs(self.node_settings)
         assert_equal(
             branch,
-            gitlab_mock.repo.attributes['default_branch']
+            gitlab_mock.repo.default_branch
         )
         assert_equal(sha, branches[0].commit['id'])  # Get refs for default branch
         assert_equal(
@@ -213,13 +213,13 @@ class TestGitLabViews(OsfTestCase):
         mock_has_auth.return_value = True
         connection = gitlab_mock
         branch = 'master'
-        mock_repository = {
+        mock_repository = mock.Mock(**{
             'user': 'fred',
             'repo': 'mock-repo',
             'permissions': {
                 'project_access': {'access_level': 20, 'notification_level': 3}
             },
-        }
+        })
         mock_repo.attributes.return_value = mock_repository
         assert_false(check_permissions(self.node_settings, self.consolidated_auth, connection, branch, repo=mock_repository))
 
@@ -230,9 +230,9 @@ class TestGitLabViews(OsfTestCase):
         gitlab_mock = self.gitlab
         mock_has_auth.return_value = True
         connection = gitlab_mock
-        mock_branch = {
+        mock_branch = mock.Mock(**{
             'commit': {'id': '67890'}
-        }
+        })
         connection.branches.return_value = mock_branch
         sha = '12345'
         assert_false(check_permissions(self.node_settings, self.consolidated_auth, connection, mock_branch, sha=sha))

--- a/addons/gitlab/tests/utils.py
+++ b/addons/gitlab/tests/utils.py
@@ -38,7 +38,7 @@ def create_mock_gitlab(user='osfio', private=False):
     """
     gitlab_mock = mock.create_autospec(GitLabClient)
 
-    gitlab_mock.repo.attributes = {
+    gitlab_mock.repo = mock.Mock(**{
         u'approvals_before_merge': 0,
         u'archived': False,
         u'avatar_url': None,
@@ -87,7 +87,7 @@ def create_mock_gitlab(user='osfio', private=False):
         u'visibility_level': 0,
         u'web_url': u'https://gitlab.com/{}/mock-repo'.format(user),
         u'wiki_enabled': True
-    }
+    })
 
     branch = mock.Mock(**{
         u'commit': {u'author_email': u'{}@gmail.com'.format(user),

--- a/addons/gitlab/utils.py
+++ b/addons/gitlab/utils.py
@@ -71,7 +71,7 @@ def get_refs(addon, branch=None, sha=None, connection=None):
         if repo is None:
             return None, None, None
 
-        branch = repo.attributes['default_branch']
+        branch = repo.default_branch
     # Get data from GitLab API if not registered
     branches = connection.branches(addon.repo_id)
 
@@ -92,8 +92,8 @@ def check_permissions(node_settings, auth, connection, branch, sha=None, repo=No
     has_auth = bool(user_settings and user_settings.has_auth)
     if has_auth:
         repo = repo or connection.repo(node_settings.repo_id)
-        project_permissions = repo['permissions'].get('project_access') or {}
-        group_permissions = repo['permissions'].get('group_access') or {}
+        project_permissions = repo.permissions.get('project_access') or {}
+        group_permissions = repo.permissions.get('group_access') or {}
         has_access = (
             repo is not None and (
                 # See https://docs.gitlab.com/ee/api/members.html
@@ -105,7 +105,7 @@ def check_permissions(node_settings, auth, connection, branch, sha=None, repo=No
     if sha:
         current_branch = connection.branches(node_settings.repo_id, branch)
         # TODO Will I ever return false?
-        is_head = sha == current_branch['commit']['id']
+        is_head = sha == current_branch.commit['id']
     else:
         is_head = True
 


### PR DESCRIPTION
## Purpose

This fixes the issue where once you pick a gitlab repo, OSF storage for that project no longer loads. It just spins indefinitely. 

## Changes

- Changes to make the branch selector not break everything 
- Fix tests to accommodate new behavior 

## QA Notes

Doing basic activities in Gitlab should work well.

## Documentation

🐞 fix

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-913