### PR TITLE
[REG-18][Registries] Add comment total count to registrations

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -108,7 +108,10 @@ class BaseRegistrationSerializer(NodeSerializer):
     comments = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-comments',
         related_view_kwargs={'node_id': '<_id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
+        related_meta={
+            'unread': 'get_unread_comments_count',
+            'total': 'get_total_comments_count',  # total count of top_level, undeleted comments on the registration (node)
+        },
         filter={'target': '<_id>'},
     ))
 
@@ -339,6 +342,11 @@ class BaseRegistrationSerializer(NodeSerializer):
 
     def get_view_only_links_count(self, obj):
         return obj.private_links.filter(is_deleted=False).count()
+
+    def get_total_comments_count(self, obj):
+        return {
+            'node': obj.comment_set.filter(page='node', target___id=obj._id, is_deleted=False).count(),
+        }
 
     def update(self, registration, validated_data):
         auth = Auth(self.context['request'].user)


### PR DESCRIPTION
## Purpose

Add related meta count for total registration comments
⚠️ This count only accounts for `top_level`, `undeleted`, and node-type `page`.

## Changes

- Add related count to comment relationship
- Add tests

## QA Notes

NotQATeam

## Documentation

## Side Effects

## Ticket

[REG-18](https://openscience.atlassian.net/browse/REG-18)
