### PR TITLE
Feature/Add temporary script for updating SHARE. [No ticket yet]

### DIFF
--- a/scripts/remove_after_use/node_preprint_share.py
+++ b/scripts/remove_after_use/node_preprint_share.py
@@ -1,0 +1,21 @@
+from website.app import setup_django
+setup_django()
+from osf.models import Preprint
+from website.preprints.tasks import update_preprint_share
+import progressbar
+
+ # To run: docker-compose run --rm web python -m scripts.remove_after_use.node_preprint_share
+def main():
+    """
+    Updates all preprints in SHARE post-divorce
+    """
+    preprints = Preprint.objects.all()
+    progress_bar = progressbar.ProgressBar(maxval=preprints.count()).start()
+    for i, preprint in enumerate(preprints, 1):
+        progress_bar.update(i)
+        update_preprint_share(preprint)
+    progress_bar.finish()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Purpose

Preprints that should be in SHARE post-divorce are not there.

## Changes

Temporary script to run through all the preprints and call update_preprint_share.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects

Should the preprints query be restricted further? Any other oddities with preprints SHARE that I'm missing? There were some preprints created Friday that were wiped from the db and they were showing up.  @aaxelb removed those.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
