### PR TITLE
Render forward_node_settings.mako in project settings

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -276,7 +276,7 @@ def node_setting(auth, node, **kwargs):
     ret['comments'] = {
         'level': node.comment_level,
     }
-    
+
     addon_settings = {}
     for addon in ['forward']:
         addon_config = apps.get_app_config('addons_{}'.format(addon))
@@ -285,7 +285,7 @@ def node_setting(auth, node, **kwargs):
         config['addon_icon_url'] = addon_config.icon_url
         config['node_settings_template'] = os.path.basename(addon_config.node_settings_template)
         addon_settings['forward'] = config
-    
+
     ret['addon_settings'] = addon_settings
 
     ret['categories'] = settings.NODE_CATEGORY_MAP

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -276,6 +276,17 @@ def node_setting(auth, node, **kwargs):
     ret['comments'] = {
         'level': node.comment_level,
     }
+    
+    addon_settings = {}
+    for addon in ['forward']:
+        addon_config = apps.get_app_config('addons_{}'.format(addon))
+        config = addon_config.to_json()
+        config['template_lookup'] = addon_config.template_lookup
+        config['addon_icon_url'] = addon_config.icon_url
+        config['node_settings_template'] = os.path.basename(addon_config.node_settings_template)
+        addon_settings['forward'] = config
+    
+    ret['addon_settings'] = addon_settings
 
     ret['categories'] = settings.NODE_CATEGORY_MAP
     ret['categories'].update({

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -284,7 +284,7 @@ def node_setting(auth, node, **kwargs):
         config['template_lookup'] = addon_config.template_lookup
         config['addon_icon_url'] = addon_config.icon_url
         config['node_settings_template'] = os.path.basename(addon_config.node_settings_template)
-        addon_settings['forward'] = config
+        addon_settings[addon] = config
 
     ret['addon_settings'] = addon_settings
 

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -332,46 +332,8 @@
 
                         <div data-bind="visible: enabled" style="display: none">
 
-                            <div class="forward-settings">
+                            ${ render_node_settings(addon_settings['forward']) }
 
-                                <form class="form" data-bind="submit: submitSettings">
-
-                                    <div class="form-group">
-                                        <label for="forwardUrl">URL</label>
-                                        <input
-                                            id="forwardUrl"
-                                            class="form-control"
-                                            data-bind="value: url"
-                                            placeholder="Send people who visit your OSF project page to this link instead"
-                                        />
-                                    </div>
-
-                                    <div class="form-group">
-                                        <label for="forwardLabel">Label</label>
-                                        <input
-                                            id="forwardLabel"
-                                            class="form-control"
-                                            data-bind="value: label"
-                                            placeholder="Optional"
-                                        />
-                                    </div>
-
-                                    <div class="row">
-                                        <div class="col-md-10 overflow">
-                                            <p data-bind="html: message, attr: {class: messageClass}"></p>
-                                        </div>
-                                        <div class="col-md-2">
-                                            <input
-                                                type="submit"
-                                               class="btn btn-success pull-right"
-                                               value="Save"
-                                            />
-                                        </div>
-                                    </div>
-
-                                </form>
-
-                            </div><!-- end .forward-settings -->
                         </div><!-- end #configureForward -->
 
                     </div>
@@ -499,6 +461,14 @@
     <!-- End right column -->
 
 </div>
+
+<%def name="render_node_settings(data)">
+    <%
+       template_name = data['node_settings_template']
+       tpl = data['template_lookup'].get_template(template_name).render(**data)
+    %>
+    ${ tpl | n }
+</%def>
 
 <%def name="stylesheets()">
     ${parent.stylesheets()}


### PR DESCRIPTION
## Purpose

There is the same code in two places: in 'addons/forward/templates/forward_node_settings' and in 'website/templates/project/settings.mako' (where it was copy-pasted!). 

## Changes

I added a new dict 'addons_settings' for addons that have configurations in the project settings page. This dict is returned from the 'node_setting' function of website.project.views.node. I filled this dict with neccesary data of the 'forward' addon. I also added the 'render_node_settings' def in project settings.mako that renders settings templates of addons from the mentioned dict. Finally I replaced copy-pasted code with 'render_node_settings' call.

## QA Notes

The only page to test is the project settings page.

## Documentation

## Side Effects

## Ticket

