### PR TITLE
[PLAT-913] Fixes for gitlab

### DIFF
--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -5,7 +5,7 @@ import gitlab
 import cachecontrol
 from requests.adapters import HTTPAdapter
 
-from addons.gitlab.exceptions import NotFoundError
+from addons.gitlab.exceptions import NotFoundError, AuthError
 from addons.gitlab.settings import DEFAULT_HOSTS
 
 # Initialize caches
@@ -30,7 +30,11 @@ class GitLabClient(object):
             user if omitted
         :return dict: GitLab API response
         """
-        self.gitlab.auth()
+        try:
+            self.gitlab.auth()
+        except gitlab.GitlabGetError as exc:
+            raise AuthError(exc.error_message)
+
         return self.gitlab.users.get(self.gitlab.user.id)
 
     def repo(self, repo_id):

--- a/addons/gitlab/exceptions.py
+++ b/addons/gitlab/exceptions.py
@@ -4,5 +4,8 @@ class ApiError(Exception):
 class NotFoundError(ApiError):
     pass
 
+class AuthError(ApiError):
+    pass
+
 class GitLabError(Exception):
     pass

--- a/addons/gitlab/settings/defaults.py
+++ b/addons/gitlab/settings/defaults.py
@@ -1,4 +1,4 @@
-DEFAULT_HOSTS = ['http://gitlab.com']
+DEFAULT_HOSTS = ['https://gitlab.com']
 
 # GitLab hook domain
 HOOK_DOMAIN = None

--- a/addons/gitlab/static/gitlabNodeConfig.js
+++ b/addons/gitlab/static/gitlabNodeConfig.js
@@ -171,7 +171,7 @@ var ViewModel = oop.extend(UserViewModel,{
             return Boolean(self.selectedHost());
         });
         self.tokenUrl = ko.pureComputed(function() {
-            return self.host() ? 'https://' + self.host() + '/profile/personal_access_tokens' : null;
+            return self.host() ? self.host() + '/profile/personal_access_tokens' : null;
         });
     },
     authSuccessCallback: function() {

--- a/addons/gitlab/static/gitlabNodeConfig.js
+++ b/addons/gitlab/static/gitlabNodeConfig.js
@@ -16,9 +16,11 @@ var connectExistingAccount = function(accountId) {
                     window.location.hash = '#configureAddonsAnchor';
                 }
                 window.location.reload();
-        }).fail(
-            $osf.handleJSONError
-        );
+        }).fail(function(){
+            $.osf.growl('Error', 'Your account could not be connected, if the problem persists you may need to' +
+             ' reconnect to Gitlab or contact us at ' + $.osf.osfSupportLink() + '.');
+            Raven.captureMessage('Unexpected error occurred in JSON request');
+        });
 };
 
 var updateHidden = function(element) {

--- a/addons/gitlab/static/gitlabUserConfig.js
+++ b/addons/gitlab/static/gitlabUserConfig.js
@@ -56,7 +56,7 @@ var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
             return Boolean(self.selectedHost());
         });
         self.tokenUrl = ko.pureComputed(function() {
-            return self.host() ? 'https://' + self.host() + '/profile/personal_access_tokens' : null;
+            return self.host() ? self.host() + '/profile/personal_access_tokens' : null;
         });
     },
     clearModal: function() {


### PR DESCRIPTION
## Purpose

http:// schemes are add to Gitlab hosts too much this removes them. Like so:
![screen shot 2018-07-24 at 12 03 02 pm](https://user-images.githubusercontent.com/9688518/43159562-acee54b4-8f50-11e8-9d76-4c754de34bb0.png)

## Changes

- removes the excessive schemes strings.
- changes default http://gitlib.com
- better a catch the TOS error.
- Add suggestion to reconnect to error message.

## QA Notes

Connect to a Gitlab instance and see that the link takes you to the right page.

## Documentation

None needed.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-913