### PR TITLE
[EMB-382] add wiki enabled computed attribute to node serializer

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -283,6 +283,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         help_text='List of strings representing the permissions '
         'for the current user on this node.',
     )
+    wiki_enabled = ser.SerializerMethodField(help_text='Whether the wiki addon is enabled')
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(
@@ -599,6 +600,9 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
             # i.e. after creating a node
             region_id = obj.osfstorage_region._id
         return region_id
+
+    def get_wiki_enabled(self, obj):
+        return obj.has_addon('wiki')
 
     def create(self, validated_data):
         request = self.context['request']

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -132,7 +132,8 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'current_user_can_comment',
             'current_user_is_contributor',
             'preprint',
-            'subjects']
+            'subjects',
+            'wiki_enabled']
         # fields that do not appear on registrations
         non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings']
 

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -48,6 +48,7 @@ class TestNodeSerializer:
         assert attributes['fork'] == node.is_fork
         assert attributes['collection'] == node.is_collection
         assert attributes['analytics_key'] == node.keenio_read_key
+        assert attributes['wiki_enabled'] == node.has_addon('wiki')
 
         # Relationships
         relationships = data['relationships']


### PR DESCRIPTION
## Purpose

In order to hide the wiki link in the node navbar, we need to know if a node has the wiki addon. Currently, the `wikis` relationship is omitted when a node doesn't have the wiki addon, but this is not definitive as it could be omitted for other reasons (e.g. sparse fieldsets). Also, ember-data does not remove or nullify an omitted relationship that has previously been defined so this is not a good source of truth for whether a node is wiki enabled. This PR adds an additional boolean attribute to indicate if the node has the wiki addon enabled.

## Changes

* Add wiki_enabled computed attribute to node serializer
* Add wiki_enabled attribute to node serializer test
* Add wiki_enabled to list of visible withdrawn registration fields

## QA Notes

This will be a new attribute `wiki_enabled` on the nodes api endpoint that should be `true` when the node has its wiki enabled, and `false` when it is disabled.

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/28

## Side Effects

Shouldn't be any.

## Ticket

https://openscience.atlassian.net/browse/EMB-382
