### PR TITLE
[PLAT-1182] Storage usage on project overview

### DIFF
--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -15,6 +15,7 @@ from framework.sessions import get_session
 from framework.exceptions import HTTPError
 from framework.auth.decorators import must_be_signed, must_be_logged_in
 
+from api.caching.tasks import update_storage_usage
 from osf.exceptions import InvalidTagError, TagNotFoundError
 from osf.models import FileVersion, OSFUser
 from osf.utils.requests import check_select_for_update
@@ -122,13 +123,16 @@ def osfstorage_get_revisions(file_node, payload, target, **kwargs):
 
 @decorators.waterbutler_opt_hook
 def osfstorage_copy_hook(source, destination, name=None, **kwargs):
-    return source.copy_under(destination, name=name).serialize(), httplib.CREATED
-
+    ret = source.copy_under(destination, name=name).serialize(), httplib.CREATED
+    update_storage_usage(destination.target)
+    return ret
 
 @decorators.waterbutler_opt_hook
 def osfstorage_move_hook(source, destination, name=None, **kwargs):
+    source_target = source.target
+
     try:
-        return source.move_under(destination, name=name).serialize(), httplib.OK
+        ret = source.move_under(destination, name=name).serialize(), httplib.OK
     except exceptions.FileNodeCheckedOutError:
         raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
             'message_long': 'Cannot move file as it is checked out.'
@@ -138,6 +142,12 @@ def osfstorage_move_hook(source, destination, name=None, **kwargs):
             'message_long': 'Cannot move file as it is the primary file of preprint.'
         })
 
+    # once the move is complete recalculate storage for both targets if it's a inter-target move.
+    if source_target != destination.target:
+        update_storage_usage(destination.target)
+        update_storage_usage(source_target)
+
+    return ret
 
 @must_be_signed
 @decorators.autoload_filenode(default_root=True)
@@ -309,27 +319,30 @@ def osfstorage_create_child(file_node, payload, **kwargs):
             )
         })
 
+    if file_node.checkout and file_node.checkout._id != user._id:
+        raise HTTPError(httplib.FORBIDDEN, data={
+            'message_long': 'File cannot be updated due to checkout status.'
+        })
+
     if not is_folder:
         try:
-            if file_node.checkout is None or file_node.checkout._id == user._id:
-                version = file_node.create_version(
-                    user,
-                    dict(payload['settings'], **dict(
-                        payload['worker'], **{
-                            'object': payload['metadata']['name'],
-                            'service': payload['metadata']['provider'],
-                        })
-                    ),
-                    dict(payload['metadata'], **payload['hashes'])
-                )
-                version_id = version._id
-                archive_exists = version.archive is not None
-            else:
-                raise HTTPError(httplib.FORBIDDEN, data={
-                    'message_long': 'File cannot be updated due to checkout status.'
-                })
+            metadata = dict(payload['metadata'], **payload['hashes'])
+            location = dict(payload['settings'], **dict(
+                payload['worker'], **{
+                    'object': payload['metadata']['name'],
+                    'service': payload['metadata']['provider'],
+                }
+            ))
         except KeyError:
             raise HTTPError(httplib.BAD_REQUEST)
+        current_version = file_node.get_version()
+        new_version = file_node.create_version(user, location, metadata)
+
+        if not current_version or not current_version.is_duplicate(new_version):
+            update_storage_usage(file_node.target)
+
+        version_id = new_version._id
+        archive_exists = new_version.archive is not None
     else:
         version_id = None
         archive_exists = False
@@ -365,6 +378,7 @@ def osfstorage_delete(file_node, payload, target, **kwargs):
             'message_long': 'Cannot delete file as it is the primary file of preprint.'
         })
 
+    update_storage_usage(file_node.target)
     return {'status': 'success'}
 
 

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -305,3 +305,19 @@ ELASTICSEARCH_DSL = {
 }
 # Store yearly indices for time-series metrics
 ELASTICSEARCH_METRICS_DATE_FORMAT = '%Y'
+
+# Prereg challenge data is uploaded to this project TODO: Delete when Prereg challenge ends
+PREREG_DATA_STORE_TOKEN = None
+PREREG_DATA_STORE_GUID = None
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'osf_cache_table',
+    },
+    'waffle_cache': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+}
+
+WAFFLE_CACHE_NAME = 'waffle_cache'

