### PR TITLE
[PLAT-1127] Get all descendants of a node

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1698,3 +1698,9 @@ class MaintenanceStateSerializer(ser.ModelSerializer):
     class Meta:
         model = MaintenanceState
         fields = ('level', 'message', 'start', 'end')
+
+
+class FilterOnlyField(ser.SerializerMethodField):
+
+    def bind(self, field_name, parent):
+        return None

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1700,7 +1700,18 @@ class MaintenanceStateSerializer(ser.ModelSerializer):
         fields = ('level', 'message', 'start', 'end')
 
 
-class FilterOnlyField(ser.SerializerMethodField):
+class FilterOnlyField(ser.Field):
+    """
+    Filtering things in the OSF is usually done more abstractly through RelationshipFields, but there are some things
+    that want to filter on that aren't RelationshipFields, these custom filters need a "hidden" field so they can be
+    treated like RelationshipFields, while not being displayed or serialized as such.
+    """
+
+    def __init__(self):
+        super(FilterOnlyField, self).__init__(read_only=True)
 
     def bind(self, field_name, parent):
         return None
+
+    def to_internal_value(self, data):
+        return data

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -223,6 +223,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'contributors',
         'preprint',
         'subjects',
+        'child_of',
     ])
 
     non_anonymized_fields = [
@@ -284,6 +285,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'for the current user on this node.',
     )
 
+    child_of = ser.HiddenField(default=None)  # This needs to be a declared field to be filtered on.
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(
         source='is_public', required=False,

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -12,7 +12,7 @@ from api.base.serializers import (
     NodeFileHyperLinkField, RelationshipField,
     ShowIfVersion, TargetTypeField, TypeField,
     WaterbutlerLink, relationship_diff, BaseAPISerializer,
-    HideIfWikiDisabled, ShowIfAdminScopeOrAnonymous,
+    HideIfWikiDisabled, ShowIfAdminScopeOrAnonymous, FilterOnlyField,
 )
 from api.base.settings import ADDONS_FOLDER_CONFIGURABLE
 from api.base.utils import (
@@ -285,7 +285,6 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'for the current user on this node.',
     )
 
-    child_of = ser.HiddenField(default=None)  # This needs to be a declared field to be filtered on.
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(
         source='is_public', required=False,
@@ -464,6 +463,8 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view='nodes:node-preprints',
         related_view_kwargs={'node_id': '<_id>'},
     ))
+
+    child_of = FilterOnlyField()
 
     def get_current_user_permissions(self, obj):
         if hasattr(obj, 'contrib_admin'):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -134,7 +134,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'preprint',
             'subjects']
         # fields that do not appear on registrations
-        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings']
+        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'child_of']
 
         for field in NodeSerializer._declared_fields:
             assert_in(field, RegistrationSerializer._declared_fields)

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -93,6 +93,10 @@ class NodesListFilteringMixin(object):
         return '{}filter[root][ne]='.format(url)
 
     @pytest.fixture()
+    def child_of_url(self, url):
+        return '{}filter[child_of]='.format(url)
+
+    @pytest.fixture()
     def tags_url(self, url):
         return '{}filter[tags]='.format(url)
 
@@ -108,7 +112,7 @@ class NodesListFilteringMixin(object):
             great_grandchild_node_two,
             root_ne_url, parent_url, root_url,
             contributors_url, parent_project_one,
-            child_project_one
+            child_project_one, child_of_url
     ):
 
         #   test_parent_filter_null
@@ -231,6 +235,18 @@ class NodesListFilteringMixin(object):
         assert project._id in ids
         assert child_node_one._id not in ids
         assert parent_project._id not in ids
+
+    #   test_child_of
+        url = '{}{}'.format(
+            child_of_url,
+            child_node_two._id
+        )
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        ids = [node_['id'] for node_ in res.json['data']]
+        assert grandchild_node_two._id in ids
+        assert great_grandchild_node_two._id in ids
 
     def test_parent_filter_excludes_linked_nodes(
             self, app, user, parent_project,

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -382,7 +382,8 @@ class TestRegistrationUpdate:
             'registration_choice',
             'lift_embargo',
             'tags',
-            'custom_citation']
+            'custom_citation',
+            'child_of']
         for field in RegistrationSerializer._declared_fields:
             reg_field = RegistrationSerializer._declared_fields[field]
             if field not in writeable_fields:
@@ -396,7 +397,8 @@ class TestRegistrationUpdate:
             'registration_choice',
             'lift_embargo',
             'tags',
-            'custom_citation']
+            'custom_citation',
+            'child_of']
         for field in RegistrationDetailSerializer._declared_fields:
             reg_field = RegistrationSerializer._declared_fields[field]
             if field not in writeable_fields:

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -382,8 +382,7 @@ class TestRegistrationUpdate:
             'registration_choice',
             'lift_embargo',
             'tags',
-            'custom_citation',
-            'child_of']
+            'custom_citation']
         for field in RegistrationSerializer._declared_fields:
             reg_field = RegistrationSerializer._declared_fields[field]
             if field not in writeable_fields:
@@ -397,8 +396,7 @@ class TestRegistrationUpdate:
             'registration_choice',
             'lift_embargo',
             'tags',
-            'custom_citation',
-            'child_of']
+            'custom_citation']
         for field in RegistrationDetailSerializer._declared_fields:
             reg_field = RegistrationSerializer._declared_fields[field]
             if field not in writeable_fields:


### PR DESCRIPTION
## Purpose

We want to be able to filter on all a nodes descendants, not just it's immediate children. This allows us to do that.

## Changes

- add a new field for filtering nodes 'child_of'
- adds special case to the node filter subclass that uses `get_children` to create a subquery.
- add test

## QA Notes

You should be able to test this with /v2/nodes/?filter[child_of]={node guid} and see all that node's descendants, not just immediate children. It should be paginated, fail properly with bad data, etc.

## Documentation

This will be added to dev docs on approval.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1127?