### PR TITLE
[Chronos][IN-372][OSF] Filter ChronosSubmission queryset according to user permissions; Add permission class.

### DIFF
--- a/api/chronos/permissions.py
+++ b/api/chronos/permissions.py
@@ -37,18 +37,15 @@ class SubmissionAcceptedOrPublishedOrPreprintAdmin(permissions.BasePermission):
             if request.method == 'GET':
                 is_preprint_contributor = node.is_contributor(auth.user)
                 user_has_perm = is_preprint_contributor or is_submission_published or is_submission_accepted
+                if not user_has_perm:
+                    raise exceptions.NotFound
+
             # However if the request is a PATCH or PUT, check whether the user is an ADMIN of this preprint
             # Because only preprint admins can create/update a submission
             if request.method in ['PATCH', 'PUT']:
                 is_preprint_admin = node.has_permission(auth.user, osf_permissions.ADMIN)
                 user_has_perm = is_preprint_admin
+                if not user_has_perm:
+                    raise exceptions.PermissionDenied
 
-            # If the user has no permission to view this submission
-            # raise NotFound instead of PermissionDenied
-            # so that malicious users can't sniff out whether a preprint has Chronos submission or not
-            if not user_has_perm:
-                raise exceptions.NotFound
-            else:
-                return user_has_perm
-        else:
-            raise exceptions.NotFound
+            return user_has_perm

--- a/api/chronos/permissions.py
+++ b/api/chronos/permissions.py
@@ -41,7 +41,7 @@ class SubmissionAcceptedOrPublishedOrPreprintAdmin(permissions.BasePermission):
                     raise exceptions.NotFound
 
             # However if the request is a PATCH or PUT, check whether the user is an ADMIN of this preprint
-            # Because only preprint admins can create/update a submission
+            # Because only preprint admins can update a submission
             if request.method in ['PATCH', 'PUT']:
                 is_preprint_admin = node.has_permission(auth.user, osf_permissions.ADMIN)
                 user_has_perm = is_preprint_admin

--- a/api/chronos/permissions.py
+++ b/api/chronos/permissions.py
@@ -5,6 +5,8 @@ from rest_framework import exceptions
 from api.base.utils import get_user_auth
 from api.preprints.permissions import PreprintPublishedOrAdmin
 from osf.models import ChronosSubmission, PreprintService
+from osf.utils import permissions as osf_permissions
+
 
 class SubmissionOnPreprintPublishedOrAdmin(permissions.BasePermission):
     def has_permission(self, request, view):
@@ -19,17 +21,27 @@ class SubmissionOnPreprintPublishedOrAdmin(permissions.BasePermission):
         return PreprintPublishedOrAdmin().has_object_permission(request, view, obj)
 
 
-class SubmissionAcceptedOrPublishedOrPreprintContributor(permissions.BasePermission):
+class SubmissionAcceptedOrPublishedOrPreprintAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if isinstance(obj, ChronosSubmission):
             submission = ChronosSubmission.objects.get(publication_id=view.kwargs.get('submission_id', None))
             node = obj.preprint.node
             auth = get_user_auth(request)
 
-            is_preprint_contributor = node.is_contributor(auth.user)
             is_submission_accepted = submission.status == 3
             is_submission_published = submission.status == 4
-            user_has_perm = is_preprint_contributor or is_submission_published or is_submission_accepted
+
+            user_has_perm = False
+            # If the request is a GET, then check whether the user is a CONTRIBUTOR
+            # Because it is okay for us to show contributors detail of all submissions of this preprint
+            if request.method == 'GET':
+                is_preprint_contributor = node.is_contributor(auth.user)
+                user_has_perm = is_preprint_contributor or is_submission_published or is_submission_accepted
+            # However if the request is a PATCH or PUT, check whether the user is an ADMIN of this preprint
+            # Because only preprint admins can create/update a submission
+            if request.method in ['PATCH', 'PUT']:
+                is_preprint_admin = node.has_permission(auth.user, osf_permissions.ADMIN)
+                user_has_perm = is_preprint_admin
 
             # If the user has no permission to view this submission
             # raise NotFound instead of PermissionDenied
