### PR TITLE
Enable celery in local development

### DIFF
--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -75,9 +75,6 @@ SESSION_COOKIE_SECURE = SECURE_MODE
 OSF_SERVER_KEY = None
 OSF_SERVER_CERT = None
 
-# Comment out to use celery in development
-USE_CELERY = False
-
 class CeleryConfig(defaults.CeleryConfig):
     """
     Celery configuration


### PR DESCRIPTION
**Purpose**

Use celery in local development for better
dev-prod parity.

We used to disable celery for local dev in the
pre-Docker days so that devs didn't have to install
rabbitmq and run celery.

Nowadays, running celery is as easy as `docker-compose up -d worker`,
so no need to disable it.

See @icereval's comment in https://github.com/CenterForOpenScience/osf.io/pull/8666#issuecomment-418939103

**Changes**

* Don't override `USE_CELERY` in local-dist.py

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
