### PR TITLE
[Hotfix] Trim whitespace when setting provider choices

### DIFF
--- a/admin/collection_providers/forms.py
+++ b/admin/collection_providers/forms.py
@@ -62,8 +62,8 @@ class CollectionProviderForm(forms.ModelForm):
         collection_provider = self.instance
         # if this is to modify an existing CollectionProvider
         if collection_provider.primary_collection:
-            type_choices_old = set(collection_provider.primary_collection.collected_type_choices)
-            type_choices_new = set(json.loads(self.data.get('collected_type_choices')))
+            type_choices_old = set([c.strip(' ') for c in collection_provider.primary_collection.collected_type_choices])
+            type_choices_new = set([c.strip(' ') for c in json.loads(self.data.get('collected_type_choices'))])
             type_choices_added = type_choices_new - type_choices_old
             type_choices_removed = type_choices_old - type_choices_new
             for item in type_choices_removed:
@@ -89,8 +89,8 @@ class CollectionProviderForm(forms.ModelForm):
         collection_provider = self.instance
         # if this is to modify an existing CollectionProvider
         if collection_provider.primary_collection:
-            status_choices_old = set(collection_provider.primary_collection.status_choices)
-            status_choices_new = set(json.loads(self.data.get('status_choices')))
+            status_choices_old = set([c.strip(' ') for c in collection_provider.primary_collection.status_choices])
+            status_choices_new = set([c.strip(' ') for c in json.loads(self.data.get('status_choices'))])
             status_choices_added = status_choices_new - status_choices_old
             status_choices_removed = status_choices_old - status_choices_new
             for item in status_choices_removed:
@@ -116,8 +116,8 @@ class CollectionProviderForm(forms.ModelForm):
         collection_provider = self.instance
         # if this is to modify an existing CollectionProvider
         if collection_provider.primary_collection:
-            volume_choices_old = set(collection_provider.primary_collection.volume_choices)
-            volume_choices_new = set(json.loads(self.data.get('volume_choices')))
+            volume_choices_old = set([c.strip(' ') for c in collection_provider.primary_collection.volume_choices])
+            volume_choices_new = set([c.strip(' ') for c in json.loads(self.data.get('volume_choices'))])
             volume_choices_added = volume_choices_new - volume_choices_old
             volume_choices_removed = volume_choices_old - volume_choices_new
             for item in volume_choices_removed:
@@ -143,8 +143,8 @@ class CollectionProviderForm(forms.ModelForm):
         collection_provider = self.instance
         # if this is to modify an existing CollectionProvider
         if collection_provider.primary_collection:
-            issue_choices_old = set(collection_provider.primary_collection.issue_choices)
-            issue_choices_new = set(json.loads(self.data.get('issue_choices')))
+            issue_choices_old = set([c.strip(' ') for c in collection_provider.primary_collection.issue_choices])
+            issue_choices_new = set([c.strip(' ') for c in json.loads(self.data.get('issue_choices'))])
             issue_choices_added = issue_choices_new - issue_choices_old
             issue_choices_removed = issue_choices_old - issue_choices_new
             for item in issue_choices_removed:
@@ -170,8 +170,8 @@ class CollectionProviderForm(forms.ModelForm):
         collection_provider = self.instance
         # if this is to modify an existing CollectionProvider
         if collection_provider.primary_collection:
-            program_area_choices_old = set(collection_provider.primary_collection.program_area_choices)
-            program_area_choices_new = set(json.loads(self.data.get('program_area_choices')))
+            program_area_choices_old = set([c.strip(' ') for c in collection_provider.primary_collection.program_area_choices])
+            program_area_choices_new = set([c.strip(' ') for c in json.loads(self.data.get('program_area_choices'))])
             program_area_choices_added = program_area_choices_new - program_area_choices_old
             program_area_choices_removed = program_area_choices_old - program_area_choices_new
             for item in program_area_choices_removed:


### PR DESCRIPTION
## Purpose
`Trim whitespace when setting provider choices`

## Changes
`Trim whitespace when setting provider choices`

## QA Notes
Should no longer be able to input leading/trailing `whitespace when setting provider choices`

## Side Effects
None expected

## Ticket
None