### PR TITLE
[Hotfix] Fix mocking for gitlab

### DIFF
--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -129,9 +129,9 @@ class TestGitLabViews(OsfTestCase):
         self.node_settings = self.project.get_addon('gitlab')
         self.node_settings.user_settings = self.project.creator.get_addon('gitlab')
         # Set the node addon settings to correspond to the values of the mock repo
-        self.node_settings.user = self.gitlab.repo.return_value.owner.name
-        self.node_settings.repo = self.gitlab.repo.return_value.name
-        self.node_settings.repo_id = self.gitlab.repo.return_value.id
+        self.node_settings.user = 'fred'
+        self.node_settings.repo = 'mock-repo'
+        self.node_settings.repo_id = 1748448
         self.node_settings.save()
 
     def _get_sha_for_branch(self, branch=None, mock_branches=None):


### PR DESCRIPTION
## Purpose

Fix mocking for Gitlab to prevent tests from failing

## Changes

- change the mocks from return values to primative datatypes

## QA Notes

Only effects travis.

## Documentation

Not user facing

## Side Effects

None that I know of.

## Ticket

None