### PR TITLE
[Hotfix] Feature/Custom Domain Route [PLAT-1108]

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -1076,7 +1076,7 @@ def make_url_map(app):
     # Web
 
     process_rules(app, [
-        Rule('/', 'get', website_views.index, notemplate),
+        Rule('/', 'get', website_views.index, OsfWebRenderer('institution.mako', trust=False)),
 
         Rule('/goodbye/', 'get', goodbye, notemplate),
 

--- a/website/views.py
+++ b/website/views.py
@@ -22,6 +22,7 @@ from framework.forms import utils as form_utils
 from framework.routing import proxy_url
 from framework.auth.core import _get_current_user
 from website import settings
+from website.institutions.views import serialize_institution
 
 from addons.osfstorage.models import Region
 from osf.models import BaseFileNode, Guid, Institution, PreprintService, AbstractNode, Node, Registration
@@ -133,7 +134,12 @@ def index():
     # Check if we're on an institution landing page
     institution = Institution.objects.filter(domains__icontains=request.host, is_deleted=False)
     if institution.exists():
-        return redirect('{}institutions/{}/'.format(DOMAIN, institution.get()._id))
+        institution = institution.get()
+        inst_dict = serialize_institution(institution)
+        inst_dict.update({
+            'redirect_url': '{}institutions/{}/'.format(DOMAIN, institution._id),
+        })
+        return inst_dict
     else:
         return use_ember_app()
 


### PR DESCRIPTION
## Purpose

Custom domains are being routed to institution detail page. For example, https://osf.io/institutions/uwstout/, used to be hosted at https://open.uwstout.edu.  The correct code is loading, but the route should not change.


## Changes
This is a fix of a fix, hopefully third time's a charm. https://github.com/CenterForOpenScience/osf.io/pull/8576 removed now obsolete code for the legacy dashboard and landing pages and simplified routing. We no longer needed some of the view and template logic for these pages, we could just reroute to the ember app.  A side effect was that custom domains also use the index route.  That ticket introduced a bug with custom domains not loading properly.  https://github.com/CenterForOpenScience/osf.io/pull/8694 attempted to fix, having a custom domain load the institution detail, which was also incorrect because we needed to retain the route.

This fix is a blend of how we were loading custom institution domains before, without the index.mako template logic (index.mako is now obsolete). A custom domain no longer redirects to the institution detail page, but instead loads the index route with the view returning what is needed for institution detail. The index route template has been changed to the institution detail template.  The only time the institution detail template will be loaded from the index route is if we're using a custom institution domain.  Otherwise, (like on the dashboard and landing pages), the ember app will be loaded.


## QA Notes
Dashboard pages, landing pages should work and reroute to ember app. Login/logout should 
work as expected.  https://osf.io/institutions/nd/ and https://osf.nd.edu should both load institution detail.  However, make sure that the custom domain does not change in location bar (If you navigate to osf.nd.edu, you should see osf.nd.edu, not osf.io/institutions/nd).  If you navigate to osf.io/institutions/nd directly, you should see osf.io/institutions/nd. Double check a few custom domains.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1108
