### PR TITLE
Ensure CSRF cookie for all session-auth requests

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -1,5 +1,6 @@
 import itsdangerous
 
+from django.middleware.csrf import get_token
 from django.utils.translation import ugettext_lazy as _
 
 import waffle
@@ -8,6 +9,7 @@ from rest_framework.authentication import BasicAuthentication, CSRFCheck
 from rest_framework import exceptions
 
 from addons.twofactor.models import UserSettings as TwoFactorUserSettings
+from api.base import settings as api_settings
 from api.base.exceptions import (UnconfirmedAccountError, UnclaimedAccountError, DeactivatedAccountError,
                                  MergedAccountError, InvalidAccountError, TwoFactorRequiredError)
 from framework.auth import cas
@@ -117,6 +119,10 @@ class OSFSessionAuthentication(authentication.BaseAuthentication):
         if reason:
             # CSRF failed, bail with explicit error message
             raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)
+
+        if not request.COOKIES.get(api_settings.CSRF_COOKIE_NAME):
+            # Make sure the CSRF cookie is set for next time
+            get_token(request)
 
 
 class OSFBasicAuthentication(BasicAuthentication):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Set the CSRF cookie so our front end can pass CSRF enforcement.
<!-- Describe the purpose of your changes -->

## Changes
Whenever a request uses session auth and doesn't have a CSRF cookie, set a CSRF cookie.
<!-- Briefly describe or list your changes  -->

## QA Notes
- enable `enforce_csrf` switch (might take a while for the waffle cache to notice)
- go to the embosf dashboard page
- create a new project
- watch it not fail
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
Limitation: Ember apps will need to make a GET request (which will set the CSRF cookie in the response) before they can POST. This will probably always happen anyway, but might be a confusing thing someday.
<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
