### PR TITLE
[PLAT-568] Upgrade Django Rest Framework

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -147,7 +147,7 @@ class OSFBasicAuthentication(BasicAuthentication):
             self.authenticate_twofactor_credentials(user_auth_tuple[0], request)
         return user_auth_tuple
 
-    def authenticate_credentials(self, userid, password):
+    def authenticate_credentials(self, userid, password, request=None):
         """
         Authenticate the user by userid (email) and password.
 

--- a/api/base/requests.py
+++ b/api/base/requests.py
@@ -17,8 +17,10 @@ class EmbeddedRequest(Request):
     ):
         self.original_user = request.user
         self.parents = parents or {Node: {}, OSFUser: {}}
+        self.version = request.version
+
         super(EmbeddedRequest, self).__init__(
-            request, parsers, authenticators,
+            request._request, parsers, authenticators,
             negotiator, parser_context,
         )
 
@@ -35,3 +37,10 @@ class EmbeddedRequest(Request):
         Returns the user from the original request
         """
         return self.original_user
+
+    @property
+    def auth(self):
+        """
+        Returns the user from the original request
+        """
+        return self._request.auth

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -657,7 +657,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             # nested attributes in relationship fields.
             try:
                 return_val = get_nested_attributes(obj, source_attrs)
-            except KeyError:
+            except (KeyError, AttributeError):
                 return None
             return return_val
 
@@ -675,10 +675,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         for lookup_url_kwarg, lookup_field in kwargs_dict.items():
 
             if _tpl(lookup_field):
-                try:
-                    lookup_value = self.lookup_attribute(obj, lookup_field)
-                except AttributeError as exc:
-                    raise AssertionError(exc)
+                lookup_value = self.lookup_attribute(obj, lookup_field)
             else:
                 lookup_value = _url_val(lookup_field, obj, self.parent, self.context['request'])
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -69,9 +69,9 @@ class JSONAPIBaseView(generics.GenericAPIView):
             else:
                 request = EmbeddedRequest(self.request)
 
-            if not hasattr(request._request._request, '_embed_cache'):
-                request._request._request._embed_cache = {}
-            cache = request._request._request._embed_cache
+            if not hasattr(request._request, '_embed_cache'):
+                request._request._embed_cache = {}
+            cache = request._request._embed_cache
 
             request.parents.setdefault(type(item), {})[item._id] = item
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -64,10 +64,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
             if not v:
                 return None
 
-            if isinstance(self.request, EmbeddedRequest):
-                request = EmbeddedRequest(self.request._request)
-            else:
-                request = EmbeddedRequest(self.request)
+            request = EmbeddedRequest(self.request)
 
             if not hasattr(request._request, '_embed_cache'):
                 request._request._embed_cache = {}

--- a/api/requests/views.py
+++ b/api/requests/views.py
@@ -80,9 +80,9 @@ class RequestDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     def get(self, request, *args, **kwargs):
         request_id = self.kwargs['request_id']
         if NodeRequest.objects.filter(_id=request_id).exists():
-            return NodeRequestDetail.as_view()(request, *args, **kwargs)
+            return NodeRequestDetail.as_view()(request._request, *args, **kwargs)
         elif PreprintRequest.objects.filter(_id=request_id).exists():
-            return PreprintRequestDetail.as_view()(request, *args, **kwargs)
+            return PreprintRequestDetail.as_view()(request._request, *args, **kwargs)
         else:
             raise NotFound
 
@@ -137,7 +137,7 @@ class RequestActionList(JSONAPIBaseView, generics.ListAPIView):
     def get(self, request, *args, **kwargs):
         request_id = self.kwargs['request_id']
         if PreprintRequest.objects.filter(_id=request_id).exists():
-            return PreprintRequestActionList.as_view()(request, *args, **kwargs)
+            return PreprintRequestActionList.as_view()(request._request, *args, **kwargs)
         else:
             raise NotFound
 

--- a/api_tests/base/test_versioning.py
+++ b/api_tests/base/test_versioning.py
@@ -116,7 +116,7 @@ class TestBaseVersioning:
         url = '/v2/?format=api'
         res = app.get(url)
         assert res.status_code == 200
-        assert '&quot;version&quot;: &quot;{}&quot'.format(
+        assert '"version": "{}"'.format(
             LATEST_VERSIONS[2]
         ) in res.body
 
@@ -124,7 +124,7 @@ class TestBaseVersioning:
         url = '/v2/?format=api&version=2.5'
         res = app.get(url)
         assert res.status_code == 200
-        assert '&quot;version&quot;: &quot;2.5&quot' in res.body
+        assert '"version": "2.5"' in res.body
 
     def test_json_defaults_to_default(self, app):
         url = '/v2/?format=json'

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -2502,7 +2502,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
         data = res.json['data']

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -2084,7 +2084,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"true and false" is not a valid boolean.'
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
         data = res.json['data']
@@ -2502,7 +2502,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"true and false" is not a valid boolean.'
+        assert res.json['errors'][0]['detail'] == '"Must be a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
         data = res.json['data']

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -322,7 +322,7 @@ class TestRegistrationUpdate:
             auth=user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"Dr.Strange" is not a valid boolean.'
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
     #   test_fields_other_than_public_are_ignored
         attribute_list = {

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -81,7 +81,7 @@ class TestUserSettingsUpdateTwoFactor:
         payload['data']['attributes']['two_factor_enabled'] = 'Yes'
         res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"Yes" is not a valid boolean.'
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
         # Already disabled - nothing happens, still disabled
         payload['data']['attributes']['two_factor_enabled'] = False
@@ -193,7 +193,7 @@ class TestUserSettingsUpdateMailingList:
         res = app.patch_json_api(url, bad_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == u'"22" is not a valid boolean.'
+        assert res.json['errors'][0]['detail'] == u'Must be a valid boolean.'
 
     def test_anonymous_patch_401(self, app, url, payload):
         res = app.patch_json_api(url, payload, expect_errors=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,7 @@ raven==5.32.0
 
 # API requirements
 Django==1.11.15  # pyup: <2.0 # Remove this when we're on Py3
-djangorestframework==3.6.3
+djangorestframework==3.9.0
 django-cors-headers==2.1.0
 djangorestframework-bulk==0.2.1
 hashids==1.2.0


### PR DESCRIPTION
## Purpose

To be on the cutting edge of we got to stay up to late with the latest DRF releases. This PR does that.

## Changes

Easy stuff:
- DRF has slightly different error messages when something is supposed to be a bool.
- `authenticate_credentials` now takes a request parameter, though we don't use it.
- the browsable API HTML is now formatted in a way that broke tests, but is easily fixed.

Difficult stuff:
- [This](https://github.com/CenterForOpenScience/osf.io/compare/develop...Johnetordoff:upgrade-django-rest?expand=1#diff-b07251433ac329b6b2c079ebe02bf8e0L67) and [this](https://github.com/CenterForOpenScience/osf.io/compare/develop...Johnetordoff:upgrade-django-rest?expand=1#diff-7d5c6cc5fa38ec2cb9834b36dbfab5a4L83) making EmbeddedRequests is now changed because DRF no longer allows you to wrap a DRF request only a native django request, so a little work has to be done to ensure EmbeddedRequests don't embed themselves in themselves.
- [This](https://github.com/CenterForOpenScience/osf.io/compare/develop...Johnetordoff:upgrade-django-rest?expand=1#diff-4b396d38a0947821679352d308445c5aR660) DRF removed a clause which returns None and now makes us wrongly throw an attribute error. Now this is fixed so we return None.

## QA Notes

Shouldn't be any noticeable changes.

## Documentation

Technical task, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-568