### PR TITLE
[PLAT-1117] Script to backfill elasticsearch metrics from PageCounter

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -297,6 +297,7 @@ HASHIDS_SALT = 'pinkhimalayan'
 ELASTICSEARCH_DSL = {
     'default': {
         'hosts': os.environ.get('ELASTIC6_URI', '127.0.0.1:9201'),
+        'retry_on_timeout': True,
     },
 }
 

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -97,6 +97,8 @@ class BasePreprintMetric(MetricMixin, metrics.Metric):
     class Index:
         settings = {
             'number_of_shards': 1,
+            'number_of_replicas': 0,
+            'refresh_interval': '-1',
         }
 
     class Meta:

--- a/scripts/remove_after_use/backfill_elasticsearch_metrics.py
+++ b/scripts/remove_after_use/backfill_elasticsearch_metrics.py
@@ -1,0 +1,59 @@
+import logging
+import sys
+import argparse
+import datetime
+
+import django
+django.setup()
+
+from elasticsearch2.helpers import bulk
+from elasticsearch_dsl.connections import connections
+
+from osf.models import PageCounter, PreprintService
+from scripts import utils
+from website.search.elastic_search import client
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+
+    es = connections.get_connection()
+
+    dry = '--dry' in sys.argv
+    preprints = PreprintService.objects.all().values_list('node__guids___id', 'node__preprint_file___id', 'guids___id',
+                                              'provider___id')
+
+    batch_to_update = []
+    for preprint in preprints:
+        node__id, file_id, preprint__id, provider__id = preprint
+        page_counters = PageCounter.objects.filter(_id__startswith='download:{node__id}:{file_id}:'.format(node__id=node__id,
+                                                                                                      file_id=file_id)).values_list('_id', 'date')
+        for page_counter in page_counters:
+            page_counter__id, date = page_counter
+            version_num = page_counter__id.split(':')[-1]
+            for date, totals in date.items():
+                for _ in range(0, totals['total']):
+                    batch_to_update.append({
+                        '_index': 'osf_preprintdownload-{}'.format(date.replace('/', '.')),
+                        '_source': {
+                            'path': '/{}'.format(file_id),
+                            'preprint_id': preprint__id,
+                            'provider_id': provider__id,
+                            'timestamp': datetime.datetime.strptime(date, '%Y/%m/%d'),
+                            'user_id': None,  # Pagecounter never tracked this
+                            'version': int(version_num) + 1
+                        },
+                        '_type': 'doc'
+                    })
+
+    logger.info('This will migrate {} Pagecounter entries to Elasticsearch'.format(len(batch_to_update)))
+    if not dry:
+        utils.add_file_logger(logger, __file__)
+        bulk(es, batch_to_update)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/remove_after_use/backfill_elasticsearch_metrics.py
+++ b/scripts/remove_after_use/backfill_elasticsearch_metrics.py
@@ -1,12 +1,20 @@
+"""Script to backfill PageCounter data into elasticsearch.
+
+* This MUST be run before enabling the elasticsearch_metrics switch.
+* This MUST run to completion without errors. If an error occurs, delete
+  the existing osf_preprint* indices, fix the error, and re-run the script.
+"""
 import logging
 import sys
 import argparse
 import datetime
+import progressbar
+from time import sleep
 
-import django
-django.setup()
+from website.app import setup_django
+setup_django()
 
-from elasticsearch2.helpers import bulk
+from elasticsearch.helpers import bulk
 from elasticsearch_dsl.connections import connections
 
 from osf.models import PageCounter, PreprintService
@@ -16,17 +24,28 @@ from website.search.elastic_search import client
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
+CHUNK_SIZE = 100
+MAX_BATCH_SIZE = 1000
+THROTTLE_PERIOD = 3  # seconds
+REQUEST_TIMEOUT = 30  # seconds
+
 
 def main():
 
     es = connections.get_connection()
 
     dry = '--dry' in sys.argv
