### PR TITLE
[no ticket] Remove ember_osf_web from docker-compose-dist.override

### DIFF
--- a/docker-compose-dist.override.yml
+++ b/docker-compose-dist.override.yml
@@ -23,10 +23,6 @@ version: "3.4"
 #    volumes:
 #      - ../modular-file-renderer:/code
 
-#  ember_osf_web:
-#    volumes:
-#      - ../ember-osf-web:/code
-
 #  preprints:
 #    volumes:
 #      - ../ember-osf-preprints:/code


### PR DESCRIPTION
## Purpose

Remove ember_osf_web from docker-compose-dist.override (since we don't use it)

## Changes

Remove ember_osf_web from docker-compose-dist.override.yml

## QA Notes

n/a

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a
