### PR TITLE
[feature] Add waffle switch for engagement emails [PLAT-1076]

### DIFF
--- a/osf/features.py
+++ b/osf/features.py
@@ -1,0 +1,1 @@
+DISABLE_ENGAGEMENT_EMAILS = 'disable_engagement_emails'

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -1,3 +1,5 @@
+import waffle
+
 from django.db import models
 from django.utils import timezone
 
@@ -6,6 +8,7 @@ from website.mails import Mail, send_mail
 from website.mails import presends
 from website import settings as osf_settings
 
+from osf.features import DISABLE_ENGAGEMENT_EMAILS
 from osf.models.base import BaseModel, ObjectIDMixin
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 
@@ -88,6 +91,8 @@ def queue_mail(to_addr, mail, send_at, user, **context):
                     not parameters.
     :return: the QueuedMail object created
     """
+    if waffle.switch_is_active(DISABLE_ENGAGEMENT_EMAILS) and mail.get('engagement', False):
+        return False
     new_mail = QueuedMail(
         user=user,
         to_addr=to_addr,
@@ -104,6 +109,7 @@ def queue_mail(to_addr, mail, send_at, user, **context):
 #    'template': the mako template used for email_type,
 #    'subject': subject used for the actual email,
 #    'categories': categories to attach to the email using Sendgrid's SMTPAPI.
+#    'engagement': Whether this is an engagement email that can be disabled with the disable_engagement_emails waffle flag
 #    'presend': predicate function that determines whether an email should be sent. May also
 #               modify mail.data.
 #}
@@ -112,21 +118,24 @@ NO_ADDON = {
     'template': 'no_addon',
     'subject': 'Link an add-on to your OSF project',
     'presend': presends.no_addon,
-    'categories': ['engagement', 'engagement-no-addon']
+    'categories': ['engagement', 'engagement-no-addon'],
+    'engagement': True
 }
 
 NO_LOGIN = {
     'template': 'no_login',
     'subject': 'What you\'re missing on the OSF',
     'presend': presends.no_login,
-    'categories': ['engagement', 'engagement-no-login']
+    'categories': ['engagement', 'engagement-no-login'],
+    'engagement': True
 }
 
 NEW_PUBLIC_PROJECT = {
     'template': 'new_public_project',
     'subject': 'Now, public. Next, impact.',
     'presend': presends.new_public_project,
-    'categories': ['engagement', 'engagement-new-public-project']
+    'categories': ['engagement', 'engagement-new-public-project'],
+    'engagement': True
 }
 
 PREREG_REMINDER = {
@@ -140,7 +149,8 @@ WELCOME_OSF4M = {
     'template': 'welcome_osf4m',
     'subject': 'The benefits of sharing your presentation',
     'presend': presends.welcome_osf4m,
-    'categories': ['engagement', 'engagement-welcome-osf4m']
+    'categories': ['engagement', 'engagement-welcome-osf4m'],
+    'engagement': True
 }
 
 NO_ADDON_TYPE = 'no_addon'

--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -5,15 +5,18 @@ import datetime as dt
 import pytest
 import mock
 from django.utils import timezone
+from waffle.testutils import override_switch
 from framework.auth.core import Auth
 from website.prereg.utils import get_prereg_schema
 
 from .factories import UserFactory, NodeFactory, DraftRegistrationFactory
 
+from osf.features import DISABLE_ENGAGEMENT_EMAILS
 from osf.models.queued_mail import (
     queue_mail, WELCOME_OSF4M,
     NO_LOGIN, NO_ADDON, NEW_PUBLIC_PROJECT, PREREG_REMINDER
 )
+from website.mails import mails
 from website.settings import DOMAIN
 
 @pytest.fixture()
@@ -183,3 +186,15 @@ class TestQueuedMail:
         prereg.deleted = timezone.now()
         prereg.save()
         assert not mail.send_mail()
+
+    def test_disabled_queued_emails_not_sent_if_switch_active(self, user):
+        with override_switch(DISABLE_ENGAGEMENT_EMAILS, active=True):
+            assert self.queue_mail(mail=NO_ADDON, user=user) is False
+            assert self.queue_mail(mail=NO_LOGIN, user=user) is False
+            assert self.queue_mail(mail=WELCOME_OSF4M, user=user) is False
+            assert self.queue_mail(mail=NEW_PUBLIC_PROJECT, user=user) is False
+
+    def test_disabled_triggered_emails_not_sent_if_switch_active(self):
+        with override_switch(DISABLE_ENGAGEMENT_EMAILS, active=True):
+            assert mails.send_mail(to_addr='', mail=mails.WELCOME) is False
+            assert mails.send_mail(to_addr='', mail=mails.WELCOME_OSF4I) is False

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -20,10 +20,12 @@ Usage: ::
 """
 import os
 import logging
