### PR TITLE
[PLAT-1129] Update share when tags are added to Nodes

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1111,6 +1111,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     # Override Taggable
     def on_tag_added(self, tag):
         self.update_search()
+        node_tasks.update_node_share(self)
 
     def remove_tag(self, tag, auth, save=True):
         if not tag:
@@ -1133,6 +1134,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             if save:
                 self.save()
             self.update_search()
+            node_tasks.update_node_share(self)
+
             return True
 
     def remove_tags(self, tags, auth, save=True):
@@ -1159,6 +1162,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         if save:
             self.save()
         self.update_search()
+        node_tasks.update_node_share(self)
+
         return True
 
     def is_contributor(self, user):


### PR DESCRIPTION
## Purpose

When you add tags to a Node they get updated in ES, but not in SHARE. This PR updates SHARE when a tag is added or removed.

## Changes

- adds `update_node_share(self)` to methods on the AbstractNode model where tags are added/removed.

## QA Notes

It's hard to test this locally as you would have to set up and configure your own SHARE instance to test it fully. However, it's simple enough fix that I think we can assume it's updating properly.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1129