### PR TITLE
Feature/APIv2 Attributes Not Required [PLAT-1000]

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -9,7 +9,6 @@ from api.base.utils import is_bulk_request
 from api.base.renderers import JSONAPIRenderer
 from api.base.exceptions import JSONAPIException
 
-NO_ATTRIBUTES_ERROR = 'Request must include /data/attributes.'
 NO_RELATIONSHIPS_ERROR = 'Request must include /data/relationships.'
 NO_DATA_ERROR = 'Request must include /data.'
 NO_TYPE_ERROR = 'Request must include /type.'
@@ -64,18 +63,13 @@ class JSONAPIParser(JSONParser):
 
         relationships = resource_object.get('relationships')
         is_relationship = parser_context.get('is_relationship')
-        attributes_required = parser_context.get('attributes_required', True)
         # allow skip type check for legacy api version
         legacy_type_allowed = parser_context.get('legacy_type_allowed', False)
         request_method = parser_context['request'].method
 
-        # Request must include "relationships" or "attributes"
         if is_relationship and request_method == 'POST':
             if not relationships:
                 raise JSONAPIException(source={'pointer': '/data/relationships'}, detail=NO_RELATIONSHIPS_ERROR)
-        else:
-            if 'attributes' not in resource_object and attributes_required and request_method != 'DELETE':
-                raise JSONAPIException(source={'pointer': '/data/attributes'}, detail=NO_ATTRIBUTES_ERROR)
 
         object_id = resource_object.get('id')
         object_type = resource_object.get('type')
@@ -111,7 +105,6 @@ class JSONAPIParser(JSONParser):
                 parsed.update(relationship)
             else:
                 parsed.update(relationships)
-
         return parsed
 
     def parse(self, stream, media_type=None, parser_context=None):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -909,15 +909,6 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
         else:
             mails.send_mail(user.email, mails.FORK_COMPLETED, title=node.title, guid=fork._id, mimetype='html', can_change_preferences=False)
 
-    # overrides ListCreateAPIView
-    def get_parser_context(self, http_request):
-        """
-        Tells parser that attributes are not required in request
-        """
-        res = super(NodeForksList, self).get_parser_context(http_request)
-        res['attributes_required'] = False
-        return res
-
 
 class NodeLinkedByNodesList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     permission_classes = (

--- a/api/tokens/serializers.py
+++ b/api/tokens/serializers.py
@@ -71,7 +71,7 @@ class ApiOAuth2PersonalTokenSerializer(JSONAPISerializer):
         return instance
 
 def validate_requested_scopes(validated_data):
-    scopes_set = set(validated_data['scopes'].split(' '))
+    scopes_set = set(validated_data.get('scopes', '').split(' '))
     for scope in scopes_set:
         if scope not in public_scopes or not public_scopes[scope].is_public:
             raise exceptions.ValidationError('User requested invalid scope')

--- a/api_tests/applications/views/test_application_detail.py
+++ b/api_tests/applications/views/test_application_detail.py
@@ -262,4 +262,4 @@ class TestApplicationDetail:
             auth=user.auth,
             expect_errors=True
         )
-        assert res.status_code == 400
+        assert res.status_code == 200

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -201,8 +201,8 @@ class TestCollectionCreate:
             auth=user_one.auth, expect_errors=True
         )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/attributes.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['detail'] == 'This field is required.'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes/title'
 
         # test_create_bookmark_collection_with_no_title
         collection = {
@@ -768,11 +768,11 @@ class TestCollectionUpdate(CollectionCRUDTestCase):
         res = app.patch_json_api(url_collection_detail, {
             'data': {
                 'id': collection._id,
-                'type': 'nodes',
+                'type': 'collections',
                 'title': new_title_collection,
             }
         }, auth=user_one.auth, expect_errors=True)
-        assert res.status_code == 400
+        assert res.status_code == 200
 
         # test_update_collection_invalid_title
         project = {
@@ -1769,7 +1769,7 @@ class TestCollectionBulkCreate:
             expect_errors=True, bulk=True
         )
         assert res.status_code == 400
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/1/attributes/title'
 
         res = app.get(url_collections, auth=user_one.auth)
         assert len(res.json['data']) == 0

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -267,15 +267,17 @@ class TestNodeChildCreate:
     #   test_creates_child_properties_not_nested
         child = {
             'data': {
-                'title': 'child',
-                'description': 'this is a child project',
-                'category': 'project',
+                'attributes': {
+                    'title': 'child',
+                    'description': 'this is a child project'
+                },
+                'category': 'project'
             }
         }
         res = app.post_json_api(url, child, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/attributes.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['detail'] == 'This field is required.'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes/category'
 
     def test_creates_child_logged_in_write_contributor(
             self, app, user, project, child, url):
@@ -618,8 +620,8 @@ class TestNodeChildrenBulkCreate:
             url, child, auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/attributes.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['detail'] == 'This field is required.'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/1/attributes/category'
 
         project.reload()
         assert len(project.nodes) == 0

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1023,7 +1023,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
                 'title': title_new,
             }
         }, auth=user.auth, expect_errors=True)
-        assert res.status_code == 400
+        assert res.status_code == 200
 
     def test_partial_update_private_project_logged_in_contributor(
             self, app, user, title_new, description, category, project_private, url_private):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1268,8 +1268,8 @@ class TestNodeCreate:
             url, project, auth=user_one.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/attributes.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['detail'] == 'This field is required.'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes/category'
 
     #   test_create_project_invalid_title
         project = {
@@ -1454,7 +1454,7 @@ class TestNodeBulkCreate:
             expect_errors=True, bulk=True)
 
         assert res.status_code == 400
-        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/1/attributes/category'
 
         res = app.get(url, auth=user_one.auth)
         assert len(res.json['data']) == 0

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -643,7 +643,7 @@ class TestUserUpdate:
             auth=user_one.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/attributes.'
+        assert res.json['errors'][0]['detail'] == 'This field is required.'
 
     #   test_partial_patch_fields_not_nested
         res = app.patch_json_api(
@@ -657,7 +657,7 @@ class TestUserUpdate:
             },
             auth=user_one.auth,
             expect_errors=True)
-        assert res.status_code == 400
+        assert res.status_code == 200
 
     #   test_patch_user_logged_out
         res = app.patch_json_api(url_user_one, {


### PR DESCRIPTION
## Purpose
Better conformity to JSON-API.

## Changes

Remove the error on receiving a JSONAPI POST/PATCH that doesn't have attributes.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

None needed- i don't think we explicitly said you needed attributes in docs previously.

## Side Effects

If there were no attributes on a POST/PATCH request this would previously fail with a 400.   More PATCH requests will pass with a 200 now, if no attributes, get a success even though nothing was updated. There may be instances where we were relying on the "attributes must exist" as a catchall instead of checking for something more specific, but I think those are handled.
## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/PLAT-1000