### PR TITLE
[PLAT-977] let s3 default settings be overridden by local.py

### DIFF
--- a/addons/s3/settings/__init__.py
+++ b/addons/s3/settings/__init__.py
@@ -1,1 +1,10 @@
+import logging
 from .defaults import *  # noqa
+
+
+logger = logging.getLogger(__name__)
+
+try:
+    from .local import *  # noqa
+except ImportError as error:
+    logger.warn('No local.py settings file found')


### PR DESCRIPTION
## Purpose

Allow config settings defined in `addons/s3/settings/defaults.py` to be overridden in `addons/s3/settings/local.py`.

## Changes

Add a local-loading stanza to `addons/s3/settings/__init__.py`.

## QA Notes

Dev will QA

## Documentation

No documentation updates needed.

## Side Effects

None expected.

## Ticket

Doesn't have its own ticket, but extends work done in [PLAT-977](https://openscience.atlassian.net/browse/PLAT-977).
