### PR TITLE
Feature/Registration Schema Relationship [PLAT-1001]

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -7,8 +7,12 @@ from rest_framework.exceptions import APIException, AuthenticationFailed
 
 def get_resource_object_member(error_key, context):
     from api.base.serializers import RelationshipField
-    field = context['view'].serializer_class._declared_fields[error_key]
-    return 'relationships' if isinstance(field, RelationshipField) else 'attributes'
+    field = context['view'].serializer_class._declared_fields.get(error_key, None)
+    if field:
+        return 'relationships' if isinstance(field, RelationshipField) else 'attributes'
+    # If field cannot be found (where read/write operations have different serializers,
+    # assume error was in 'attributes' by default
+    return 'attributes'
 
 def dict_error_formatting(errors, context, index=None):
     """

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -555,14 +555,6 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             assert not self.read_only, 'May not set both `read_only` and `required`'
             self.required = required
 
-    def bind(self, field_name, parent):
-        super(RelationshipField, self).bind(field_name, parent)
-        self.source_attrs = [field_name]
-
-    def get_attribute(self, instance):
-        self.source_attrs = []
-        return super(RelationshipField, self).get_attribute(instance)
-
     def resolve(self, resource, field_name, request):
         """
         Resolves the view when embedding.

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -554,7 +554,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         if required:
             assert not self.read_only, 'May not set both `read_only` and `required`'
             self.required = required
-    
+
     def bind(self, field_name, parent):
         super(RelationshipField, self).bind(field_name, parent)
         self.source_attrs = [field_name]

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -554,6 +554,14 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         if required:
             assert not self.read_only, 'May not set both `read_only` and `required`'
             self.required = required
+    
+    def bind(self, field_name, parent):
+        super(RelationshipField, self).bind(field_name, parent)
+        self.source_attrs = [field_name]
+
+    def get_attribute(self, instance):
+        self.source_attrs = []
+        return super(RelationshipField, self).get_attribute(instance)
 
     def resolve(self, resource, field_name, request):
         """

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1210,6 +1210,11 @@ class DraftRegistrationDetailSerializer(DraftRegistrationSerializer):
     id = IDField(source='_id', required=True)
     registration_metadata = ser.DictField(required=True)
 
+    registration_schema = RelationshipField(
+        related_view='schemas:registration-schema-detail',
+        related_view_kwargs={'schema_id': '<registration_schema._id>'}
+    )
+
     def update(self, draft, validated_data):
         """
         Update draft instance with the validated metadata.

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1146,7 +1146,6 @@ class DraftRegistrationSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    registration_supplement = ser.CharField(source='registration_schema._id', required=True)
     registration_metadata = ser.DictField(required=False)
     datetime_initiated = VersionedDateTimeField(read_only=True)
     datetime_updated = VersionedDateTimeField(read_only=True)
@@ -1163,7 +1162,9 @@ class DraftRegistrationSerializer(JSONAPISerializer):
 
     registration_schema = RelationshipField(
         related_view='schemas:registration-schema-detail',
-        related_view_kwargs={'schema_id': '<registration_schema._id>'}
+        related_view_kwargs={'schema_id': '<registration_schema._id>'},
+        required=True,
+        read_only=False
     )
 
     links = LinksField({
@@ -1178,7 +1179,7 @@ class DraftRegistrationSerializer(JSONAPISerializer):
         initiator = validated_data.pop('initiator')
         metadata = validated_data.pop('registration_metadata', None)
 
-        schema_id = validated_data.pop('registration_schema').get('_id')
+        schema_id = validated_data.pop('registration_schema_id')
         schema = get_object_or_error(RegistrationSchema, schema_id, self.context['request'])
         if schema.schema_version != LATEST_SCHEMA_VERSION or not schema.active:
             raise exceptions.ValidationError('Registration supplement must be an active schema.')

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1175,11 +1175,10 @@ class DraftRegistrationSerializer(JSONAPISerializer):
         return obj.absolute_url
 
     def create(self, validated_data):
-        node = validated_data.pop('node')
-        initiator = validated_data.pop('initiator')
+        initiator = get_user_auth(self.context['request']).user
+        node = self.context['view'].get_node()
         metadata = validated_data.pop('registration_metadata', None)
-
-        schema_id = validated_data.pop('registration_schema_id')
+        schema_id = validated_data.pop('registration_schema')
         schema = get_object_or_error(RegistrationSchema, schema_id, self.context['request'])
         if schema.schema_version != LATEST_SCHEMA_VERSION or not schema.active:
             raise exceptions.ValidationError('Registration supplement must be an active schema.')
@@ -1210,7 +1209,6 @@ class DraftRegistrationDetailSerializer(DraftRegistrationSerializer):
     """
     id = IDField(source='_id', required=True)
     registration_metadata = ser.DictField(required=True)
-    registration_supplement = ser.CharField(read_only=True, source='registration_schema._id')
 
     def update(self, draft, validated_data):
         """

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -511,6 +511,8 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
         base_permissions.TokenHasScope,
     )
 
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
+
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
@@ -529,12 +531,6 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
             branched_from=node,
             deleted__isnull=True
         )
