### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -158,7 +158,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         return self.get_preprint_url(obj)
 
     def get_article_doi_url(self, obj):
-        return 'https://dx.doi.org/{}'.format(obj.article_doi) if obj.article_doi else None
+        return 'https://doi.org/{}'.format(obj.article_doi) if obj.article_doi else None
 
     def get_preprint_doi_url(self, obj):
         doi = None
@@ -169,7 +169,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         elif obj.is_published:
             client = obj.get_doi_client()
             doi = client.build_doi(preprint=obj) if client else None
-        return 'https://dx.doi.org/{}'.format(doi) if doi else None
+        return 'https://doi.org/{}'.format(doi) if doi else None
 
     def update(self, preprint, validated_data):
         assert isinstance(preprint, PreprintService), 'You must specify a valid preprint to be updated'

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -171,7 +171,7 @@ class TestPreprintDetail:
         assert res.json['data']['id'] == preprint._id
         assert res.json['data']['attributes']['is_published'] is True
         assert 'preprint_doi' in res.json['data']['links'].keys()
-        assert res.json['data']['links']['preprint_doi'] == 'https://dx.doi.org/{}'.format(
+        assert res.json['data']['links']['preprint_doi'] == 'https://doi.org/{}'.format(
             expected_doi)
         assert res.json['data']['attributes']['preprint_doi_created']
 
@@ -397,7 +397,7 @@ class TestPreprintUpdate:
         assert preprint.article_doi == new_doi
 
         preprint_detail = app.get(url, auth=user.auth).json['data']
-        assert preprint_detail['links']['doi'] == 'https://dx.doi.org/{}'.format(
+        assert preprint_detail['links']['doi'] == 'https://doi.org/{}'.format(
             new_doi)
 
     @mock.patch('website.preprints.tasks.update_or_enqueue_on_preprint_updated')

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3034,7 +3034,7 @@ class TestDOIValidation:
         with pytest.raises(ValidationError):
             Node(preprint_article_doi='nope').save()
         with pytest.raises(ValidationError):
-            Node(preprint_article_doi='https://dx.doi.org/10.123.456').save()  # should save the bare DOI, not a URL
+            Node(preprint_article_doi='https://doi.org/10.123.456').save()  # should save the bare DOI, not a URL
         with pytest.raises(ValidationError):
             Node(preprint_article_doi='doi:10.10.1038/nwooo1170').save()  # should save without doi: prefix
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -604,7 +604,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
 
         workidentifiers = {nodes.pop(k)['uri'] for k, v in nodes.items() if v['@type'] == 'workidentifier'}
         # URLs should *always* be osf.io/guid/
-        assert workidentifiers == set([urlparse.urljoin(settings.DOMAIN, self.preprint._id) + '/', 'http://dx.doi.org/{}'.format(self.preprint.get_identifier('doi').value)])
+        assert workidentifiers == set([urlparse.urljoin(settings.DOMAIN, self.preprint._id) + '/', 'https://doi.org/{}'.format(self.preprint.get_identifier('doi').value)])
 
         assert nodes == {}
 

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -162,7 +162,7 @@ def format_preprint(preprint, share_type, old_subjects=None):
     ]
 
     if preprint.get_identifier('doi'):
-        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri='http://dx.doi.org/{}'.format(preprint.get_identifier('doi').value)))
+        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri='https://doi.org/{}'.format(preprint.get_identifier('doi').value)))
 
     if preprint.provider.domain_redirect_enabled:
         to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri=preprint.absolute_url))
@@ -171,7 +171,7 @@ def format_preprint(preprint, share_type, old_subjects=None):
         # Article DOI refers to a clone of this preprint on another system and therefore does not qualify as an identifier for this preprint
         related_work = GraphNode('creativework')
         to_visit.append(GraphNode('workrelation', subject=preprint_graph, related=related_work))
-        to_visit.append(GraphNode('workidentifier', creative_work=related_work, uri='http://dx.doi.org/{}'.format(preprint.article_doi)))
+        to_visit.append(GraphNode('workidentifier', creative_work=related_work, uri='https://doi.org/{}'.format(preprint.article_doi)))
 
     preprint_graph.attrs['tags'] = [
         GraphNode('throughtags', creative_work=preprint_graph, tag=GraphNode('tag', name=tag))

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -348,7 +348,7 @@ WATERBUTLER_ADDRS = ['127.0.0.1']
 ####################
 #   Identifiers   #
 ###################
-DOI_URL_PREFIX = 'https://dx.doi.org/'
+DOI_URL_PREFIX = 'https://doi.org/'
 
 # General Format for DOIs
 DOI_FORMAT = '{prefix}/osf.io/{guid}'

--- a/website/static/vendor/citeproc-js/citeproc.js
+++ b/website/static/vendor/citeproc-js/citeproc.js
@@ -12811,7 +12811,7 @@ CSL.Output.Formats.prototype.html = {
         return "<a href=\"" + str + "\">" + str + "</a>";
     },
     "@DOI/true": function (state, str) {
-        return "<a href=\"http://dx.doi.org/" + str + "\">" + str + "</a>";
+        return "<a href=\"https://doi.org/" + str + "\">" + str + "</a>";
     }
 };
 CSL.Output.Formats.prototype.text = {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Same as #5436: Updating code that generates DOI links to use the preferred resolver, see √https://www.doi.org/doi_handbook/3_Resolution.html#3.8

## Changes

See above.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

I'm not sure whether the change to `citeproc.js` should be included here. My PR against their source is "open": https://bitbucket.org/fbennett/citeproc-js/pull-requests/8/

Also, instead of updating [the test](https://github.com/CenterForOpenScience/osf.io/compare/develop...katrinleinweber:resolve-DOIs-securely#diff-ff12d43019bc9d10aba358d19ec9bbe6), maybe duplicating it with both URL variants makes more sense?

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
