### PR TITLE
[hotfix] Update parent as well as target for user quick files merges [PLAT-1026]

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -703,6 +703,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
         from osf.models import QuickFilesNode
         from osf.models import BaseFileNode
+        from addons.osfstorage.models import OsfStorageFolder
 
         # - projects where the user was the creator
         user.nodes_created.exclude(type=QuickFilesNode._typedmodels_type).update(creator=self)
@@ -714,6 +715,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
         # - move files in the merged user's quickfiles node, checking for name conflicts
         primary_quickfiles = QuickFilesNode.objects.get(creator=self)
+        primary_quickfiles_root = OsfStorageFolder.objects.get_root(target=primary_quickfiles)
         merging_user_quickfiles = QuickFilesNode.objects.get(creator=user)
 
         files_in_merging_user_quickfiles = merging_user_quickfiles.files.filter(type='osf.osfstoragefile')
@@ -743,7 +745,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
                 merging_user_file.name = new_name
                 merging_user_file.save()
 
-            merging_user_file.target = primary_quickfiles
+            merging_user_file.move_under(primary_quickfiles_root)
             merging_user_file.save()
 
         # finalize the merge

--- a/osf_tests/test_quickfiles.py
+++ b/osf_tests/test_quickfiles.py
@@ -115,6 +115,7 @@ class TestQuickFilesNode:
         assert stored_files.count() == 2
         for stored_file in stored_files:
             assert stored_file.target == quickfiles
+            assert stored_file.parent.target == quickfiles
 
     def test_quickfiles_moves_files_on_triple_merge_with_name_conflict(self, user, quickfiles):
         name = 'Woo.pdf'


### PR DESCRIPTION
[PLAT-1026]



<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
This will ensure that the root folder is also updated and not just the target, as the API endpoint relies on getting the children of the root folder.

## Changes

- Get the destination quickfiles root folder, and instead of manually updating the file's target, move it under the destination root folder instead. 
- Update the test to not only check the file's target, but the file's parent's target (which was not getting updated properly)

## QA Notes

Merging users quickfiles should now work as expected!

## Documentation

None necessary

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1026
