### PR TITLE
[PLAT-1146] Fix weekly digest of Prereg Challenge Admin app

### DIFF
--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -40,3 +40,7 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'test-anon': '1/hour',
     'send-email': '2/minute',
 }
+
+# Prereg challenge data is uploaded to this project TODO: Delete when Prereg challenge ends
+PREREG_DATA_STORE_TOKEN = None
+PREREG_DATA_STORE_GUID = None


### PR DESCRIPTION
## Purpose

Currently our automated emails for sending prereg challenge data aren't sending because the attachment size is too large. This fix uploads the data to an OSF project instead of emailing it.

## Changes

- add request to upload prereg data if project guid and token are specified.

## QA Notes

Locally create a project to upload the prereg data to and copy the guid into the settings file, then create a personal token with write permissions and do the same. After that you should just have to run the script to get the data uploaded to your project.

## Documentation

🐞 fix, no docs

## Side Effects

Someone will have to create a project and get the token for this once it deploys

## Ticket

https://openscience.atlassian.net/browse/PLAT-1146