### PR TITLE
[PLAT-1095] Some users' bookmarks don't load

### DIFF
--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -113,11 +113,13 @@ class CollectionSerializer(JSONAPISerializer):
 
     def get_node_links_count(self, obj):
         auth = get_user_auth(self.context['request'])
-        return Node.objects.filter(guids__in=obj.guid_links.all(), is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
+        node_ids = obj.guid_links.all().values_list('id', flat=True)
+        return Node.objects.filter(id__in=node_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
 
     def get_registration_links_count(self, obj):
         auth = get_user_auth(self.context['request'])
-        return Registration.objects.filter(guids__in=obj.guid_links.all(), is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
+        registration_ids = obj.guid_links.all().values_list('id', flat=True)
+        return Registration.objects.filter(id__in=registration_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
 
     def create(self, validated_data):
         node = Collection(**validated_data)

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -413,7 +413,8 @@ class LinkedNodesList(BaseLinkedList, CollectionMixin, NodeOptimizationMixin):
 
     def get_queryset(self):
         auth = get_user_auth(self.request)
-        nodes = Node.objects.filter(guids__in=self.get_collection().guid_links.all(), is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).order_by('-modified')
+        node_ids = self.get_collection().guid_links.all().values_list('object_id', flat=True)
+        nodes = Node.objects.filter(id__in=node_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).order_by('-modified')
         return self.optimize_node_queryset(nodes)
 
     # overrides APIView

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -580,20 +580,14 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         return obj.linked_nodes.count()
 
     def get_node_links_count(self, obj):
-        count = 0
         auth = get_user_auth(self.context['request'])
-        for pointer in obj.linked_nodes.filter(is_deleted=False).exclude(type='osf.collection').exclude(type='osf.registration'):
-            if pointer.can_view(auth):
-                count += 1
-        return count
+        linked_nodes = obj.linked_nodes.filter(is_deleted=False).exclude(type='osf.collection').exclude(type='osf.registration')
+        return linked_nodes.can_view(auth.user, auth.private_link).count()
 
     def get_registration_links_count(self, obj):
-        count = 0
         auth = get_user_auth(self.context['request'])
-        for pointer in obj.linked_nodes.filter(is_deleted=False, type='osf.registration').exclude(type='osf.collection'):
-            if pointer.can_view(auth):
-                count += 1
-        return count
+        linked_registrations = obj.linked_nodes.filter(is_deleted=False, type='osf.registration').exclude(type='osf.collection')
+        return linked_registrations.can_view(auth.user, auth.private_link).count()
 
     def get_linked_by_nodes_count(self, obj):
         return obj._parents.filter(is_node_link=True, parent__is_deleted=False, parent__type='osf.node').count()

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1795,12 +1795,7 @@ class NodeLinkedRegistrationsList(BaseLinkedList, NodeMixin):
     view_name = 'linked-registrations'
 
     def get_queryset(self):
-        ret = [
-            node for node in
-            super(NodeLinkedRegistrationsList, self).get_queryset()
-            if node.is_registration
-        ]
-        return ret
+        return super(NodeLinkedRegistrationsList, self).get_queryset().filter(type='osf.registration')
 
     # overrides APIView
     def get_parser_context(self, http_request):


### PR DESCRIPTION
## Purpose

When users with >1000 go to the My Projects page their collections query times out, so that their bookmarks don't show. This PR attempts to address that.

## Changes

- adds minor optimizations to
  - NodeLinkedRegistrationsList get_queryset
  - related counts for linked nodes and registrations
  - LinkedNodesList get_queryset

## QA Notes

This issue can't be reproduced locally because a local node table is going to be too small to time out. If this is successful endpoints like `/v2/collections/<collection_guid>/relationships/linked_nodes/` for collections with >1000 nodes should load without timing out.

## Documentation

🐞 fix, no docs.


## Side Effects

Just want to note that there's no guarantee this will work, I tried to optimize this but I have no way of telling  locally if this will time out. If there was a better way of benchmarking/reproducing this that would be great.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1095