### PR TITLE
[Chronos][EMB-409][OSF] Put some back-end restricts on what preprints can be submitted to Chronos

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -223,7 +223,7 @@ class FilterMixin(object):
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id']:
+                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id']:
                         query.get(key).update({
                             field_name: {
                                 'op': 'in',

--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -20,7 +20,7 @@ class ChronosJournalSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'chronos-journals'
 
-    filterable_fields = frozenset(['title', 'name'])
+    filterable_fields = frozenset(['title', 'name', 'id'])
 
     id = ser.CharField(source='journal_id', read_only=True)
     name = ser.CharField(read_only=True)

--- a/api/chronos/views.py
+++ b/api/chronos/views.py
@@ -33,6 +33,7 @@ class ChronosJournalList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin)
     required_write_scopes = [CoreScopes.NULL]
 
     serializer_class = ChronosJournalSerializer
+    model_class = ChronosJournal
 
     # This view goes under the _/ namespace
     versioning_class = PrivateVersioning

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -180,8 +180,10 @@ class ChronosClient(object):
         # regardless of journals
         if submission_qs.filter(status=2).exists():
             raise ValueError('Cannot submit because a pending submission exists')
-        if submission_qs.filter(status__in=[3, 4]).exists():
-            raise ValueError('Cannot submit because your submission was accepted or published')
+        if submission_qs.filter(status=3).exists():
+            raise ValueError('Cannot submit because your submission was accepted')
+        if submission_qs.filter(status=4).exists():
+            raise ValueError('Cannot submit because your submission was published')
         if preprint.machine_state != ReviewStates.ACCEPTED.value:
             raise ValueError('Cannot submit to Chronos if the preprint is not accepted by moderators')
 

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -178,8 +178,6 @@ class ChronosClient(object):
         # 1 = draft, 2 = submitted, 3 = accepted, 4 = published
         # Disallow submission if the current preprint has submissions that are submitted, accepted or publishes
         # regardless of journals
-        if submission_qs.filter(status=1).exists():
-            raise ValueError('Cannot submit because a drafted submission exists')
         if submission_qs.filter(status=2).exists():
             raise ValueError('Cannot submit because a pending submission exists')
         if submission_qs.filter(status__in=[3, 4]).exists():

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -171,8 +171,19 @@ class ChronosClient(object):
         return ChronosJournal.objects.all()
 
     def submit_manuscript(self, journal, preprint, submitter):
-        if ChronosSubmission.objects.filter(journal=journal, preprint=preprint).exists():
+        submission_qs = ChronosSubmission.objects.filter(preprint=preprint)
+        if submission_qs.filter(journal=journal).exists():
             raise ValueError('{!r} already has an existing submission to {!r}.'.format(preprint, journal))
+
+        # 1 = draft, 2 = submitted, 3 = accepted, 4 = published
+        # Disallow submission if the current preprint has submissions that are submitted, accepted or publishes
+        # regardless of journals
+        if submission_qs.filter(status=1).exists():
+            raise ValueError('Cannot submit because a drafted submission exists')
+        if submission_qs.filter(status=2).exists():
+            raise ValueError('Cannot submit because a pending submission exists')
+        if submission_qs.filter(status__in=[3, 4]).exists():
+            raise ValueError('Cannot submit because your submission was accepted or published')
         if preprint.machine_state != ReviewStates.ACCEPTED.value:
             raise ValueError('Cannot submit to Chronos if the preprint is not accepted by moderators')
 

--- a/osf/models/chronos.py
+++ b/osf/models/chronos.py
@@ -12,6 +12,8 @@ class ChronosJournal(BaseModel):
 
     raw_response = DateTimeAwareJSONField(null=False, blank=False)
 
+    primary_identifier_name = 'journal_id'
+
     def __repr__(self):
         return '<{}({} - {})>'.format(
             self.__class__.__name__,


### PR DESCRIPTION
## Purpose

Only allow submission to Chronos if a preprint has never been submitted to a journal or the submission has been rejected.

## QA Notes

A Chronos submission has four states: drafted, submitted, accepted, rejected. A preprint can be submitted iff there is no Chronos submission or all of the submissions are rejected.


## Ticket

https://openscience.atlassian.net/browse/EMB-409
