### PR TITLE
[REG-16][OSF] Add wiki page counts to registration

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -341,6 +341,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     wikis = HideIfWikiDisabled(RelationshipField(
         related_view='nodes:node-wikis',
         related_view_kwargs={'node_id': '<_id>'},
+        related_meta={'count': 'get_wiki_page_count'},
     ))
 
     forked_from = RelationshipField(
@@ -556,6 +557,9 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
 
     def get_pointers_count(self, obj):
         return obj.linked_nodes.count()
+
+    def get_wiki_page_count(self, obj):
+        return obj.wikis.filter(deleted__isnull=True).count()
 
     def get_node_links_count(self, obj):
         count = 0

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -132,6 +132,7 @@ class BaseRegistrationSerializer(NodeSerializer):
     wikis = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-wikis',
         related_view_kwargs={'node_id': '<_id>'},
+        related_meta={'count': 'get_wiki_page_count'},
     ))
 
     forked_from = HideIfWithdrawal(RelationshipField(


### PR DESCRIPTION
## Purpose

Add wiki page counts to registration
for registries ember app

## Changes
- Add `wiki_page_count` to related counts node and registrations detail
- Add tests to registration, node detail

## QA Notes

## Documentation

## Side Effects

## Ticket

[[REG-16]](https://openscience.atlassian.net/browse/REG-16)
