### PR TITLE
When moving a file, update the most recent version's region if needbe [PLAT-1053]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -166,6 +166,10 @@ class OsfStorageFileNode(BaseFileNode):
                 raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
+        most_recent_fileversion = self.versions.select_related('region').order_by('-created').first()
+        if most_recent_fileversion.region != destination_parent.target.osfstorage_region:
+            most_recent_fileversion.region = destination_parent.target.osfstorage_region
+            most_recent_fileversion.save()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)
 
     def check_in_or_out(self, user, checkout, save=False):


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When moving a file, update the file's most recent version's region to match the destination region, if it's different. The region metadata for a move is already updated waterbutler side on an inter-region move, so we should update this end as well!

## Changes

- On an inter-region move, update the most recent version of the file being moved to match the destination's region

## QA Notes

This is for that side use case we talked about! This should fix the case in which a file is moved regions and then a new version of that file is updated.

## Documentation

None needed

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-1053
