### PR TITLE
Add logging to keen analysis scripts [PLAT-1023]

### DIFF
--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -11,10 +11,8 @@ from website.settings import KEEN as keen_settings
 from keen.client import KeenClient
 from scripts import utils as script_utils
 
-logger = logging.getLogger('scripts.analytics')
+logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-script_utils.add_file_logger(logger, 'keen_analytics')
 
 
 class BaseAnalytics(object):

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -9,9 +9,12 @@ from django.utils import timezone
 from website.app import init_app
 from website.settings import KEEN as keen_settings
 from keen.client import KeenClient
+from scripts import utils as script_utils
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('scripts.analytics')
 logging.basicConfig(level=logging.INFO)
+
+script_utils.add_file_logger(logger, 'keen_analytics')
 
 
 class BaseAnalytics(object):

--- a/scripts/analytics/preprint_summary.py
+++ b/scripts/analytics/preprint_summary.py
@@ -71,6 +71,7 @@ class PreprintSummary(SummaryAnalytics):
                     'total': resp['hits']['total'],
                 },
             })
+            logger.info('{} Preprints counted for the provider {}'.format(resp['hits']['total'], preprint_provider.name))
 
         return counts
 

--- a/scripts/analytics/run_keen_events.py
+++ b/scripts/analytics/run_keen_events.py
@@ -1,3 +1,4 @@
+import logging
 import django
 django.setup()
 
@@ -5,6 +6,9 @@ from framework.celery_tasks import app as celery_app
 from scripts.analytics.base import DateAnalyticsHarness
 from scripts.analytics.node_log_events import NodeLogEvents
 from scripts.analytics.user_domain_events import UserDomainEvents
+from scripts.utils import add_file_logger
+
+logger = logging.getLogger('scripts.analytics')
 
 
 class EventAnalyticsHarness(DateAnalyticsHarness):
@@ -16,8 +20,9 @@ class EventAnalyticsHarness(DateAnalyticsHarness):
 
 @celery_app.task(name='scripts.analytics.run_keen_events')
 def run_main(date=None, yesterday=False):
+    add_file_logger(logger, __file__)
     EventAnalyticsHarness().main(date, yesterday, False)
 
 
 if __name__ == '__main__':
-    EventAnalyticsHarness().main()
+    run_main(yesterday=True)

--- a/scripts/analytics/run_keen_snapshots.py
+++ b/scripts/analytics/run_keen_snapshots.py
@@ -1,10 +1,13 @@
+import logging
 import django
 django.setup()
 
 from framework.celery_tasks import app as celery_app
 from scripts.analytics.base import BaseAnalyticsHarness
 from scripts.analytics.addon_snapshot import AddonSnapshot
+from scripts.utils import add_file_logger
 
+logger = logging.getLogger('scripts.analytics')
 
 class SnapshotHarness(BaseAnalyticsHarness):
 
@@ -15,7 +18,8 @@ class SnapshotHarness(BaseAnalyticsHarness):
 
 @celery_app.task(name='scripts.analytics.run_keen_snapshots')
 def run_main():
+    add_file_logger(logger, __file__)
     SnapshotHarness().main(command_line=False)
 
 if __name__ == '__main__':
-    SnapshotHarness().main()
+    run_main()

--- a/scripts/analytics/run_keen_summaries.py
+++ b/scripts/analytics/run_keen_summaries.py
@@ -1,3 +1,4 @@
+import logging
 import django
 django.setup()
 
@@ -8,6 +9,9 @@ from scripts.analytics.file_summary import FileSummary
 from scripts.analytics.preprint_summary import PreprintSummary
 from scripts.analytics.institution_summary import InstitutionSummary
 from scripts.analytics.base import DateAnalyticsHarness
+from scripts.utils import add_file_logger
+
+logger = logging.getLogger('scripts.analytics')
 
 
 class SummaryHarness(DateAnalyticsHarness):
@@ -19,6 +23,7 @@ class SummaryHarness(DateAnalyticsHarness):
 
 @celery_app.task(name='scripts.analytics.run_keen_summaries')
 def run_main(date=None, yesterday=False):
+    add_file_logger(logger, __file__)
     SummaryHarness().main(date, yesterday, False)
 
 

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -11,6 +11,7 @@ from dateutil.parser import parse
 from datetime import datetime, timedelta
 from django.db.models import Q
 from django.utils import timezone
+from keen import exceptions as keen_exceptions
 
 from osf.models import OSFUser
 from website.app import init_app
@@ -117,7 +118,7 @@ class UserSummary(SummaryAnalytics):
         try:
             # Because this data reads from Keen it could fail if Keen read api fails while writing is still allowed
             counts['status']['stickiness'] = self.calculate_stickiness(timestamp_datetime, query_datetime)
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, keen_exceptions.InvalidProjectIdError):
             sentry.log_message('Unable to read from Keen. stickiness metric not collected for date {}'.format(timestamp_datetime.isoformat()))
 
         logger.info(


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Figuring out what was actually done when running Keen analytics after the fact is hard as there was no file logger – add one and use it to log all keen analytic script logs to a file!

## Changes

- change file logger in `scripts/analysis/base.py` to be for all analysis scripts
- add file logger that will log all child loggers in `scripts/analysis`
- small script improvements discovered with local testing

## QA Notes

No QA needed!

## Documentation
None necessary
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-1023

