### PR TITLE
[EMB-362] Expose "is contributor" on registrations

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -283,6 +283,9 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         help_text='List of strings representing the permissions '
         'for the current user on this node.',
     )
+    current_user_is_contributor = ser.SerializerMethodField(
+        help_text='Whether the current user is a contributor on this node.',
+    )
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(
@@ -493,6 +496,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
             return obj.contrib_read or False
         else:
             return obj.can_comment(auth)
+
+    def get_current_user_is_contributor(self, obj):
+        user = self.context['request'].user
+        user = None if user.is_anonymous else user
+        return obj.is_contributor(user)
 
     class Meta:
         type_ = 'nodes'
@@ -915,12 +923,6 @@ class NodeDetailSerializer(NodeSerializer):
     Overrides NodeSerializer to make id required.
     """
     id = IDField(source='_id', required=True)
-    current_user_is_contributor = ser.SerializerMethodField(help_text='Whether the current user is a contributor on this node.')
-
-    def get_current_user_is_contributor(self, obj):
-        user = self.context['request'].user
-        user = None if user.is_anonymous else user
-        return obj.is_contributor(user)
 
 
 class NodeForksSerializer(NodeSerializer):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -498,8 +498,12 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
             return obj.can_comment(auth)
 
     def get_current_user_is_contributor(self, obj):
+        if hasattr(obj, 'user_is_contrib'):
+            return obj.user_is_contrib
+
         user = self.context['request'].user
-        user = None if user.is_anonymous else user
+        if user.is_anonymous:
+            return False
         return obj.is_contributor(user)
 
     class Meta:

--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -78,6 +78,7 @@ class NodeOptimizationMixin(object):
         wiki_addon = WikiNodeSettings.objects.filter(owner=OuterRef('pk'), deleted=False)
         contribs = Contributor.objects.filter(user=auth.user, node=OuterRef('pk'))
         return queryset.prefetch_related('root').prefetch_related('subjects').annotate(
+            user_is_contrib=Exists(contribs),
             contrib_read=Subquery(contribs.values('read')[:1]),
             contrib_write=Subquery(contribs.values('write')[:1]),
             contrib_admin=Subquery(contribs.values('admin')[:1]),

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -71,6 +71,7 @@ class TestRegistrationDetail:
             data['relationships']['registered_from']['links']['related']['href']
         ).path
         assert data['attributes']['registration'] is True
+        assert data['attributes']['current_user_is_contributor'] is False
         assert registered_from == '/{}nodes/{}/'.format(
             API_BASE, public_project._id)
 
@@ -82,6 +83,7 @@ class TestRegistrationDetail:
         registered_from = urlparse(
             data['relationships']['registered_from']['links']['related']['href']).path
         assert data['attributes']['registration'] is True
+        assert data['attributes']['current_user_is_contributor'] is True
         assert registered_from == '/{}nodes/{}/'.format(
             API_BASE, public_project._id)
 
@@ -98,6 +100,7 @@ class TestRegistrationDetail:
         registered_from = urlparse(
             data['relationships']['registered_from']['links']['related']['href']).path
         assert data['attributes']['registration'] is True
+        assert data['attributes']['current_user_is_contributor'] is True
         assert registered_from == '/{}nodes/{}/'.format(
             API_BASE, private_project._id)
 


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make it easy to tell whether the current user is a contributor on a given registration, to correct a bug in the embosf'd project navbar.
<!-- Describe the purpose of your changes -->

## Changes
Move `current_user_is_contributor` field from NodeDetailSerializer to the base NodeSerializer. This makes the field available on registrations, and on nodes fetched via list views.
<!-- Briefly describe or list your changes  -->

## QA Notes
- Open the analytics or forks page of one of your registrations
- Check the "Contributors" link appears
- Open the analytics or forks page of someone else's registration
- Check the "Contributors" link does not appear

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
n/a
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects
n/a
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/EMB-362
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
