### PR TITLE
[No ticket] Fix OSF Requirements Install Using `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -353,7 +353,7 @@ services:
     command:
       - /bin/bash
       - -c
-      - invoke requirements --quick &&
+      - invoke requirements --all &&
         (python -m compileall /usr/local/lib/python2.7 || true) &&
         rm -Rf /python2.7/* &&
         cp -Rf -p /usr/local/lib/python2.7 /


### PR DESCRIPTION
## Purpose

Fix OSF Requirements Install Using `docker-compose`

## Changes

Use `--all` instead of `--quick`.

## QA Notes

No

## Documentation

No

## Side Effects

No

## Ticket

No
