### PR TITLE
[hotfix] Check for external auth when claiming an unregistered user [PLAT-1070]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -24,7 +24,8 @@ from django.test.utils import CaptureQueriesContext
 
 from addons.github.tests.factories import GitHubAccountFactory
 from addons.wiki.models import WikiPage
-from framework.auth import cas
+from framework.auth import cas, authenticate
+from framework.flask import redirect
 from framework.auth.core import generate_verification_key
 from framework import auth
 from framework.auth.campaigns import get_campaigns, is_institution_login, is_native_login, is_proxy_login, campaign_url_for
@@ -66,6 +67,7 @@ from tests.base import (
     assert_datetime_equal,
 )
 from tests.base import test_app as mock_app
+from tests.test_cas_authentication import generate_external_user_with_resp, make_external_response
 from api_tests.utils import create_test_file
 
 pytestmark = pytest.mark.django_db
@@ -2598,6 +2600,39 @@ class TestClaimViews(OsfTestCase):
             token=token,
         )
         assert_equal(res.request.path, expected)
+
+    @mock.patch('framework.auth.cas.make_response_from_ticket')
+    def test_claim_user_when_user_is_registered_with_orcid(self, mock_response_from_ticket):
+        token = self.user.get_unclaimed_record(self.project._primary_key)['token']
+        url = '/user/{uid}/{pid}/claim/verify/{token}/'.format(
+            uid=self.user._id,
+            pid=self.project._id,
+            token=token
+        )
+        # logged out user gets redirected to cas login
+        res = self.app.get(url)
+        assert res.status_code == 302
+        res = res.follow()
+        expected = cas.get_login_url(service_url='http://localhost:80{}'.format(url))
+        assert res.request.url == expected
+
+        # user logged in with orcid automatically becomes a contributor
+        orcid_user, validated_credentials, cas_resp = generate_external_user_with_resp(url)
+        mock_response_from_ticket.return_value = authenticate(
+            orcid_user,
+            cas_resp.attributes.get('accessToken', ''),
+            redirect(url)
+        )
+        orcid_user.set_unusable_password()
+        orcid_user.save()
+
+        ticket = fake.md5()
+        url += '?ticket={}'.format(ticket)
+        res = self.app.get(url)
+        res = res.follow()
+        assert res.status_code == 302
+        assert self.project.is_contributor(orcid_user)
+        assert self.project.url in res.headers.get('Location')
 
     def test_get_valid_form(self):
         url = self.user.get_claim_url(self.project._primary_key)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -624,6 +624,14 @@ def verify_claim_token(user, token, pid):
     return True
 
 
+def check_external_auth(user):
+    if user:
+        return not user.has_usable_password() and (
+            'VERIFIED' in sum([each.values() for each in user.external_identity.values()], [])
+        )
+    return False
+
+
 @block_bing_preview
 @collect_auth
 @must_be_valid_project
@@ -635,7 +643,7 @@ def claim_user_registered(auth, node, **kwargs):
 
     current_user = auth.user
 
-    sign_out_url = web_url_for('auth_register', logout=True, next=request.url)
+    sign_out_url = cas.get_login_url(service_url=request.url)
     if not current_user:
         return redirect(sign_out_url)
 
@@ -665,22 +673,26 @@ def claim_user_registered(auth, node, **kwargs):
     }
     session.save()
 
+    # If a user is already validated though external auth, it is OK to claim
+    should_claim = check_external_auth(auth.user)
     form = PasswordForm(request.form)
     if request.method == 'POST':
         if form.validate():
             if current_user.check_password(form.password.data):
-                node.replace_contributor(old=unreg_user, new=current_user)
-                node.save()
-                status.push_status_message(
-                    'You are now a contributor to this project.',
-                    kind='success',
-                    trust=False
-                )
-                return redirect(node.url)
+                should_claim = True
             else:
                 status.push_status_message(language.LOGIN_FAILED, kind='warning', trust=False)
         else:
             forms.push_errors_to_status(form.errors)
+    if should_claim:
+        node.replace_contributor(old=unreg_user, new=current_user)
+        node.save()
+        status.push_status_message(
+            'You are now a contributor to this project.',
+            kind='success',
+            trust=False
+        )
+        return redirect(node.url)
     if is_json_request():
         form_ret = forms.utils.jsonify(form)
         user_ret = profile_utils.serialize_user(current_user, full=False)


### PR DESCRIPTION


If a user is authenticated with external auth, confirm the claim when clicking the link sent by a contributor instead of requiring an OSF password. This is because a user with external auth does not have an OSF password to enter, and we'll trust the external auth to be valid.

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

A user who has signed in to the OSF through an external service (right now only ORCID) cannot then claim an unregistered user via a link sent to them by a project's contributor, because this relies on a password page. An externally verified user has no password.

## Changes

- An externally-verified user no longer is asked for a password to confirm once they've clicked the link in their email
- Test for an ORCID verified user clicking a password confirm link from an email

<!-- Briefly describe or list your changes  -->

## QA Notes

Steps to reproduce:
1. Create a new OSF account via ORCID.
2. Attempt to claim an unregistered contributor on a node.
3. Have the node creator forward you the claim link.
4. Click the claim link
5. You should now be a contributor on the project

You can also repeat the above but log out of the ORCID user before clicking the claim link. Once you log back in via ORCID, you should be confirmed as a contributor.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->
None needed

## Side Effects

none anticipated
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-1070