### PR TITLE
[REG-47][Registries] Add FormBlock API

### DIFF
--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -1,6 +1,12 @@
 from rest_framework import serializers as ser
-from api.base.serializers import (JSONAPISerializer, IDField, TypeField, LinksField)
 
+from api.base.serializers import (
+    JSONAPISerializer,
+    IDField,
+    TypeField,
+    LinksField,
+    RelationshipField,
+)
 
 class SchemaSerializer(JSONAPISerializer):
 
@@ -23,7 +29,40 @@ class SchemaSerializer(JSONAPISerializer):
         type_ = 'schemas'
 
 
+class RegistrationSchemaFormBlockSerializer(JSONAPISerializer):
+
+    id = IDField(source='_id', read_only=True)
+    type = TypeField()
+    page = ser.CharField(max_length=255, read_only=True)
+    section = ser.CharField(max_length=255, read_only=True)
+    help_text = ser.CharField(read_only=True, allow_blank=True)
+    block_id = ser.CharField(max_length=255)
+    block_type = ser.CharField(read_only=True)
+    block_text = ser.CharField(allow_blank=True)
+    size = ser.CharField(read_only=True, allow_blank=True)
+    choices = ser.ListField(
+        child=ser.CharField(read_only=True, allow_blank=True),
+        default=list(),
+    )
+    required = ser.BooleanField(default=True, read_only=True)
+    index = ser.IntegerField(required=False, read_only=True, source='_order')
+
+    links = LinksField({
+        'self': 'get_absolute_url',
+    })
+
+    def get_absolute_url(self, obj):
+        return obj.absolute_api_v2_url
+
+    class Meta:
+        type_ = 'form_blocks'
+
 class RegistrationSchemaSerializer(SchemaSerializer):
+    form_blocks = RelationshipField(
+        related_view='schemas:registration-schema-form-blocks',
+        related_view_kwargs={'schema_id': '<_id>'},
+        always_embed=True,
+    )
 
     class Meta:
         type_ = 'registration_schemas'

--- a/api/schemas/urls.py
+++ b/api/schemas/urls.py
@@ -7,4 +7,6 @@ app_name = 'osf'
 urlpatterns = [
     url(r'^registrations/$', views.RegistrationSchemaList.as_view(), name=views.RegistrationSchemaList.view_name),
     url(r'^registrations/(?P<schema_id>\w+)/$', views.RegistrationSchemaDetail.as_view(), name=views.RegistrationSchemaDetail.view_name),
+    url(r'^registrations/(?P<schema_id>\w+)/form_blocks/$', views.RegistrationSchemaFormBlocks.as_view(), name=views.RegistrationSchemaFormBlocks.view_name),
+    url(r'^registrations/(?P<schema_id>\w+)/form_blocks/(?P<form_block_id>\w+)/$', views.RegistrationSchemaFormBlockDetail.as_view(), name=views.RegistrationSchemaFormBlockDetail.view_name),
 ]

--- a/api/schemas/views.py
+++ b/api/schemas/views.py
@@ -1,4 +1,4 @@
-from rest_framework import generics, permissions as drf_permissions
+from rest_framework import exceptions, generics, permissions as drf_permissions
 from framework.auth.oauth_scopes import CoreScopes
 
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
@@ -6,8 +6,11 @@ from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
 from api.base.utils import get_object_or_error
 
-from osf.models import RegistrationSchema
-from api.schemas.serializers import RegistrationSchemaSerializer
+from osf.models import RegistrationFormBlock, RegistrationSchema
+from api.schemas.serializers import (
+    RegistrationSchemaSerializer,
+    RegistrationSchemaFormBlockSerializer,
+)
 
 
 class RegistrationSchemaList(JSONAPIBaseView, generics.ListAPIView):
@@ -23,7 +26,7 @@ class RegistrationSchemaList(JSONAPIBaseView, generics.ListAPIView):
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
     serializer_class = RegistrationSchemaSerializer
-    view_category = 'registration-schemas'
+    view_category = 'schemas'
     view_name = 'registration-schema-list'
 
     ordering = ('-id',)
@@ -45,10 +48,49 @@ class RegistrationSchemaDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     required_write_scopes = [CoreScopes.NULL]
 
     serializer_class = RegistrationSchemaSerializer
-    view_category = 'registration-schemas'
+    view_category = 'schemas'
     view_name = 'registration-schema-detail'
 
     # overrides RetrieveAPIView
     def get_object(self):
         schema_id = self.kwargs['schema_id']
         return get_object_or_error(RegistrationSchema, schema_id, self.request)
+
+class RegistrationSchemaFormBlocks(JSONAPIBaseView, generics.ListAPIView):
+
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.SCHEMA_FORM_BLOCKS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = RegistrationSchemaFormBlockSerializer
+    view_category = 'schemas'
+    view_name = 'registration-schema-form-blocks'
+    ordering = ('_order',)
+
+    def get_queryset(self):
+        schema_id = self.kwargs.get('schema_id')
+        schema = get_object_or_error(RegistrationSchema, schema_id, self.request)
+        if schema.schema_version != LATEST_SCHEMA_VERSION or not schema.active:
+            raise exceptions.ValidationError('Registration schema must be active.')
+        return schema.form_blocks.all()
+
+class RegistrationSchemaFormBlockDetail(JSONAPIBaseView, generics.RetrieveAPIView):
+
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.SCHEMA_FORM_BLOCKS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = RegistrationSchemaFormBlockSerializer
+    view_category = 'schemas'
+    view_name = 'registration-schema-form-block-detail'
+
+    def get_object(self):
+        return get_object_or_error(RegistrationFormBlock, self.kwargs.get('form_block_id'), self.request)

