### PR TITLE
[PLAT-901][Hotfix] Block outgoing requests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=osf_tests.settings
-addopts = --tb=short --reuse-db --allow-hosts=fakehost
+addopts = --tb=short --reuse-db --allow-hosts=127.0.0.1
 filterwarnings =
     once::UserWarning
     once::DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=osf_tests.settings
-addopts = --tb=short --reuse-db
+addopts = --tb=short --reuse-db --allow-hosts=fakehost
 filterwarnings =
     once::UserWarning
     once::DeprecationWarning

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,8 @@
 # Requirements that are used in the development environment only
 
 # Testing
-pytest==3.0.3
+pytest==3.6.3
+pytest-socket==0.3.1
 pytest-xdist==1.15.0
 pytest-django==3.2.1
 pytest-cov==2.5.1

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1251,7 +1251,8 @@ class TestViewUtils(OsfTestCase):
         self.user_addon.oauth_grants[self.node._id] = {self.oauth_settings._id: []}
         self.user_addon.save()
 
-    def test_serialize_addons(self):
+    @mock.patch('addons.github.models.NodeSettings.get_folders', return_value=[])
+    def test_serialize_addons(self, mock_folders):
         addon_dicts = serialize_addons(self.node, self.auth_obj)
 
         enabled_addons = [addon for addon in addon_dicts if addon['enabled']]
@@ -1263,7 +1264,8 @@ class TestViewUtils(OsfTestCase):
         assert len(default_addons) == 1
         assert default_addons[0]['short_name'] == 'osfstorage'
 
-    def test_include_template_json(self):
+    @mock.patch('addons.github.models.NodeSettings.get_folders', return_value=[])
+    def test_include_template_json(self, mock_folders):
         """ Some addons (github, gitlab) need more specialized template infomation so we want to
         ensure we get those extra variables that when the addon is enabled.
         """
@@ -1276,7 +1278,8 @@ class TestViewUtils(OsfTestCase):
         assert 'node_has_auth' in enabled_addons[0]
         assert 'valid_credentials' in enabled_addons[0]
 
-    def test_collect_node_config_js(self):
+    @mock.patch('addons.github.models.NodeSettings.get_folders', return_value=[])
+    def test_collect_node_config_js(self, mock_folders):
 
         addon_dicts = serialize_addons(self.node, self.auth_obj)
 


### PR DESCRIPTION
## Purpose

We don't want to make external HTTP requests during Travis tests. This ensures we don't and fixes a few cases where we do.

## Changes

- implements pytest plugin pytest_socket to block HTTP requests
- fixes the mocks for three addon tests that were making external calls

## QA Notes

No QA, should have no visible effects on testing.

## Documentation

Not user-facing, none needed.

## Side Effects

Pytest must be upgraded to work with current version.

## Ticket

https://openscience.atlassian.net/browse/PLAT-901