### PR TITLE
Use pre-commit for formatting and linting

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+website/static/vendor/**/*
+admin/**/*
+addons/**/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v1.3.0
+  hooks:
+  - id: double-quote-string-fixer
+  - id: flake8
+    additional_dependencies: ["flake8-quotes==1.0.0", "flake8-mutable==1.2.0"]
+- repo: https://github.com/pre-commit/mirrors-jshint
+  rev: v2.9.6
+  hooks:
+  - id: jshint

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ The code for [https://osf.io](https://osf.io).
 
 To run the OSF for local development, see [README-docker-compose.md](https://github.com/CenterForOpenScience/osf.io/blob/develop/README-docker-compose.md).
 
+Optional, but recommended: To set up pre-commit hooks (will run
+formatters and linters on staged files):
+
+```
+pip install pre-commit
+
+pre-commit install --allow-missing-config
+```
+
 ## More Resources
 
 The [COS Development Docs](http://cosdev.readthedocs.org/) provide detailed information about all aspects of OSF development.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,6 +21,7 @@ responses==0.8.1
 flake8==3.5.0
 flake8-quotes==1.0.0
 flake8-mutable==1.2.0
+pre-commit==1.10.5
 
 # Avoid eating cpu with live reloading
 watchdog==0.8.3

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -217,17 +217,9 @@ def mailserver(ctx, port=1025):
 
 
 @task
-def jshint(ctx):
-    """Run JSHint syntax check"""
-    js_folder = os.path.join(HERE, 'website', 'static', 'js')
-    jshint_bin = os.path.join(HERE, 'node_modules', '.bin', 'jshint')
-    cmd = '{} {}'.format(jshint_bin, js_folder)
-    ctx.run(cmd, echo=True)
-
-
-@task(aliases=['flake8'])
-def flake(ctx):
-    ctx.run('flake8 .', echo=True)
+def syntax(ctx):
+    """Use pre-commit to run formatters and linters."""
+    ctx.run('pre-commit run --all-files --show-diff-on-failure', echo=True)
 
 
 @task(aliases=['req'])
@@ -413,13 +405,12 @@ def test_addons(ctx, numprocesses=None, coverage=False):
 
 
 @task
-def test(ctx, all=False, syntax=False):
+def test(ctx, all=False, lint=False):
     """
     Run unit tests: OSF (always), plus addons and syntax checks (optional)
     """
-    if syntax:
-        flake(ctx)
-        jshint(ctx)
+    if lint:
+        syntax(ctx)
 
     test_website(ctx)  # /tests
     test_api1(ctx)
@@ -447,28 +438,23 @@ def travis_setup(ctx):
 @task
 def test_travis_addons(ctx, numprocesses=None, coverage=False):
     """
-    Run half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from wasting test time.
+    Run half of the tests to help travis go faster.
     """
     travis_setup(ctx)
-    flake(ctx)
+    syntax(ctx)
     test_addons(ctx, numprocesses=numprocesses, coverage=coverage)
 
 @task
 def test_travis_website(ctx, numprocesses=None, coverage=False):
     """
-    Run other half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from
-    wasting test time.
+    Run other half of the tests to help travis go faster.
     """
-    # flake(ctx)
-    # jshint(ctx)
     travis_setup(ctx)
     test_website(ctx, numprocesses=numprocesses, coverage=coverage)
 
 
 @task
 def test_travis_api1_and_js(ctx, numprocesses=None, coverage=False):
-    # flake(ctx)
-    # jshint(ctx)
     # TODO: Uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved
     # karma(ctx)
     travis_setup(ctx)
@@ -477,16 +463,12 @@ def test_travis_api1_and_js(ctx, numprocesses=None, coverage=False):
 
 @task
 def test_travis_api2(ctx, numprocesses=None, coverage=False):
-    # flake(ctx)
-    # jshint(ctx)
     travis_setup(ctx)
     test_api2(ctx, numprocesses=numprocesses, coverage=coverage)
 
 
 @task
 def test_travis_api3_and_osf(ctx, numprocesses=None, coverage=False):
-    # flake(ctx)
-    # jshint(ctx)
     travis_setup(ctx)
     test_api3(ctx, numprocesses=numprocesses, coverage=coverage)
 


### PR DESCRIPTION
**Purpose**

Prevent formatting and syntax errors from ever making it to
Travis.

**Changes**

* Use [pre-commit](https://pre-commit.com/) to run flake8 and jshint
  on git staged files
* Added a .jshintignore so that only website/static/js gets linted
  (same behavior that `invoke jshint` had)
* Added `invoke syntax` which runs all hooks on all files. This
  replaces both `invoke flake8` and `invoke jshint`

**Side effects**

Devs should install the pre-commit hook with

```
pip install pre-commit

pre-commit install --allow-missing-config
```

**Documentation**

Added a small blurb in the README about how to install the
pre-commit hook.

**Notes**

The pre-commit config was purposefully kept minimal to reduce
the size of this PR's diff.

I'd like to follow up this up with a PR to add more formatting
hooks, including `trailing-whitespace` and
[add-trailing-comma](https://github.com/asottile/add-trailing-comma)


