### PR TITLE
Downgrade to fork of celery 4.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,11 @@ Mako==1.0.7
 Markdown==2.6.9
 WTForms==1.0.4
 beautifulsoup4==4.6.0
-celery==4.2.1
+# Fork of celery 4.1.1 with https://github.com/celery/celery/pull/4278 backported,
+# which fixes a bug that was causing stuck registrations
+# Need to pin to 4.1.1 due to https://github.com/celery/celery/issues/4355
+# TODO: Remove usage of this fork when celery/celery#4355 is resolved
+git+https://github.com/cos-forks/celery@v4.1.1+cos0
 kombu==4.2.0
 amqp==2.2.2
 vine==1.1.4


### PR DESCRIPTION
**Purpose**

Celery 4.2 contains a regression that causes
celery to disconnect from RabbitMQ
(celery/celery#4355).

**Changes**

* Forked celery
* Created new branch off of v4.1.1
* Backported celery/celery#4278, which
  is needed in order to prevent stuck registrations

**QA Notes**

* Make sure that registrations of projects
  with many components (>=7) is working as expected

**Ticket**

https://openscience.atlassian.net/browse/PLAT-1186
