### PR TITLE
[EMB-186] registrations archiving and node draft registrations count

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -328,7 +328,8 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
 
     draft_registrations = HideIfRegistration(RelationshipField(
         related_view='nodes:node-draft-registrations',
-        related_view_kwargs={'node_id': '<_id>'}
+        related_view_kwargs={'node_id': '<_id>'},
+        related_meta={'count': 'get_draft_registration_count'}
     ))
 
     registrations = HideIfRegistration(RelationshipField(
@@ -457,6 +458,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         auth = get_user_auth(self.context['request'])
         registrations = [node for node in obj.registrations_all if node.can_view(auth)]
         return len(registrations)
+
+    def get_draft_registration_count(self, obj):
+        auth = get_user_auth(self.context['request'])
+        if obj.has_permission(auth.user, osf_permissions.ADMIN):
+            return obj.draft_registrations_active.count()
 
     def get_pointers_count(self, obj):
         return obj.linked_nodes.count()

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -46,6 +46,7 @@ class BaseRegistrationSerializer(NodeSerializer):
 
     pending_embargo_approval = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_pending_embargo',
                                                                  help_text='The associated Embargo is awaiting approval by project admins.'))
+    embargoed = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_embargoed'))
     pending_registration_approval = HideIfWithdrawal(ser.BooleanField(source='is_pending_registration', read_only=True,
                                                                       help_text='The associated RegistrationApproval is awaiting approval by project admins.'))
     archiving = HideIfWithdrawal(ser.BooleanField(read_only=True))

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -48,6 +48,7 @@ class BaseRegistrationSerializer(NodeSerializer):
                                                                  help_text='The associated Embargo is awaiting approval by project admins.'))
     pending_registration_approval = HideIfWithdrawal(ser.BooleanField(source='is_pending_registration', read_only=True,
                                                                       help_text='The associated RegistrationApproval is awaiting approval by project admins.'))
+    archiving = HideIfWithdrawal(ser.BooleanField(read_only=True))
     pending_withdrawal = HideIfWithdrawal(ser.BooleanField(source='is_pending_retraction', read_only=True,
                                                            help_text='The registration is awaiting withdrawal approval by project admins.'))
     withdrawn = ser.BooleanField(source='is_retracted', read_only=True,


### PR DESCRIPTION
## Purpose

Add `archiving` property to registrations serializer and `draft_registrations` count to node serializer.

## Changes

* serialize `archiving` property of registrations
* add ability to get related count for `draft_registrations` to node serializer

## QA Notes

Will be QAed along with front-end.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->
**developer.osf.io PR needed to document new attribute for registrations!!!**

## Side Effects

Shouldn't be any.

## Ticket

https://openscience.atlassian.net/browse/EMB-186
