### PR TITLE
Lack of style for remove-or-reject class on the settings page.

### DIFF
--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -92,6 +92,13 @@
     .osf-project-navbar a.project-title {
         max-width: 190px;
     }
+    .remove-or-reject {
+        padding-top: 4px;
+        color: #333333;
+        cursor: pointer;
+        float: right;
+        font-size: 1.5em;
+    }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
## Purpose

View-only Links can be configured in two places: on contributors page and on settings page. There is used a template with class 'remove-or-reject' in both places - the same template. But on settings page, there is no definition of CSS styles for this class (another .css file is linked), so "x"-es removing table's rows are not so pretty like on contributors page.

## Changes

I added the same style for the 'remove-or-reject' class as it is defined for contributors page.

## QA Notes

Project settings page changed - configuration of View-only Links.

## Documentation

## Side Effects

## Ticket
