### PR TITLE
[PLAT-851] Storage Internationalization UI Fixes

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -14,7 +14,7 @@ from framework.auth import get_or_create_user
 
 from osf.models import Institution
 from website.mails import send_mail, WELCOME_OSF4I
-from website.settings import OSF_SUPPORT_EMAIL
+from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
 
 
 class InstitutionAuthentication(BaseAuthentication):
@@ -108,6 +108,7 @@ class InstitutionAuthentication(BaseAuthentication):
                 mail=WELCOME_OSF4I,
                 mimetype='html',
                 user=user,
+                domain=DOMAIN,
                 osf_support_email=OSF_SUPPORT_EMAIL
             )
 

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -628,6 +628,7 @@ def confirm_email_get(token, auth=None, **kwargs):
             mail=mails.WELCOME,
             mimetype='html',
             user=user,
+            domain=settings.DOMAIN,
             osf_support_email=settings.OSF_SUPPORT_EMAIL
         )
 

--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -14,6 +14,7 @@ from osf.models.queued_mail import (
     queue_mail, WELCOME_OSF4M,
     NO_LOGIN, NO_ADDON, NEW_PUBLIC_PROJECT, PREREG_REMINDER
 )
+from website.settings import DOMAIN
 
 @pytest.fixture()
 def user():
@@ -86,7 +87,8 @@ class TestQueuedMail:
             mail=WELCOME_OSF4M,
             user=user,
             conference='Buttjamz conference',
-            fid=''
+            fid='',
+            domain=DOMAIN
         )
         assert bool(mail.send_mail()) is True
         assert mail.data['downloads'] == 0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -98,6 +98,7 @@ class TestAuthUtils(OsfTestCase):
             'user': user,
             'mimetype': 'html',
             'mail': mails.WELCOME,
+            'domain': settings.DOMAIN,
             'to_addr': user.username,
             'osf_support_email': settings.OSF_SUPPORT_EMAIL
         })

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -59,5 +59,5 @@ def queue_osf4m_welcome_email(user, conference, node):
         fullname=user.fullname,
         fid=root_children[0]._id if len(root_children) else None,
         osf_support_email=settings.OSF_SUPPORT_EMAIL,
-        domain=DOMAIN,
+        domain=settings.DOMAIN,
     )

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -59,4 +59,5 @@ def queue_osf4m_welcome_email(user, conference, node):
         fullname=user.fullname,
         fid=root_children[0]._id if len(root_children) else None,
         osf_support_email=settings.OSF_SUPPORT_EMAIL,
+        domain=DOMAIN,
     )

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -15,7 +15,7 @@ Thank you for verifying your account on OSF, a free, open source service maintai
 <br>
 
 <h4>Select your storage location</h4>
-Files can be stored in a location you specify from the available geographic regions for new projects. <a href="https://osf.io/settings/account/?utm_source=notification&utm_medium=email&utm_campaign=welcome#updateDefaultStorageLocation">Set storage location.</a><br>
+Files can be stored in a location you specify from the available geographic regions for new projects. <a href="${domain}settings/account/?utm_source=notification&utm_medium=email&utm_campaign=welcome#updateDefaultStorageLocation">Set storage location.</a><br>
 <br>
 
 <h4>Store your files</h4>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -15,7 +15,7 @@ Thank you for verifying your account on OSF, a free, open source service maintai
 <br>
 
 <h4>Select your storage location</h4>
-Files can be stored in a location you specify from the available geographic regions for new projects. <a href="https://osf.io/settings/account/?utm_source=notification&utm_medium=email&utm_campaign=welcome#updateDefaultStorageLocation">Set storage location.</a><br>
+Files can be stored in a location you specify from the available geographic regions for new projects. <a href="${domain}settings/account/?utm_source=notification&utm_medium=email&utm_campaign=welcome#updateDefaultStorageLocation">Set storage location.</a><br>
 <br>
 
 <h4>Store your files</h4>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -136,7 +136,7 @@
                     <b>Storage location:</b> ${node['storage_location']}
                 </p>
                 <div class="help-block">
-                    <p class="text-muted">This is set on project creation and cannot be changed once set.</p>
+                    <p class="text-muted">Storage location cannot be changed after project is created.</p>
                 </div>
 
             </div>


### PR DESCRIPTION
## Purpose

To fix email links and improve language for setting page.

## Changes

- pass current domain to email templates
- change language about being unable to change node regions.

## QA Notes

Click and new welcome email link and check out new text on settings page.

## Documentation

None

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-851