### PR TITLE
Integrate Mergify for auto-merging PRs after conditions have been met [PLAT-1048]

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,8 @@ rules:
             required_status_checks:
                 contexts:
                 - continuous-integration/travis-ci
-        enabling_label: null
-        disabling_label: no-mergify
+        enabling_label: enable-mergify
+        disabling_label: null
         disabling_files:
         - .mergify.yml
         - .travis.yml

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+rules:
+    default:
+        protection:
+            required_pull_request_reviews:
+                required_approving_review_count: 1
+                dismiss_stale_reviews: true
+            required_status_checks:
+                contexts:
+                - continuous-integration/travis-ci
+        enabling_label: null
+        disabling_label: no-mergify
+        disabling_files:
+        - .mergify.yml
+        - .travis.yml
+    branches:
+        master: null


### PR DESCRIPTION

## Purpose
See full notes for this PR [on the notion page](https://www.notion.so/cos/Mergify-19d768e2d65e4bf9bf6375acafca130f)

Keeping track of PRs to be merged can be an extra hassle for maintainers - let's try out Mergify to help manage that workflow. Mergify will automatically merge any PRs that meet a certain set of requirements.

The full docs [can be found here](https://doc.mergify.io/)

Out of those options, here's what this initial config does:
- Any PR with the label `enable-mergify` (added to the PR on github) will be eligible to be merged by mergify.
- By default, requires approving reviews from 1 contributor with **write access**
    - Any review that comes before another commit has been made **will not count**
- Requires travis to pass
- Any PR that changes either `.travis.yml` or `.mergify.yml` will not be automatically merged
- Is **not** enabled for PRs to the `master` branch

Things to probably add for the future:
- "Strict" mode, which requires the PR branch to be up to date with the one it's merging into. If this is set, Mergify will try to auto-update the PR branch, and error if it can't, forcing the person who made the PR to update it before it canbe merged. See [the notion notes](https://www.notion.so/cos/Mergify-19d768e2d65e4bf9bf6375acafca130f) for more details.

## Changes

- Add a mergify config file

## QA Notes
None needed

## Documentation
None needed

## Side Effects
This will not go into effect until [Mergify is officially enabled](https://mergify.io/) by COS. When this happens and `osf.io` is added as a project, Mergify will automatically make a PR to `develop` with a config file similar to this one with the default settings. That PR can be ignored, as that's what this is for.

## Ticket
https://openscience.atlassian.net/browse/PLAT-1048
