### PR TITLE
Recursively update most recent fileversion for folder contents [PLAT-1118]

### DIFF
--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -304,6 +304,30 @@ class TestOsfstorageFileNode(StorageTestCase):
         assert_equal(new_project, move_to.target)
         assert_equal(new_project, child.target)
 
+    def test_move_nested_between_regions(self):
+        canada = RegionFactory()
+        new_component = NodeFactory(parent=self.project)
+        component_node_settings = new_component.get_addon('osfstorage')
+        component_node_settings.region = canada
+        component_node_settings.save()
+
+        move_to = component_node_settings.get_root()
+        to_move = self.node_settings.get_root().append_folder('Aaah').append_folder('Woop')
+        child = to_move.append_file('There it is')
+
+        for _ in range(2):
+            version = factories.FileVersionFactory(region=self.node_settings.region)
+            child.versions.add(version)
+        child.save()
+
+        moved = to_move.move_under(move_to)
+        child.reload()
+
+        assert new_component == child.target
+        versions = child.versions.order_by('-created')
+        assert versions.first().region == component_node_settings.region
+        assert versions.last().region == self.node_settings.region
+
     def test_copy_rename(self):
         to_copy = self.node_settings.get_root().append_file('Carp')
         copy_to = self.node_settings.get_root().append_folder('Cloud')


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

With new WB side changes brewing, there will be one request to the move and copy hooks, even for a folder. So, we need to account for that OSF side by recursively updating the most recent fileversion for all files inside the folder received in the WB request.

The method called by the hook is also responsible for checking checked-out status and preprint file status, and those both seem to already be able to handle folders and their contents so that should be OK unchanged.

## Changes

- Add a method to loop through all files in folders and update the most recent fileversion's region to match the destination region
- A test for nested fileversion region updates

## QA Notes
This touches updating file version regions when a file is located in a folder that is moved or copied between regions. To test, move a folder with files with multiple versions between regions and make sure everything looks ok!

## Documentation

Internal change, none needed

## Side Effects

The only thing would be if anything else that uses the `move_under` method doesn't account for the fact that WB won't be making a separate call for each file any longer, but I don't think that's the case...

## Ticket
https://openscience.atlassian.net/browse/PLAT-1118