-
-    # overrides ListBulkCreateJSONAPIView
-    def perform_create(self, serializer):
-        user = self.request.user
-        schema = self.request.data.get('id')
-        serializer.save(initiator=user, node=self.get_node(), registration_schema_id=schema)
 
 
 class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, DraftMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -541,6 +541,7 @@ class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestro
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope
     )
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
 
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -533,7 +533,8 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     # overrides ListBulkCreateJSONAPIView
     def perform_create(self, serializer):
         user = self.request.user
-        serializer.save(initiator=user, node=self.get_node())
+        schema = self.request.data.get('id')
+        serializer.save(initiator=user, node=self.get_node(), registration_schema_id=schema)
 
 
 class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, DraftMixin):

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -49,7 +49,7 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
         res = app.get(url_draft_registrations, auth=user.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert data['attributes']['registration_supplement'] == schema._id
+        assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['id'] == draft_registration._id
         assert data['attributes']['registration_metadata'] == {}
 
@@ -113,7 +113,7 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
         res = app.get(url_draft_registrations, auth=user.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert data['attributes']['registration_supplement'] == schema._id
+        assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['id'] == draft_registration._id
         assert data['attributes']['registration_metadata'] == {}
 
@@ -215,7 +215,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             payload, auth=user.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert data['attributes']['registration_supplement'] == schema._id
+        assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['attributes']['registration_metadata'] == payload['data']['attributes']['registration_metadata']
 
     def test_draft_must_be_branched_from_node(
@@ -345,13 +345,20 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
     def test_cannot_update_registration_schema(
             self, app, user, schema, payload,
             schema_prereg, url_draft_registrations):
-        payload['data']['attributes']['registration_supplement'] = schema_prereg._id
+        payload['data']['relationships'] = {
+            'registration_schema': {
+                'data': {
+                    'id': schema_prereg._id,
+                    'type': 'registration_schema'
+                }
+            }
+        }
         res = app.put_json_api(
             url_draft_registrations,
             payload, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['registration_supplement'] == schema._id
+        assert schema._id in res.json['data']['relationships']['registration_schema']['links']['related']['href']
 
     def test_required_metaschema_questions_not_required_on_update(
             self, app, user, project_public,
@@ -594,7 +601,7 @@ class TestDraftRegistrationPatch(DraftRegistrationTestCase):
             payload, auth=user.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert data['attributes']['registration_supplement'] == schema._id
+        assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['attributes']['registration_metadata'] == payload['data']['attributes']['registration_metadata']
 
     def test_cannot_update_draft(

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -96,7 +96,8 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         assert res.status_code == 200
         data = res.json['data']
         assert len(data) == 1
-        assert data[0]['attributes']['registration_supplement'] == schema._id
+
+        assert schema._id in data[0]['relationships']['registration_schema']['links']['related']['href']
         assert data[0]['id'] == draft_registration._id
         assert data[0]['attributes']['registration_metadata'] == {}
 
@@ -162,7 +163,7 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         assert res.status_code == 200
         data = res.json['data']
         assert len(data) == 1
-        assert data[0]['attributes']['registration_supplement'] == schema._id
+        assert schema._id in data[0]['relationships']['registration_schema']['links']['related']['href']
         assert data[0]['id'] == draft_registration._id
         assert data[0]['attributes']['registration_metadata'] == {}
 
@@ -182,8 +183,15 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         return {
             'data': {
                 'type': 'draft_registrations',
-                'attributes': {
-                    'registration_supplement': metaschema_open_ended._id
+                'attributes': {},
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': metaschema_open_ended._id
+                        }
+
+                    }
                 }
             }
         }
@@ -199,8 +207,15 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         draft_data = {
             'data': {
                 'type': 'nodes',
-                'attributes': {
-                    'registration_supplement': metaschema_open_ended._id
+                'attributes': {},
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': metaschema_open_ended._id
+                        }
+
+                    }
                 }
             }
         }
@@ -218,7 +233,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         data = res.json['data']
-        assert data['attributes']['registration_supplement'] == metaschema_open_ended._id
+        assert metaschema_open_ended._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['attributes']['registration_metadata'] == {}
         assert data['embeds']['branched_from']['data']['id'] == project_public._id
         assert data['embeds']['initiator']['data']['id'] == user._id
@@ -268,8 +283,15 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         draft_data = {
             'data': {
                 'type': 'draft_registrations',
-                'attributes': {
-                    'registration_supplement': 'Invalid schema'
+                'attributes': {},
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': 'Invalid schema'
+                        }
+
+                    }
                 }
             }
         }
