### PR TITLE
[Hotfix] Use `query_string` for collections search

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -293,7 +293,7 @@ class SearchParser(JSONAPIParser):
         else:
             res['query']['bool'].update({
                 'must': {
-                    'multi_match': {
+                    'query_string': {
                         'query': q,
                         'fields': view.search_fields,
                     },


### PR DESCRIPTION
## Purpose
Make search behave as expected

## Changes
* Switch `multi_match` to `query_string`

## QA Notes
Should only affect collections search, as only `POST`s to `/v2/search/*` use `SearchParser`

## Side Effects
None expected

## Ticket
None