### PR TITLE
Add `:cached` to override bind mounts

### DIFF
--- a/docker-compose-dist.override.yml
+++ b/docker-compose-dist.override.yml
@@ -5,27 +5,27 @@ version: "3.4"
 
 #  wb:
 #    volumes:
-#      - ../waterbutler:/code
+#      - ../waterbutler:/code:cached
 
 #  wb_worker:
 #    volumes:
-#      - ../waterbutler:/code
+#      - ../waterbutler:/code:cached
 
 #  wb_requirements:
 #    volumes:
-#      - ../waterbutler:/code
+#      - ../waterbutler:/code:cached
 
 #  mfr:
 #    volumes:
-#      - ../modular-file-renderer:/code
+#      - ../modular-file-renderer:/code:cached
 
 #  mfr_requirements:
 #    volumes:
-#      - ../modular-file-renderer:/code
+#      - ../modular-file-renderer:/code:cached
 
 #  preprints:
 #    volumes:
-#      - ../ember-osf-preprints:/code
+#      - ../ember-osf-preprints:/code:cached
 #
 ##      # Use this for ember-osf linked development:
 ##      - preprints_dist_vol:/code/dist
@@ -47,7 +47,7 @@ version: "3.4"
 
 #  registries:
 #    volumes:
-#      - ../ember-osf-registries:/code
+#      - ../ember-osf-registries:/code:cached
 #
 ##      # Use this for ember-osf linked development:
 ##      - registries_dist_vol:/code/dist
@@ -67,7 +67,7 @@ version: "3.4"
 
 #  reviews:
 #    volumes:
-#      - ../ember-osf-reviews:/code
+#      - ../ember-osf-reviews:/code:cached
 #
 ##      # Use this for ember-osf linked development:
 ##      - reviews_dist_vol:/code/dist


### PR DESCRIPTION
Similar to 7b1aed6305d07dbcc38ec9812e6cb90b073fa192, default to using
`:cached` mode on mounted volumes in
`docker-compose-dist.override.yml` to avoid high CPU usage on
Docker4Mac.  See [1], [2].  If you've already created a
`docker-compose.override.yml`, manual append `:cached` to all volumes
except those under `emberosf` and `rabbitmq`.

[1] https://docs.docker.com/docker-for-mac/osxfs-caching/#cached

[2] https://github.com/docker/for-mac/issues/1759#issuecomment-366632793

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
