### PR TITLE
[PLAT-1028] Use consistent naming for JSON-API "type" (snake_case)

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1298,6 +1298,10 @@ class JSONAPISerializer(BaseAPISerializer):
         assert type_ is not None, 'Must define Meta.type_'
         self.parse_sparse_fields(allow_unsafe=True, context=self.context)
 
+        request = self.context['request']
+        if not request.version or StrictVersion(request.version) > StrictVersion('2.11'):
+            type_ = type_.replace('-', '_')
+
         data = {
             'id': '',
             'type': type_,

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -162,6 +162,7 @@ REST_FRAMEWORK = {
         '2.9',
         '2.10',
         '2.11',
+        '2.12',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',


### PR DESCRIPTION
## Purpose

Our casing for the `type` JSON-API field is annoyingly inconsistent. This fix converts them all to snake_case for versions > 2.11 .

## Changes

- Simple change to base serializer and add version to API

## QA Notes

All type fields for v2 json responses should be snake case for version 2.12, earlier versions are about have some kebab-case. `external-identities` is a good endpoint to check.

## Documentation

Will have to refactor docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1028