### PR TITLE
typo in image/png for url-loader

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -215,7 +215,7 @@ module.exports = {
             {test: /\.es6\.js$/, exclude: [/node_modules/, /bower_components/, /vendor/], loader: 'babel-loader'},
             {test: /\.css$/, use: [{loader: 'style-loader'}, {loader: 'css-loader'}]},
             // url-loader uses DataUrls; files-loader emits files
-            {test: /\.png$/, loader: 'url-loader?limit=100000&mimetype=image/ng'},
+            {test: /\.png$/, loader: 'url-loader?limit=100000&mimetype=image/png'},
             {test: /\.gif$/, loader: 'url-loader?limit=10000&mimetype=image/gif'},
             {test: /\.jpg$/, loader: 'url-loader?limit=10000&mimetype=image/jpg'},
             {test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader?mimetype=application/font-woff'},


### PR DESCRIPTION
## Purpose

Simple typo in "image/png" in the webpack.config for url-loader

## Changes

image/ng -> image/png

## QA Notes

## Documentation

## Side Effects

## Ticket

