### PR TITLE
[Travis Probablistic Failure] TestRegistrationFiltering tests

### DIFF
--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -152,11 +152,11 @@ class TestRegistrationFiltering(ApiTestCase):
         self.project_two_reg = RegistrationFactory(
             creator=self.user_one, project=self.project_two, is_public=True)
         self.project_three_reg = RegistrationFactory(
-            creator=self.user_two, project=self.project_three, is_public=True)
+            creator=self.user_two, project=self.project_three, is_public=True, title='No search terms!')
         self.private_project_user_one_reg = RegistrationFactory(
-            creator=self.user_one, project=self.private_project_user_one, is_public=False)
+            creator=self.user_one, project=self.private_project_user_one, is_public=False, title='No search terms!')
         self.private_project_user_two_reg = RegistrationFactory(
-            creator=self.user_two, project=self.private_project_user_two, is_public=False)
+            creator=self.user_two, project=self.private_project_user_two, is_public=False, title='No search terms!')
 
         self.folder = CollectionFactory()
         self.bookmark_collection = find_bookmark_collection(self.user_one)


### PR DESCRIPTION
## Purpose

Currently sometimes randomly generated factory registration titles coincidently match search terms in our filter tests and cause them to fail. This fixes that.

## Changes

- change the factory registration names to something not random.

## QA Notes

No really testable.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

No ticket