@@ -38,3 +50,5 @@ class SubmissionAcceptedOrPublishedOrPreprintContributor(permissions.BasePermiss
                 raise exceptions.NotFound
             else:
                 return user_has_perm
+        else:
+            raise exceptions.NotFound

--- a/api/chronos/permissions.py
+++ b/api/chronos/permissions.py
@@ -2,6 +2,7 @@
 from rest_framework import permissions
 from rest_framework import exceptions
 
+from api.base.utils import get_user_auth
 from api.preprints.permissions import PreprintPublishedOrAdmin
 from osf.models import ChronosSubmission, PreprintService
 
@@ -16,3 +17,24 @@ class SubmissionOnPreprintPublishedOrAdmin(permissions.BasePermission):
         if isinstance(obj, ChronosSubmission):
             obj = obj.preprint
         return PreprintPublishedOrAdmin().has_object_permission(request, view, obj)
+
+
+class SubmissionAcceptedOrPublishedOrPreprintContributor(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, ChronosSubmission):
+            submission = ChronosSubmission.objects.get(publication_id=view.kwargs.get('submission_id', None))
+            node = obj.preprint.node
+            auth = get_user_auth(request)
+
+            is_preprint_contributor = node.is_contributor(auth.user)
+            is_submission_accepted = submission.status == 3
+            is_submission_published = submission.status == 4
+            user_has_perm = is_preprint_contributor or is_submission_published or is_submission_accepted
+
+            # If the user has no permission to view this submission
+            # raise NotFound instead of PermissionDenied
+            # so that malicious users can't sniff out whether a preprint has Chronos submission or not
+            if not user_has_perm:
+                raise exceptions.NotFound
+            else:
+                return user_has_perm

--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -37,6 +37,7 @@ class ChronosSubmissionSerializer(JSONAPISerializer):
     id = ser.CharField(source='publication_id', read_only=True)
     submission_url = ser.CharField(read_only=True)
     status = ser.SerializerMethodField()
+    date_modified = ser.DateTimeField(source='modified', read_only=True)
 
     journal = RelationshipField(
         read_only=True,

--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -37,7 +37,7 @@ class ChronosSubmissionSerializer(JSONAPISerializer):
     id = ser.CharField(source='publication_id', read_only=True)
     submission_url = ser.CharField(read_only=True)
     status = ser.SerializerMethodField()
-    date_modified = ser.DateTimeField(source='modified', read_only=True)
+    modified = ser.DateTimeField(read_only=True)
 
     journal = RelationshipField(
         read_only=True,

--- a/api/chronos/urls.py
+++ b/api/chronos/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     url(r'^journals/$', views.ChronosJournalList.as_view(), name=views.ChronosJournalList.view_name),
     url(r'^journals/(?P<journal_id>[-0-9A-Za-z]+)/$', views.ChronosJournalDetail.as_view(), name=views.ChronosJournalDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/submissions/$', views.ChronosSubmissionList.as_view(), name=views.ChronosSubmissionList.view_name),
-    url(r'^(?P<preprint_id>\w+)/submissions/(?P<submission_id>\w+)/$', views.ChronosSubmissionDetail.as_view(), name=views.ChronosSubmissionDetail.view_name),
+    url(r'^(?P<preprint_id>\w+)/submissions/(?P<submission_id>[-0-9A-Za-z]+)/$', views.ChronosSubmissionDetail.as_view(), name=views.ChronosSubmissionDetail.view_name),
 ]

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -100,7 +100,7 @@ class ChronosSubmissionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
                 Q(preprint__node__contributor__user__id=user.id if user else None) |
                 Q(status__in=[3, 4])
             )
-        )
+        ).distinct()
         update_list_id = queryset.filter(modified__lt=timezone.now() - settings.CHRONOS_SUBMISSION_UPDATE_TIME).values_list('id',flat=True)
         if len(update_list_id) > 0:
             enqueue_task(update_submissions_status_async.s(list(update_list_id)))

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -21,7 +21,6 @@ from api.chronos.permissions import SubmissionOnPreprintPublishedOrAdmin, Submis
 from api.chronos.serializers import ChronosJournalSerializer, ChronosSubmissionSerializer, ChronosSubmissionCreateSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import ChronosJournal, ChronosSubmission, PreprintService
