### PR TITLE
[hotfix] Preserve next url for unauthorized login link [PLAT-930]

### DIFF
--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -18,10 +18,6 @@ class HTTPError(FrameworkError):
             'message_long': ('If this should not have occurred and the issue persists, '
                              + language.SUPPORT_LINK),
         },
-        http.UNAUTHORIZED: {
-            'message_short': 'Unauthorized',
-            'message_long': 'You must <a href="/login/">log in</a> to access this resource.',
-        },
         http.FORBIDDEN: {
             'message_short': 'Forbidden',
             'message_long': ('You do not have permission to perform this action. '
@@ -83,6 +79,11 @@ class HTTPError(FrameworkError):
             data = {
                 'message_short': self.error_msgs[self.code]['message_short'],
                 'message_long': self.error_msgs[self.code]['message_long']
+            }
+        elif self.code == http.UNAUTHORIZED:
+            data = {
+                'message_short': 'Unauthorized',
+                'message_long': 'You must <a href="/login/?next={}">log in</a> to access this resource.'.format(request.url),
             }
         else:
             data['message_short'] = 'Unable to resolve'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The unauthorized page provided a bare `/login/` route which did not give CAS the info it needed to redirect to the proper place after authorizing
<!-- Describe the purpose of your changes -->

## Changes
Add a `?next=` request arg that `auth_login` can use when redirecting the request after login.
<!-- Briefly describe or list your changes  -->

## QA Notes
This should actually be a bit more global than what the ticket describes, and should now (hopefully) redirect to the place you were trying to go if before it just sent you to the dashboard. I know for most things like nodes it shows the "request access" thing which is indeed different, and I'm not sure where else this would apply -- but if there used to be a link clicked that got you to unauthorized when logged out and then redirected to the dashboard instead, this should lead you to the original link location after login. If that makes sense?

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
None needed
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-930
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
