### PR TITLE
Feature/Forked Projects take User Default Region [PLAT-1033]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -523,8 +523,9 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
     def after_fork(self, node, fork, user, save=True):
         clone = self.clone()
         clone.owner = fork
-        clone.user_settings = self.user_settings
-        clone.region_id = self.region_id
+        user_settings = user.get_addon('osfstorage')
+        clone.user_settings = user_settings
+        clone.region_id = user_settings.default_region_id
 
         clone.save()
         if not self.root_node:

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -8,10 +8,11 @@ import pytz
 from django.utils import timezone
 from nose.tools import *  # noqa
 
+from framework.auth import Auth
 from addons.osfstorage.models import OsfStorageFile, OsfStorageFileNode, OsfStorageFolder
 from osf.exceptions import ValidationError
 from osf.utils.fields import EncryptedJSONField
-from osf_tests.factories import ProjectFactory, UserFactory, RegionFactory
+from osf_tests.factories import ProjectFactory, UserFactory, RegionFactory, NodeFactory
 
 from addons.osfstorage.tests import factories
 from addons.osfstorage.tests.utils import StorageTestCase
@@ -577,6 +578,37 @@ class TestNodeSettingsModel(StorageTestCase):
         cloned_record = fork_node_settings.get_root().find_child_by_name(path)
         assert_equal(list(cloned_record.versions.all()), list(record.versions.all()))
         assert_true(fork_node_settings.root_node)
+
+    def test_fork_reverts_to_using_user_storage_default(self):
+        user = UserFactory()
+        user2 = UserFactory()
+        us = RegionFactory()
+        canada = RegionFactory()
+
+        user_settings = user.get_addon('osfstorage')
+        user_settings.default_region = us
+        user_settings.save()
+        user2_settings = user2.get_addon('osfstorage')
+        user2_settings.default_region = canada
+        user2_settings.save()
+
+        project = ProjectFactory(creator=user, is_public=True)
+        child = NodeFactory(parent=project, creator=user, is_public=True)
+        child_settings = child.get_addon('osfstorage')
+        child_settings.region_id = canada.id
+        child_settings.save()
+
+        fork = project.fork_node(Auth(user))
+        child_fork = models.Node.objects.get_children(fork).first()
+        assert fork.get_addon('osfstorage').region_id == us.id
+        assert fork.get_addon('osfstorage').user_settings == user.get_addon('osfstorage')
+        assert child_fork.get_addon('osfstorage').region_id == us.id
+
+        fork = project.fork_node(Auth(user2))
+        child_fork = models.Node.objects.get_children(fork).first()
+        assert fork.get_addon('osfstorage').region_id == canada.id
+        assert fork.get_addon('osfstorage').user_settings == user2.get_addon('osfstorage')
+        assert child_fork.get_addon('osfstorage').region_id == canada.id
 
     def test_region_wb_url_from_creators_defaults(self):
         user = UserFactory()


### PR DESCRIPTION
## Purpose

When you fork a project and its components, the storage regions of the fork are the same as the original. They should instead be stored under the user's default region.

## Changes

Fork region changed and test added.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

It looks like to me that a node's NodeSettings should point to the creator's UserSettings.  Currently forks are getting the same UserSettings as the original user.  I may be misunderstanding what this is for.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1033