### PR TITLE
Allow write contributors to modify Registrations

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -342,6 +342,7 @@ class BaseRegistrationSerializer(NodeSerializer):
         return obj.private_links.filter(is_deleted=False).count()
 
     def update(self, registration, validated_data):
+        # TODO - when withdrawl is added, make sure to restrict to admin only here
         user = self.context['request'].user
         auth = Auth(user)
         # Update tags

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -352,7 +352,10 @@ class BaseRegistrationSerializer(NodeSerializer):
             except NodeStateError as err:
                 raise Conflict(err.message)
         if 'custom_citation' in validated_data:
-            registration.update_custom_citation(validated_data.pop('custom_citation'), auth)
+            if registration.has_permission(user, permissions.ADMIN):
+                registration.update_custom_citation(validated_data.pop('custom_citation'), auth)
+            else:
+                raise exceptions.PermissionDenied()
         is_public = validated_data.get('is_public', None)
         if is_public is not None:
             if is_public:

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -149,7 +149,7 @@ class RegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, Regist
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
-        AdminOrPublic,
+        ContributorOrPublic,
         base_permissions.TokenHasScope,
     )
 

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -435,7 +435,7 @@ class TestRegistrationTags:
         return AuthUserFactory()
 
     @pytest.fixture()
-    def user_read_contrib(self):
+    def read_write_contrib(self):
         return AuthUserFactory()
 
     @pytest.fixture()
@@ -443,7 +443,7 @@ class TestRegistrationTags:
         return AuthUserFactory()
 
     @pytest.fixture()
-    def project_public(self, user_admin, user_read_contrib):
+    def project_public(self, user_admin, read_write_contrib):
         project_public = ProjectFactory(
             title='Project One',
             is_public=True,
@@ -453,7 +453,7 @@ class TestRegistrationTags:
             permissions=permissions.CREATOR_PERMISSIONS,
             save=True)
         project_public.add_contributor(
-            user_read_contrib,
+            read_write_contrib,
             permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS,
             save=True)
         return project_public
@@ -546,7 +546,7 @@ class TestRegistrationTags:
             self, app, registration_public, registration_private,
             url_registration_public, url_registration_private,
             new_tag_payload_public, new_tag_payload_private,
-            user_admin, user_non_contrib):
+            user_admin, user_non_contrib, read_write_contrib):
         # test_registration_starts_with_no_tags
         res = app.get(url_registration_public)
         assert res.status_code == 200
@@ -622,6 +622,14 @@ class TestRegistrationTags:
             auth=user_admin.auth)
         assert res.status_code == 200
         assert len(res.json['data']['attributes']['tags']) == 1
+
+        # test read-write contributor can update tags
+        new_tag_payload_public['data']['attributes']['tags'] = ['from-readwrite']
+        res = app.patch_json_api(
+            url_registration_public,
+            new_tag_payload_public,
+            auth=read_write_contrib.auth)
+        assert res.status_code == 200
 
     def test_tags_add_and_remove_properly(
             self, app, user_admin, registration_public,

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -426,6 +426,15 @@ class TestRegistrationUpdate:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'An unapproved registration cannot be made public.'
 
+    def test_read_write_contributor_cannot_update_custom_citation(
+            self, app, read_write_contributor, private_registration, private_url, make_payload):
+        payload = make_payload(
+            id=private_registration._id,
+            attributes={'custom_citation': 'This is a custom citation yay'}
+        )
+        res = app.put_json_api(private_url, payload, auth=read_write_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
 
 @pytest.mark.django_db
 class TestRegistrationTags:


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Contributors with write permissions weren't being allowed to add tags to a registration because a registration's `permission_classes` included `AdminOrPublic`.

## Changes

- Change `AdminOrPublic` to `ContributorOrPublic` 
- Move the check for updating privacy to the `update` method to ensure only admins have that power

## QA Notes

Users with write permissions should now be able to add tags to a registration.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects

Are there other things that only admins could do on registrations other than changing private to public? If so, contributors with `write` permissions should now be able to do those things where they could not before. 

## Ticket
https://openscience.atlassian.net/browse/PLAT-1130
