### PR TITLE
[feature] Add FileMetadataSchema list and detail endpoints [PLAT-820]

### DIFF
--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -29,6 +29,12 @@ class RegistrationSchemaSerializer(SchemaSerializer):
         type_ = 'registration_schemas'
 
 
+class FileMetadataSchemaSerializer(SchemaSerializer):
+
+    class Meta:
+        type_ = 'file_metadata_schemas'
+
+
 class DeprecatedMetaSchemaSerializer(SchemaSerializer):
 
     class Meta:

--- a/api/schemas/urls.py
+++ b/api/schemas/urls.py
@@ -7,4 +7,6 @@ app_name = 'osf'
 urlpatterns = [
     url(r'^registrations/$', views.RegistrationSchemaList.as_view(), name=views.RegistrationSchemaList.view_name),
     url(r'^registrations/(?P<schema_id>\w+)/$', views.RegistrationSchemaDetail.as_view(), name=views.RegistrationSchemaDetail.view_name),
+    url(r'^files/$', views.FileMetadataSchemaList.as_view(), name=views.FileMetadataSchemaList.view_name),
+    url(r'^files/(?P<schema_id>\w+)/$', views.FileMetadataSchemaDetail.as_view(), name=views.FileMetadataSchemaDetail.view_name),
 ]

--- a/api/schemas/views.py
+++ b/api/schemas/views.py
@@ -6,8 +6,14 @@ from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
 from api.base.utils import get_object_or_error
 
-from osf.models import RegistrationSchema
-from api.schemas.serializers import RegistrationSchemaSerializer
+from osf.models import (
+    RegistrationSchema,
+    FileMetadataSchema,
+)
+from api.schemas.serializers import (
+    RegistrationSchemaSerializer,
+    FileMetadataSchemaSerializer,
+)
 
 
 class RegistrationSchemaList(JSONAPIBaseView, generics.ListAPIView):
@@ -52,3 +58,44 @@ class RegistrationSchemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     def get_object(self):
         schema_id = self.kwargs['schema_id']
         return get_object_or_error(RegistrationSchema, schema_id, self.request)
+
+
+class FileMetadataSchemaList(JSONAPIBaseView, generics.ListAPIView):
+
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.SCHEMA_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = FileMetadataSchemaSerializer
+    view_category = 'file-metadata-schemas'
+    view_name = 'file-metadata-schema-list'
+
+    ordering = ('-id',)
+
+    # overrides ListCreateAPIView
+    def get_queryset(self):
+        return FileMetadataSchema.objects.filter(active=True)
+
+
+class FileMetadataSchemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
+
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.SCHEMA_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = FileMetadataSchemaSerializer
+    view_category = 'file-metadata-schemas'
+    view_name = 'file-metadata-schema-detail'
+
+    # overrides RetrieveAPIView
+    def get_object(self):
+        schema_id = self.kwargs['schema_id']
+        return get_object_or_error(FileMetadataSchema, schema_id, self.request)

--- a/api_tests/schemas/views/test_file_metadata_schema_detail.py
+++ b/api_tests/schemas/views/test_file_metadata_schema_detail.py
@@ -1,0 +1,43 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf.models import FileMetadataSchema
+from osf_tests.factories import (
+    AuthUserFactory,
+)
+
+
+@pytest.mark.django_db
+class TestFileMetadataSchemaDetail:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def schema(self):
+        return FileMetadataSchema.objects.filter(name='datacite', active=True).first()
+
+    @pytest.fixture()
+    def url(self, schema):
+        return '/{}schemas/files/{}/'.format(API_BASE, schema._id)
+
+    def test_schema_detail_crud(self, app, user, schema, url):
+        # test_authenticated_user_can_view_schema
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == schema._id
+
+        # test_cannot_update_schema
+        res = app.put_json_api(url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # test_unauthenticated_user_can_view_schema
+        res = app.get(url)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == schema._id
+
+    def test_invalid_schema_not_found(self, app):
+        bad_url = '/{}schemas/files/garbage/'.format(API_BASE)
+        res = app.get(bad_url, expect_errors=True)
+        assert res.status_code == 404

--- a/api_tests/schemas/views/test_file_metadata_schema_list.py
+++ b/api_tests/schemas/views/test_file_metadata_schema_list.py
@@ -1,0 +1,33 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf.models.metaschema import FileMetadataSchema
+from osf_tests.factories import (
+    AuthUserFactory,
+)
+
+
+@pytest.mark.django_db
+class TestFileMetadataSchemaList:
+
+    def test_schema_list_crud(self, app):
+
+        user = AuthUserFactory()
+        url = '/{}schemas/files/'.format(API_BASE)
+
+        # test_authenticated_user_can_view_schemas
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert (len(res.json['data']) == FileMetadataSchema.objects.filter(active=True).count())
+
+        # test_cannot_update_schemas
+        res = app.put_json_api(url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # test_cannot_create_schemas
+        res = app.post_json_api(url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # test_unauthenticated_user_can_view_schemas
+        res = app.get(url)
+        assert res.status_code == 200

--- a/osf/metadata/schemas/datacite.json
+++ b/osf/metadata/schemas/datacite.json
@@ -1,5 +1,4 @@
 {
-  "__comment": "Schema copied from https://github.com/inveniosoftware/datacite/blob/v1.0.1/datacite/schemas/datacite-v4.0.json and should not be changed.",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "datacite-v4.0.json",
   "title": "DataCite v4.0",

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -83,4 +83,7 @@ class RegistrationSchema(AbstractSchema):
 
 class FileMetadataSchema(AbstractSchema):
 
-    pass
+    @property
+    def absolute_api_v2_url(self):
+        path = '/schemas/files/{}/'.format(self._id)
+        return api_v2_url(path)


### PR DESCRIPTION
#### Purpose
Make file metadata schemas discoverable via the API. 

#### Changes 
* Add `FileMetadataSchema` list and detail endpoints. 
  * Add basic test suites. 
* Stub out `FileMetadataSchemaSerializer`.

#### Ticket
https://openscience.atlassian.net/browse/PLAT-820
