### PR TITLE
[hotfix] Adjust count to be fore all AbstractNode targets [PLAT-1024]

### DIFF
--- a/scripts/analytics/file_summary.py
+++ b/scripts/analytics/file_summary.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse
 from datetime import datetime, timedelta
 from django.utils import timezone
 
-from osf.models import Node, QuickFilesNode
+from osf.models import AbstractNode
 from website.app import init_app
 from scripts.analytics.base import SummaryAnalytics
 
@@ -31,21 +31,16 @@ class FileSummary(SummaryAnalytics):
         timestamp_datetime = datetime(date.year, date.month, date.day).replace(tzinfo=timezone.utc)
 
         file_qs = OsfStorageFile.objects
-        node_content_type = ContentType.objects.get_for_model(Node)
-
-        quickfiles_query = Q(
-            target_object_id__in=QuickFilesNode.objects.values('id'),
-            target_content_type=ContentType.objects.get_for_model(QuickFilesNode)
-        )
+        abstract_node_content_type = ContentType.objects.get_for_model(AbstractNode)
 
         public_query = Q(
-            target_object_id__in=Node.objects.filter(is_public=True).values('id'),
-            target_content_type=node_content_type
+            target_object_id__in=AbstractNode.objects.filter(is_public=True).values('id'),
+            target_content_type=abstract_node_content_type
         )
 
         private_query = Q(
-            target_object_id__in=Node.objects.filter(is_public=False).values('id'),
-            target_content_type=node_content_type
+            target_object_id__in=AbstractNode.objects.filter(is_public=False).values('id'),
+            target_content_type=abstract_node_content_type
         )
 
         daily_query = Q(created__gte=timestamp_datetime)
@@ -57,10 +52,10 @@ class FileSummary(SummaryAnalytics):
             # OsfStorageFiles - the number of files on OsfStorage
             'osfstorage_files_including_quickfiles': {
                 'total': file_qs.count(),
-                'public': file_qs.filter(public_query).count() + file_qs.filter(quickfiles_query).count(),
+                'public': file_qs.filter(public_query).count(),
                 'private': file_qs.filter(private_query).count(),
                 'total_daily': file_qs.filter(daily_query).count(),
-                'public_daily': file_qs.filter(public_query & daily_query).count() + file_qs.filter(quickfiles_query & daily_query).count(),
+                'public_daily': file_qs.filter(public_query & daily_query).count(),
                 'private_daily': file_qs.filter(private_query & daily_query).count(),
             },
         }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

With files on anything, this script was refactored for new targets, which accidentally excluded Registrations.

Turns out the `ContentType` for `Node`, `Registration` and `QuickFilesNode` is all the content type for the base class `AbstractNode` anyhow. 

## Changes
Simplify the query to be for all `AbstractNode` targets, which include QuickFiles and Registrations. 

This makes the public and private totals match the total files once again.

```
{'private': 265828, 'total': 558372, 'public': 292544}
```

## QA Notes
Sara and those looking at file analytics on keen should see this change reflected.

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1024
