### PR TITLE
[Hotfix][PLAT-1136] Fix unclickable storage i18n locations 

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -353,7 +353,7 @@ var UpdateDefaultStorageLocation = oop.defclass({
         var self = this;
         this.client = new UserProfileClient();
         this.profile = ko.observable(new UserProfile());
-        this.locationSelected = ko.observable({'name': ''});
+        this.locationSelected = ko.observable();
         this.locations = ko.observableArray([]);
 
         this.client.fetch().done(
@@ -371,9 +371,9 @@ var UpdateDefaultStorageLocation = oop.defclass({
         'update': '/api/v1/profile/region/'
     },
     updateDefaultStorageLocation: function() {
-        var request = $osf.ajaxJSON('PUT', this.urls.update, {'data': {'region_id': this.locationSelected()()._id}});
+        var request = $osf.ajaxJSON('PUT', this.urls.update, {'data': {'region_id': this.locationSelected()._id}});
         request.done(function() {
-            $osf.growl('Success', 'You have successfully changed your default storage location to <b>' + this.locationSelected()().name + '</b>.', 'success');
+            $osf.growl('Success', 'You have successfully changed your default storage location to <b>' + this.locationSelected().name + '</b>.', 'success');
         }.bind(this));
         request.fail(function(xhr, status, error) {
             $osf.growl('Error',

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -82,33 +82,21 @@
                         </table>
                     </div>
                 </div>
-                % if storage_flag_is_active:
-                    <div id="updateDefaultStorageLocation" class="panel panel-default">
+                % if True:
+                    <div class="panel panel-default">
                         <div class="panel-heading clearfix"><h3 class="panel-title">Default Storage Location</h3></div>
                         <div class="panel-body">
                             <form id="updateDefaultStorageLocation" role="form">
                                 <div class="form-group">
-                                    <label for="default_storage_location">Default storage location:</label>
-                                    <span class="p-l-sm dropdown generic-dropdown category-list">
-                                        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                                            <span data-bind="text: locationSelectedName" class="text-capitalize"></span>
-                                            <i class="fa fa-sort"></i>
-                                        </button>
-                                        <ul class="dropdown-menu" data-bind="foreach: {data: profile().availableRegions, as: 'location'}">
-                                            <li>
-                                                  <a href="#" data-bind="click: $root.setLocation.bind($root, location)">
-                                                      <span data-bind="text: location.name"></span>
-                                                  </a>
-                                            </li>
-                                        </ul>
-                                        <div class="help-block">
-                                                <p>
-                                                    This location will be applied to new projects and components. It will not affect existing projects and components.
-                                                </p>
-                                        </div>
-                                    </span>
+                                    <select class="form-control" data-bind="options: locations, value: locationSelected(), optionsText: function(item) { return item.name }">
+                                    </select>
+                                    <div class="help-block">
+                                        <p>
+                                            This location will be applied to new projects and components. It will not affect existing projects and components.
+                                        </p>
+                                    </div>
                                 </div>
-                                <button class="btn btn-primary" data-bind="click: $root.updateDefaultStorageLocation.bind($root)">Update location</button>
+                                <a class="btn btn-primary" data-bind="click: $root.updateDefaultStorageLocation.bind($root)">Update location</a>
                                 <p class="text-muted"></p>
                             </form>
                         </div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -88,7 +88,7 @@
                         <div class="panel-body">
                             <form id="updateDefaultStorageLocation" data-bind="submit: $root.updateDefaultStorageLocation.bind($root)" role="form">
                                 <div class="form-group">
-                                    <select class="form-control" data-bind="options: locations, value: locationSelected(), optionsText: function(item) { return item.name }">
+                                    <select class="form-control" data-bind="options: locations, value: locationSelected, optionsText: function(item) { return item.name }">
                                     </select>
                                     <div class="help-block">
                                         <p>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -86,7 +86,7 @@
                     <div class="panel panel-default">
                         <div class="panel-heading clearfix"><h3 class="panel-title">Default Storage Location</h3></div>
                         <div class="panel-body">
-                            <form id="updateDefaultStorageLocation" role="form">
+                            <form id="updateDefaultStorageLocation" data-bind="submit: $root.updateDefaultStorageLocation.bind($root)" role="form">
                                 <div class="form-group">
                                     <select class="form-control" data-bind="options: locations, value: locationSelected(), optionsText: function(item) { return item.name }">
                                     </select>
@@ -95,9 +95,9 @@
                                             This location will be applied to new projects and components. It will not affect existing projects and components.
                                         </p>
                                     </div>
-                                    <input type="submit" class="btn btn-primary" data-bind="click: $root.updateDefaultStorageLocation.bind($root)" value="Update location" />
                                 </div>
                                 <p class="text-muted"></p>
+                                <button class="btn btn-primary" type="submit">Update location</button>
                             </form>
                         </div>
                     </div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -82,7 +82,7 @@
                         </table>
                     </div>
                 </div>
-                % if True:
+                % if storage_flag_is_active:
                     <div class="panel panel-default">
                         <div class="panel-heading clearfix"><h3 class="panel-title">Default Storage Location</h3></div>
                         <div class="panel-body">
@@ -95,8 +95,8 @@
                                             This location will be applied to new projects and components. It will not affect existing projects and components.
                                         </p>
                                     </div>
+                                    <input type="submit" class="btn btn-primary" data-bind="click: $root.updateDefaultStorageLocation.bind($root)" value="Update location" />
                                 </div>
-                                <a class="btn btn-primary" data-bind="click: $root.updateDefaultStorageLocation.bind($root)">Update location</a>
                                 <p class="text-muted"></p>
                             </form>
                         </div>


### PR DESCRIPTION
## Purpose

Currently the Storage Internationalization user default dropdown has a bootstrap bug where it can't be clicked/touched on mobile screens. This PR fixes that.

## Changes

- simple CSS fix

## QA Notes

Very similar to an earlier touchscreen problem we had here:  https://github.com/CenterForOpenScience/osf.io/pull/8448

## Documentation

🐞  fix no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1136