### PR TITLE
[Hotfix][PLAT-1139] Fix infinite redirect loop for folder link

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -712,6 +712,13 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         transaction.savepoint_rollback(savepoint_id)
         if not file_node.pk:
             file_node = BaseFileNode.load(path)
+
+            if file_node.kind == 'folder':
+                raise HTTPError(httplib.BAD_REQUEST, data={
+                    'message_short': 'Bad Request',
+                    'message_long': 'File not associated with required object.'
+                })
+
             # Allow osfstorage to redirect if the deep url can be used to find a valid file_node
             if file_node and file_node.provider == 'osfstorage' and not file_node.is_deleted:
                 return redirect(

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -716,7 +716,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
             if file_node.kind == 'folder':
                 raise HTTPError(httplib.BAD_REQUEST, data={
                     'message_short': 'Bad Request',
-                    'message_long': 'File not associated with required object.'
+                    'message_long': 'You cannot request a folder from this endpoint.'
                 })
 
             # Allow osfstorage to redirect if the deep url can be used to find a valid file_node

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -28,7 +28,7 @@ from addons.base import views
 from addons.github.exceptions import ApiError
 from addons.github.models import GithubFolder, GithubFile, GithubFileNode
 from addons.github.tests.factories import GitHubAccountFactory
-from addons.osfstorage.models import OsfStorageFileNode
+from addons.osfstorage.models import OsfStorageFileNode, OsfStorageFolder
 from addons.osfstorage.tests.factories import FileVersionFactory
 from osf.models import Session, RegistrationSchema, QuickFilesNode
 from osf.models import files as file_models
@@ -961,6 +961,26 @@ class TestAddonFileViews(OsfTestCase):
         )
 
         assert_equals(resp.status_code, 401)
+
+    def test_resolve_folder_raise(self):
+        folder = OsfStorageFolder(
+            name='folder',
+            target=self.project,
+            path='/test/folder/',
+            materialized_path='/test/folder/',
+        )
+        folder.save()
+        resp = self.app.get(
+            self.project.web_url_for(
+                'addon_view_or_download_file',
+                path=folder._id,
+                provider='osfstorage',
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 400)
 
     def test_delete_action_creates_trashed_file_node(self):
         file_node = self.get_test_file()


### PR DESCRIPTION
## Purpose

Currently going to https://osf.io/2ba8c/files/osfstorage/58a5bcb66c613b01f3ead217/  or any `/<nid>/files/osfstorage/<folder path>/` link will cause the browser to detect an infinite redirect loop and stop the page from loading. This fix prevents that.

## Changes

- changed addon_view_or_download_file to properly handle folders
- add test

## QA Notes

Links like this one https://osf.io/2ba8c/files/osfstorage/58a5bcb66c613b01f3ead217/ where the path points to a valid folder should resolve to a 400 Bad Request message instead of forcing the browser into a redirect loop.

## Documentation

🐞 fix no, docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1139