### PR TITLE
[EMB-377] Remove premature serving of ember front-end for node guid routes

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -301,14 +301,6 @@ def resolve_guid(guid, suffix=None):
 
                 return send_from_directory(registries_dir, 'index.html')
 
-        if isinstance(referent, Node) and not referent.is_registration and suffix:
-            page = suffix.strip('/').split('/')[0]
-            flag_name = 'ember_project_{}_page'.format(page)
-            request.user = _get_current_user() or MockUser()
-
-            if waffle.flag_is_active(request, flag_name):
-                return use_ember_app()
-
         url = _build_guid_url(urllib.unquote(referent.deep_url), suffix)
         return proxy_url(url)
 


### PR DESCRIPTION
## Purpose

Remove premature serving of ember front-end for node guid routes so that back-end handling of forbidden projects continues to work.

## Changes

Remove code that checks for an active flag matching the current project page and returns a response serving the ember front end without processing through the Flask views.

## QA Notes

Attempts to access embosfed project pages for private projects should match the behavior on prod, namely:
* logged out: redirect or log in page
* logged in, no access: present page telling you so and buttons for requesting access and switching accounts 

## Documentation

n/a

## Side Effects

🤞

## Ticket

n/a
