### PR TITLE
Hotfix/Custom Domains Redirect Fix [PLAT-1108]

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -130,7 +130,7 @@ def serialize_node_summary(node, auth, primary=True, show_path=False):
 
 def index():
     # Check if we're on an institution landing page
-    institution = Institution.objects.filter(domains__icontains=[request.host], is_deleted=False)
+    institution = Institution.objects.filter(domains__icontains=request.host, is_deleted=False)
     if institution.exists():
         return redirect('{}institutions/{}/'.format(DOMAIN, institution.get()._id))
     else:


### PR DESCRIPTION
## Purpose

Custom institution domain redirects aren't working.  ember-osf-web’s index.html is served instead of the institution detail page.  


## Changes

Fixes bug introduced in https://github.com/CenterForOpenScience/osf.io/pull/8576

Line used to be this institution = Institution.objects.get(domains__contains=[request.host.lower()], is_deleted=False)

https://github.com/CenterForOpenScience/osf.io/pull/8576 made it institution = Institution.objects.filter(domains__icontains=[request.host], is_deleted=False)  (which will return an empty queryset)

should be something like:
 institution = Institution.objects.get(domains__contains=request.host.lower(), is_deleted=False), removing array since using `icontains`


## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here. 
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-1108