### PR TITLE
[Hotfix][PLAT-1014] Fix email write only

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -906,7 +906,7 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
 
     id = IDField(source='_id', required=False, allow_null=True)
     full_name = ser.CharField(required=False)
-    email = ser.EmailField(required=False, source='user.email')
+    email = ser.EmailField(required=False, source='user.email', write_only=True)
     index = ser.IntegerField(required=False, source='_order')
 
     users = RelationshipField(

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -596,6 +596,15 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
+    def test_add_contributor_dont_expose_email( self, app, user, user_two, project_public, data_user_two, url_public):
+
+        res = app.post_json_api(
+            url_public,
+            data_user_two,
+            auth=user.auth)
+        assert res.status_code == 201
+        assert res.json['data']['attributes'].get('email') is None
+
     def test_add_contributor_is_visible_by_default(
             self, app, user, user_two, project_public,
             data_user_two, url_public):

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -596,7 +596,8 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
-    def test_add_contributor_dont_expose_email( self, app, user, user_two, project_public, data_user_two, url_public):
+    def test_add_contributor_dont_expose_email(
+            self, app, user, user_two, project_public, data_user_two, url_public):
 
         res = app.post_json_api(
             url_public,
@@ -961,7 +962,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_public.reload()
             assert res.status_code == 201
             assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-            assert res.json['data']['attributes']['email'] is None
+            assert res.json['data']['attributes'].get('email') is None
             assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
                 'guids___id', flat=True)
 
@@ -981,7 +982,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_public.reload()
             assert res.status_code == 201
             assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-            assert res.json['data']['attributes']['email'] == 'john@doe.com'
+            assert res.json['data']['attributes'].get('email') is None
             assert res.json['data']['attributes']['bibliographic'] is True
             assert res.json['data']['attributes']['permission'] == permissions.WRITE
             assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
@@ -1005,7 +1006,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_public.reload()
             assert res.status_code == 201
             assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-            assert res.json['data']['attributes']['email'] == 'john@doe.com'
+            assert res.json['data']['attributes'].get('email') is None
             assert res.json['data']['attributes']['bibliographic'] is False
             assert res.json['data']['attributes']['permission'] == permissions.READ
             assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
@@ -1028,7 +1029,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_public.reload()
             assert res.status_code == 201
             assert res.json['data']['attributes']['unregistered_contributor'] is None
-            assert res.json['data']['attributes']['email'] == user_contrib.username
+            assert res.json['data']['attributes'].get('email') is None
             assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
                 'guids___id', flat=True)
 


### PR DESCRIPTION
## Purpose

We don't want to show the email for contributors that have just been added.

## Changes

- makes email write-only
- adds test

## QA Notes

If you add a contributor you should see the contributor's email in the response.

## Documentation

Not a user facing change,

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1014