### PR TITLE
[IN-282][OSF] Fix issue with updating preprint DOI metadata

### DIFF
--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -45,10 +45,10 @@ class IdentifierMixin(models.Model):
         if client:
             return client.create_identifier(self, category)
 
-    def request_identifier_update(self, category):
+    def request_identifier_update(self, category, status=None):
         client = self.get_doi_client()
         if client:
-            return client.update_identifier(self, category)
+            return client.update_identifier(self, category, status=status)
 
     def get_identifier(self, category):
         """Returns None of no identifier matches"""

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -238,8 +238,9 @@ class CrossRefClient(AbstractIdentifierClient):
         else:
             raise NotImplementedError()
 
-    def update_identifier(self, preprint, category):
-        status = self.get_status(preprint)
+    def update_identifier(self, preprint, category, status=None):
+        if status is None:
+            status = self.get_status(preprint)
         return self.create_identifier(preprint, category, status)
 
     def get_status(self, preprint):

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -8,4 +8,4 @@ def update_doi_metadata_on_change(target_guid, status):
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     if target_object.get_identifier('doi'):
-        target_object.request_identifier_update(category='doi')
+        target_object.request_identifier_update(category='doi', status=status)


### PR DESCRIPTION
## Purpose

Fix issue where updating preprint DOI metadata
upon withdrawal, deletion, etc. fail

## Changes

Pass `status` down to `request_identifier_update` instead of
doing a db query. We suspect a stale data somehow where preprint doi status is still
public (`verified_publishable`) after  withdrawal, deletion

## QA Notes
Create a preprint and make sure it gets crossref doi, checking at `test.crossref.org` using the preprint doi to retrieve the submission xml. The status should be 'resolved' and you should be able to see the following fields `item_number`, `title`, `description`, `description`, etc elements in the submission xml file.

Create a withdrawal request and approve it, make sure that (may take a while) the fields mentioned above don't show in the submission xml file.

## Documentation

## Side Effects


## Ticket

[[IN-282]](https://openscience.atlassian.net/browse/IN-282)
