### PR TITLE
[PLAT-410] Add link on OSF Search to Institutions landing page

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -293,6 +293,10 @@ var ViewModel = function(params) {
                 ), '_blank');
             win.opener = null;
             win.focus();
+        } else if (alias.name === 'institution') {
+            win = window.open(window.location.origin + '/institutions/', '_blank');
+            win.opener = null;
+            win.focus();
         } else {
             self.search();
         }


### PR DESCRIPTION
## Purpose

When we click the institutions link on the search page we want to open a tab to that page instead of filtering the search results for institutions. 

## Changes

- JS change to make sure link opens when the institutions button is clicked

## QA Notes

Go to search page, click the institutions button. if a tab with institutions landing page is opened, then this worked.

## Documentation

🐞 fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-410