### PR TITLE
[HotFix]  Fix the institution logo cut-off issue on the project settings page [SVCS-917]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -868,6 +868,7 @@ def get_affiliated_institutions(obj):
         ret.append({
             'name': institution.name,
             'logo_path': institution.logo_path,
+            'logo_path_rounded_corners': institution.logo_path_rounded_corners,
             'id': institution._id,
         })
     return ret

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -442,7 +442,7 @@
                          <tbody>
                              <!-- ko foreach: {data: affiliatedInstitutions, as: 'item'} -->
                              <tr>
-                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
+                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path_rounded_corners}"></td>
                                  <td><span data-bind="text: item.name"></span></td>
                                  <td>
                                      % if 'admin' in user['permissions']:
@@ -464,7 +464,7 @@
                          <tbody>
                              <!-- ko foreach: {data: availableInstitutions, as: 'item'} -->
                              <tr>
-                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
+                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path_rounded_corners}"></td>
                                  <td><span data-bind="text: item.name"></span></td>
                                  % if 'write' in user['permissions']:
                                      <td><button


### PR DESCRIPTION
## Purpose

Section "Affiliated Institutions" and "Available Institutions" in the "Project Settings" page should use the logo with rounded corners to prevent the circular image frame from cutting off its corners.

## Changes

* Updated the `projects/settings.mako` to use `logo_path_rounded_corners` instead of `logo_path`.
* Updated `get_affiliated_institutions()` in `node.py` to return `logo_path_rounded_corners`.

### Before

![screen shot 2018-09-18 at 9 51 22 am](https://user-images.githubusercontent.com/3750414/45692425-ba17ad80-bb28-11e8-85ae-b8a90c26092e.png)

### After

![screen shot 2018-09-18 at 9 27 54 am](https://user-images.githubusercontent.com/3750414/45692447-c439ac00-bb28-11e8-896b-7cfcd214a733.png)

## QA Notes

It is impossible to test on staging without having a working institution. One thing QA can do is to either use the Admin App or ask Devs who can modify staging DB to manually affiliate users with a few institutions. I did the same thing locally. Make sure the logos looks good in section "Affiliated Institutions" and "Available Institutions" on the "Project Settings" page.

## Documentation

No

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/SVCS-917
