### PR TITLE
[hotfix] django-celery-results

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = (
 
     # 3rd party
     'django_celery_beat',
+    'django_celery_results',
     'rest_framework',
     'corsheaders',
     'raven.contrib.django.raven_compat',

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ pyjwt==1.5.3
 # django-celery-beat==1.0.1  # BSD 3 Clause
 # Contains a fix for handling disabled tasks that still has not been release
 git+git://github.com/celery/django-celery-beat@f014edcb954c707cb7628f4416257b6a58689523# BSD 3 Clause
+django-celery-results==1.0.1
 # Issue: sorry, but this version only supports 100 named groups (https://github.com/eliben/pycparser/issues/147)
 pycparser==2.18
 pyjwe==1.0.0

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -485,7 +485,7 @@ class CeleryConfig:
     broker_use_ssl = False
 
     # Default RabbitMQ backend
-    result_backend = os.environ.get('CELERY_RESULT_BACKEND', broker_url)
+    result_backend = 'django-db'  # django-celery-results
 
     beat_scheduler = 'django_celery_beat.schedulers:DatabaseScheduler'
 


### PR DESCRIPTION
## Purpose

Use `django-celery-results` and configure the `django-db` as the storage source for the Celery task results backend.

The `amqp` backend we're using is no longer supported by celery.

This should reduce some of the high load on rabbitmq we've been seeing on production lately.

## Changes

Configures the backend PostgreSQL database for results storage.

## QA Notes

Double check to ensure registrations archive.

## Documentation

To test locally you'll need to ensure `USE_CELERY = true` is set in the `website/settings/local.py` settings file.

## Side Effects

DevOps will need to monitor both the database size, and ensure the `celery.task.backend_cleanup` task is running nightly (currently is) via the beat scheduler.

## Ticket

N/A