### PR TITLE
[WIP][PLAT-1121][Hotfix] User emails from meeting submissions no longer fullname

### DIFF
--- a/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
+++ b/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
@@ -10,15 +10,16 @@ from osf.models import OSFUser
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
 def main():
     dry_run = '--dry' in sys.argv
-    with transaction.atomic():
-        users = OSFUser.objects.filter(fullname__regex=r'^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$', tags__name='osf4m')
-        logger.info('{} users found added by OSF 4 Meetings with emails for fullnames'.format(users.count()))
-        for user in users:
-            user.fullname = user._id
-            if not dry_run:
-                user.save()
+    users = OSFUser.objects.filter(fullname__regex=r'^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$', tags__name='osf4m')
+    logger.info('{} users found added by OSF 4 Meetings with emails for fullnames'.format(users.count()))
+    for user in users:
+        user.fullname = user._id
+        if not dry_run:
+            user.save()
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
+++ b/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
@@ -2,10 +2,10 @@ import sys
 import logging
 
 import django
-from django.db import transaction
 django.setup()
 
 from osf.models import OSFUser
+from scripts import utils as script_utils
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -13,6 +13,8 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
     dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
     users = OSFUser.objects.filter(fullname__regex=r'^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$', tags__name='osf4m')
     logger.info('{} users found added by OSF 4 Meetings with emails for fullnames'.format(users.count()))
     for user in users:

--- a/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
+++ b/scripts/remove_after_use/set_meetings_users_fullnames_to_guids.py
@@ -1,0 +1,24 @@
+import sys
+import logging
+
+import django
+from django.db import transaction
+django.setup()
+
+from osf.models import OSFUser
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+def main():
+    dry_run = '--dry' in sys.argv
+    with transaction.atomic():
+        users = OSFUser.objects.filter(fullname__regex=r'^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$', tags__name='osf4m')
+        logger.info('{} users found added by OSF 4 Meetings with emails for fullnames'.format(users.count()))
+        for user in users:
+            user.fullname = user._id
+            if not dry_run:
+                user.save()
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -231,6 +231,18 @@ class TestProvisionNode(ContextTestCase):
             data=self.content,
         )
 
+    @mock.patch('website.conferences.utils.upload_attachments')
+    def test_add_poster_by_email(self, mock_upload_attachments):
+        conference = ConferenceFactory()
+
+        with self.make_context(data={'from': 'bdawk@sb52champs.com', 'subject': 'It\'s PARTY TIME!'}):
+            msg = message.ConferenceMessage()
+            views.add_poster_by_email(conference, msg)
+
+        user = OSFUser.objects.get(username='bdawk@sb52champs.com')
+        assert user.email == 'bdawk@sb52champs.com'
+        assert user.fullname == user._id  # user's shouldn't be able to use email as fullname, so we use the guid.
+
 
 class TestMessage(ContextTestCase):
 

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -330,7 +330,7 @@ class TestMessage(ContextTestCase):
         names = [
             (' Fred', 'Fred'),
             (u'Me‰¨ü', u'Me‰¨ü'),
-            (u'fred@queen.com', None),  # Don't use email as display name
+            (u'fred@queen.com', u'fred@queen.com'),
             (u'Fred <fred@queen.com>', u'Fred'),
             (u'"Fred" <fred@queen.com>', u'Fred'),
         ]

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -330,7 +330,7 @@ class TestMessage(ContextTestCase):
         names = [
             (' Fred', 'Fred'),
             (u'Me‰¨ü', u'Me‰¨ü'),
-            (u'fred@queen.com', u'fred@queen.com'),
+            (u'fred@queen.com', None),  # Don't use email as display name
             (u'Fred <fred@queen.com>', u'Fred'),
             (u'"Fred" <fred@queen.com>', u'Fred'),
         ]

--- a/website/conferences/message.py
+++ b/website/conferences/message.py
@@ -117,7 +117,6 @@ class ConferenceMessage(object):
         else:
             # sender format: email@domain.tld
             name = self.sender
-
         return unicode(HumanName(name))
 
     @cached_property

--- a/website/conferences/message.py
+++ b/website/conferences/message.py
@@ -117,6 +117,8 @@ class ConferenceMessage(object):
         else:
             # sender format: email@domain.tld
             name = self.sender
+        if '@' in name:
+            return None
         return unicode(HumanName(name))
 
     @cached_property

--- a/website/conferences/message.py
+++ b/website/conferences/message.py
@@ -117,8 +117,7 @@ class ConferenceMessage(object):
         else:
             # sender format: email@domain.tld
             name = self.sender
-        if '@' in name:
-            return None
+
         return unicode(HumanName(name))
 
     @cached_property

--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -7,6 +7,8 @@ from website import settings
 from osf.models import MailRecord
 from api.base.utils import waterbutler_api_url_for
 from website.exceptions import NodeStateError
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 
 
 def record_message(message, node_created, user_created):
@@ -75,3 +77,11 @@ def upload_attachment(user, node, attachment):
 def upload_attachments(user, node, attachments):
     for attachment in attachments:
         upload_attachment(user, node, attachment)
+
+
+def is_valid_email(email):
+    try:
+        validate_email(email)
+        return True
+    except ValidationError:
+        return False

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -77,6 +77,9 @@ def add_poster_by_email(conference, message):
             is_spam=message.is_spam,
         )
         if user_created:
+            if utils.is_valid_email(user.fullname):
+                user.fullname = user._id  # Users cannot use an email as their full name
+
             user.save()  # need to save in order to access m2m fields (e.g. tags)
             user.add_system_tag('osf4m')
             user.update_date_last_login()


### PR DESCRIPTION
## Purpose

We don't want to show user emails as their fullname name when they submit a poster via email and don't provide a real fullname. This PR will give the users the guid instead of email for fullnane and migrates old users who have email for fullname.

## Changes

- migration script for changing fullname to guid
- change to add_poster_by_email to prevent users from repeating this in the future
- add unittest

## QA Notes

It's hard to test this in a local environment as it requires setting up mailgun I recommend just using the unittests.

## Documentation

Product wants to notify users that their fullname has been this is marked WIP while we wait on that language. Might want to split off the migration in the meantime and just merge the fix.


## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1121