--- a/api/caching/settings.py
+++ b/api/caching/settings.py
@@ -1,0 +1,4 @@
+NEVER_TIMEOUT = None  # for django caches setting None as a timeout value means the cache never times out.
+FIVE_MIN_TIMEOUT = 60 * 5
+
+STORAGE_USAGE_KEY = 'storage_usage:{target_id}'

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -3,6 +3,12 @@ import urlparse
 import requests
 import logging
 
+from django.apps import apps
+from django.core.cache import cache
+from django.db import models
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
+
+from api.caching import settings as cache_settings
 from framework.celery_tasks import app
 from website import settings
 
@@ -94,3 +100,22 @@ def ban_url(instance):
                     logger.info('Banning {} succeeded'.format(
                         url_to_ban,
                     ))
+
+
+@app.task(max_retries=5, default_retry_delay=10)
+def update_storage_usage_cache(target_id):
+    AbstractNode = apps.get_model('osf.AbstractNode')
+
+    storage_usage_total = AbstractNode.objects.get(
+        guids___id=target_id,
+    ).files.aggregate(sum=models.Sum('versions__size'))['sum'] or 0
+
+    key = cache_settings.STORAGE_USAGE_KEY.format(target_id=target_id)
+    cache.set(key, storage_usage_total, cache_settings.FIVE_MIN_TIMEOUT)
+
+
+def update_storage_usage(target):
+    Preprint = apps.get_model('osf.preprint')
+
+    if not isinstance(target, Preprint) and not target.is_quickfiles:
+        enqueue_postcommit_task(update_storage_usage_cache, (target._id,), {}, celery=True)

--- a/osf/features.py
+++ b/osf/features.py
@@ -1,5 +1,6 @@
 DISABLE_ENGAGEMENT_EMAILS = 'disable_engagement_emails'
 ELASTICSEARCH_METRICS = 'elasticsearch_metrics'
+STORAGE_USAGE = 'storage_usage'
 ENABLE_INACTIVE_SCHEMAS = 'enable_inactive_schemas'
 ENFORCE_CSRF = 'enforce_csrf'
 INSTITUTIONAL_LANDING_FLAG = 'institutions_nav_bar'

--- a/osf/migrations/0156_create_cache_table.py
+++ b/osf/migrations/0156_create_cache_table.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('osf', '0155_merge_20190115_1437'),
+    ]
+    operations = [
+        migrations.RunSQL([
+            """
+            CREATE TABLE "{}" (
+                "cache_key" varchar(255) NOT NULL PRIMARY KEY,
+                "value" text NOT NULL,
+                "expires" timestamp with time zone NOT NULL
+            );
+            """.format(settings.CACHES['default']['LOCATION'])
+        ], [
+            """DROP TABLE "{}"; """.format(settings.CACHES['default']['LOCATION'])
+        ])
+    ]

--- a/osf/migrations/0157_add_storage_usage_flag.py
+++ b/osf/migrations/0157_add_storage_usage_flag.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations
+
+from osf import features
+from osf.utils.migrations import AddWaffleFlags
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('osf', '0156_create_cache_table'),
+    ]
+
+    operations = [
+        AddWaffleFlags([features.STORAGE_USAGE]),
+    ]

--- a/website/ember_osf_web/decorators.py
+++ b/website/ember_osf_web/decorators.py
@@ -34,3 +34,8 @@ def ember_flag_is_active(flag_name):
 def storage_i18n_flag_active():
     request.user = _get_current_user() or MockUser()
     return waffle.flag_is_active(request, features.STORAGE_I18N)
+
+
+def storage_usage_flag_active():
+    request.user = _get_current_user() or MockUser()
+    return waffle.flag_is_active(request, features.STORAGE_USAGE)

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -102,3 +102,12 @@ def activity():
         'popular_public_projects': popular_public_projects,
         'popular_public_registrations': popular_public_registrations
     }
