### PR TITLE
[IN-425][IN-32][OSF] Add hierarchies to registries

### DIFF
--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3534,7 +3534,7 @@ class TestOnNodeUpdate:
     @mock.patch('website.project.tasks.requests')
     @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
     def test_format_registration_gets_parent_hierarchy_for_component_registrations(self, requests, project, component_registration, user, request_context):
-    
+
         graph = format_registration(component_registration)
 
         parent_relation = [i for i in graph if i['@type'] == 'ispartof'][0]

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -148,6 +148,14 @@ def format_registration(node):
     to_visit.extend(format_contributor(registration_graph, user, bool(user._id in node.visible_contributor_ids), i) for i, user in enumerate(node.contributors))
     to_visit.extend(GraphNode('AgentWorkRelation', creative_work=registration_graph, agent=GraphNode('institution', name=institution.name)) for institution in node.affiliated_institutions.all())
 
+    if node.parent_node:
+        parent = GraphNode('registration')
+        to_visit.extend([
+            parent,
+            GraphNode('workidentifier', creative_work=parent, uri=urlparse.urljoin(settings.DOMAIN, node.parent_node.url)),
+            GraphNode('ispartof', subject=registration_graph, related=parent),
+        ])
+
     visited = set()
     to_visit.extend(registration_graph.get_related())
 


### PR DESCRIPTION
## Purpose

Whenever a registration is submitted, the parent-child relationship isn't being sent if it exists.

## Changes

- Pass through parent-child relationship
- Add test

## QA Notes

No front-end changes

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/IN-32
https://openscience.atlassian.net/browse/IN-425