### PR TITLE
Feature/Catch Blacklisted Email Error[PLAT-1148]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -13,7 +13,7 @@ from api.base.serializers import (
 )
 from api.base.utils import absolute_reverse, get_user_auth, waterbutler_api_url_for, is_deprecated
 from api.files.serializers import QuickFilesSerializer
-from osf.exceptions import ValidationValueError, ValidationError
+from osf.exceptions import ValidationValueError, ValidationError, BlacklistedEmailError
 from osf.models import OSFUser, QuickFilesNode
 from website.settings import MAILCHIMP_GENERAL_LIST, OSF_HELP_LIST, CONFIRM_REGISTRATIONS_BY_EMAIL
 from osf.models.provider import AbstractProviderGroupObjectPermission
@@ -509,6 +509,8 @@ class UserEmailsSerializer(JSONAPISerializer):
                 send_confirm_email(user, email=address)
         except ValidationError as e:
             raise exceptions.ValidationError(e.args[0])
+        except BlacklistedEmailError as e:
+            raise exceptions.ValidationError('This email address is blacklisted.')
 
         return UserEmail(email_id=token, address=address, confirmed=False, primary=False)
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -509,7 +509,7 @@ class UserEmailsSerializer(JSONAPISerializer):
                 send_confirm_email(user, email=address)
         except ValidationError as e:
             raise exceptions.ValidationError(e.args[0])
-        except BlacklistedEmailError as e:
+        except BlacklistedEmailError:
             raise exceptions.ValidationError('This email address is blacklisted.')
 
         return UserEmail(email_id=token, address=address, confirmed=False, primary=False)

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -8,6 +8,7 @@ from osf_tests.factories import (
     UserFactory,
 )
 from osf.models import Email
+from website.settings.defaults import BLACKLISTED_DOMAINS
 
 @pytest.fixture()
 def user_one():
@@ -308,6 +309,13 @@ class TestUserEmailsList:
         res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Enter a valid email address.'
+
+    def test_create_blacklisted_email(self, app, url, payload, user_one):
+        new_email = 'freddie@{}'.format(BLACKLISTED_DOMAINS[0])
+        payload['data']['attributes']['email_address'] = new_email
+        res = app.post_json_api(url, payload, auth=user_one.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'This email address is blacklisted.'
 
     def test_unconfirmed_email_with_expired_token_not_in_results(self, app, url, payload, user_one):
         unconfirmed = 'notyet@unconfirmed.test'


### PR DESCRIPTION
## Purpose

POST to `/v2/users/user_id/settings/emails` with a blacklisted email needs to 400 instead of throwing an uncaught 500 error with a message that the email is blacklisted.

## Changes

Catch BlacklistedEmailError and add a test.

## QA Notes

None needed

## Documentation

No docs update needed.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1148