### PR TITLE
[hotfix] Fix first custom citation log [PLAT-1124]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2889,7 +2889,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             return
         elif custom_citation == '':
             log_action = NodeLog.CUSTOM_CITATION_REMOVED
-        elif self.custom_citation != '':
+        elif self.custom_citation:
             log_action = NodeLog.CUSTOM_CITATION_EDITED
         else:
             log_action = NodeLog.CUSTOM_CITATION_ADDED


### PR DESCRIPTION
#### Purpose
Add the correct log ("custom citation added") when a custom citation is first created (instead of "custom citation edited"). 

#### Changes
Logic for adding the "custom citation added" log needed to be adjusted since custom citations are now nullable.

#### QA Notes
Confirm that when making a custom citation for the first time you receive the "custom citation added" log instead of "custom citation edited".

#### Side Effects
None expected 

#### Ticket
https://openscience.atlassian.net/browse/PLAT-1124
