### PR TITLE
[PLAT-1083] Python 3: update mock to 2.0.0

### DIFF
--- a/addons/base/tests/models.py
+++ b/addons/base/tests/models.py
@@ -514,7 +514,7 @@ class OAuthCitationsNodeSettingsTestSuiteMixin(
         # The first call to .api returns a new object
         with mock.patch.object(self.NodeSettingsClass, 'oauth_provider') as mock_api:
             api = self.node_settings.api
-            mock_api.assert_called_once()
+            mock_api.assert_called_once_with(account=self.external_account)
             assert_equal(api, mock_api())
 
     def test_api_cached(self):
@@ -661,7 +661,7 @@ class CitationAddonProviderTestSuiteMixin(OAuthCitationsTestSuiteMixinBase):
             mock_account.expires_at = timezone.now()
             self.provider.account = mock_account
             self.provider.client
-            mock_get_client.assert_called
+            mock_get_client.assert_called_with()
             assert_true(mock_get_client.called)
 
     def test_client_cached(self):

--- a/addons/dropbox/tests/test_views.py
+++ b/addons/dropbox/tests/test_views.py
@@ -100,8 +100,8 @@ class TestFilebrowserViews(DropboxAddonTestCase, OsfTestCase):
             if isinstance(each, MockFolderMetadata)
         ]
 
-        mock_list_folder.assert_called_once()
-        mock_list_folder_continue.assert_called_once()
+        mock_list_folder.assert_called_once_with('')
+        mock_list_folder_continue.assert_called_once_with('ZtkX9_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAu')
 
         assert len(res.json) == 2
         assert len(res.json) == len(contents)

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -75,7 +75,7 @@ class TestGitHubConfigViews(GitHubAddonTestCase, OAuthAddonConfigViewsTestCaseMi
             self.project.logs.latest().action,
             '{0}_repo_linked'.format(self.ADDON_SHORT_NAME)
         )
-        mock_add_hook.assert_called_once()
+        mock_add_hook.assert_called_once_with(save=False)
 
 
 # TODO: Test remaining CRUD methods
@@ -445,7 +445,7 @@ class TestGithubSettings(OsfTestCase):
         assert_equal(self.node_settings.user, 'queen')
         assert_equal(self.node_settings.repo, 'night at the opera')
         assert_equal(self.project.logs.latest().action, 'github_repo_linked')
-        mock_add_hook.assert_called_once()
+        mock_add_hook.assert_called_once_with(save=False)
 
     @mock.patch('addons.github.models.NodeSettings.add_hook')
     @mock.patch('addons.github.api.GitHubClient.repo')

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -82,7 +82,7 @@ class TestGitLabConfigViews(GitLabAddonTestCase, OAuthAddonConfigViewsTestCaseMi
             self.project.logs.latest().action,
             '{0}_repo_linked'.format(self.ADDON_SHORT_NAME)
         )
-        mock_add_hook.assert_called_once()
+        mock_add_hook.assert_called_once_with(save=False)
 
 
 # TODO: Test remaining CRUD methods
@@ -458,7 +458,7 @@ class TestGitLabSettings(OsfTestCase):
         assert_equal(self.node_settings.user, 'queen')
         assert_equal(self.node_settings.repo, 'night at the opera')
         assert_equal(self.project.logs.latest().action, 'gitlab_repo_linked')
-        mock_add_hook.assert_called_once()
+        mock_add_hook.assert_called_once_with(save=False)
 
     @mock.patch('addons.gitlab.models.NodeSettings.add_hook')
     @mock.patch('addons.gitlab.api.GitLabClient.repo')

--- a/addons/googledrive/tests/test_models.py
+++ b/addons/googledrive/tests/test_models.py
@@ -67,7 +67,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def test_api_not_cached(self, mock_gdp):
         # The first call to .api returns a new object
         api = self.node_settings.api
-        mock_gdp.assert_called_once()
+        mock_gdp.assert_called_once_with(self.external_account)
         assert_equal(api, mock_gdp())
 
     @mock.patch('addons.googledrive.models.GoogleDriveProvider')

--- a/addons/onedrive/tests/test_models.py
+++ b/addons/onedrive/tests/test_models.py
@@ -67,7 +67,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def test_api_not_cached(self, mock_odp):
         # The first call to .api returns a new object
         api = self.node_settings.api
-        mock_odp.assert_called_once()
+        mock_odp.assert_called_once_with(self.external_account)
         assert api == mock_odp()
 
     @mock.patch('addons.onedrive.models.OneDriveProvider')

--- a/api_tests/applications/views/test_application_reset.py
+++ b/api_tests/applications/views/test_application_reset.py
@@ -45,7 +45,7 @@ class TestApplicationReset:
         mock_method.return_value(True)
         old_secret = user_app.client_secret
         user_app.reset_secret(save=True)