+
+
+# Credit to https://gist.github.com/cizixs/be41bbede49a772791c08491801c396f
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        if abs(num) < 1000.0:
+            return '%3.1f%s%s' % (num, unit, suffix)
+        num /= 1000.0
+    return '%.1f%s%s' % (num, 'Y', suffix)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -16,7 +16,7 @@ from framework import status
 from framework.utils import iso8601format
 from framework.flask import redirect  # VOL-aware redirect
 from framework.auth.decorators import must_be_logged_in, collect_auth
-from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_flag_active
+from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_flag_active, storage_usage_flag_active
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
 from osf.utils.functional import rapply
@@ -40,6 +40,7 @@ from website.tokens import process_token_or_pass
 from website.util.rubeus import collect_addon_js
 from website.project.model import has_anonymous_link, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
+from website.project.utils import sizeof_fmt
 from website.project.metadata.utils import serialize_meta_schemas
 from osf.models import AbstractNode, Collection, Guid, PrivateLink, Contributor, Node, NodeRelation, Preprint
 from addons.wiki.models import WikiPage
@@ -824,6 +825,10 @@ def _view_project(node, auth, primary=False,
 
     data.update({'storage_regions': region_list})
     data.update({'storage_flag_is_active': storage_i18n_flag_active()})
+    if storage_usage_flag_active():
+        storage_usage = node.storage_usage
+        if storage_usage:
+            data['node']['storage_usage'] = sizeof_fmt(storage_usage)
 
     if embed_contributors and not anonymous:
         data['node']['contributors'] = utils.serialize_visible_contributors(node)

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -54,7 +54,7 @@ var mfrURL = window.contextVars.node.urls.mfr;
 var osfURL = window.contextVars.osfURL;
 
 var getMfrUrl = function (guid) {
-    var mfrLink = mfrURL + 'render?url='+ osfURL + guid + '/?action=download%26mode=render';
+    var mfrLink = mfrURL + 'render?url='+ osfURL + guid + '/download/?action=download%26mode=render';
     if ($osf.urlParams().view_only) {
         mfrLink += '%26view_only=' + $osf.urlParams().view_only;
     }

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -35,6 +35,11 @@
             <div class="clearfix visible-md-block"></div>
             <div class="col-lg-4">
                 <div class="btn-toolbar node-control pull-right">
+                    % if node.get('storage_usage'):
+                    <div class="btn-group">
+                        <button style="pointer-events: auto;" class="btn disabled" data-toggle="tooltip" data-placement="bottom" title="This is the amount of OSF Storage used for this project.">${node['storage_usage']}</button>
+                    </div>
+                    % endif
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class="btn btn-default disabled">Private</button>


### PR DESCRIPTION
## Purpose

This will show the user how much storage space they are using for on a node.

## Changes

- adds property `storage_usage` to node
- add caching configuration and migration for cache table
- adds a a signal event to update cache up file change with tests
- adds waffled front-end elements to display total

# Figures
<img width="1112" alt="screen shot 2018-11-13 at 1 41 53 pm" src="https://user-images.githubusercontent.com/9688518/48435217-f1ca5c80-e749-11e8-928e-52110bb983ad.png">


## QA Notes

Bench marked new query here courtesy of Micheal:
```
SELECT SUM("versions__size__sum")
FROM
  (SELECT SUM("osf_fileversion"."size") AS "versions__size__sum"
   FROM "osf_basefilenode"
   LEFT OUTER JOIN "osf_basefilenode_versions" ON ("osf_basefilenode"."id" = "osf_basefilenode_versions"."basefilenode_id")
   LEFT OUTER JOIN "osf_fileversion" ON ("osf_basefilenode_versions"."fileversion_id" = "osf_fileversion"."id")
   WHERE ("osf_basefilenode"."type" = 'osf.osfstoragefile'
          AND "osf_basefilenode"."provider" = 'osfstorage'
          AND "osf_basefilenode"."target_content_type_id" = 28
          AND "osf_basefilenode"."target_object_id" = 255729)
   GROUP BY "osf_basefilenode"."id") subquery

Execution time: 0.014265s [Database: default]
```
Worth noting takes about half the time of the original query which was also per osfstorage addon on the page so the speed hit we take here is going to be a fraction of the original storage usage PR.

## Documentation

technical task, no docs.

## Side Effects

possible performance issues

## Ticket

https://openscience.atlassian.net/browse/PLAT-1182