-from osf.external.chronos import ChronosClient
 from osf.external.tasks import update_submissions_status_async
 
 
@@ -101,7 +100,7 @@ class ChronosSubmissionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
                 Q(status__in=[3, 4])
             ),
         ).distinct()
-        update_list_id = queryset.filter(modified__lt=timezone.now() - settings.CHRONOS_SUBMISSION_UPDATE_TIME).values_list('id',flat=True)
+        update_list_id = queryset.filter(modified__lt=timezone.now() - settings.CHRONOS_SUBMISSION_UPDATE_TIME).values_list('id', flat=True)
         if len(update_list_id) > 0:
             enqueue_task(update_submissions_status_async.s(list(update_list_id)))
         return queryset

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -95,7 +95,7 @@ class ChronosSubmissionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
         node = preprint.node
         queryset = ChronosSubmission.objects.filter(preprint__guids___id=preprint._id)
 
-        # TODO: refactor the ChronosClient to use async requests
+        # TODO: [IN-478] Use celery to update Chronos submission status
         # If the user is a contributor, return all submissions of this preprint
         if node.is_contributor(user):
             for submission in queryset:

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -99,7 +99,7 @@ class ChronosSubmissionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
             (
                 Q(preprint__node__contributor__user__id=user.id if user else None) |
                 Q(status__in=[3, 4])
-            )
+            ),
         ).distinct()
         update_list_id = queryset.filter(modified__lt=timezone.now() - settings.CHRONOS_SUBMISSION_UPDATE_TIME).values_list('id',flat=True)
         if len(update_list_id) > 0:

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -1,9 +1,11 @@
 from __future__ import unicode_literals
 
+from django.utils import timezone
 from rest_framework import generics
 from rest_framework import permissions as drf_permissions
 from rest_framework.exceptions import NotFound
 
+from website import settings
 from api.base.filters import ListFilterMixin
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
@@ -12,11 +14,12 @@ from api.base.parsers import (
 from api.base.versioning import PrivateVersioning
 from api.base.views import JSONAPIBaseView
 from api.base import permissions as base_permissions
-from api.chronos.permissions import SubmissionOnPreprintPublishedOrAdmin, SubmissionAcceptedOrPublishedOrPreprintContributor
+from api.base.utils import get_user_auth
+from api.chronos.permissions import SubmissionOnPreprintPublishedOrAdmin, SubmissionAcceptedOrPublishedOrPreprintAdmin
 from api.chronos.serializers import ChronosJournalSerializer, ChronosSubmissionSerializer, ChronosSubmissionCreateSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import ChronosJournal, ChronosSubmission, PreprintService
-from osf.utils.permissions import DEFAULT_CONTRIBUTOR_PERMISSIONS
+from osf.external.chronos import ChronosClient
 
 
 class ChronosJournalList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
@@ -87,17 +90,25 @@ class ChronosSubmissionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
             return ChronosSubmissionSerializer
 
     def get_default_queryset(self):
-        user = self.request.user
-        queryset = ChronosSubmission.objects.filter(preprint__guids___id=self.kwargs['preprint_id'])
+        user = get_user_auth(self.request).user
+        preprint = PreprintService.load(self.kwargs['preprint_id'])
+        node = preprint.node
+        queryset = ChronosSubmission.objects.filter(preprint__guids___id=preprint._id)
+
+        # TODO: refactor the ChronosClient to use async requests
         # If the user is a contributor, return all submissions of this preprint
-        if user.has_perm(DEFAULT_CONTRIBUTOR_PERMISSIONS, PreprintService.load(self.kwargs['preprint_id'])):
+        if node.is_contributor(user):
+            for submission in queryset:
+                if timezone.now() - submission.modified > settings.CHRONOS_SUBMISSION_UPDATE_TIME:
+                    ChronosClient().sync_manuscript(submission)
             return queryset
         # Otherwise, only return accepted (status = 3) and published (status = 4) submissions
         else:
-            return queryset.filter(
-                preprint__guids___id=self.kwargs['preprint_id'],
-                status__in=[3, 4]
-            )
+            queryset = queryset.filter(status__in=[3, 4])
+            for submission in queryset:
+                if timezone.now() - submission.modified > settings.CHRONOS_SUBMISSION_UPDATE_TIME:
+                    ChronosClient().sync_manuscript(submission)
+            return queryset.filter(status__in=[3, 4])
 
     def get_queryset(self):
         return self.get_queryset_from_request()
@@ -115,7 +126,7 @@ class ChronosSubmissionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        SubmissionAcceptedOrPublishedOrPreprintContributor,
+        SubmissionAcceptedOrPublishedOrPreprintAdmin,
     )
     required_read_scopes = [CoreScopes.CHRONOS_SUBMISSION_READ]
     required_write_scopes = [CoreScopes.CHRONOS_SUBMISSION_WRITE]
