### PR TITLE
[Chronos] Change how FILE_DOWNLOAD_URL is constructed

### DIFF
--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -127,7 +127,7 @@ class ChronosSerializer(object):
         if CHRONOS_USE_FAKE_FILE:
             file_url = CHRONOS_FAKE_FILE_URL
         else:
-            file_url = '/'.join([DOMAIN.strip('/'), file_node.get_guid(create=True)._id, 'download'])
+            file_url = '/'.join([DOMAIN.strip('/'), 'download', file_node._id])
 
         return {
             'FILE_DOWNLOAD_URL': file_url,


### PR DESCRIPTION
## Purpose

Currently, the `FILE_DOWNLOAD_URL` is not constructed properly. This PRs fixes that by constructing the url using the `_id` of the file.

## Changes

Change the `serialize_file()` method of `ChronosSerializer` so that it construct the download link correctly.