@@ -285,8 +307,15 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         draft_data = {
             'data': {
                 'type': 'draft_registrations',
-                'attributes': {
-                    'registration_supplement': schema._id
+                'attributes': {},
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': schema._id
+                        }
+
+                    }
                 }
             }
         }
@@ -303,8 +332,15 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         draft_data = {
             'data': {
                 'type': 'draft_registrations',
-                'attributes': {
-                    'registration_supplement': schema._id
+                'attributes': {},
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': schema._id
+                        }
+
+                    }
                 }
             }
         }
@@ -373,8 +409,16 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             'data': {
                 'type': 'draft_registrations',
                 'attributes': {
-                    'registration_supplement': prereg_schema._id,
                     'registration_metadata': registration_metadata
+                },
+                'relationships': {
+                    'registration_schema': {
+                        'data': {
+                            'type': 'registration_schema',
+                            'id': prereg_schema._id
+                        }
+
+                    }
                 }
             }
         }
@@ -384,7 +428,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         assert res.status_code == 201
         data = res.json['data']
         assert res.json['data']['attributes']['registration_metadata']['q2']['value'] == 'Test response'
-        assert data['attributes']['registration_supplement'] == prereg_schema._id
+        assert prereg_schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['embeds']['branched_from']['data']['id'] == project_public._id
         assert data['embeds']['initiator']['data']['id'] == user._id
 
@@ -404,7 +448,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         errors = res.json['errors'][0]
         assert res.status_code == 400
         assert errors['detail'] == 'This field is required.'
-        assert errors['source']['pointer'] == '/data/attributes/registration_supplement'
+        assert errors['source']['pointer'] == '/data/relationships/registration_schema'
 
     def test_registration_metadata_must_be_a_dictionary(
             self, app, user, payload, url_draft_registrations):
@@ -424,7 +468,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
         schema = RegistrationSchema.objects.get(
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=LATEST_SCHEMA_VERSION)
-        payload['data']['attributes']['registration_supplement'] = schema._id
+        payload['data']['relationships']['registration_schema']['data']['id'] = schema._id
         payload['data']['attributes']['registration_metadata'] = {}
         payload['data']['attributes']['registration_metadata']['datacompletion'] = 'No, data collection has not begun'
 
@@ -442,7 +486,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=LATEST_SCHEMA_VERSION)
 
-        payload['data']['attributes']['registration_supplement'] = schema._id
+        payload['data']['relationships']['registration_schema']['data']['id'] = schema._id
         payload['data']['attributes']['registration_metadata'] = {}
         payload['data']['attributes']['registration_metadata']['datacompletion'] = {
             'incorrect_key': 'No, data collection has not begun'}
@@ -461,7 +505,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=LATEST_SCHEMA_VERSION)
 
-        payload['data']['attributes']['registration_supplement'] = schema._id
+        payload['data']['relationships']['registration_schema']['data']['id'] = schema._id
         payload['data']['attributes']['registration_metadata'] = {}
         payload['data']['attributes']['registration_metadata']['q11'] = {
             'value': 'No, data collection has not begun'
@@ -481,7 +525,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=LATEST_SCHEMA_VERSION)
 
-        payload['data']['attributes']['registration_supplement'] = schema._id
+        payload['data']['relationships']['registration_schema']['data']['id'] = schema._id
         payload['data']['attributes']['registration_metadata'] = {}
         payload['data']['attributes']['registration_metadata']['datacompletion'] = {
             'value': 'Nope, data collection has not begun'}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The going-forward ember method of connecting related resources is by manipulating the relationship instead of setting attributes, and this endpoint is just now being used by ember.

## Changes
- Specify the `registration_schema` for a draft registration via relationships instead of an attribute.
### Before

```json
POST localhost:8000/v2/nodes/<node_id>/draft_registrations/

{
    "data": {
        "type": "draft_registrations",
        "attributes": {
            "registration_supplement": "<schema_id"
        
        }
            
    }
}

```
### After (empty attributes until PLAT-1000 gets rid of this)
```json
POST localhost:8000/v2/nodes/<node_id>/draft_registrations/

{
    "data": {
        "type": "draft_registrations",
        "attributes": {},
        "relationships": {
        	"registration_schema": {
        	    "data": {
        	        "type": "registration_schemas",
        	        "id": "<schema_id>"
        	    }
        	}
        }
            
    }
}

```
- Errors in relationship field are serialized under source > pointer as error being under relationships instead of attributes
```
{
    "errors": [
        {
            "source": {
                "pointer": "/data/relationships/registration_schema"
            },
            "detail": "This field is required."
        }
    ],
    "meta": {
        "version": "2.0"
    }
}
```

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
API tests passing are sufficient checks.  Will be better tested on front end.

## Documentation

Will wait until approved before writing docs

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1001