### PR TITLE
Fix/Remove Self from Project and Components [PLAT-991]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1053,7 +1053,7 @@ class TestGetNodeTree(OsfTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.json, [])
 
-    # Parent node should show because of user2 read access, the children should not
+    # Parent node should show because of user2 read access, and only child3
     def test_get_node_parent_not_admin(self):
         project = ProjectFactory(creator=self.user)
         project.add_contributor(self.user2, auth=Auth(self.user))
@@ -1061,13 +1061,15 @@ class TestGetNodeTree(OsfTestCase):
         child1 = NodeFactory(parent=project, creator=self.user)
         child2 = NodeFactory(parent=project, creator=self.user)
         child3 = NodeFactory(parent=project, creator=self.user)
+        child3.add_contributor(self.user2, auth=Auth(self.user))
         url = project.api_url_for('get_node_tree')
         res = self.app.get(url, auth=self.user2.auth)
         tree = res.json[0]
         parent_node_id = tree['node']['id']
         children = tree['children']
         assert_equal(parent_node_id, project._primary_key)
-        assert_equal(children, [])
+        assert_equal(len(children), 1)
+        assert_equal(children[0]['node']['id'], child3._primary_key)
 
 
 @pytest.mark.enable_enqueue_task


### PR DESCRIPTION
## Purpose

Fix a regression where a non-admin contributor no longer has the option to remove themselves from a project and its components and add a test.

## Changes

In order to give you the option to remove yourself from components as well, the UI needs to know that you're a contributor on children in the first place. https://github.com/CenterForOpenScience/osf.io/pull/7951 mistakenly removed this capability, only returning children if you were an admin.  This reverts some of that PR, returning children if you're a read contributor on the node, and then for each child, making sure you're a read contributor there as well.  This still leaves a lot of the optimizations that were done to speed things up.  A regression test added to ensure read contributors can still see children.

## QA Notes
Same tests as https://openscience.atlassian.net/browse/OSF-8536. Making sure that users can remove themselves from projects and their components. Make sure you can't remove yourself if you're the last admin.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-991