### PR TITLE
[PLAT-999] Allow removing stuck registrations with addons

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -19,6 +19,7 @@ from osf.models.user import OSFUser
 from osf.models.node import Node
 from osf.models.registrations import Registration
 from osf.models import SpamStatus
+from osf.management.commands.force_archive import archive, verify
 from admin.base.utils import change_embargo_date, validate_embargo_date
 from admin.base.views import GuidFormView, GuidView
 from osf.models.admin_log_entry import (
@@ -455,7 +456,6 @@ class RestartStuckRegistrationsView(StuckRegistrationsView):
     template_name = 'nodes/restart_registrations_modal.html'
 
     def post(self, request, *args, **kwargs):
-        from osf.management.commands.force_archive import archive, verify
         stuck_reg = self.get_object()
         if verify(stuck_reg):
             try:
@@ -476,9 +476,8 @@ class RemoveStuckRegistrationsView(StuckRegistrationsView):
     template_name = 'nodes/remove_registrations_modal.html'
 
     def post(self, request, *args, **kwargs):
-        from osf.management.commands.force_archive import verify
         stuck_reg = self.get_object()
-        if verify(stuck_reg):
+        if Registration.find_failed_registrations().filter(id=stuck_reg.id).exists():
             stuck_reg.delete_registration_tree(save=True)
             messages.success(request, 'The registration has been deleted')
         else:


### PR DESCRIPTION


## Purpose

<!-- Describe the purpose of your changes -->
This allows stuck registrations with addons to be remove via the admin.

See https://github.com/CenterForOpenScience/osf.io/pull/8444/files#r205158303

## Changes

<!-- Briefly describe or list your changes  -->
* Fix check for stuck registrations
* Some cleanup

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-999
