### PR TITLE
[PLAT-1108][Hotfix] Fix custom institution domain redirects

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -1076,7 +1076,7 @@ def make_url_map(app):
     # Web
 
     process_rules(app, [
-        Rule('/', 'get', website_views.index, notemplate),
+        Rule('/', 'get', website_views.index, OsfWebRenderer('institution.mako', trust=False)),
 
         Rule('/goodbye/', 'get', goodbye, notemplate),
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -85,7 +85,7 @@ def get_globals():
     location = geolite2.reader().get(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:
-            inst_id = Institution.objects.get(domains__icontains=[request.host])._id
+            inst_id = Institution.objects.get(domains__icontains=request.host, is_deleted=False)._id
             request_login_url = '{}institutions/{}'.format(settings.DOMAIN, inst_id)
         except Institution.DoesNotExist:
             request_login_url = request.url.replace(request.host_url, settings.DOMAIN)

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -266,7 +266,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='HOME', service_url='/', service_support_url='/support/')}
+    ${nav_helper.nav(service_name='HOME', service_url=domain, service_support_url='/support/')}
 </%def>
 
 <%def name="title()">

--- a/website/views.py
+++ b/website/views.py
@@ -22,6 +22,7 @@ from framework.forms import utils as form_utils
 from framework.routing import proxy_url
 from framework.auth.core import _get_current_user
 from website import settings
+from website.institutions.views import serialize_institution
 
 from addons.osfstorage.models import Region
 from osf.models import BaseFileNode, Guid, Institution, PreprintService, AbstractNode, Node, Registration
@@ -133,7 +134,12 @@ def index():
     # Check if we're on an institution landing page
     institution = Institution.objects.filter(domains__icontains=request.host, is_deleted=False)
     if institution.exists():
-        return redirect('{}institutions/{}/'.format(DOMAIN, institution.get()._id))
+        institution = institution.get()
+        inst_dict = serialize_institution(institution)
+        inst_dict.update({
+            'redirect_url': '{}institutions/{}/'.format(DOMAIN, institution._id),
+        })
+        return inst_dict
     else:
         return use_ember_app()
 


### PR DESCRIPTION
## Purpose

This makes sure custom domains are redirected so they are preserved in the search bar when possible and login attempts redirect back to the correct page.

## Changes

- @pattisdr's Orignal PR [here](https://github.com/CenterForOpenScience/osf.io/pull/8719) covers most of this, leaving the custom url intact when logged out and redirecting when logged in.
- change I added to login_url so login attempts redirect properly back to the Institutions landing page.

## QA Notes

The expected behavior for this ticket changed and the up to date verison is now in the ticket description. 

To test this I had to mock a subdomain locally, so took a test institution, ASU and changed it's custom domain to `http://asu.lvh.me:5000/` this created more or less the same as what you'd see in production with a custom domain.

To clarify here is the expected behavior as I understand it:

1. User with no auth goes to a custom domain, that domain loads with the address in the search bar.

2. The click login into login and is redirected to `osf.io/institutions/<institution_id>/` where the instituion landing loads with them logged in.

If the user attempts to go back to the custom domain they will have to log in again.


## Documentation

Not user facing, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1108