### PR TITLE
Add missing api_tests to inv task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -329,18 +329,25 @@ API_TESTS1 = [
 API_TESTS2 = [
     'api_tests/actions',
     'api_tests/nodes',
-    'api_tests/requests'
+    'api_tests/requests',
+    'api_tests/subscriptions',
+    'api_tests/waffle',
+    'api_tests/wb',
 ]
 API_TESTS3 = [
     'api_tests/addons_tests',
+    'api_tests/alerts',
     'api_tests/applications',
+    'api_tests/banners',
     'api_tests/base',
     'api_tests/collections',
     'api_tests/comments',
+    'api_tests/crossref',
     'api_tests/files',
     'api_tests/guids',
     'api_tests/reviews',
     'api_tests/search',
+    'api_tests/scopes',
     'api_tests/taxonomies',
     'api_tests/test',
     'api_tests/tokens',

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -331,8 +331,8 @@ API_TESTS2 = [
     'api_tests/nodes',
     'api_tests/requests',
     'api_tests/subscriptions',
-    'api_tests/waffle',
-    'api_tests/wb',
+    # 'api_tests/waffle',
+    # 'api_tests/wb',
 ]
 API_TESTS3 = [
     'api_tests/addons_tests',


### PR DESCRIPTION
#### Purpose
* Add missing api_test directories to invoke tasks so they'll be run by travis. 

#### Changes
* Added missing directories to `API_TESTS`

#### Side Effects
* I randomly picked between `API_TESTS2` and `API_TESTS3` lists. Looking at a recent build, 1 seems to be the slowest and 2 is currently the fastest. 

