### PR TITLE
 [PLAT-1100] Update the most recent fileversions region for copied files across regions

### DIFF
--- a/website/files/utils.py
+++ b/website/files/utils.py
@@ -2,7 +2,7 @@
 def copy_files(src, target_node, parent=None, name=None):
     """Copy the files from src to the target node
     :param Folder src: The source to copy children from
-    :param Node target_node: The node settings of the project to copy files to
+    :param Node target_node: The node to copy files to
     :param Folder parent: The parent of to attach the clone of src to, if applicable
     """
     assert not parent or not parent.is_file, 'Parent must be a folder'
@@ -17,6 +17,10 @@ def copy_files(src, target_node, parent=None, name=None):
 
     if src.is_file and src.versions.exists():
         cloned.versions.add(*src.versions.all())
+        most_recent_fileversion = cloned.versions.select_related('region').order_by('-created').first()
+        if most_recent_fileversion.region != target_node.osfstorage_region:
+            most_recent_fileversion.region = target_node.osfstorage_region
+            most_recent_fileversion.save()
 
     if not src.is_file:
         for child in src.children:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When a file is copied from one region to another, none of its versions followed and it was simply treated as a new node. Now, let's bring along all the other regions for the move and just update the most recent version to be the same as the destination node's region, leaving the other versions in their original region.
<!-- Describe the purpose of your changes -->

## Changes
- in `copy_files`, copy over all the old versions and then update the most recent one to be in the destination node's region

## QA Notes
This is the OSF side of being able to copy all the versions of a file across regions! For a super through test the most recent version of a file would be stored on the destination nodes region, and all the other versions of the node would be on the origin node's region.


## Documentation
None needed

## Side Effects
None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1100
