### PR TITLE
[PLAT-719] Bring Google analytics up to date with Ember

### DIFF
--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -199,7 +199,7 @@
             ga('create', ${ settings.GOOGLE_ANALYTICS_ID | sjson, n }, 'auto', {'allowLinker': true});
             ga('require', 'linker');
             ga('linker:autoLink', ['centerforopenscience.org', 'cos.io'] );
-            ga('set', 'dimension1', (${ user_id | sjson, n} != "") ? 'logged in': 'not logged in');
+            ga('set', 'dimension1', (${ user_id | sjson, n} != "") ? 'Logged in': 'Logged out');
             ga('set', 'dimension2', '${self.resource()}');
             ga('set', 'dimension3', '${self.public()}');
             ga('set', 'anonymizeIp', true);
@@ -275,12 +275,12 @@
 </%def>
 
 <%def name="resource()"><%
-    return None
+    return 'n/a'
 %> ### What resource is displayed on page ###
 </%def>
 
 <%def name="public()"><%
-    return None
+    return 'n/a'
 %> ### What the public/private status of the resource displayed on page ###
 </%def>
 

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -2,17 +2,13 @@
 
 <%def name="resource()"><%
     if context.get('file_id'):
-        prefix = 'file for a '
-    else:
-        prefix = ''
+        return 'files'
     if node.get('is_registration', False):
-        return prefix + 'registration'
+        return 'registrations'
     elif node.get('is_preprint', False):
-        return prefix + 'preprint'
-    elif parent_node['exists']:
-        return prefix + 'component'
+        return 'preprints'
     else:
-        return prefix + 'project'
+        return 'nodes'
     %>
 </%def>
 

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -2,18 +2,20 @@
 
 <%def name="resource()"><%
     if context.get('file_id'):
-        return 'files'
-    if node.get('is_registration', False):
-        return 'registrations'
-    elif node.get('is_preprint', False):
-        return 'preprints'
+        prefix = 'file for a '
     else:
-        return 'nodes'
+        prefix = ''
+    if node.get('is_registration', False):
+        return prefix + 'registrations'
+    elif node.get('is_preprint', False):
+        return prefix + 'preprints'
+    else:
+        return prefix + 'nodes'
     %>
 </%def>
 
 <%def name="public()"><%
-    return node.get('is_public', False)
+    return 'public' if node.get('is_public', False) else 'private'
     %>
 </%def>
 


### PR DESCRIPTION
## Purpose

GA custom dimension reporting for Embosf and osf.io is slightly different. This should make them identical.

## Changes

- custom dimension #1 is now capitalized
- custom dimension #2 now uses the resource type so "projects" or "components" are now "nodes"
- custom dimension #3 is no longer a bool, but either "public", "private" or "n/a"
## QA Notes

You should be able to set up a GA account and see the custom analytics been sent to it and see that they are seemly with the Ember analytics. Instructions on how to set up a GA account with custom dimensions are in the old PR for this [here](https://github.com/CenterForOpenScience/osf.io/pull/8140)

## Documentation

Basically a bug fix, no docs required.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-719