### PR TITLE
[PLAT-1188] Catch permission denied error which was causing browsable API to break

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -1,6 +1,6 @@
 from rest_framework import generics
 from rest_framework import permissions as drf_permissions
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied
 
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -77,7 +77,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     def get_serializer_class(self):
         try:
             target = self.get_target()
-        except (NotFound, Gone):
+        except (NotFound, Gone, PermissionDenied):
             return FileDetailSerializer
         else:
             if isinstance(target, QuickFilesNode):


### PR DESCRIPTION
## Purpose

Using the `v2/files/<file_id>/` for any user that doesn't have permissions for that file will appear to throw a 502 instead of a 403 in the browsable API. This PR fixes that.

## Changes

- catches PermissionDenied in `get_serializer_class` so the error is serialized properly.

## QA Notes

For Devs [this stack overflow question](https://stackoverflow.com/questions/20868189/django-rest-framework-has-object-permission-raising-permissiondenied-exception) has essentially the exact same issue observed here.

❗️There are no additional unit tests for this because it only effects the browsable API.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1188