### PR TITLE
[PLAT-1069][Hotfix] Catch Gitlab TOS Error

### DIFF
--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -49,7 +49,7 @@ class GitLabClient(object):
         try:
             return gitlab.Project(self.gitlab, repo_id)
         except gitlab.GitlabGetError as exc:
-            if exc.code == 404:
+            if exc.response_code == 404:
                 raise NotFoundError
             else:
                 raise exc

--- a/addons/gitlab/models.py
+++ b/addons/gitlab/models.py
@@ -276,7 +276,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             repo = connect.repo(self.repo_id)
         except (ApiError, GitLabError):
             return
-        except gitlab.GitlabGetError as exc:
+        except gitlab.exceptions.GitlabError as exc:
             if exc.response_code == 403 and 'must accept the Terms of Service' in exc.error_message:
                 return [('Your gitlab account does not have proper authentication. Ensure you have agreed to Gitlab\'s '
                          'current Terms of Service by disabling and re-enabling your account.')]

--- a/addons/gitlab/views.py
+++ b/addons/gitlab/views.py
@@ -159,7 +159,7 @@ def gitlab_set_config(auth, **kwargs):
 
     try:
         repo = connection.repo(gitlab_repo_id)
-    except gitlab.GitlabGetError as exc:
+    except gitlab.exceptions.GitlabError as exc:
         if exc.response_code == 403 and 'must accept the Terms of Service' in exc.error_message:
             return {'message': 'Your gitlab account does not have proper authentication. Ensure you have agreed to Gitlab\'s '
                      'current Terms of Service by disabling and re-enabling your account.'}, http.BAD_REQUEST


### PR DESCRIPTION
## Purpose

Currently If a user hasn't agreed to the TOS the user is locked out of their account. This fixes that.

## Changes

- refactor `.code` to `.response_code` to catch exception better
- add descriptive messages to catch error.
![screen shot 2018-08-29 at 3 46 06 pm](https://user-images.githubusercontent.com/9688518/44811734-678b4700-aba3-11e8-9ed4-33cbb4bcc2f3.png)
![screen shot 2018-08-29 at 3 33 26 pm](https://user-images.githubusercontent.com/9688518/44811735-678b4700-aba3-11e8-9edc-3615a17047a1.png)

## QA Notes

I tested this by inserting an error into the repo method like so:
```python
    def repo(self, repo_id):
        """Get a single GitLab repo's info.

        https://docs.gitlab.com/ce/api/projects.html#get-single-project

        :param str repo_id: GitLab repository id
        :return: gitlab.Project a object representing the repo
        """

        try:
            raise gitlab.GitlabGetError('You (@latifn2) must accept the Terms of Service in order to perform this action. Please access GitLab from a web browser to accept these terms.', response_code=403)
            return gitlab.Project(self.gitlab, repo_id)
        except gitlab.GitlabGetError as exc:
            if exc.response_code == 404:
                raise NotFoundError
            else:
                raise exc
```
The elusive TOS error's sentry info is here: https://sentry2.cos.io/cos/osf-back-end/issues/7576/

## Documentation

None

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1069

