### PR TITLE
[PLAT-1100] Create a new version from the most recent when copying

### DIFF
--- a/website/files/utils.py
+++ b/website/files/utils.py
@@ -1,5 +1,3 @@
-from osf.models.base import generate_object_id
-
 
 def copy_files(src, target_node, parent=None, name=None):
     """Copy the files from src to the target node
@@ -23,12 +21,11 @@ def copy_files(src, target_node, parent=None, name=None):
         if most_recent_fileversion.region != target_node.osfstorage_region:
             # add all original version except the most recent
             cloned.versions.add(*fileversions[1:])
-            # setting the id to None and calling save generates a new object
-            most_recent_fileversion.id = None
-            most_recent_fileversion._id = generate_object_id()
-            most_recent_fileversion.region = target_node.osfstorage_region
-            most_recent_fileversion.save()
-            cloned.versions.add(most_recent_fileversion)
+            # create a new most recent version and update the region before adding
+            new_fileversion = most_recent_fileversion.clone()
+            new_fileversion.region = target_node.osfstorage_region
+            new_fileversion.save()
+            cloned.versions.add(new_fileversion)
         else:
             cloned.versions.add(*src.versions.all())
     if not src.is_file:

--- a/website/files/utils.py
+++ b/website/files/utils.py
@@ -18,7 +18,7 @@ def copy_files(src, target_node, parent=None, name=None):
     if src.is_file and src.versions.exists():
         fileversions = src.versions.select_related('region').order_by('-created')
         most_recent_fileversion = fileversions.first()
-        if most_recent_fileversion.region != target_node.osfstorage_region:
+        if most_recent_fileversion.region and most_recent_fileversion.region != target_node.osfstorage_region:
             # add all original version except the most recent
             cloned.versions.add(*fileversions[1:])
             # create a new most recent version and update the region before adding


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This will allow the most recent version of the cloned file to have the correct region, while the fileversion from the original file keeps its region

## Changes

- Create a new fileversion instead of adding FKs to all the old fileversions


## QA Notes

This should fix Lauren's most recent reported bug, and expected shouldnow happen!
Upload a file to region A
Give the file at least 2 versions
Copy it to region B
Upload a new version to region A
Try to render the file from region A
Expected
File would render.

## Documentation
none

## Side Effects
none

## Ticket
https://openscience.atlassian.net/browse/PLAT-1100
