### PR TITLE
[EMB-410][OSF]simplify how we add moderators/admins to preprint providers

### DIFF
--- a/admin/common_auth/forms.py
+++ b/admin/common_auth/forms.py
@@ -24,7 +24,7 @@ class UserRegistrationForm(forms.Form):
 
     # TODO: Moving to guardian, find a better way to distinguish "admin-like" groups from object permission groups
     group_perms = forms.ModelMultipleChoiceField(
-        queryset=Group.objects.exclude(Q(name__startswith='collections_') | Q(name__startswith='preprint_')),
+        queryset=Group.objects.exclude(Q(name__startswith='collections_') | Q(name__startswith='reviews_') | Q(name__startswith='preprint_')),
         required=False,
         widget=forms.CheckboxSelectMultiple
     )

--- a/admin/preprint_providers/forms.py
+++ b/admin/preprint_providers/forms.py
@@ -1,6 +1,7 @@
 import bleach
 
 from django import forms
+from django.contrib.auth.models import Group
 
 from osf.models import PreprintProvider, Subject
 from admin.base.utils import (get_subject_rules, get_toplevel_subjects,
@@ -95,3 +96,19 @@ class PreprintProviderCustomTaxonomyForm(forms.Form):
             if hasattr(field, 'choices'):
                 if field.choices == []:
                     field.choices = subject_choices
+
+
+class PreprintProviderRegisterModeratorOrAdminForm(forms.Form):
+    """ A form that finds an existing OSF User, and grants permissions to that
+        user so that they can use the admin app"""
+
+    def __init__(self, *args, **kwargs):
+        provider_id = kwargs.pop('provider_id')
+        super(PreprintProviderRegisterModeratorOrAdminForm, self).__init__(*args, **kwargs)
+        self.fields['group_perms'] = forms.ModelMultipleChoiceField(
+            queryset=Group.objects.filter(name__startswith='reviews_preprint_{}'.format(provider_id)),
+            required=False,
+            widget=forms.CheckboxSelectMultiple
+        )
+
+    user_id = forms.CharField(required=True, max_length=5, min_length=5)

--- a/admin/preprint_providers/urls.py
+++ b/admin/preprint_providers/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     url(r'^(?P<preprint_provider_id>[a-z0-9]+)/delete/$', views.DeletePreprintProvider.as_view(), name='delete'),
     url(r'^(?P<preprint_provider_id>[a-z0-9]+)/export/$', views.ExportPreprintProvider.as_view(), name='export'),
     url(r'^(?P<preprint_provider_id>[a-z0-9]+)/share_source/$', views.ShareSourcePreprintProvider.as_view(), name='share_source'),
+    url(r'^(?P<preprint_provider_id>[a-z0-9]+)/register/$', views.PreprintProviderRegisterModeratorOrAdmin.as_view(), name='register_moderator_admin'),
 ]

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -3,19 +3,22 @@ from __future__ import unicode_literals
 import json
 import requests
 
+from django.http import Http404
 from django.core import serializers
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse_lazy, reverse
 from django.http import HttpResponse, JsonResponse
 from django.views.generic import ListView, DetailView, View, CreateView, DeleteView, TemplateView, UpdateView
+from django.views.generic.edit import FormView
 from django.core.management import call_command
+from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.forms.models import model_to_dict
 from django.shortcuts import redirect, render
 
 from admin.base import settings
 from admin.base.forms import ImportFileForm
-from admin.preprint_providers.forms import PreprintProviderForm, PreprintProviderCustomTaxonomyForm
-from osf.models import PreprintProvider, Subject, NodeLicense
+from admin.preprint_providers.forms import PreprintProviderForm, PreprintProviderCustomTaxonomyForm, PreprintProviderRegisterModeratorOrAdminForm
+from osf.models import PreprintProvider, Subject, NodeLicense, OSFUser
 from osf.models.provider import rules_to_subjects, WhitelistedSHAREPreprintProvider
 from website import settings as osf_settings
 
@@ -440,3 +443,43 @@ class SharePreprintProviderWhitelist(PermissionRequiredMixin, View):
         share_api_url = settings.SHARE_URL
         api_v2_url = settings.API_DOMAIN + settings.API_BASE
         return render(request, self.template_name, {'share_api_url': share_api_url, 'api_v2_url': api_v2_url})
