### PR TITLE
Requests to old /metaschemas/ routes can still use metaschemas type [PLAT-978]

### DIFF
--- a/api/metaschemas/views.py
+++ b/api/metaschemas/views.py
@@ -1,6 +1,6 @@
 from api.base.views import DeprecatedView
 from api.schemas import views
-from api.schemas.serializers import SchemaSerializer
+from api.schemas.serializers import DeprecatedMetaSchemaSerializer
 
 
 class DeprecatedRegistrationMetaSchemaList(DeprecatedView, views.RegistrationSchemaList):
@@ -21,7 +21,7 @@ class DeprecatedMetaSchemasList(DeprecatedView, views.RegistrationSchemaList):
     max_version = '2.7'
     view_category = 'metaschemas'
     view_name = 'metaschema-list'
-    serializer_class = SchemaSerializer
+    serializer_class = DeprecatedMetaSchemaSerializer
 
 
 class DeprecatedMetaSchemaDetail(DeprecatedView, views.RegistrationSchemaDetail):
@@ -30,4 +30,4 @@ class DeprecatedMetaSchemaDetail(DeprecatedView, views.RegistrationSchemaDetail)
     max_version = '2.7'
     view_category = 'metaschemas'
     view_name = 'metaschema-detail'
-    serializer_class = SchemaSerializer
+    serializer_class = DeprecatedMetaSchemaSerializer

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -27,3 +27,9 @@ class RegistrationSchemaSerializer(SchemaSerializer):
 
     class Meta:
         type_ = 'registration_schemas'
+
+
+class DeprecatedMetaSchemaSerializer(SchemaSerializer):
+
+    class Meta:
+        type_ = 'metaschemas'


### PR DESCRIPTION

[#PLAT-978]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Even though the `/metaschemas/` route will be deprecated, old requests should still work unchanged. 

## Changes

- Add a serializer that allows `metaschemas` type for old requests

## QA Notes

None needed

## Documentation

Nope

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-978
