### PR TITLE
Hotfix/Password Change Invalidate Sessions [PLAT-1052]

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1283,6 +1283,10 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             raise ChangePasswordError(issues)
         self.set_password(raw_new_password)
         self.reset_old_password_invalid_attempts()
+        if self.verification_key_v2:
+            self.verification_key_v2['expires'] = timezone.now()
+        # new verification key (v1) for CAS
+        self.verification_key = generate_verification_key(verification_type=None)
 
     def reset_old_password_invalid_attempts(self):
         self.old_password_invalid_attempts = 0

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1540,9 +1540,7 @@ class TestUserAccount(OsfTestCase):
         self.user.auth = (self.user.username, 'password')
         self.user.save()
 
-    @mock.patch('website.profile.views.push_status_message')
     def test_password_change_valid(self,
-                                   mock_push_status_message,
                                    old_password='password',
                                    new_password='Pa$$w0rd',
                                    confirm_password='Pa$$w0rd'):
@@ -1558,6 +1556,11 @@ class TestUserAccount(OsfTestCase):
         assert_true(200, res.status_code)
         self.user.reload()
         assert_true(self.user.check_password(new_password))
+
+    @mock.patch('website.profile.views.push_status_message')
+    def test_user_account_password_reset_query_params(self, mock_push_status_message):
+        url = web_url_for('user_account') + '?password_reset=True'
+        res = self.app.get(url, auth=(self.user.auth))
         assert_true(mock_push_status_message.called)
         assert_in('Password updated successfully', mock_push_status_message.mock_calls[0][1][0])
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -13,7 +13,6 @@ from framework import sentry
 from framework.auth import utils as auth_utils
 from framework.auth import cas
 from framework.auth import logout as osf_logout
-from framework.auth.core import generate_verification_key
 from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
 from framework.auth.decorators import must_be_confirmed
@@ -283,7 +282,7 @@ def user_profile(auth, **kwargs):
 def user_account(auth, **kwargs):
     user = auth.user
     user_addons = addon_utils.get_addons_by_config_type('user', user)
-    if 'password_reset' in request.query_string:
+    if 'password_reset' in request.args:
         push_status_message('Password updated successfully.', kind='success', trust=False)
 
     return {
@@ -318,16 +317,12 @@ def user_account_password(auth, **kwargs):
 
     try:
         user.change_password(old_password, new_password, confirm_password)
-        if user.verification_key_v2:
-            user.verification_key_v2['expires'] = timezone.now()
     except ChangePasswordError as error:
         for m in error.messages:
             push_status_message(m, kind='warning', trust=False)
     else:
-        # new verification key (v1) for CAS
-        user.verification_key = generate_verification_key(verification_type=None)
-        user.save()
         # We have to logout the user first so all CAS sessions are invalid
+        user.save()
         osf_logout()
         return redirect(cas.get_logout_url(cas.get_login_url(
             web_url_for('user_account', _absolute=True) + '?password_reset=True',

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -327,15 +327,14 @@ def user_account_password(auth, **kwargs):
         # new verification key (v1) for CAS
         user.verification_key = generate_verification_key(verification_type=None)
         user.save()
-        # We have to logout the user so all CAS sessions are invalid
+        # We have to logout the user first so all CAS sessions are invalid
         osf_logout()
-        return redirect(cas.get_login_url(
+        return redirect(cas.get_logout_url(cas.get_login_url(
             web_url_for('user_account', _absolute=True) + '?password_reset=True',
             username=user.username,
             verification_key=user.verification_key,
-        ))
+        )))
     user.save()
-
     return redirect(web_url_for('user_account'))
 
 


### PR DESCRIPTION
❗️ Needs to be accompanied by https://github.com/CenterForOpenScience/cas-overlay/pull/128
## Purpose

Password changes are not invalidating your other sessions in other browsers.  
The solution maybe issue a logout request on password reset and redirect to login with verification key and username automatically.

## Changes

Needs to accompany Longze's CAS-side fix. On my side, logout the user when they reset their password, and then log them in automatically with a verification key and username. Longze's CAS piece will make a logout from the OSF make all CAS sessions invalid.

## QA Notes
1.  Log in in two browsers as the same user.
2. Change your user's password in one browser.
3. Confirm you see a green "password changed" indication at the top
4. In the other browser, refresh or hit sign in, and confirm that you are logged out, and have to log back in again. 

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1052