+
+
+class PreprintProviderRegisterModeratorOrAdmin(PermissionRequiredMixin, FormView):
+    permission_required = 'osf.change_preprintprovider'
+    raise_exception = True
+    template_name = 'preprint_providers/register_moderator_admin.html'
+    form_class = PreprintProviderRegisterModeratorOrAdminForm
+
+    def get_form_kwargs(self):
+        kwargs = super(PreprintProviderRegisterModeratorOrAdmin, self).get_form_kwargs()
+        kwargs['provider_id'] = self.kwargs['preprint_provider_id']
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super(PreprintProviderRegisterModeratorOrAdmin, self).get_context_data(**kwargs)
+        context['provider_name'] = PreprintProvider.objects.get(id=self.kwargs['preprint_provider_id']).name
+        return context
+
+    def form_valid(self, form):
+        user_id = form.cleaned_data.get('user_id')
+        osf_user = OSFUser.load(user_id)
+
+        if not osf_user:
+            raise Http404('OSF user with id "{}" not found. Please double check.'.format(user_id))
+
+        for group in form.cleaned_data.get('group_perms'):
+            osf_user.groups.add(group)
+            split = group.name.split('_')
+            group_type = split[0]
+            if group_type == 'reviews':
+                provider_id = split[2]
+                provider = PreprintProvider.objects.get(id=provider_id)
+                provider.notification_subscriptions.get(event_name='new_pending_submissions').add_user_to_subscription(osf_user, 'email_transactional')
+
+        osf_user.save()
+        messages.success(self.request, 'Permissions update successful for OSF User {}!'.format(osf_user.username))
+        return super(PreprintProviderRegisterModeratorOrAdmin, self).form_valid(form)
+
+    def get_success_url(self):
+        return reverse('preprint_providers:register_moderator_admin', kwargs={'preprint_provider_id': self.kwargs['preprint_provider_id']})

--- a/admin/templates/preprint_providers/detail.html
+++ b/admin/templates/preprint_providers/detail.html
@@ -38,6 +38,9 @@
                     Modify Preprint Provider
                 </button>
             </div>
+            <div class="col-md-12">
+                <a class="btn btn-link" href={% url 'preprint_providers:register_moderator_admin' preprint_provider.id %}>Register Moderator/Admin</a>
+            </div>
         </div>
         {% endif %}
         <div class="row" id="table-view">

--- a/admin/templates/preprint_providers/register_moderator_admin.html
+++ b/admin/templates/preprint_providers/register_moderator_admin.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% load render_bundle from webpack_loader %}
+{% load staticfiles %}
+
+{% block content %}
+<div class="register-box">
+    <div class="register-box-body">
+        <h4>Add or Update Moderator/Admin for {{ provider_name }}</h4>
+        <div>
+            {% if messages %}
+                <ul class="login_page_messages">
+                    {% for message in messages %}
+                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+        <form action="" method="post">
+            {% csrf_token %}
+
+            {% if form.non_field_errors %}
+            <ul>
+            {% for error in form.non_field_errors %}
+            <li class="errorclass">{{ error }}</li>
+            {% endfor %}
+            </ul>
+            {% endif %}
+            <div class="form-group">
+                <label for="email">OSF ID:</label>
+                <p>{{ form.user_id }}</p>
+                {% if form.user_id.errors %}<span class="text-danger"> {{ form.user_id.errors }}</span>{% endif %}
+            </div>
+            <div class="form-group">
+                <p>{{ form.group_perms }}</p>
+                {% if form.group_perms.errors %}<span class="text-danger"> {{ form.group_perms.errors }}</span>{% endif %}
+            </div>
+            <div class="row">
+                <div class="col-xs-4">
+                    <button type="submit" class="btn btn-primary btn-block btn-flat">Register</button>
+                </div><!-- /.col -->
+            </div>
+        </form>
+    </div><!-- /.form-box -->
+</div><!-- /.register-box -->
+{% endblock %}


### PR DESCRIPTION
## Purpose

Make a separate view for adding moderators for each preprint providers.

## Changes

A new view is added for each preprint provider so that OSFAdmin can register users as moderators or admins for the specific provider.

## Ticket

https://openscience.atlassian.net/browse/EMB-410
