### PR TITLE
[EMB-186] status message fixes

### DIFF
--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -40,12 +40,12 @@ def serialize_draft_registration(draft, auth=None):
         'updated': utils.iso8601format(draft.datetime_updated),
         'flags': draft.flags,
         'urls': {
-            'edit': node.web_url_for('edit_draft_registration_page', draft_id=draft._id),
+            'edit': node.web_url_for('edit_draft_registration_page', draft_id=draft._id, _guid=True),
             'submit': node.api_url_for('submit_draft_for_review', draft_id=draft._id),
             'before_register': node.api_url_for('project_before_register'),
             'register': node.api_url_for('register_draft_registration', draft_id=draft._id),
-            'register_page': node.web_url_for('draft_before_register_page', draft_id=draft._id),
-            'registrations': node.web_url_for('node_registrations')
+            'register_page': node.web_url_for('draft_before_register_page', draft_id=draft._id, _guid=True),
+            'registrations': node.web_url_for('node_registrations', _guid=True)
         },
         'requires_approval': draft.requires_approval,
         'is_pending_approval': draft.is_pending_review,

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -158,7 +158,8 @@ def submit_draft_for_review(auth, node, draft, *args, **kwargs):
 
     push_status_message(language.AFTER_SUBMIT_FOR_REVIEW,
                         kind='info',
-                        trust=False)
+                        trust=False,
+                        id='registration_submitted')
     return {
         'status': 'initiated',
         'urls': {
@@ -216,7 +217,8 @@ def register_draft_registration(auth, node, draft, *args, **kwargs):
     register.save()
     push_status_message(language.AFTER_REGISTER_ARCHIVING,
                         kind='info',
-                        trust=False)
+                        trust=False,
+                        id='registration_archiving')
     return {
         'status': 'initiated',
         'urls': {

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -162,7 +162,7 @@ def submit_draft_for_review(auth, node, draft, *args, **kwargs):
     return {
         'status': 'initiated',
         'urls': {
-            'registrations': node.web_url_for('node_registrations')
+            'registrations': node.web_url_for('node_registrations', _guid=True)
         }
     }, http.ACCEPTED
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -49,7 +49,9 @@ def node_register_page(auth, node, **kwargs):
     else:
         status.push_status_message(
             'You have been redirected to the project\'s registrations page. From here you can initiate a new Draft Registration to complete the registration process',
-            trust=False)
+            trust=False,
+            id='redirected_to_registrations',
+        )
         return redirect(node.web_url_for('node_registrations', view='draft'))
 
 @must_be_valid_project
@@ -149,7 +151,8 @@ def node_register_template_page(auth, node, metaschema_id, **kwargs):
     else:
         status.push_status_message(
             'You have been redirected to the project\'s registrations page. From here you can initiate a new Draft Registration to complete the registration process',
-            trust=False
+            trust=False,
+            id='redirected_to_registrations',
         )
         return redirect(node.web_url_for('node_registrations', view=kwargs.get('template')))
 

--- a/website/views.py
+++ b/website/views.py
@@ -306,7 +306,7 @@ def resolve_guid(guid, suffix=None):
             request.user = _get_current_user() or MockUser()
 
             if waffle.flag_is_active(request, flag_name):
-                use_ember_app()
+                return use_ember_app()
 
         url = _build_guid_url(urllib.unquote(referent.deep_url), suffix)
         return proxy_url(url)


### PR DESCRIPTION
## Purpose

Fix issues preventing proper status messages to be passed to Embosfed project registrations page (and, in fact, all Embosfed node guid routes).

## Changes

* For node guid routes, return `use_ember_app()` response instead of throwing it away
* Use guid routes throughout the registration process to avoid any redirection
* Set ids for registration-related status messages (translations keys for the Ember front-end)

## QA Notes

This will affect all Embosfed guid routes (especially the registrations tab). It also changes the URLs during the registration process to all be `/<guid>/draft/...` instead of `/project/<guid>/draft/...`. This can be tested as part of the full regression for 18.0.0 and does not require API nor cross-browser testing.

## Documentation

N/A

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/EMB-186