--- a/api_tests/schemas/views/test_registration_schemas_detail.py
+++ b/api_tests/schemas/views/test_registration_schemas_detail.py
@@ -7,20 +7,20 @@ from osf_tests.factories import (
 )
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db
-class TestMetaSchemaDetail:
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
 
-    @pytest.fixture()
-    def user(self):
-        return AuthUserFactory()
+@pytest.fixture()
+def schema():
+    return RegistrationSchema.objects.filter(
+        name='Prereg Challenge',
+        schema_version=LATEST_SCHEMA_VERSION
+    ).first()
 
-    @pytest.fixture()
-    def schema(self):
-        return RegistrationSchema.objects.filter(
-            name='Prereg Challenge',
-            schema_version=LATEST_SCHEMA_VERSION
-        ).first()
+class TestDeprecatedMetaSchemaDetail:
 
     def test_deprecated_metaschemas_routes(self, app, user, schema):
         # test base /metaschemas/ GET with min version
@@ -44,6 +44,9 @@ class TestMetaSchemaDetail:
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
         assert res.json['errors'][0]['detail'] == 'This route has been deprecated. It was last available in version 2.8'
+
+@pytest.mark.django_db
+class TestRegistrationSchemaDetail:
 
     def test_schemas_detail_visibility(self, app, user, schema):
         # test_pass_authenticated_user_can_retrieve_schema
@@ -73,3 +76,28 @@ class TestMetaSchemaDetail:
         url = '/{}schemas/registrations/garbage/'.format(API_BASE)
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
+
+    def test_registration_schema_form_blocks(self, app, user, schema):
+        # test_authenticated_user_can_retrieve_schema_form_blocks
+        url = '/{}schemas/registrations/{}/form_blocks/'.format(API_BASE, schema._id)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+
+        # test_unauthenticated_user_can_retrieve_schema_form_blocks
+        url = '/{}schemas/registrations/{}/form_blocks/'.format(API_BASE, schema._id)
+        res = app.get(url)
+        assert res.status_code == 200
+
+        # test_form_blocks_are_always_embedded_on_schema
+        url = '/{}schemas/registrations/{}/'.format(API_BASE, schema._id)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert 'form_blocks' in res.json['data']['embeds']
+        assert res.json['data']['embeds']['form_blocks']['links']['meta']['total'] == schema.form_blocks.count()
+
+        # test_form_blocks_detail
+        form_block_id = schema.form_blocks.first()._id
+        url = '/{}schemas/registrations/{}/form_blocks/{}/'.format(API_BASE, schema._id, form_block_id)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == form_block_id

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -72,6 +72,7 @@ class CoreScopes(object):
     REGISTRATION_VIEW_ONLY_LINKS_WRITE = 'registration.view_only_links_write'
 
     SCHEMA_READ = 'schemas.read'
+    SCHEMA_FORM_BLOCKS_READ = 'schema.form_block_read'
 
     NODE_DRAFT_REGISTRATIONS_READ = 'nodes.draft_registrations_read'
     NODE_DRAFT_REGISTRATIONS_WRITE = 'nodes.draft_registrations_write'
@@ -176,6 +177,9 @@ class ComposedScopes(object):
 
     # Metaschemas collection
     METASCHEMAS_READ = (CoreScopes.SCHEMA_READ, )
+
+    # Schemas form blocks
+    SCHEMA_FORM_BLOCKS_READ = METASCHEMAS_READ + (CoreScopes.SCHEMA_FORM_BLOCKS_READ, )
 
     # Draft registrations
     DRAFT_READ = (CoreScopes.NODE_DRAFT_REGISTRATIONS_READ, )

--- a/osf/models/__init__.py
+++ b/osf/models/__init__.py
@@ -1,4 +1,4 @@
-from osf.models.metaschema import RegistrationSchema  # noqa
+from osf.models.metaschema import RegistrationFormBlock, RegistrationSchema  # noqa
 from osf.models.base import Guid, BlackListGuid  # noqa
 from osf.models.user import OSFUser, Email  # noqa
 from osf.models.contributor import Contributor, RecentlyAddedContributor  # noqa

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -115,3 +115,8 @@ class RegistrationFormBlock(ObjectIDMixin, BaseModel):
     size = models.CharField(max_length=2, null=True, choices=FORMBLOCK_SIZES)
     choices = ArrayField(models.TextField(), default=list)  # Longest on prod: >511 chars
     required = models.BooleanField(default=True)
+
+    @property
+    def absolute_api_v2_url(self):
+        path = '{}form_blocks/{}/'.format(self.schema.absolute_api_v2_url, self._id)
+        return api_v2_url(path)


### PR DESCRIPTION
## Purpose

Add API v2 endpoints for Registration Schema form blocks.
Normalize formblock for Registries frontend needs normalized data structure for submission

## Changes

- Add detail and list related views on RegistrationSchema `/v2/schemas/registrations/<schema_id>/form_blocks/<form_block_id>`
`/v2/schemas/registrations/<schema_id>/form_blocks/`
- Add tests

## QA Notes

NotQATeam

## Documentation

- Coming soon

## Side Effects

## Ticket

[REG-47](https://openscience.atlassian.net/browse/REG-47)
