### PR TITLE
Fix installation of elasticsearch==6.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,8 +34,8 @@ bleach==2.1.3
 html5lib==0.999999999
 blinker==1.4
 furl==0.4.92
-elasticsearch==6.3.1
 elasticsearch2==2.5.0  # pyup: >=2.4,<3.0 # Major version must be same as ES version
+elasticsearch==6.3.1
 google-api-python-client==1.6.4
 Babel==2.5.1
 citeproc-py==0.4.0


### PR DESCRIPTION
**Purpose**

Currently, elasticsearch 5.4.0 gets installed, even though
pip thinks that 6.3.1 (the correct version) is installed.

```python
>>> import elasticsearch
>>> elasticsearch.VERSION
(5, 4, 0)
```

```
$ pip freeze | grep elasticsearch==
elasticsearch==6.3.1
```

**Changes**

Switch the order of elasticsearch2 and elasticsearch
in requirements.txt.

~~I have no idea why this fixes it...~~

Update: This was caused by an issue with the 2.5.0 distribution: https://github.com/elastic/elasticsearch-py/issues/824 . The 5.4.0 code was accidentally included in the wheel.

**Side Effects**

**Ticket**

No ticket

h/t @binoculars and @mfraezz

