### PR TITLE
Modify public file query to prevent Postgres hanging [PLAT-1021]

### DIFF
--- a/scripts/analytics/file_summary.py
+++ b/scripts/analytics/file_summary.py
@@ -38,10 +38,10 @@ class FileSummary(SummaryAnalytics):
             target_content_type=ContentType.objects.get_for_model(QuickFilesNode)
         )
 
-        public_query = (quickfiles_query | Q(
+        public_query = Q(
             target_object_id__in=Node.objects.filter(is_public=True).values('id'),
             target_content_type=node_content_type
-        ))
+        )
 
         private_query = Q(
             target_object_id__in=Node.objects.filter(is_public=False).values('id'),
@@ -57,10 +57,10 @@ class FileSummary(SummaryAnalytics):
             # OsfStorageFiles - the number of files on OsfStorage
             'osfstorage_files_including_quickfiles': {
                 'total': file_qs.count(),
-                'public': file_qs.filter(public_query).count(),
+                'public': file_qs.filter(public_query).count() + file_qs.filter(quickfiles_query).count(),
                 'private': file_qs.filter(private_query).count(),
                 'total_daily': file_qs.filter(daily_query).count(),
-                'public_daily': file_qs.filter(public_query & daily_query).count(),
+                'public_daily': file_qs.filter(public_query & daily_query).count() + file_qs.filter(quickfiles_query & daily_query).count(),
                 'private_daily': file_qs.filter(private_query & daily_query).count(),
             },
         }


### PR DESCRIPTION
[#PLAT-1021]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The former query for counting total public files was hanging unexpectedly - simplify the query to make it run much faster. Perhaps related to the files-on-anything release.

## Changes

- combine public node counts and quickfile counts after querying instead of the former OR query

## QA Notes
None needed really, all the analytics should run normally though after this!


<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

None necessary
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1021