### PR TITLE
[Hotfix][PLAT-1067] Bitbucket pagination fix 

### DIFF
--- a/addons/bitbucket/api.py
+++ b/addons/bitbucket/api.py
@@ -145,11 +145,9 @@ class BitbucketClient(BaseClient):
         :param str repo: Bitbucket repo name
         :return: List of branch dicts
         """
-        branches, page_nbr = [], 1
+        branches = []
+        url = self._build_url(settings.BITBUCKET_V2_API_URL, 'repositories', user, repo, 'refs', 'branches')
         while True:
-            url = self._build_url(settings.BITBUCKET_V2_API_URL, 'repositories', user, repo,
-                                  'refs', 'branches')
-            url = '{}?page={}'.format(url, page_nbr)
             res = self._make_request(
                 'GET',
                 url,
@@ -158,8 +156,8 @@ class BitbucketClient(BaseClient):
             )
             res_data = res.json()
             branches.extend(res_data['values'])
-            page_nbr += 1
-            if not res_data.get('next', None):
+            url = res_data.get('next', None)
+            if not url:
                 break
         return branches
 


### PR DESCRIPTION
## Purpose

Bitbucket will connect properly, but when it attempts to retrieve your list of branches it returns a 400, because it's been updated to accept a page code instead of sequential page number.

## Changes

- re-writes part of code that iterates over pages to account for new behavor

## QA Notes

You should be able to view your bitbucket account connected and look at all your files/branches on the files page.

I decided not to include unit tests, because this a one-off that's largely dependent on bitbuckets outside behavior and so tests won't necessarily reflect working behavior and there are not pre-existing test for the bitbucket client.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1067