### PR TITLE
[IN-417] V2 Claim Unregistered User Endpoint

### DIFF
--- a/api/users/permissions.py
+++ b/api/users/permissions.py
@@ -34,3 +34,16 @@ class ReadOnlyOrCurrentUserRelationship(permissions.BasePermission):
             return True
         else:
             return obj['self']._id == request_user._id
+
+class ClaimUserPermission(permissions.BasePermission):
+    """ Allows anyone to attempt to claim an unregistered user.
+    Allows no one to attempt to claim a registered user.
+    """
+    def has_permission(self, request, view):
+        claimed_user = view.get_user(check_permissions=False)
+        assert isinstance(claimed_user, OSFUser), 'obj must be a User, got {}'.format(claimed_user)
+        return not claimed_user.is_registered
+
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, OSFUser), 'obj must be a User, got {}'.format(obj)
+        return not obj.is_registered

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     url(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/$', views.UserAddonDetail.as_view(), name=views.UserAddonDetail.view_name),
     url(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/accounts/$', views.UserAddonAccountList.as_view(), name=views.UserAddonAccountList.view_name),
     url(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/accounts/(?P<account_id>\w+)/$', views.UserAddonAccountDetail.as_view(), name=views.UserAddonAccountDetail.view_name),
+    url(r'^(?P<user_id>\w+)/claim/$', views.ClaimUser.as_view(), name=views.ClaimUser.view_name),
     url(r'^(?P<user_id>\w+)/institutions/$', views.UserInstitutions.as_view(), name=views.UserInstitutions.view_name),
     url(r'^(?P<user_id>\w+)/nodes/$', views.UserNodes.as_view(), name=views.UserNodes.view_name),
     url(r'^(?P<user_id>\w+)/preprints/$', views.UserPreprints.as_view(), name=views.UserPreprints.view_name),

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -19,7 +19,8 @@ from api.nodes.serializers import NodeSerializer
 from api.preprints.serializers import PreprintSerializer
 from api.registrations.serializers import RegistrationSerializer
 from api.users.permissions import (CurrentUser, ReadOnlyOrCurrentUser,
-                                   ReadOnlyOrCurrentUserRelationship)
+                                   ReadOnlyOrCurrentUserRelationship,
+                                   ClaimUserPermission)
 from api.users.serializers import (UserAddonSettingsSerializer,
                                    UserDetailSerializer,
                                    UserIdentitiesSerializer,
@@ -31,14 +32,16 @@ from api.users.serializers import (UserAddonSettingsSerializer,
                                    ReadEmailUserDetailSerializer,)
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
+from framework.auth.core import get_user
 from framework.auth.oauth_scopes import CoreScopes, normalize_scopes
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.exceptions import NotAuthenticated, NotFound
+from rest_framework.exceptions import NotAuthenticated, NotFound, ValidationError
 from osf.models import (Contributor,
                         ExternalAccount,
+                        Guid,
                         QuickFilesNode,
                         AbstractNode,
                         PreprintService,
@@ -46,6 +49,7 @@ from osf.models import (Contributor,
                         Registration,
                         OSFUser)
 from website import mails, settings
+from website.project.views.contributor import send_claim_email, send_claim_registered_email
 
 
 class UserMixin(object):
@@ -573,4 +577,80 @@ class UserAccountDeactivate(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         user.email_last_sent = timezone.now()
         user.requested_deactivation = True
         user.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ClaimUser(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
+    permission_classes = (
+        base_permissions.TokenHasScope,
+        ClaimUserPermission,
+    )
+
+    required_read_scopes = [CoreScopes.NULL]  # Tokens should not be able to access this
+    required_write_scopes = [CoreScopes.NULL]  # Tokens should not be able to access this
+
+    view_category = 'users'
+    view_name = 'claim-user'
+
+    def _send_claim_email(self, *args, **kwargs):
+        """ This avoids needing to reimplement all of the logic in the sender methods.
+        When v1 is more fully deprecated, those send hooks should be reworked to not
+        rely upon a flask context and placed in utils (or elsewhere).
+
+        :param bool registered: Indicates which sender to call (passed in as keyword)
+        :param \*args: Positional arguments passed to senders
+        :param \*\*kwargs: Keyword arguments passed to senders
+        :return: None
+        """
+        from website.app import app
+        from website.routes import make_url_map
+        try:
+            make_url_map(app)
+        except AssertionError:
+            # Already mapped
+            pass
+        ctx = app.test_request_context()
+        ctx.push()
+        if kwargs.pop('registered', False):
+            send_claim_registered_email(*args, **kwargs)
+        else:
+            send_claim_email(*args, **kwargs)
+        ctx.pop()
+
+    def post(self, request, *args, **kwargs):
+        claimer = request.user
+        email = (request.data.get('email', None) or '').lower().strip()
+        record_id = (request.data.get('id', None) or '').lower().strip()
+        if not record_id:
+            raise ValidationError('Must specify record "id".')
+        claimed_user = self.get_user(check_permissions=True)  # Ensures claimability
+        if claimed_user.is_disabled:
+            raise ValidationError('Cannot claim disabled account.')
+        try:
+            record_referent = Guid.objects.get(_id=record_id).referent
+        except Guid.DoesNotExist:
+            raise NotFound('Unable to find specified record.')
+
+        try:
+            unclaimed_record = claimed_user.unclaimed_records[record_referent._id]
+        except KeyError:
+            if isinstance(record_referent, PreprintService) and record_referent.node and record_referent.node._id in claimed_user.unclaimed_records:
+                record_referent = record_referent.node
+                unclaimed_record = claimed_user.unclaimed_records[record_referent._id]
+            else:
+                raise NotFound('Unable to find specified record.')
+
+        if claimer.is_anonymous and email:
+            claimer = get_user(email=email)
+            if claimer and claimer.is_registered:
+                self._send_claim_email(claimer, claimed_user, record_referent, registered=True)
+            else:
+                self._send_claim_email(email, claimed_user, record_referent, notify=True, registered=False)
+        elif isinstance(claimer, OSFUser):
+            if unclaimed_record.get('referrer_id', '') == claimer._id:
+                raise ValidationError('Referrer cannot claim user.')
+            self._send_claim_email(claimer, claimed_user, record_referent, registered=True)
+        else:
+            raise ValidationError('Must either be logged in or specify claim email.')
+
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -14,8 +14,9 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.settings.defaults import API_BASE
 from api.search.permissions import IsAuthenticatedOrReadOnlyForSearch
-from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from api.crossref.views import ParseCrossRefConfirmation
+from api.users.views import ClaimUser
+from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
 from api.base.permissions import TokenHasScope
 from website.settings import DEBUG_MODE
@@ -48,7 +49,7 @@ for mod in URLS_MODULES:
 class TestApiBaseViews(ApiTestCase):
     def setUp(self):
         super(TestApiBaseViews, self).setUp()
-        self.EXCLUDED_VIEWS = [MoveFileMetadataView, CopyFileMetadataView, ParseCrossRefConfirmation]
+        self.EXCLUDED_VIEWS = [ClaimUser, MoveFileMetadataView, CopyFileMetadataView, ParseCrossRefConfirmation]
 
     def test_root_returns_200(self):
         res = self.app.get('/{}'.format(API_BASE))

--- a/api_tests/users/views/test_user_claim.py
+++ b/api_tests/users/views/test_user_claim.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api.users.views import ClaimUser
+from api_tests.utils import only_supports_methods
+from framework.auth.core import Auth
+from osf_tests.factories import (
+    AuthUserFactory,
+    ProjectFactory,
+    PreprintFactory,
+)
+
+@pytest.mark.django_db
+class TestClaimUser:
+
+    @pytest.fixture
+    def mock_mail(self):
+        with mock.patch('website.project.views.contributor.mails.send_mail') as patch:
+            yield patch
+
+    @pytest.fixture()
+    def referrer(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def project(self, referrer):
+        return ProjectFactory(creator=referrer)
+
+    @pytest.fixture()
+    def preprint(self, referrer, project):
+        return PreprintFactory(creator=referrer, project=project)
+
+    @pytest.fixture()
+    def wrong_preprint(self, referrer):
+        return PreprintFactory(creator=referrer)
+
+    @pytest.fixture()
+    def unreg_user(self, referrer, project):
+        return project.add_unregistered_contributor(
+            'David Davidson',
+            'david@david.son',
+            auth=Auth(referrer),
+            save=True
+        )
+
+    @pytest.fixture()
+    def claimer(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def url(self):
+        return '/{}users/{{}}/claim/'.format(API_BASE)
+
+    def payload(self, **kwargs):
+        payload = {
+            'data': {
+                'attributes': {}
+            }
+        }
+        _id = kwargs.pop('id', None)
+        if _id:
+            payload['data']['id'] = _id
+        if kwargs:
+            payload['data']['attributes'] = kwargs
+        return payload
+
+    def test_unacceptable_methods(self):
+        assert only_supports_methods(ClaimUser, ['POST'])
+
+    def test_claim_unauth_failure(self, app, url, unreg_user, project, wrong_preprint):
+        _url = url.format(unreg_user._id)
+        # no record locator
+        payload = self.payload(email='david@david.son')
+        res = app.post_json_api(
+            _url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Must specify record "id".'
+
+        # bad record locator
+        payload = self.payload(email='david@david.son', id='notaguid')
+        res = app.post_json_api(
+            _url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == 'Unable to find specified record.'
+
+        # wrong record locator
+        payload = self.payload(email='david@david.son', id=wrong_preprint._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == 'Unable to find specified record.'
+
+        # no email
+        payload = self.payload(id=project._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Must either be logged in or specify claim email.'
+
+        # active user
+        _url = url.format(project.creator._id)
+        payload = self.payload(email=project.creator.email, id=project._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            expect_errors=True
+        )
+        assert res.status_code == 401
+
+    def test_claim_unauth_success_with_original_email(self, app, url, project, unreg_user, mock_mail):
+        res = app.post_json_api(
+            url.format(unreg_user._id),
+            self.payload(email='david@david.son', id=project._id),
+        )
+        assert res.status_code == 204
+        assert mock_mail.call_count == 1
+
+    def test_claim_unauth_success_with_claimer_email(self, app, url, unreg_user, project, claimer, mock_mail):
+        res = app.post_json_api(
+            url.format(unreg_user._id),
+            self.payload(email=claimer.username, id=project._id)
+        )
+        assert res.status_code == 204
+        assert mock_mail.call_count == 2
+
+    def test_claim_unauth_success_with_unknown_email(self, app, url, project, unreg_user, mock_mail):
+        res = app.post_json_api(
+            url.format(unreg_user._id),
+            self.payload(email='asdf@fdsa.com', id=project._id),
+        )
+        assert res.status_code == 204
+        assert mock_mail.call_count == 2
+
+    def test_claim_unauth_success_with_preprint_id(self, app, url, preprint, unreg_user, mock_mail):
+        res = app.post_json_api(
+            url.format(unreg_user._id),
+            self.payload(email='david@david.son', id=preprint._id),
+        )
+        assert res.status_code == 204
+        assert mock_mail.call_count == 1
+
+    def test_claim_auth_failure(self, app, url, claimer, wrong_preprint, project, unreg_user, referrer):
+        _url = url.format(unreg_user._id)
+        # no record locator
+        payload = self.payload(email='david@david.son')
+        res = app.post_json_api(
+            _url,
+            payload,
+            auth=claimer.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Must specify record "id".'
+
+        # bad record locator
+        payload = self.payload(email='david@david.son', id='notaguid')
+        res = app.post_json_api(
+            _url,
+            payload,
+            auth=claimer.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == 'Unable to find specified record.'
+
+        # wrong record locator
+        payload = self.payload(email='david@david.son', id=wrong_preprint._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            auth=claimer.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == 'Unable to find specified record.'
+
+        # referrer auth
+        payload = self.payload(email='david@david.son', id=project._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            auth=referrer.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Referrer cannot claim user.'
+
+        # active user
+        _url = url.format(project.creator._id)
+        payload = self.payload(email=project.creator.email, id=project._id)
+        res = app.post_json_api(
+            _url,
+            payload,
+            auth=claimer.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 403
+
+    def test_claim_auth_success(self, app, url, claimer, unreg_user, project, mock_mail):
+        res = app.post_json_api(
+            url.format(unreg_user._id),
+            self.payload(id=project._id),
+            auth=claimer.auth
+        )
+        assert res.status_code == 204
+        assert mock_mail.call_count == 2

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -39,3 +39,9 @@ def disconnected_from_listeners(signal):
     yield
     for listener in listeners:
         signal.connect(listener)
+
+def only_supports_methods(view, expected_methods):
+    if isinstance(view.__class__, type):
+        view = view()
+    expected_methods.append('OPTIONS')
+    return set(expected_methods) == set(view.allowed_methods)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -361,6 +361,7 @@ def project_remove_contributor(auth, **kwargs):
     return redirect_url
 
 
+# TODO: consider moving this into utils
 def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 3600):
     """
     A registered user claiming the unclaimed user account as an contributor to a project.
@@ -426,6 +427,7 @@ def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 360
     )
 
 
+# TODO: consider moving this into utils
 def send_claim_email(email, unclaimed_user, node, notify=True, throttle=24 * 3600, email_template='default'):
     """
     Unregistered user claiming a user account as an contributor to a project. Send an email for claiming the account.


### PR DESCRIPTION
## Purpose
Allow Ember apps to let unregistered users be claimed

## Changes
* Add endpoint
* Add tests

## QA Notes
No UI components, API testing would duplicate TCI

## Side Effects
None expected

## Ticket
[[IN-417]](https://openscience.atlassian.net/browse/IN-417)
