### PR TITLE
[IN-372][OSF] Fix ChronosJournalDetail url, change OsfStorageFile query.

### DIFF
--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -20,6 +20,8 @@ class ChronosJournalSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'chronos-journals'
 
+    filterable_fields = frozenset(['title', 'name'])
+
     id = ser.CharField(source='journal_id', read_only=True)
     name = ser.CharField(read_only=True)
     title = ser.CharField(read_only=True)

--- a/api/chronos/urls.py
+++ b/api/chronos/urls.py
@@ -6,7 +6,7 @@ app_name = 'osf'
 
 urlpatterns = [
     url(r'^journals/$', views.ChronosJournalList.as_view(), name=views.ChronosJournalList.view_name),
-    url(r'^journals/(?P<journal_id>\w+)/$', views.ChronosJournalDetail.as_view(), name=views.ChronosJournalDetail.view_name),
+    url(r'^journals/(?P<journal_id>[0-9]{4}-[0-9]{4})/$', views.ChronosJournalDetail.as_view(), name=views.ChronosJournalDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/submissions/$', views.ChronosSubmissionList.as_view(), name=views.ChronosSubmissionList.view_name),
     url(r'^(?P<preprint_id>\w+)/submissions/(?P<submission_id>\w+)/$', views.ChronosSubmissionDetail.as_view(), name=views.ChronosSubmissionDetail.view_name),
 ]

--- a/api/chronos/urls.py
+++ b/api/chronos/urls.py
@@ -6,7 +6,7 @@ app_name = 'osf'
 
 urlpatterns = [
     url(r'^journals/$', views.ChronosJournalList.as_view(), name=views.ChronosJournalList.view_name),
-    url(r'^journals/(?P<journal_id>[0-9]{4}-[0-9]{4})/$', views.ChronosJournalDetail.as_view(), name=views.ChronosJournalDetail.view_name),
+    url(r'^journals/(?P<journal_id>[-0-9A-Za-z]+)/$', views.ChronosJournalDetail.as_view(), name=views.ChronosJournalDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/submissions/$', views.ChronosSubmissionList.as_view(), name=views.ChronosSubmissionList.view_name),
     url(r'^(?P<preprint_id>\w+)/submissions/(?P<submission_id>\w+)/$', views.ChronosSubmissionDetail.as_view(), name=views.ChronosSubmissionDetail.view_name),
 ]

--- a/api_tests/chronos/views/test_chronos_journal_list.py
+++ b/api_tests/chronos/views/test_chronos_journal_list.py
@@ -29,3 +29,33 @@ class TestChronosJournalList:
     def test_journal_list(self, res, data, journal_ids):
         assert res.status_code == 200
         assert set(journal_ids) == set([datum['id'] for datum in data])
+
+
+@pytest.mark.django_db
+class TestChronosJournalListFilter:
+
+    @pytest.fixture()
+    def journal_one(self):
+        return ChronosJournalFactory()
+
+    @pytest.fixture()
+    def journal_two(self):
+        return ChronosJournalFactory()
+
+    @pytest.fixture()
+    def journal_one_filter_name_url(self, journal_one):
+        return '/_/chronos/journals/?filter[name]={}'.format(journal_one.name)
+
+    @pytest.fixture()
+    def journal_one_filter_title_url(self, journal_one):
+        return '/_/chronos/journals/?filter[title]={}'.format(journal_one.title)
+
+    def test_journal_list_filter_by_name(self, app, journal_one, journal_two, journal_one_filter_name_url):
+        res = app.get(journal_one_filter_name_url)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['name'] == journal_one.name
+
+    def test_journal_list_filter_by_title(self, app, journal_one, journal_two, journal_one_filter_title_url):
+        res = app.get(journal_one_filter_title_url)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['title'] == journal_one.title

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -60,7 +60,7 @@ class ChronosSerializer(object):
             ],
             'MANUSCRIPT_FILES': [
                 cls.serialize_file(preprint, file_node)
-                for file_node in OsfStorageFile.objects.filter(node=preprint.node)
+                for file_node in OsfStorageFile.objects.filter(abstractnode=preprint.node)
             ],
             'STATUS_CODE': status,
             'ABSTRACT': preprint.node.description,


### PR DESCRIPTION
## Purpose

This PR fixes two problems:
- When we serialize the manuscript, the `OsfStorageFile` query fails because the name of the keyworded argument should be `abstractnode` instead of `node`.
- For the `ChronosJournalDetailView`, the regex that matches the url is incorrect as the `journal_id` returned from the Chronos API is in different formats (e.g. `2160-3308`, `1234-123X`, `12345678`). Therefore, `\w+` does not match the id because `\w` only matches `[0-9a-zA-Z_]` and does not match `-`.

This PR adds one functionality:
- Enable filtering by `name` and `title` for journals.

## Changes

Three changes are made:
- For `osf/external/chronos.py`, the `OsfFileStorage` query is changed to use `abstractnode` as the name of the keyworded argument.
- For `api/chronos/urls.py`, the regex for `ChronosJournalDetailView` is changed to `[-0-9A-Za-z]+` to match the journal id.
- `name` and `title` is added as `filterable_fields` for `ChronosJournalSerializers`

## QA Notes

No QA is needed.

## Ticket

https://openscience.atlassian.net/browse/IN-372
