### PR TITLE
[PLAT-1108][Hotfix] Custom domain instutions fix sign up button

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -83,7 +83,7 @@
                 %else :
                 <li class="dropdown sign-in">
                     <div class="col-sm-12">
-                        <a data-bind="click: trackClick.bind($data, 'SignUp')" href="${web_url_for('auth_register')}" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
+                        <a data-bind="click: trackClick.bind($data, 'SignUp')" href="${web_url_for('auth_register', _absolute=True)}" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
                         <a data-bind="click: trackClick.bind($data, 'SignIn')" href="${login_url}" class="btn btn-info btn-top-login p-sm">Sign In</a>
                     </div>
                 </li>


### PR DESCRIPTION
## Purpose

To make the sign-up button redirect away from the institution's custom domain.

## Changes

- small change to nav.mako

## QA Notes

You should be able to go to a custom domain, click "Sign-up" and be redirected back to osf.io

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1108