### PR TITLE
[hotfix] DeprecatedView for versions higher than x.9 [PLAT-1015]

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -2,6 +2,7 @@
 import urllib
 import furl
 import urlparse
+from distutils.version import StrictVersion
 
 from django.utils.http import urlquote
 from django.core.exceptions import ObjectDoesNotExist
@@ -174,7 +175,9 @@ def has_admin_scope(request):
 def is_deprecated(request_version, min_version=None, max_version=None):
     if not min_version and not max_version:
         raise NotImplementedError('Must specify min or max version.')
-    if min_version and request_version < min_version or max_version and request_version > max_version:
+    min_version_deprecated = min_version and StrictVersion(request_version) < StrictVersion(min_version)
+    max_version_deprecated = max_version and StrictVersion(request_version) > StrictVersion(max_version)
+    if min_version_deprecated or max_version_deprecated:
         return True
     return False
 

--- a/api/base/versioning.py
+++ b/api/base/versioning.py
@@ -127,18 +127,3 @@ class BaseVersioning(drf_versioning.BaseVersioning):
         return utils.absolute_reverse(
             viewname, query_kwargs=query_kwargs, args=args, kwargs=kwargs
         )
-
-class DeprecatedEndpointMixin(object):
-    @property
-    def min_version(self):
-        return '2.0'
-
-    @property
-    def max_version(self):
-        raise NotImplementedError('Deprecated endpoints must define `max_version`')
-
-    def determine_version(self, request, *args, **kwargs):
-        version, scheme = super(DeprecatedEndpointMixin, self).determine_version(request, *args, **kwargs)
-        if utils.is_deprecated(version, self.min_version, self.max_version):
-            raise drf_exceptions.NotFound()
-        return version, scheme

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from distutils.version import StrictVersion
 
 from django_bulk_update.helper import bulk_update
 from django.conf import settings as django_settings
@@ -618,7 +619,7 @@ class DeprecatedView(JSONAPIBaseView):
 
     def determine_version(self, request, *args, **kwargs):
         version, scheme = super(DeprecatedView, self).determine_version(request, *args, **kwargs)
-        if version > self.max_version:
+        if StrictVersion(version) > StrictVersion(self.max_version):
             self.is_deprecated = True
             raise NotFound(detail='This route has been deprecated. It was last available in version {}'.format(self.max_version))
         return version, scheme

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -2,18 +2,17 @@ from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import NotFound
 from django.core.exceptions import ObjectDoesNotExist
 
-from api.base.views import JSONAPIBaseView
+from api.base.views import JSONAPIBaseView, DeprecatedView
 from api.base.filters import ListFilterMixin
 from api.base.pagination import NoMaxPageSizePagination
 from api.base import permissions as base_permissions
-from api.base.versioning import DeprecatedEndpointMixin
 from api.taxonomies.serializers import TaxonomySerializer
 from api.taxonomies.utils import optimize_subject_query
 from osf.models import Subject
 from framework.auth.oauth_scopes import CoreScopes
 
 
-class TaxonomyList(DeprecatedEndpointMixin, JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+class TaxonomyList(DeprecatedView, JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/taxonomies_list).
     """
     permission_classes = (

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -41,6 +41,13 @@ class TestIsDeprecated(unittest.TestCase):
             request_version, self.min_version, self.max_version)
         assert_equal(is_deprecated, False)
 
+    def test_is_deprecated_larger_versions(self):
+        request_version = '2.10'
+        is_deprecated = api_utils.is_deprecated(
+            request_version, self.min_version, self.max_version
+        )
+        assert is_deprecated is True
+
 
 class TestFlaskDjangoIntegration:
     def test_push_status_message_no_response(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Use standard library distutils to compare versions instead of relying on string comparisons (where 2.9 > 2.10)

## Changes

- Wrap version numbers to be compared in `StrictVersion`
- Update tests for version comparison utils

## QA Notes
No QA needed, this was just to prevent future confusion as our API is just about to reach version 2.10


## Documentation

Nope!

## Side Effects
None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1015