-        mock_method.assert_called()
+        mock_method.assert_called_with(user_app.client_id, old_secret)
         user_app.reload()
         assert old_secret != user_app.client_secret
 
@@ -65,7 +65,7 @@ class TestApplicationReset:
         old_secret = user_app.client_secret
         res = app.post_json_api(user_reset_url, correct, auth=user.auth)
         assert res.status_code == 201
-        mock_method.assert_called()
+        mock_method.assert_called_with(user_app.client_id, old_secret)
         user_app.reload()
         assert old_secret != user_app.client_secret
 

--- a/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
@@ -117,14 +117,14 @@ class TestPreprintProviderModeratorList:
         payload = self.create_payload(permission_group='moderator', **unreg_user)
         res = app.post_json_api(url, payload, auth=nonmoderator.auth, expect_errors=True)
         assert res.status_code == 403
-        assert mock_mail.assert_not_called()
+        assert mock_mail.call_count == 0
 
         # test_user_with_moderator_admin_permissions
         payload = self.create_payload(permission_group='moderator', **unreg_user)
         res = app.post_json_api(url, payload, auth=admin.auth)
 
         assert res.status_code == 201
-        assert mock_mail.assert_called_once()
+        assert mock_mail.call_count == 1
         assert mock_mail.call_args[0][0] == unreg_user['email']
 
     @mock.patch('framework.auth.views.mails.send_mail')

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3476,8 +3476,7 @@ class TestOnNodeUpdate:
         assert task.kwargs['first_save'] is False
         assert 'title' in task.kwargs['saved_fields']
 
-    @mock.patch('osf.models.identifiers.IdentifierMixin.request_identifier_update')
-    def test_queueing_on_node_updated(self, mock_request_update, node, user):
+    def test_queueing_on_node_updated(self, node, user):
         node.set_identifier_value(category='doi', value=settings.DOI_FORMAT.format(prefix=settings.DATACITE_PREFIX, guid=node._id))
         node.title = 'Something New'
         node.save()
@@ -3505,7 +3504,6 @@ class TestOnNodeUpdate:
         task = handlers.get_task_from_queue('website.project.tasks.on_node_updated', predicate=lambda task: task.kwargs['node_id'] == node._id)
         assert 'contributors' in task.kwargs['saved_fields']
         assert 'node_license' in task.kwargs['saved_fields']
-        mock_request_update.assert_called_once_with()
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3505,7 +3505,7 @@ class TestOnNodeUpdate:
         task = handlers.get_task_from_queue('website.project.tasks.on_node_updated', predicate=lambda task: task.kwargs['node_id'] == node._id)
         assert 'contributors' in task.kwargs['saved_fields']
         assert 'node_license' in task.kwargs['saved_fields']
-        mock_request_update.assert_called_once()
+        mock_request_update.assert_called_once_with()
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ python-coveralls==2.9.1
 nose
 factory-boy==2.10.0
 webtest-plus==0.3.3
-mock==1.0.1
+mock==2.0.0
 Faker==0.8.13
 schema==0.3.1
 responses==0.8.1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,21 +89,15 @@ class TestAuthUtils(OsfTestCase):
         assert_in('login?service=', res.location)
 
         user.reload()
-        mock_mail.assert_called()
-        assert_equal(len(mock_mail.call_args_list), 1)
-        empty, kwargs = mock_mail.call_args
-        kwargs['user'].reload()
 
-        assert_equal(empty, ())
-        assert_equal(kwargs, {
-            'user': user,
-            'mimetype': 'html',
-            'mail': mails.WELCOME,
-            'domain': settings.DOMAIN,
-            'to_addr': user.username,
-            'osf_support_email': settings.OSF_SUPPORT_EMAIL,
-            'storage_flag_is_active': storage_i18n_flag_active(),
-        })
+        mock_mail.assert_called_with(osf_support_email=settings.OSF_SUPPORT_EMAIL,
+                                     mimetype='html',
+                                     storage_flag_is_active=False,
+                                     to_addr=user.username,
+                                     domain=settings.DOMAIN,
+                                     user=user,
+                                     mail=mails.WELCOME)
+
 
         self.app.set_cookie(settings.COOKIE_NAME, user.get_or_create_cookie())
         res = self.app.get('/confirm/{}/{}'.format(user._id, token))


### PR DESCRIPTION
## Purpose
In order to best prepare for the big changes coming with Python 3 we're going to implement some backward compatible changes first to defray the amount we have to CR in the final PR.

One thing we have to do is update mock. Currently mock 1.0.1 autospec function isn't compatible with Python 3 so it's best to upgrade to 2.0.0 now so there will be a seamless transition. 

## Changes

- change dev.txt requirements
- change assert_called_once to assert_called_once_with/call_count
- remove mock for test_queueing_on_node_updated which was always throwing a false positive

## QA Notes

No user-facing QA just run Unittests

## Documentation

No docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1083