### PR TITLE
[Hotfix][No Ticket] User can_view_reviews

### DIFF
--- a/admin/common_auth/views.py
+++ b/admin/common_auth/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth import login, REDIRECT_FIELD_NAME, authenticate, logout
 
 from osf.models.user import OSFUser
-from osf.models import AdminProfile, PreprintProvider
+from osf.models import AdminProfile, AbstractProvider
 from admin.common_auth.forms import LoginForm, UserRegistrationForm, DeskUserForm
 
 
@@ -73,15 +73,14 @@ class RegisterUser(PermissionRequiredMixin, FormView):
         # create AdminProfile for this new user
         profile, created = AdminProfile.objects.get_or_create(user=osf_user)
 
-        osf_user.groups.clear()
         prereg_admin_group = Group.objects.get(name='prereg_admin')
         for group in form.cleaned_data.get('group_perms'):
             osf_user.groups.add(group)
             split = group.name.split('_')
             group_type = split[0]
             if group_type == 'reviews':
-                provider_id = split[1]
-                provider = PreprintProvider.load(provider_id)
+                provider_id = split[2]
+                provider = AbstractProvider.objects.get(id=provider_id)
                 provider.notification_subscriptions.get(event_name='new_pending_submissions').add_user_to_subscription(osf_user, 'email_transactional')
             if group == prereg_admin_group:
                 administer_permission = Permission.objects.get(codename='administer_prereg')

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,5 +1,3 @@
-from guardian.models import GroupObjectPermission
-
 from django.utils import timezone
 from rest_framework import serializers as ser
 
@@ -14,6 +12,7 @@ from api.base.utils import absolute_reverse, get_user_auth, waterbutler_api_url_
 from api.files.serializers import QuickFilesSerializer
 from osf.exceptions import ValidationValueError, ValidationError
 from osf.models import OSFUser, QuickFilesNode
+from osf.models.provider import AbstractProviderGroupObjectPermission
 from api.users.schemas.utils import validate_user_json
 
 
@@ -119,8 +118,8 @@ class UserSerializer(JSONAPISerializer):
         })
 
     def get_can_view_reviews(self, obj):
-        group_qs = GroupObjectPermission.objects.filter(group__user=obj, permission__codename='view_submissions')
-        return group_qs.exists() or obj.userobjectpermission_set.filter(permission__codename='view_submissions')
+        group_qs = AbstractProviderGroupObjectPermission.objects.filter(group__user=obj, permission__codename='view_submissions')
+        return group_qs.exists() or obj.abstractprovideruserobjectpermission_set.filter(permission__codename='view_submissions')
 
     def get_accepted_terms_of_service(self, obj):
         return bool(obj.accepted_terms_of_service)

--- a/api_tests/users/views/test_user_can_review.py
+++ b/api_tests/users/views/test_user_can_review.py
@@ -1,0 +1,36 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    AuthUserFactory,
+    PreprintProviderFactory,
+)
+
+
+@pytest.mark.django_db
+class TestUserCanReview:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def moderator(self, provider):
+        user = AuthUserFactory()
+        provider.add_to_group(user, 'admin')
+        return user
+
+    @pytest.fixture()
+    def provider(self):
+        return PreprintProviderFactory(name='Sockarxiv')
+
+    @pytest.fixture()
+    def url(self):
+        return '/{}users/me/?fields[users]=can_view_reviews'.format(API_BASE)
+
+    def test_can_review(self, app, url, user, moderator, provider):
+        res = app.get(url, auth=moderator.auth)
+        assert res.json['data']['attributes']['can_view_reviews']
+
+        res = app.get(url, auth=user.auth)
+        assert not res.json['data']['attributes']['can_view_reviews']


### PR DESCRIPTION
## Purpose
Fix permissions check in user serializer

## Changes
* Use the right kind of `GroupObjectPermission` sub-class
* Fix lookup in Admin module

## QA Notes
This should affect whether or not non-superusers can view the reviews app, and also allow additional users to be added to reviews groups through the admin module

## Documentation
None

## Side Effects
None expected

## Ticket
None