### PR TITLE
[EMB-341] Consistent oauth scope description punctuation

### DIFF
--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -247,7 +247,7 @@ public_scopes = {
                                         'private projects.',
                             is_public=True),
     'osf.users.profile_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
-                                description='Read your profile data',
+                                description='Read your profile data.',
                                 is_public=True),
     'osf.users.email_read': scope(parts_=frozenset(ComposedScopes.USER_EMAIL_READ),
                                         description='Read your primary email address.',
@@ -257,18 +257,18 @@ public_scopes = {
 if settings.DEV_MODE:
     public_scopes.update({
         'osf.users.profile_write': scope(parts_=frozenset(ComposedScopes.USERS_WRITE),
-                                     description='Read and edit your profile data',
+                                     description='Read and edit your profile data.',
                                      is_public=True),
 
         'osf.nodes.metadata_read': scope(parts_=frozenset(ComposedScopes.NODE_METADATA_READ),
                                          description='Read a list of all public and private nodes accessible to this '
                                                      'account, and view associated metadata such as project descriptions '
-                                                     'and titles',
+                                                     'and titles.',
                                          is_public=True),
         'osf.nodes.metadata_write': scope(parts_=frozenset(ComposedScopes.NODE_METADATA_WRITE),
                                           description='Read a list of all public and private nodes accessible to this '
                                                       'account, and view and edit associated metadata such as project '
-                                                      'descriptions and titles',
+                                                      'descriptions and titles.',
                                           is_public=True),
 
         'osf.nodes.data_read': scope(parts_=frozenset(ComposedScopes.NODE_DATA_READ),
@@ -282,7 +282,7 @@ if settings.DEV_MODE:
 
         'osf.nodes.access_read': scope(parts_=frozenset(ComposedScopes.NODE_ACCESS_READ),
                                        description='View the contributors list and any established registrations '
-                                                   'associated with public or private projects',
+                                                   'associated with public or private projects.',
                                        is_public=True),
         'osf.nodes.access_write': scope(parts_=frozenset(ComposedScopes.NODE_ACCESS_WRITE),
                                         description='View and edit the contributors list associated with public or '


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
OAuth scope descriptions are more visible on the embosf'd personal access tokens page. Inconsistent punctuation makes us look bad.
<!-- Describe the purpose of your changes -->

## Changes
Add a period to the end of each scope description that doesn't already have one.
<!-- Briefly describe or list your changes  -->

## QA Notes
Check the scope descriptions at `/settings/tokens/create` (or on a token edit page) all end in a period.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
n/a
<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects
n/a
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/EMB-341
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
