### PR TITLE
[hotfix] Also revert /metaschemas/registrations type

### DIFF
--- a/api/metaschemas/views.py
+++ b/api/metaschemas/views.py
@@ -1,18 +1,20 @@
 from api.base.views import DeprecatedView
 from api.schemas import views
-from api.schemas.serializers import DeprecatedMetaSchemaSerializer
+from api.schemas.serializers import DeprecatedMetaSchemaSerializer, DeprecatedRegistrationMetaSchemaSerializer
 
 
 class DeprecatedRegistrationMetaSchemaList(DeprecatedView, views.RegistrationSchemaList):
     max_version = '2.8'
     view_category = 'registration-metaschemas'
     view_name = 'registration-schema-detail'
+    serializer_class = DeprecatedRegistrationMetaSchemaSerializer
 
 
 class DeprecatedRegistrationMetaSchemaDetail(DeprecatedView, views.RegistrationSchemaDetail):
     max_version = '2.8'
     view_category = 'registration-metaschemas'
     view_name = 'registration-schema-detail'
+    serializer_class = DeprecatedRegistrationMetaSchemaSerializer
 
 
 class DeprecatedMetaSchemasList(DeprecatedView, views.RegistrationSchemaList):

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -33,3 +33,9 @@ class DeprecatedMetaSchemaSerializer(SchemaSerializer):
 
     class Meta:
         type_ = 'metaschemas'
+
+
+class DeprecatedRegistrationMetaSchemaSerializer(SchemaSerializer):
+
+    class Meta:
+        type_ = 'registration_metaschemas'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

While #8614 reverted the type for `/metaschemas` it did not for `/metascheas/registrations`. 

Registries relies on this to be correct: https://osf.io/registries/discover

## Changes

* add `DeprecatedRegistrationMetaSchemaSerializer`, which sets type to `registration_metaschemas`
* use `DeprecatedRegistrationMetaSchemaSerializer` for `DeprecatedRegistrationMetaSchemaList` and `DeprecatedRegistrationMetaSchemaDetail` views.

## QA Notes

* make sure resources returned by `/v2/metaschemas/registrations` are of type `registration_metaschemas`.
* make sure registries discover page doesn't display an error

## Documentation

Don't think so?

## Side Effects

Registries works again.

## Ticket

N/A