### PR TITLE
Always respect logging level set in website.settings

### DIFF
--- a/framework/logging/__init__.py
+++ b/framework/logging/__init__.py
@@ -29,7 +29,4 @@ handler.setFormatter(formatter)
 
 logger = logging.getLogger()
 logger.addHandler(handler)
-if settings.DEBUG_MODE:
-    logger.setLevel(logging.DEBUG)
-else:
-    logger.setLevel(settings.LOG_LEVEL)
+logger.setLevel(settings.LOG_LEVEL)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -28,7 +28,6 @@ STATIC_URL_PATH = '/static'
 ASSET_HASH_PATH = os.path.join(APP_PATH, 'webpack-assets.json')
 ROOT = os.path.join(BASE_PATH, '..')
 BCRYPT_LOG_ROUNDS = 12
-# Logging level to use when DEBUG is False
 LOG_LEVEL = logging.INFO
 
 with open(os.path.join(APP_PATH, 'package.json'), 'r') as fobj:


### PR DESCRIPTION
**Purpose**

DEBUG is too chatty, even for local dev. My flask server logs are full of junk like this:

![image](https://user-images.githubusercontent.com/2379650/45226660-6fc34080-b28d-11e8-8169-3a0aa2584b43.png)


There's no need to implicitly set the logging level to DEBUG
when DEBUG_MODE is one. This can be set explicitly in local.py
if needed.

**Changes**

The log level for the flask app will always be whatever
`settings.LOG_LEVEL` is set to, even if `DEBUG_MODE = True`

**Side effects**

DEBUG logs will no longer show by default in local dev.

If you need these, set `LOG_LEVEL = logging.DEBUG` in
`website/settings/local.py`.

**QA**

No QA--this only affects local dev