+import waffle
 
 from mako.lookup import TemplateLookup, Template
 
 from framework.email import tasks
+from osf.features import DISABLE_ENGAGEMENT_EMAILS
 from website import settings
 
 logger = logging.getLogger(__name__)
@@ -36,6 +38,10 @@ _tpl_lookup = TemplateLookup(
 
 HTML_EXT = '.html.mako'
 
+DISABLED_MAILS = [
+    'welcome',
+    'welcome_osf4i'
+]
 
 class Mail(object):
     """An email object.
@@ -45,12 +51,15 @@ class Mail(object):
     :param iterable categories: Categories to add to the email using SendGrid's
         SMTPAPI. Used for email analytics.
         See https://sendgrid.com/docs/User_Guide/Statistics/categories.html
+    :param: bool engagement: Whether this is an engagement email that can be disabled with
+        the disable_engagement_emails waffle flag
     """
 
-    def __init__(self, tpl_prefix, subject, categories=None):
+    def __init__(self, tpl_prefix, subject, categories=None, engagement=False):
         self.tpl_prefix = tpl_prefix
         self._subject = subject
         self.categories = categories
+        self.engagement = engagement
 
     def html(self, **context):
         """Render the HTML email message."""
@@ -87,6 +96,8 @@ def send_mail(
     .. note:
          Uses celery if available
     """
+    if waffle.switch_is_active(DISABLE_ENGAGEMENT_EMAILS) and mail.engagement:
+        return False
 
     from_addr = from_addr or settings.FROM_EMAIL
     mailer = mailer or tasks.send_email
@@ -367,12 +378,14 @@ ARCHIVE_SUCCESS = Mail(
 
 WELCOME = Mail(
     'welcome',
-    subject='Welcome to the Open Science Framework'
+    subject='Welcome to the Open Science Framework',
+    engagement=True
 )
 
 WELCOME_OSF4I = Mail(
     'welcome_osf4i',
-    subject='Welcome to the Open Science Framework'
+    subject='Welcome to the Open Science Framework',
+    engagement=True
 )
 
 PREREG_CHALLENGE_REJECTED = Mail(


### PR DESCRIPTION
## Purpose
Allows engagement emails to be temporarily disabled by a waffle switch ("disable_engagement_emails"). When the switch is active, users should not receive **any** of the emails listed below.  

## Changes
Added osf/features.py to start keeping track of waffle flags/switches.

## QA Notes
Confirm that when the switch is active, you **do not** receive the following emails. The google doc in the ticket description will be helpful in determining how some emails are triggered.

**Welcome**
* Sent immediately
* Subject: "Welcome to the Open Science Framework"

**Welcome OSF4I** 
* Sent immediately
* Subject: "Welcome to the Open Science Framework" (contains "Affiliate your projects with your institution" in the email body)

**No addons**
* Queued 
* Subject: "Link an add-on to your OSF project"

**No login**
* Queued
* Subject: "What you're missing on the OSF"

**New public project** 
* Queued
* Subject: "Now, public. Next, impact."

**Welcome OSF4M**
* Queued
* Subject: "The benefits of sharing your presentation"

## Ticket
https://openscience.atlassian.net/browse/PLAT-1076
