### PR TITLE
Render Dataverse Files, Deleted File metadata [PLAT-578]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -545,9 +545,8 @@ def addon_view_or_download_file_legacy(**kwargs):
         code=httplib.MOVED_PERMANENTLY
     )
 
-@must_be_valid_project
 @must_be_contributor_or_public
-def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
+def addon_deleted_file(auth, target, error_type='BLAME_PROVIDER', **kwargs):
     """Shows a nice error message to users when they try to view a deleted file
     """
     # Allow file_node to be passed in so other views can delegate to this one
@@ -588,37 +587,39 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
     if deleted_by:
         format_params['deleted_by_guid'] = markupsafe.escape(deleted_by_guid)
 
-    error_msg = ''.join([
-        ERROR_MESSAGES[error_type].format(**format_params),
-        format_last_known_metadata(auth, node, file_node, error_type)
-    ])
-    ret = serialize_node(node, auth, primary=True)
-    ret.update(rubeus.collect_addon_assets(node))
-    ret.update({
-        'error': error_msg,
-        'urls': {
-            'render': None,
-            'sharejs': None,
-            'mfr': settings.MFR_SERVER_URL,
-            'profile_image': get_profile_image_url(auth.user, 25),
-            'files': node.web_url_for('collect_file_trees'),
-        },
-        'extra': {},
-        'size': 9966699,  # Prevent file from being edited, just in case
-        'sharejs_uuid': None,
-        'file_name': file_name,
-        'file_path': file_path,
-        'file_name_title': file_name_title,
-        'file_name_ext': file_name_ext,
-        'version_id': None,
-        'file_guid': file_guid,
-        'file_id': file_node._id,
-        'provider': file_node.provider,
-        'materialized_path': file_node.materialized_path or file_path,
-        'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
-        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],  # Only access ManyRelatedManager if saved
-        'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE,
-    })
+    error_msg = ERROR_MESSAGES[error_type].format(**format_params)
+    if isinstance(target, AbstractNode):
+        error_msg += format_last_known_metadata(auth, target, file_node, error_type)
+        ret = serialize_node(target, auth, primary=True)
+        ret.update(rubeus.collect_addon_assets(target))
+        ret.update({
+            'error': error_msg,
+            'urls': {
+                'render': None,
+                'sharejs': None,
+                'mfr': settings.MFR_SERVER_URL,
+                'profile_image': get_profile_image_url(auth.user, 25),
+                'files': target.web_url_for('collect_file_trees'),
+            },
+            'extra': {},
+            'size': 9966699,  # Prevent file from being edited, just in case
+            'sharejs_uuid': None,
+            'file_name': file_name,
+            'file_path': file_path,
+            'file_name_title': file_name_title,
+            'file_name_ext': file_name_ext,
+            'version_id': None,
+            'file_guid': file_guid,
+            'file_id': file_node._id,
+            'provider': file_node.provider,
+            'materialized_path': file_node.materialized_path or file_path,
+            'private': getattr(target.get_addon(file_node.provider), 'is_private', False),
+            'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],  # Only access ManyRelatedManager if saved
+            'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE,
+        })
+    else:
+        # TODO - serialize deleted metadata for future types of deleted file targets
+        ret = {'error': error_msg}
 
     return ret, httplib.GONE
 
@@ -684,7 +685,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
                 return redirect(
                     file_node.target.web_url_for('addon_view_or_download_file', path=file_node._id, provider=file_node.provider)
                 )
-        return addon_deleted_file(file_node=file_node, path=path, **kwargs)
+        return addon_deleted_file(target=target, file_node=file_node, path=path, **kwargs)
     else:
         transaction.savepoint_commit(savepoint_id)
 

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -40,7 +40,7 @@ class DataverseFile(DataverseFileNode, File):
         version.identifier = revision
 
         user = user or _get_current_user()
-        if not user or not self.node.can_edit(user=user):
+        if not user or not self.target.has_permission(user, 'write'):
             try:
                 # Users without edit permission can only see published files
                 if not data['extra']['hasPublishedVersion']:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Just a few little things to address the most recent round of QA.

## Changes

dataverse:
- dataverse files node > target
- check write permissions directly for editing

deleted file metadata:
- update addon_deleted_file to take target
- return only node specific metadata when target is a node


## QA Notes

Viewing dataverse files and deleted file metadata should work now!

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-578