@@ -130,6 +141,8 @@ class ChronosSubmissionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
     def get_object(self):
         try:
             submission = ChronosSubmission.objects.get(publication_id=self.kwargs['submission_id'])
+            if timezone.now() - submission.modified > settings.CHRONOS_SUBMISSION_UPDATE_TIME:
+                ChronosClient().sync_manuscript(submission)
         except ChronosSubmission.DoesNotExist:
             raise NotFound
         else:

--- a/api_tests/chronos/views/test_chronos_submission_detail.py
+++ b/api_tests/chronos/views/test_chronos_submission_detail.py
@@ -65,11 +65,11 @@ class TestChronosSubmissionDetail:
         mock_update.return_value = submission
         payload = self.update_payload(submission)
         res = app.patch_json_api(url, payload, auth=preprint_contributor.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
         res = app.patch_json_api(url, payload, auth=moderator.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
         res = app.patch_json_api(url, payload, auth=user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
         res = app.patch_json_api(url, payload, expect_errors=True)
         assert res.status_code == 401
         assert not mock_update.called

--- a/api_tests/chronos/views/test_chronos_submission_list.py
+++ b/api_tests/chronos/views/test_chronos_submission_list.py
@@ -24,7 +24,15 @@ class TestChronosSubmissionList:
         return AuthUserFactory()
 
     @pytest.fixture()
-    def journal(self):
+    def journal_one(self):
+        return ChronosJournalFactory()
+
+    @pytest.fixture()
+    def journal_two(self):
+        return ChronosJournalFactory()
+
+    @pytest.fixture()
+    def journal_three(self):
         return ChronosJournalFactory()
 
     @pytest.fixture()
@@ -43,12 +51,20 @@ class TestChronosSubmissionList:
         return PreprintFactory(creator=submitter, provider=preprint.provider)
 
     @pytest.fixture()
-    def submission(self, preprint, journal, submitter):
-        return ChronosSubmissionFactory(submitter=submitter, journal=journal, preprint=preprint)
+    def submission_submitted(self, preprint, journal_one, submitter):
+        return ChronosSubmissionFactory(submitter=submitter, journal=journal_one, preprint=preprint, status=2)
 
     @pytest.fixture()
-    def other_submission(self, other_preprint, journal, submitter):
-        return ChronosSubmissionFactory(submitter=submitter, journal=journal, preprint=other_preprint)
+    def submission_accepted(self, preprint, journal_two, submitter):
+        return ChronosSubmissionFactory(submitter=submitter, journal=journal_two, preprint=preprint, status=3)
+
+    @pytest.fixture()
+    def submission_published(self, preprint, journal_three, submitter):
+        return ChronosSubmissionFactory(submitter=submitter, journal=journal_three, preprint=preprint, status=4)
+
+    @pytest.fixture()
+    def other_submission(self, other_preprint, journal_one, submitter):
+        return ChronosSubmissionFactory(submitter=submitter, journal=journal_one, preprint=other_preprint)
 
     @pytest.fixture()
     def url(self, preprint):
@@ -92,8 +108,51 @@ class TestChronosSubmissionList:
 
         assert not mock_submit.called
 
-    def test_list(self, app, url, submission, other_submission):
+    # Preprint submitters can view all submissions, regardless of states
+    def test_list_submitter(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, submitter):
+        res = app.get(url, auth=submitter.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 3
+        submission_ids = [submission_submitted.publication_id, submission_accepted.publication_id,
+                          submission_published.publication_id]
+        assert res.json['data'][0]['id'] in submission_ids
+        assert res.json['data'][1]['id'] in submission_ids
+        assert res.json['data'][2]['id'] in submission_ids
+
+    # Preprint contributors can view all submissions, regardless of states
+    def test_list_contributor(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, preprint_contributor):
+        res = app.get(url, auth=preprint_contributor.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 3
+        submission_ids = [submission_submitted.publication_id, submission_accepted.publication_id,
+                          submission_published.publication_id]
+        assert res.json['data'][0]['id'] in submission_ids
+        assert res.json['data'][1]['id'] in submission_ids
+        assert res.json['data'][2]['id'] in submission_ids
+
+    # Moderators can only see accepted and published submissions
+    def test_list_moderator(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, moderator):
+        res = app.get(url, auth=moderator.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
+        assert res.json['data'][0]['id'] in submission_ids
+        assert res.json['data'][1]['id'] in submission_ids
+
+    # Logged in users can only see accepted and published submissions
+    def test_list_user(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, user):
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
+        assert res.json['data'][0]['id'] in submission_ids
+        assert res.json['data'][1]['id'] in submission_ids
+
+    # Users with no auth can only see accepted and published submissions
+    def test_list_no_auth(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission):
         res = app.get(url)
         assert res.status_code == 200
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['id'] == submission.publication_id
+        assert len(res.json['data']) == 2
+        submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
+        assert res.json['data'][0]['id'] in submission_ids
+        assert res.json['data'][1]['id'] in submission_ids

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -171,6 +171,9 @@ class ChronosClient(object):
         return ChronosJournal.objects.all()
 
     def submit_manuscript(self, journal, preprint, submitter):
+        if ChronosSubmission.objects.filter(journal=journal, preprint=preprint).exists():
+            raise ValueError('{!r} already has an existing submission to {!r}.'.format(preprint, journal))
+        
         if preprint.machine_state != ReviewStates.ACCEPTED.value:
             raise ValueError('Cannot submit to Chronos if the preprint is not accepted by moderators')
 

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -173,7 +173,6 @@ class ChronosClient(object):
     def submit_manuscript(self, journal, preprint, submitter):
         if ChronosSubmission.objects.filter(journal=journal, preprint=preprint).exists():
             raise ValueError('{!r} already has an existing submission to {!r}.'.format(preprint, journal))
-        
         if preprint.machine_state != ReviewStates.ACCEPTED.value:
             raise ValueError('Cannot submit to Chronos if the preprint is not accepted by moderators')
 

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -174,6 +174,18 @@ class ChronosClient(object):
         if ChronosSubmission.objects.filter(journal=journal, preprint=preprint).exists():
             raise ValueError('{!r} already has an existing submission to {!r}.'.format(preprint, journal))
 
+        # 1 = draft, 2 = submitted, 3 = accepted, 4 = published
+        # Disallow submission if the current preprint has submissions that are submitted, accepted or publishes
+        # regardless of journals
+        if ChronosSubmission.objects.filter(status__in=[1], preprint=preprint).exists():
+            raise ValueError('Cannot submit because a drafted submission exists')
+
+        if ChronosSubmission.objects.filter(status=[2], preprint=preprint).exists():
+            raise ValueError('Cannot submit because a pending submission exists')
+
+        if ChronosSubmission.objects.filter(status__in=[3, 4], preprint=preprint).exists():
+            raise ValueError('Cannot submit because your submission was accepted or published')
+
         body = ChronosSerializer.serialize_manuscript(journal.journal_id, preprint)
         body['USER'] = ChronosSerializer.serialize_user(submitter)
 

--- a/osf/external/tasks.py
+++ b/osf/external/tasks.py
@@ -1,0 +1,15 @@
+from framework.celery_tasks import app as celery_app
+from django.apps import apps
+from osf.external.chronos import ChronosClient
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(ignore_results=True)
+def update_submissions_status_async(ids):
+    client = ChronosClient()
+    ChronosSubmission = apps.get_model('osf.ChronosSubmission')
+    for submission_id in ids:
+        submission = ChronosSubmission.load(submission_id)
+        client.sync_manuscript(submission)

--- a/osf/external/tasks.py
+++ b/osf/external/tasks.py
@@ -1,5 +1,8 @@
 from framework.celery_tasks import app as celery_app
 from django.apps import apps
+from django.utils import timezone
+
+from website import settings
 from osf.external.chronos import ChronosClient
 import logging
 
@@ -12,4 +15,5 @@ def update_submissions_status_async(ids):
     ChronosSubmission = apps.get_model('osf.ChronosSubmission')
     for submission_id in ids:
         submission = ChronosSubmission.load(submission_id)
-        client.sync_manuscript(submission)
+        if submission.modified < timezone.now() - settings.CHRONOS_SUBMISSION_UPDATE_TIME:
+            client.sync_manuscript(submission)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -65,6 +65,7 @@ REGISTRATION_APPROVAL_TIME = datetime.timedelta(days=2)
 # Date range for embargo periods
 EMBARGO_END_DATE_MIN = datetime.timedelta(days=2)
 EMBARGO_END_DATE_MAX = datetime.timedelta(days=1460)  # Four years
+
 # Question titles to be reomved for anonymized VOL
 ANONYMIZED_TITLES = ['Authors']
 
@@ -1940,3 +1941,5 @@ CHRONOS_USERNAME = os_env.get('CHRONOS_USERNAME', '')
 CHRONOS_PASSWORD = os_env.get('CHRONOS_PASSWORD', '')
 CHRONOS_API_KEY = os_env.get('CHRONOS_API_KEY', '')
 CHRONOS_HOST = os_env.get('CHRONOS_HOST', 'http://sandbox.api.chronos-oa.com')
+# Maximum minutes we allow ChronosSubmission status to be stale (only update when user is requesting it)
+CHRONOS_SUBMISSION_UPDATE_TIME = timedelta(days=1)


### PR DESCRIPTION
## Purpose

This PR aims to do two things:

1. Return different `ChronosSubmission` querysets depending on user permissions
2. Modify Chronos submission detail view so that non-published or non-accepted submissions can only be viewed by preprint creator and contributors.
3. Sync status of `ChronosSubmission` when user is requesting the information through API.

## Changes

The following changes are made, respectively:

- In `api/chornos/views.py`, the `ChronosSubmissionList` view is modified so that the default queryset return is filtered based on user permissions.
- The `urls.py` is modified so that `ChronosSubmissionDetail` view uses a new regex `[-0-9A-Za-z]` as the original regex doesn't match the format of `publication_id`.
- A new permission class `SubmissionAcceptedOrPublishedOrPreprintAdmin` is added and used by the `ChronosSubmissionDetail ` view.
- In both the list view and the detail view, if the `ChronosSubmission` object is out of sync longer than a set time period (as defined in `settings/defaults.py`) at the time of API request, the object is synced.

## Ticket

https://openscience.atlassian.net/browse/IN-372