+    if not dry:
+        utils.add_file_logger(logger, __file__)
     preprints = PreprintService.objects.all().values_list('node__guids___id', 'node__preprint_file___id', 'guids___id',
                                               'provider___id')
 
+    logger.info('Collecting data on {} preprints...'.format(preprints.count()))
+
+    progress_bar = progressbar.ProgressBar(maxval=preprints.count()).start()
     batch_to_update = []
-    for preprint in preprints:
+    for i, preprint in enumerate(preprints, 1):
+        progress_bar.update(i)
         node__id, file_id, preprint__id, provider__id = preprint
         page_counters = PageCounter.objects.filter(_id__startswith='download:{node__id}:{file_id}:'.format(node__id=node__id,
                                                                                                       file_id=file_id)).values_list('_id', 'date')
@@ -34,24 +53,36 @@ def main():
             page_counter__id, date = page_counter
             version_num = page_counter__id.split(':')[-1]
             for date, totals in date.items():
-                for _ in range(0, totals['total']):
-                    batch_to_update.append({
-                        '_index': 'osf_preprintdownload-{}'.format(date.replace('/', '.')),
-                        '_source': {
-                            'path': '/{}'.format(file_id),
-                            'preprint_id': preprint__id,
-                            'provider_id': provider__id,
-                            'timestamp': datetime.datetime.strptime(date, '%Y/%m/%d'),
-                            'user_id': None,  # Pagecounter never tracked this
-                            'version': int(version_num) + 1
-                        },
-                        '_type': 'doc'
-                    })
+                batch_to_update.append({
+                    '_index': 'osf_preprintdownload-{}'.format(date.replace('/', '.')),
+                    '_source': {
+                        'count': totals['total'],
+                        'path': '/{}'.format(file_id),
+                        'preprint_id': preprint__id,
+                        'provider_id': provider__id,
+                        'timestamp': datetime.datetime.strptime(date, '%Y/%m/%d'),
+                        'user_id': None,  # Pagecounter never tracked this
+                        'version': int(version_num) + 1
+                    },
+                    '_type': 'doc'
+                })
 
+                if len(batch_to_update) >= MAX_BATCH_SIZE:
+                    logger.info('Bulk-indexing data from {} PageCounter records'.format(len(batch_to_update)))
+                    if not dry:
+                        bulk(es, batch_to_update, max_retries=3, chunk_size=CHUNK_SIZE, request_timeout=REQUEST_TIMEOUT)
+                    batch_to_update = []
+                    # Allow elasticsearch to catch up
+                    sleep(THROTTLE_PERIOD)
+
+    # Index final batch
+    if len(batch_to_update):
+        logger.info('Bulk-indexing data from {} PageCounter records'.format(len(batch_to_update)))
+        if not dry:
+            bulk(es, batch_to_update, max_retries=3, chunk_size=CHUNK_SIZE, request_timeout=REQUEST_TIMEOUT)
+
+    progress_bar.finish()
     logger.info('This will migrate {} Pagecounter entries to Elasticsearch'.format(len(batch_to_update)))
-    if not dry:
-        utils.add_file_logger(logger, __file__)
-        bulk(es, batch_to_update)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Backfill elasticsearch with PageCounter data for preprint downloads

## Changes

<!-- Briefly describe or list your changes  -->
* Temporarily turn off replication and set refresh_interval to '-1'
* Add script

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
I will QA this after I run it. Need to make sure that the counts in ES match the ones in Postgres.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - Developer documentation? If so, link developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

- [ ] Need to run the following:

```
python manage.py sync_metrics
python -m scripts.remove_after_use.backfill_elasticsearch_metrics
```

- [ ] When the script finishes, enable the elasticsearch_metrics waffle switch.

Then verify that the counts are consistent with the PageCounter data displayed on the preprint detail pages.

- [ ] Once verified, send a follow-up PR to (1) remove the script (2) remove the replication factor and refresh_interval settings
- [ ] Run `sync_metrics` again

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/PLAT-1117
