### PR TITLE
[PLAT-1108][Hotfix] Redirect back to institutions landing page after clicking on sign up

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -134,6 +134,7 @@ def get_globals():
         'osf_url': settings.INTERNAL_DOMAIN,
         'waterbutler_url': settings.WATERBUTLER_URL,
         'login_url': cas.get_login_url(request_login_url),
+        'sign_up_url': util.web_url_for('auth_register', _absolute=True) + '?next=' + request_login_url,
         'reauth_url': util.web_url_for('auth_logout', redirect_url=request.url, reauth=True),
         'profile_url': cas.get_profile_url(),
         'enable_institutions': settings.ENABLE_INSTITUTIONS,

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -83,7 +83,7 @@
                 %else :
                 <li class="dropdown sign-in">
                     <div class="col-sm-12">
-                        <a data-bind="click: trackClick.bind($data, 'SignUp')" href="${web_url_for('auth_register', _absolute=True)}" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
+                        <a data-bind="click: trackClick.bind($data, 'SignUp')" href="${sign_up_url}" class="btn btn-success btn-top-signup m-r-xs">Sign Up</a>
                         <a data-bind="click: trackClick.bind($data, 'SignIn')" href="${login_url}" class="btn btn-info btn-top-login p-sm">Sign In</a>
                     </div>
                 </li>


### PR DESCRIPTION
## Purpose

When a user is coming from a custom domain currently clicking signup will unhelpfully redirect them back to the dashboard and log them in. This fix logs them in and redirects them back to whatever page they were on.

## Changes

- simple change to dashboard mako and template

## QA Notes

When clicking signup when logged out from a custom domain you should always land back on the page you were on.


## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1108