### PR TITLE
[hotfix] Don't let users move a folder with a preprint in it [PLAT-1116]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -432,7 +432,7 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
     @property
     def is_preprint_primary(self):
         if hasattr(self.target, 'preprint_file') and self.target.preprint_file:
-            for child in self.children.all().prefetch_related('target'):
+            for child in self.children.all():
                 if getattr(child.target, 'preprint_file', None):
                     if child.is_preprint_primary:
                         return True


### PR DESCRIPTION

## Purpose

Prefetching `target` on children when checking `is_preprint_primary` was causing the child's `is_preprint_primary` property to not work properly. Removing this prevents folders from preprints from being moved. Thanks @felliott!  (aaah sorry other Fitz I accidentally tagged just now!)
 

## Changes

- Remove prefetch related on children query for `is_preprint_primary` on `OsfStorageFolder`

## QA Notes

You should no longer be able to move a folder containing a preprint to another component. 

This should happen (modified from the ticket):
1. Create a preprint
2. After preprint is created, go to the OSF project
3. Create a component under the project
4. On the OSF project (with preprint), create a folder 
5. Move the preprint file into this folder.
6. Try Move this folder into the component
7. This action should fail

## Documentation

None anticipated

## Side Effects

Nope

## Ticket
https://openscience.atlassian.net/browse/PLAT-1116