### PR TITLE
[Warmfix][PLAT-1132] Report non spam numbers

### DIFF
--- a/scripts/remove_after_use/create_spam_node_count_csv.py
+++ b/scripts/remove_after_use/create_spam_node_count_csv.py
@@ -1,0 +1,39 @@
+import sys
+import csv
+import logging
+import datetime
+
+from website.app import setup_django
+setup_django()
+
+from osf.models import Node, SpamStatus
+from django.db.models import Count
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+
+    nodes_excluding_spam = Node.objects.filter(is_deleted=False,  created__gte=datetime.datetime(2018, 3, 14)).exclude(spam_status__in=[SpamStatus.SPAM, SpamStatus.FLAGGED])
+
+    # The extra statement here is to round down the datetimes so we can count by dates only
+    data = nodes_excluding_spam.extra({'date_created': 'date(created)'}).values('date_created').annotate(count=Count('id')).order_by('date_created')
+
+    with open('spamless_node_count_through_2018_3_14.csv', mode='w') as csv_file:
+        fieldnames = ['date_created', 'count']
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        if not dry_run:
+            writer.writeheader()
+            for data_point in data:
+                writer.writerow(data_point)
+
+    logger.info('Writing csv data for {} dates'.format(data.count()))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_node_summary.py
+++ b/scripts/tests/test_node_summary.py
@@ -44,6 +44,9 @@ class TestNodeCount(OsfTestCase):
         self.deleted_node = ProjectFactory(is_deleted=True)
         self.deleted_node2 = ProjectFactory(is_deleted=True)
 
+        # Add Spam
+        self.spam_node = ProjectFactory(spam_status=2)
+
         self.date = timezone.now() - datetime.timedelta(days=1)
 
         for node in AbstractNode.objects.all():
@@ -58,22 +61,26 @@ class TestNodeCount(OsfTestCase):
     # test_get_node_count
         nodes = self.results['nodes']
 
-        assert_equal(nodes['total'], 3)  # 2 Projects, 1 component
+        assert_equal(nodes['total'], 4)  # 2 Projects, 1 component, 1 spam node
+        assert_equal(nodes['total_excluding_spam'], 3)  # 2 Projects, 1 component
         assert_equal(nodes['public'], 1)  # 1 Project
-        assert_equal(nodes['private'], 2)  # 1 Project, 1 Component
-        assert_equal(nodes['total_daily'], 3)  # 2 Projects, 1 component
+        assert_equal(nodes['private'], 3)  # 1 Project, 1 Component, 1 spam node (spam is always private)
+        assert_equal(nodes['total_daily'], 4)  # 2 Projects, 1 component,  1 spam node
+        assert_equal(nodes['total_daily_excluding_spam'], 3)  # 2 Projects, 1 component
         assert_equal(nodes['public_daily'], 1)  # 1 Project
-        assert_equal(nodes['private_daily'], 2)  # 1 Project, 1 Component
+        assert_equal(nodes['private_daily'], 3)  # 1 Project, 1 Component, 1 spam node
 
     # test_get_project_count
         projects = self.results['projects']
 
-        assert_equal(projects['total'], 2)
+        assert_equal(projects['total'], 3)
+        assert_equal(projects['total_excluding_spam'], 2)
         assert_equal(projects['public'], 1)
-        assert_equal(projects['private'], 1)
-        assert_equal(projects['total_daily'], 2)
+        assert_equal(projects['private'], 2)
+        assert_equal(projects['total_daily'], 3)
+        assert_equal(projects['total_daily_excluding_spam'], 2)
         assert_equal(projects['public_daily'], 1)
-        assert_equal(projects['private_daily'], 1)
+        assert_equal(projects['private_daily'], 2)
 
 
     # test_get_registered_nodes_count
@@ -115,22 +122,24 @@ class TestNodeCount(OsfTestCase):
     # test_get_node_count daily zero
         nodes = self.results['nodes']
 
-        assert_equal(nodes['total'], 3)  # 2 Projects, 1 component
+        assert_equal(nodes['total'], 4)  # 2 Projects, 1 component, 1 spam node
         assert_equal(nodes['public'], 1)  # 1 Project
-        assert_equal(nodes['private'], 2)  # 1 Project, 1 Component
+        assert_equal(nodes['private'], 3)  # 1 Project, 1 Component, 1 spam node
 
         assert_equal(nodes['total_daily'], 0)  # 2 Projects, 1 component
+        assert_equal(nodes['total_daily_excluding_spam'], 0)
         assert_equal(nodes['public_daily'], 0)  # 1 Project
         assert_equal(nodes['private_daily'], 0)  # 1 Project, 1 Component
 
     # test_get_project_count daily zero
         projects = self.results['projects']
 
-        assert_equal(projects['total'], 2)
+        assert_equal(projects['total'], 3)
         assert_equal(projects['public'], 1)
-        assert_equal(projects['private'], 1)
+        assert_equal(projects['private'], 2)
 
         assert_equal(projects['total_daily'], 0)
+        assert_equal(projects['total_daily_excluding_spam'], 0)
         assert_equal(projects['public_daily'], 0)
         assert_equal(projects['private_daily'], 0)
 


### PR DESCRIPTION
## Purpose

This PR will start sending the number of nodes created daily excluding spam to keen and contains a script to generate a csv of that data for all dates through March 14 2018.

## Changes

- Add excluding spam queries to node summary keen event
- update tests for node summary
- add script to generate csv for nodes created excluding spam

## QA Notes

Fairly straightforward this can be tested by running the unit test and scripts and checking that the data is accurate.

## Documentation

None

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1132