### PR TITLE
[Travis Failure] test_update_two_factor_verification

### DIFF
--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -140,7 +140,7 @@ class TestUserSettingsUpdateTwoFactor:
         addon = user_one.get_addon('twofactor')
         addon.totp_secret = TOTP_SECRET
         addon.save()
-        payload['data']['attributes']['two_factor_verification'] = _valid_code(TOTP_SECRET)
+        payload['data']['attributes']['two_factor_verification'] = _valid_code(TOTP_SECRET, drift=-1)
         res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
         assert res.json['data']['attributes']['two_factor_enabled'] is True
         assert res.status_code == 200


### PR DESCRIPTION
## Purpose

`test_update_two_factor_verification` fails seemingly at random, this fix addresses that.

## Changes

- give the function that generates a valid two factor code a negative drift value so it has more time before it expires.

## QA Notes

Should pass Travis, not user-facing.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

No ticket