### PR TITLE
[IN-421][OSF] Remove NoneIfWithdrawal on reviews_state

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -92,7 +92,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view='nodes:node-contributors',
         related_view_kwargs={'node_id': '<node._id>'},
     )
-    reviews_state = NoneIfWithdrawal(ser.CharField(source='machine_state', read_only=True, max_length=15))
+    reviews_state = ser.CharField(source='machine_state', read_only=True, max_length=15)
     date_last_transitioned = NoneIfWithdrawal(VersionedDateTimeField(read_only=True))
 
     citation = NoneIfWithdrawal(RelationshipField(


### PR DESCRIPTION
## Purpose

We need to see the `reviews_state` of withdrawn preprints for the reviews app to work with withdrawals.

## Changes

- Removed `NoneIfWithdrawal` check from `reviews_state`

## QA Notes

No front end changes

## Side Effects

`N/A`

## Ticket

https://openscience.atlassian.net/browse/IN-421
