### PR TITLE
[PLAT-1095] Fix related counts for collections bookmark issue

### DIFF
--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -113,13 +113,13 @@ class CollectionSerializer(JSONAPISerializer):
 
     def get_node_links_count(self, obj):
         auth = get_user_auth(self.context['request'])
-        node_ids = obj.guid_links.all().values_list('id', flat=True)
-        return Node.objects.filter(id__in=node_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
+        node_ids = obj.guid_links.all().values_list('_id', flat=True)
+        return Node.objects.filter(guids___id__in=node_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
 
     def get_registration_links_count(self, obj):
         auth = get_user_auth(self.context['request'])
-        registration_ids = obj.guid_links.all().values_list('id', flat=True)
-        return Registration.objects.filter(id__in=registration_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
+        registration_ids = obj.guid_links.all().values_list('_id', flat=True)
+        return Registration.objects.filter(guids___id__in=registration_ids, is_deleted=False).can_view(user=auth.user, private_link=auth.private_link).count()
 
     def create(self, validated_data):
         node = Collection(**validated_data)


### PR DESCRIPTION
## Purpose

Previously there was an issue where bookmark would timeout while loading, this was optimized to be faster, but unfortunately it was faster because the query was incorrect. This fix should fix the related counts query.

## Changes

- query by the guid rather then the guid id

## QA Notes

This will still take a very long time to load for users with >1000 nodes, but it should load without timing out.

## Documentation

🐞 fix no docs.

## Side Effects

According to Django debug toolbar this query should take 7000ms

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1095