### PR TITLE
[Hotfix][PLAT-1122] Fix newly created forks last_logged date 

### DIFF
--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -273,10 +273,12 @@ class TestNodeForkCreate:
             public_project_url,
             fork_data,
             auth=non_contrib.auth)
+        fork = public_project.forks.first()
         assert res.status_code == 201
-        assert res.json['data']['id'] == public_project.forks.first()._id
+        assert res.json['data']['id'] == fork._id
         assert res.json['data']['attributes']['title'] == 'Fork of ' + \
             public_project.title
+        assert public_project.logs.latest().date and fork.last_logged
 
     def test_cannot_fork_errors(
             self, app, fork_data, public_project_url,

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2041,8 +2041,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         forked.root = None  # Recompute root on save
 
-        forked.save()
-
         # Need to call this after save for the notifications to be created with the _primary_key
         project_signals.contributor_added.send(forked, contributor=user, auth=auth, email_template='false')
 
@@ -2061,11 +2059,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         # Clone each log from the original node for this fork.
         self.clone_logs(forked)
-        forked.refresh_from_db()
 
         # After fork callback
         for addon in original.get_addons():
             addon.after_fork(original, forked, user)
+
+        forked.save()
 
         return forked
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2041,9 +2041,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         forked.root = None  # Recompute root on save
 
-        # Need to call this after save for the notifications to be created with the _primary_key
-        project_signals.contributor_added.send(forked, contributor=user, auth=auth, email_template='false')
-
         forked.add_log(
             action=NodeLog.NODE_FORKED,
             params={
@@ -2065,6 +2062,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             addon.after_fork(original, forked, user)
 
         forked.save()
+
+        # Need to call this after save for the notifications to be created with the _primary_key
+        project_signals.contributor_added.send(forked, contributor=user, auth=auth, email_template='false')
 
         return forked
 


### PR DESCRIPTION
## Purpose

Currently the last logged date for forks is incorrect, because logs are are cloned before the "fork created" log is added. This PR fixes that.

## Changes

- Move save statement to proper place

## QA Notes

`node.logs.lastest().date` and ` fork.last_logged` should be the same date. Forked nodes should be listed properly.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/PLAT-1122