### PR TITLE
[PLAT-1145][Hotfix] Confirming ORCID account doesn't work if you are logged in

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -496,23 +496,6 @@ def external_login_confirm_email_get(auth, uid, token):
     if not destination:
         raise HTTPError(http.BAD_REQUEST)
 
-    # if user is already logged in
-    if auth and auth.user:
-        # if it is a wrong user
-        if auth.user._id != user._id:
-            return auth_logout(redirect_url=request.url)
-        # if it is the expected user
-        new = request.args.get('new', None)
-        if destination in campaigns.get_campaigns():
-            # external domain takes priority
-            campaign_url = campaigns.external_campaign_url_for(destination)
-            if not campaign_url:
-                campaign_url = campaigns.campaign_url_for(destination)
-            return redirect(campaign_url)
-        if new:
-            status.push_status_message(language.WELCOME_MESSAGE, kind='default', jumbotron=True, trust=True, id='welcome_message')
-        return redirect(web_url_for('dashboard'))
-
     # token is invalid
     if token not in user.email_verifications:
         raise HTTPError(http.BAD_REQUEST)
@@ -542,6 +525,23 @@ def external_login_confirm_email_get(auth, uid, token):
     del user.email_verifications[token]
     user.verification_key = generate_verification_key()
     user.save()
+
+    # if user is already logged in
+    if auth and auth.user:
+        # if it is a wrong user
+        if auth.user._id != user._id:
+            return auth_logout(redirect_url=request.url)
+        # if it is the expected user
+        new = request.args.get('new', None)
+        if destination in campaigns.get_campaigns():
+            # external domain takes priority
+            campaign_url = campaigns.external_campaign_url_for(destination)
+            if not campaign_url:
+                campaign_url = campaigns.campaign_url_for(destination)
+            return redirect(campaign_url)
+        if new:
+            status.push_status_message(language.WELCOME_MESSAGE, kind='default', jumbotron=True, trust=True, id='welcome_message')
+        return redirect(web_url_for('dashboard'))
 
     service_url = request.url
 

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -519,29 +519,11 @@ def external_login_confirm_email_get(auth, uid, token):
     if not user.emails.filter(address=email.lower()):
         user.emails.create(address=email.lower())
 
-    user.date_last_logged_in = timezone.now()
     user.external_identity[provider][provider_id] = 'VERIFIED'
     user.social[provider.lower()] = provider_id
     del user.email_verifications[token]
     user.verification_key = generate_verification_key()
     user.save()
-
-    # if user is already logged in
-    if auth and auth.user:
-        # if it is a wrong user
-        if auth.user._id != user._id:
-            return auth_logout(redirect_url=request.url)
-        # if it is the expected user
-        new = request.args.get('new', None)
-        if destination in campaigns.get_campaigns():
-            # external domain takes priority
-            campaign_url = campaigns.external_campaign_url_for(destination)
-            if not campaign_url:
-                campaign_url = campaigns.campaign_url_for(destination)
-            return redirect(campaign_url)
-        if new:
-            status.push_status_message(language.WELCOME_MESSAGE, kind='default', jumbotron=True, trust=True, id='welcome_message')
-        return redirect(web_url_for('dashboard'))
 
     service_url = request.url
 
@@ -563,6 +545,25 @@ def external_login_confirm_email_get(auth, uid, token):
             external_id_provider=provider,
             can_change_preferences=False,
         )
+
+    # if user is already logged in
+    if auth and auth.user:
+        # if it is a wrong user
+        if auth.user._id != user._id:
+            return auth_logout(redirect_url=request.url)
+        # if it is the expected user
+        new = request.args.get('new', None)
+        if destination in campaigns.get_campaigns():
+            # external domain takes priority
+            campaign_url = campaigns.external_campaign_url_for(destination)
+            if not campaign_url:
+                campaign_url = campaigns.campaign_url_for(destination)
+            return redirect(campaign_url)
+        if new:
+            status.push_status_message(language.WELCOME_MESSAGE, kind='default', jumbotron=True, trust=True, id='welcome_message')
+        return redirect(web_url_for('dashboard'))
+
+    user.date_last_logged_in = timezone.now()
 
     # redirect to CAS and authenticate the user with the verification key
     return redirect(cas.get_login_url(

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -564,6 +564,7 @@ def external_login_confirm_email_get(auth, uid, token):
         return redirect(web_url_for('dashboard'))
 
     user.date_last_logged_in = timezone.now()
+    user.save()
 
     # redirect to CAS and authenticate the user with the verification key
     return redirect(cas.get_login_url(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3943,21 +3943,20 @@ class TestExternalAuthViews(OsfTestCase):
         assert_true(self.user.has_usable_password())
 
     def test_external_login_confirm_email_get_while_logged_in(self):
-        external_identity = {
+        self.user.external_identity = {
             'orcid': {
                 self.provider_id: 'PENDING'
             }
         }
-        user = AuthUserFactory(external_identity=external_identity)
-        user.email_verifications = {'token': {'expiration': timezone.now() + dt.timedelta(days=1), 'email': user.email, 'external_identity': {'orcid': {self.provider_id: 'status'}}}}
-        user.save()
-        url = user.get_confirmation_url(user.username, external_id_provider='orcid', destination='dashboard')
-        res = self.app.get(url, auth=user.auth)
+        self.user.email_verifications = {'token': {'expiration': timezone.now() + dt.timedelta(days=1), 'email': self.user.email, 'external_identity': {'orcid': {self.provider_id: 'status'}}}}
+        self.user.save()
+        url = self.user.get_confirmation_url(self.user.username, external_id_provider='orcid', destination='dashboard')
+        res = self.app.get(url, auth=Auth(self.user))
         assert_equal(res.status_code, 302, 'redirects to cas login')
-        assert_in('/dashboard/', res.location)
+        assert_in('destination=dashboard', res.location)
 
-        user.reload()
-        assert_equal(user.external_identity['orcid'][self.provider_id], 'VERIFIED')
+        self.user.reload()
+        assert_equal(self.user.external_identity['orcid'][self.provider_id], 'VERIFIED')
 
     @mock.patch('website.mails.send_mail')
     def test_external_login_confirm_email_get_link(self, mock_link_confirm):


### PR DESCRIPTION
## Purpose

If you try to confirm your ORCID account while logged in the OSF will redirect to the dashboard without confirming the account. This fix allows you to comfirm it without logging out.

## Changes

- moves redirect clause to after confirmation clause so it's not missed.
- adds test

## QA Notes

I tested this in the shell by creating a user with (paraphasing) :
```python 
user.email_verifications = {'token': {'email': user.email, 'external_identity': {'ORCID' {'fake_external_identity_id': 'fake status'}}}}
me.external_identity = {'ORCID': {'fake_external_identity_id': 'fake status'}}
```
and hitting endpoint `http://localhost:5000/confirm/external/<user guid>/token/?destination=dashboard` then checking account setting to see if the user had a confirmed fake ORCID.

## Documentation

🐞 fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1145