### PR TITLE
[no ticket] Remove ember-osf linked config for ember_osf_web

### DIFF
--- a/docker-compose-dist.override.yml
+++ b/docker-compose-dist.override.yml
@@ -26,22 +26,6 @@ version: "3.4"
 #  ember_osf_web:
 #    volumes:
 #      - ../ember-osf-web:/code
-#
-##      # Use this for ember-osf linked development:
-##      - ember_osf_web_dist_vol:/code/dist
-##      - ../ember-osf:/ember-osf
-##    depends_on:
-##      - emberosf
-##    command:
-##      - /bin/bash
-##      - -c
-##      - cd /ember-osf &&
-##        yarn link &&
-##        cd /code &&
-##        (rm -r node_modules || true) &&
-##        yarn --frozen-lockfile &&
-##        yarn link @centerforopenscience/ember-osf &&
-##        yarn start --host 0.0.0.0 --port 4200 --live-reload-port 41953
 
 #  preprints:
 #    volumes:


### PR DESCRIPTION
## Purpose

`ember-osf-web` does not consume `ember-osf`

## Changes

Remove commented out config for linked `ember-osf` development from `ember_osf_web` section of `docker-compose-dist.override.yml`.

## QA Notes

n/a

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a