### PR TITLE
Return explicitly assigned node permissions for current user [PLAT-1135]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -160,6 +160,7 @@ REST_FRAMEWORK = {
         '2.8',
         '2.9',
         '2.10',
+        '2.11',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -406,6 +406,42 @@ class TestNodeDetail:
         res = app.get(forks_url, auth=user.auth)
         assert len(res.json['data']) == 1
 
+    def test_current_user_permissions(self, app, user, url_public, project_public, user_two):
+        # in most recent API version, read isn't implicit for public nodes
+        url = url_public + '?version=2.11'
+        res = app.get(url, auth=user_two.auth)
+        assert not project_public.has_permission(user_two, permissions.READ)
+        assert permissions.READ not in res.json['data']['attributes']['current_user_permissions']
+
+        # test read perm older versions for anon user
+        res = app.get(url)
+        assert permissions.READ not in res.json['data']['attributes']['current_user_permissions']
+
+        # ensure both read and write included for a write contributor
+        new_user = AuthUserFactory()
+        project_public.add_contributor(
+            new_user,
+            permissions=(permissions.READ, permissions.WRITE),
+            auth=Auth(project_public.creator)
+        )
+        res = app.get(url, auth=new_user.auth)
+        assert res.json['data']['attributes']['current_user_permissions'] == [permissions.READ, permissions.WRITE]
+
+        # make sure 'read' is there for implicit read contributors
+        comp = NodeFactory(parent=project_public, is_public=True)
+        comp_url = '/{}nodes/{}/?version=2.11'.format(API_BASE, comp._id)
+        res = app.get(comp_url, auth=user.auth)
+        assert project_public.has_permission(user, permissions.ADMIN)
+        assert permissions.READ in res.json['data']['attributes']['current_user_permissions']
+
+        # ensure 'read' is still included with older versions
+        res = app.get(url_public, auth=user_two.auth)
+        assert not project_public.has_permission(user_two, permissions.READ)
+        assert permissions.READ in res.json['data']['attributes']['current_user_permissions']
+
+        # est read perm older versions for anon user
+        res = app.get(url_public)
+        assert permissions.READ in res.json['data']['attributes']['current_user_permissions']
 
 @pytest.mark.django_db
 class NodeCRUDTestCase:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For the `get_current_user_permissions` field, we no longer want to include read by default for every random/anonymous user looking at a public project. Instead return the actual permissions assigned/implied for any particular project.


## Changes

- Modify `get_current_user_permissions` for the node serializer, only return the permissions assigned to the user, or implied by being an admin on a parent.
- Add new API version to keep around old behavior
- Tests to make sure correct permissions are returned

## QA Notes

Before API version 2.11, requests from a user on any public node should return at least ['read'] for `current_user_permissions`, and should never be an empty list. Using version 2.11 or later, if a user doesn't have explicit permissions on a node, or doesn't have implicit read on a node, the `current_user_permissions` field can return an empty list. 

## Documentation

- Updated the help text for the `current_user_permissions` field
- Docs at developer.osf.io are still accurate with this change (perhaps even more accurate with this change!)
<img width="488" alt="screen shot 2018-10-08 at 4 35 09 pm" src="https://user-images.githubusercontent.com/801594/46632306-36922080-cb18-11e8-803c-f0b3fa3414e0.png">


## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-1135
