### PR TITLE
[hotfix] Prevent current_user_permissions from returning None [PLAT-1189]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -485,8 +485,12 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         if hasattr(obj, 'contrib_admin'):
             if obj.contrib_admin:
                 return ['admin', 'write', 'read']
-            if obj.contrib_write:
+            elif obj.contrib_write:
                 return ['write', 'read']
+            elif obj.contrib_read:
+                return ['read']
+            else:
+                return default_perm
         else:
             user = self.context['request'].user
             if user.is_anonymous:


### PR DESCRIPTION
#### Purpose
* Fix `current_user_permissions` in the API for nodes where you are a read contributor.

#### Bug Description
* Visit /v2/users/me/nodes/ and find a project for which you are a read contributor. Note that the "current_user_permissions" attribute is null.

* Visit osf.io/prereg/, click "Preregister a project you have on the OSF" and note that the typeahead field doesn't list your project. Note the error in the console and the error sent to sentry in the networking tab.

#### Ticket
https://openscience.atlassian.net/browse/PLAT-1189
