### PR TITLE
[Hotfix] [EMB-347] 409 for existing emails

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -832,7 +832,7 @@ def register_user(**kwargs):
         framework_auth.signals.user_registered.send(user)
     except (ValidationValueError, DuplicateEmailError):
         raise HTTPError(
-            http.BAD_REQUEST,
+            http.CONFLICT,
             data=dict(
                 message_long=language.ALREADY_REGISTERED.format(
                     email=markupsafe.escape(request.json['email1'])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3256,6 +3256,25 @@ class TestAuthViews(OsfTestCase):
         users = OSFUser.objects.filter(username=email)
         assert_equal(users.count(), 0)
 
+    def test_register_email_already_registered(self):
+        url = api_url_for('register_user')
+        name, email, password = fake.name(), fake_email(), fake.password()
+        existing_user = UserFactory(
+            username=email,
+        )
+        res = self.app.post_json(
+            url, {
+                'fullName': name,
+                'email1': email,
+                'email2': email,
+                'password': password
+            },
+            expect_errors=True
+        )
+        assert_equal(res.status_code, http.CONFLICT)
+        users = OSFUser.objects.filter(username=email)
+        assert_equal(users.count(), 1)
+
     def test_register_blacklisted_email_domain(self):
         url = api_url_for('register_user')
         name, email, password = fake.name(), 'bad@mailinator.com', 'agreatpasswordobviously'


### PR DESCRIPTION
## Purpose

Return `409 CONFLICT` when attempting to register a user with an email address of an existing user.

## Changes

* raise `http.CONFLICT` when email already exists
* added a test for this

## QA Notes

Will be tested in [EMB-347](https://openscience.atlassian.net/browse/EMB-347).

## Documentation

v1 endpoint

## Side Effects

None.

## Ticket

https://openscience.atlassian.net/browse/EMB-34
