### PR TITLE
[PLAT-1084] Py3 stringify exceptions

### DIFF
--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -344,7 +344,7 @@ def edit_wiki_settings(node, auth, **kwargs):
     except NodeStateError as e:
         raise HTTPError(http.BAD_REQUEST, data=dict(
             message_short="Can't change privacy",
-            message_long=e.message
+            message_long=str(e)
         ))
 
     return {

--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -138,7 +138,7 @@ class BaseActionSerializer(JSONAPISerializer):
                 return target.run_submit(user)
         except InvalidTriggerError as e:
             # Invalid transition from the current state
-            raise Conflict(e.message)
+            raise Conflict(str(e))
         else:
             raise JSONAPIAttributeException(attribute='trigger', detail='Invalid trigger.')
 
@@ -201,7 +201,7 @@ class ReviewActionSerializer(BaseActionSerializer):
             return target.run_withdraw(user=user, comment=comment)
         except InvalidTriggerError as e:
             # Invalid transition from the current state
-            raise Conflict(e.message)
+            raise Conflict(str(e))
         else:
             raise JSONAPIAttributeException(attribute='trigger', detail='Invalid trigger.')
 

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -192,7 +192,7 @@ class CollectionSubmissionSerializer(TaxonomizableSerializerMixin, JSONAPISerial
             except PermissionsError as e:
                 raise exceptions.PermissionDenied(detail=str(e))
             except (ValueError, NodeStateError) as e:
-                raise exceptions.ValidationError(detail=e.message)
+                raise exceptions.ValidationError(detail=str(e))
         if 'status' in validated_data:
             obj.status = validated_data.pop('status')
         if 'collected_type' in validated_data:
@@ -232,7 +232,7 @@ class CollectionSubmissionCreateSerializer(CollectionSubmissionSerializer):
             except PermissionsError as e:
                 raise exceptions.PermissionDenied(detail=str(e))
             except (ValueError, NodeStateError) as e:
-                raise exceptions.ValidationError(detail=e.message)
+                raise exceptions.ValidationError(detail=str(e))
         return obj
 
 

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -190,7 +190,7 @@ class CollectionSubmissionSerializer(TaxonomizableSerializerMixin, JSONAPISerial
             try:
                 obj.set_subjects(subjects, auth)
             except PermissionsError as e:
-                raise exceptions.PermissionDenied(detail=e.message)
+                raise exceptions.PermissionDenied(detail=str(e))
             except (ValueError, NodeStateError) as e:
                 raise exceptions.ValidationError(detail=e.message)
         if 'status' in validated_data:
@@ -230,7 +230,7 @@ class CollectionSubmissionCreateSerializer(CollectionSubmissionSerializer):
             try:
                 obj.set_subjects(subjects, auth)
             except PermissionsError as e:
-                raise exceptions.PermissionDenied(detail=e.message)
+                raise exceptions.PermissionDenied(detail=str(e))
             except (ValueError, NodeStateError) as e:
                 raise exceptions.ValidationError(detail=e.message)
         return obj

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -593,7 +593,7 @@ class NodeLinksList(JSONAPIBaseView, bulk_views.BulkDestroyJSONAPIView, bulk_vie
         try:
             collection.remove_object(instance)
         except ValueError as err:  # pointer doesn't belong to node
-            raise ValidationError(err.message)
+            raise ValidationError(str(err))
 
     # overrides ListCreateAPIView
     def get_parser_context(self, http_request):
@@ -674,7 +674,7 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
         try:
             collection.remove_object(pointer.guid.referent)
         except ValueError as err:  # pointer doesn't belong to node
-            raise ValidationError(err.message)
+            raise ValidationError(str(err))
         collection.save()
 
 

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -262,4 +262,4 @@ class CommentReportDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView
         try:
             comment.retract_report(user, save=True)
         except ValueError as error:
-            raise ValidationError(error.message)
+            raise ValidationError(str(error))

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -701,9 +701,9 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
                 except PermissionsError as e:
                     raise exceptions.PermissionDenied(detail=str(e))
                 except ValueError as e:
-                    raise exceptions.ValidationError(detail=e.message)
+                    raise exceptions.ValidationError(detail=str(e))
                 except NodeStateError as e:
-                    raise exceptions.ValidationError(detail=e.message)
+                    raise exceptions.ValidationError(detail=str(e))
 
             try:
                 node.update(validated_data, auth=auth)
@@ -714,7 +714,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
             except NodeUpdateError as e:
                 raise exceptions.ValidationError(detail=e.reason)
             except NodeStateError as e:
-                raise InvalidModelValueError(detail=e.message)
+                raise InvalidModelValueError(detail=str(e))
 
         return node
 
@@ -1112,9 +1112,9 @@ class NodeContributorDetailSerializer(NodeContributorsSerializer):
                 node.move_contributor(instance.user, auth, index, save=True)
             node.update_contributor(instance.user, permission, bibliographic, auth, save=True)
         except NodeStateError as e:
-            raise exceptions.ValidationError(detail=e.message)
+            raise exceptions.ValidationError(detail=str(e))
         except ValueError as e:
-            raise exceptions.ValidationError(detail=e.message)
+            raise exceptions.ValidationError(detail=str(e))
         instance.refresh_from_db()
         return instance
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -699,7 +699,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
                 try:
                     node.set_subjects(subjects, auth)
                 except PermissionsError as e:
-                    raise exceptions.PermissionDenied(detail=e.message)
+                    raise exceptions.PermissionDenied(detail=str(e))
                 except ValueError as e:
                     raise exceptions.ValidationError(detail=e.message)
                 except NodeStateError as e:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -325,7 +325,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
         try:
             instance.remove_node(auth=auth)
         except NodeStateError as err:
-            raise ValidationError(err.message)
+            raise ValidationError(str(err))
         instance.save()
 
 
@@ -360,7 +360,7 @@ class NodeDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMix
         try:
             node.remove_node(auth=auth)
         except NodeStateError as err:
-            raise ValidationError(err.message)
+            raise ValidationError(str(err))
         node.save()
 
     def get_renderer_context(self):
@@ -720,7 +720,7 @@ class NodeCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, NodeMix
         try:
             citation = render_citation(node=node, style=style)
         except ValueError as err:  # style requested could not be found
-            csl_name = re.findall('[a-zA-Z]+\.csl', err.message)[0]
+            csl_name = re.findall('[a-zA-Z]+\.csl', str(err))[0]
             raise NotFound('{} is not a known style.'.format(csl_name))
 
         return {'citation': citation, 'id': style}
@@ -817,7 +817,7 @@ class NodeLinksList(BaseNodeLinksList, bulk_views.BulkDestroyJSONAPIView, bulk_v
         try:
             node.rm_pointer(instance, auth=auth)
         except ValueError as err:  # pointer doesn't belong to node
-            raise ValidationError(err.message)
+            raise ValidationError(str(err))
         node.save()
 
     # overrides ListCreateAPIView
@@ -904,7 +904,7 @@ class NodeLinksDetail(BaseNodeLinksDetail, generics.RetrieveDestroyAPIView, Node
         try:
             node.rm_pointer(pointer, auth=auth)
         except ValueError as err:  # pointer doesn't belong to node
-            raise NotFound(err.message)
+            raise NotFound(str(err))
         node.save()
 
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -272,7 +272,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         try:
             func(val, auth)
         except PermissionsError as e:
-            raise exceptions.PermissionDenied(detail=e.message)
+            raise exceptions.PermissionDenied(detail=str(e))
         except (ValueError, ValidationError, NodeStateError) as e:
             raise exceptions.ValidationError(detail=e.message)
 

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -190,7 +190,7 @@ class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, Pre
             try:
                 citation = render_citation(node=preprint, style=style)
             except ValueError as err:  # style requested could not be found
-                csl_name = re.findall('[a-zA-Z]+\.csl', err.message)[0]
+                csl_name = re.findall('[a-zA-Z]+\.csl', str(err))[0]
                 raise NotFound('{} is not a known style.'.format(csl_name))
 
             return {'citation': citation, 'id': style}

--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -271,7 +271,7 @@ class ModeratorSerializer(JSONAPISerializer):
         try:
             provider.remove_from_group(instance, instance.permission_group, unsubscribe=False)
         except ValueError as e:
-            raise ValidationError(e.message)
+            raise ValidationError(str(e))
         provider.add_to_group(instance, perm_group)
         setattr(instance, 'permission_group', perm_group)
         return instance

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -478,4 +478,4 @@ class PreprintProviderModeratorsDetail(ModeratorMixin, JSONAPIBaseView, generics
         try:
             self.get_provider().remove_from_group(instance, instance.permission_group)
         except ValueError as e:
-            raise ValidationError(e.message)
+            raise ValidationError(str(e))

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -342,7 +342,7 @@ class BaseRegistrationSerializer(NodeSerializer):
             try:
                 registration.update_tags(new_tags, auth=auth)
             except NodeStateError as err:
-                raise Conflict(err.message)
+                raise Conflict(str(err))
         if 'custom_citation' in validated_data:
             registration.update_custom_citation(validated_data.pop('custom_citation'), auth)
         is_public = validated_data.get('is_public', None)
@@ -353,7 +353,7 @@ class BaseRegistrationSerializer(NodeSerializer):
                 except NodeUpdateError as err:
                     raise exceptions.ValidationError(err.reason)
                 except NodeStateError as err:
-                    raise exceptions.ValidationError(err.message)
+                    raise exceptions.ValidationError(str(err))
             else:
                 raise exceptions.ValidationError('Registrations can only be turned from private to public.')
         return registration

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -111,6 +111,7 @@ class InvalidTriggerError(Exception):
         self.state = state
         self.valid_triggers = valid_triggers
         self.message = 'Cannot trigger "{}" from state "{}". Valid triggers: {}'.format(trigger, state, valid_triggers)
+        super(Exception, self).__init__(self.message)
 
 class InvalidTransitionError(Exception):
     def __init__(self, machine, transition):

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -241,7 +241,7 @@ class TestOSFUser:
     def test_add_blacklisted_domain_unconfirmed_email(self, user):
         with pytest.raises(BlacklistedEmailError) as e:
             user.add_unconfirmed_email('kanye@mailinator.com')
-        assert e.value.message == 'Invalid Email'
+        assert str(e.value) == 'Invalid Email'
 
     @mock.patch('website.security.random_string')
     def test_get_confirmation_url_for_external_service(self, random_string):
@@ -724,7 +724,7 @@ class TestChangePassword:
         with pytest.raises(ChangePasswordError) as excinfo:
             user.change_password(old_password, new_password, confirm_password)
             user.save()
-        assert error_message in excinfo.value.message
+        assert error_message in str(excinfo)
         assert bool(user.check_password(new_password)) is False
 
     def test_change_password_invalid_old_password(self):
@@ -961,7 +961,7 @@ class TestUnregisteredUser:
             unreg_user.add_unclaimed_record(project,
                 given_name='fred m', referrer=referrer)
             unreg_user.save()
-        assert e.value.message == 'Referrer does not have permission to add a contributor to project {}'.format(project._primary_key)
+        assert str(e.value) == 'Referrer does not have permission to add a contributor to project {}'.format(project._primary_key)
 
         # test_referrer_is_not_admin_or_moderator
         referrer = UserFactory()
@@ -969,7 +969,7 @@ class TestUnregisteredUser:
             unreg_moderator.add_unclaimed_record(provider,
                 given_name='hodor', referrer=referrer)
             unreg_user.save()
-        assert e.value.message == 'Referrer does not have permission to add a moderator to provider {}'.format(provider._id)
+        assert str(e.value) == 'Referrer does not have permission to add a moderator to provider {}'.format(provider._id)
 
     @mock.patch('osf.models.OSFUser.update_search_nodes')
     @mock.patch('osf.models.OSFUser.update_search')
@@ -1460,7 +1460,7 @@ class TestUser(OsfTestCase):
     def test_cannot_remove_primary_email_from_email_list(self):
         with pytest.raises(PermissionsError) as e:
             self.user.remove_email(self.user.username)
-        assert e.value.message == 'Can\'t remove primary email'
+        assert str(e.value) == 'Can\'t remove primary email'
 
     def test_add_same_unconfirmed_email_twice(self):
         email = 'test@mail.com'

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -130,7 +130,7 @@ def update_user(auth):
                 try:
                     user.remove_email(address)
                 except PermissionsError as e:
-                    raise HTTPError(httplib.FORBIDDEN, e.message)
+                    raise HTTPError(httplib.FORBIDDEN, str(e))
             user.remove_unconfirmed_email(address)
 
         # additions

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -211,7 +211,7 @@ def register_draft_registration(auth, node, draft, *args, **kwargs):
         try:
             register.require_approval(auth.user)
         except NodeStateError as err:
-            raise HTTPError(http.BAD_REQUEST, data=dict(message_long=err.message))
+            raise HTTPError(http.BAD_REQUEST, data=dict(message_long=str(err)))
 
     register.save()
     push_status_message(language.AFTER_REGISTER_ARCHIVING,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -543,7 +543,7 @@ def project_set_privacy(auth, node, **kwargs):
     except NodeStateError as e:
         raise HTTPError(http.BAD_REQUEST, data=dict(
             message_short="Can't change privacy",
-            message_long=e.message
+            message_long=str(e)
         ))
 
     return {
@@ -589,7 +589,7 @@ def component_remove(auth, node, **kwargs):
             http.BAD_REQUEST,
             data={
                 'message_short': 'Error',
-                'message_long': 'Could not delete component: ' + e.message
+                'message_long': 'Could not delete component: ' + str(e)
             },
         )
     node.save()

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -111,7 +111,7 @@ def node_registration_retraction_post(auth, node, **kwargs):
         node.save()
         node.retraction.ask(node.get_active_contributors_recursive(unique_users=True))
     except NodeStateError as err:
-        raise HTTPError(http.FORBIDDEN, data=dict(message_long=err.message))
+        raise HTTPError(http.FORBIDDEN, data=dict(message_long=str(err)))
 
     return {'redirectUrl': node.web_url_for('view_project')}
 

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -95,7 +95,7 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
         except PermissionsError as e:
             raise HTTPError(http.UNAUTHORIZED, data={
                 'message_short': 'Unauthorized access',
-                'message_long': e.message
+                'message_long': str(e)
             })
         sanction.save()
         return {


### PR DESCRIPTION
## Purpose

We want to make the transition to Python 3 as seamless as possible and that means we're going to have to do a lot of refactoring. To defray the amount we have to do I a single big change-over we're starting by preemptively changing code so it's valid in both Python 2 and Python 3.

Anyway part of that is the string-ifing exception messages. Which traditionally we do like `e.message` which is valid in Python 2, but not Python 3. However `str(e)` is valid in both, so we're changing as many of those exceptions as we can. 

Worth noting this only applies to built-in exceptions or those that inherit directly from those, so this isn't really exhaustive.

## Changes

The following exceptions are now string-ified differently:
- PermissionsError
- ValueError
- NodeStateError
- InvalidTriggerError
- BlacklistedEmailError

## QA Notes

Should be no user facing changes, all behavior should remain unchanged.

## Documentation

No docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1084