### PR TITLE
[hotfix] Mark all osfstorage files on a deleted node as deleted [PLAT-1199]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -153,7 +153,11 @@ class OsfStorageFileNode(BaseFileNode):
 
     @property
     def is_preprint_primary(self):
-        return getattr(self.target, 'preprint_file', None) == self and not getattr(self.target, '_has_abandoned_preprint', None)
+        return (
+            getattr(self.target, 'preprint_file', None) == self and
+            not getattr(self.target, '_has_abandoned_preprint', None) and
+            not getattr(self.target, 'is_deleted', None)
+        )
 
     def delete(self, user=None, parent=None, **kwargs):
         self._path = self.path

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -266,6 +266,13 @@ class TestOsfstorageFileNode(StorageTestCase):
 
         assert_is(OsfStorageFileNode.load(child._id), None)
 
+    def test_file_deleted_when_node_deleted(self):
+        child = self.node_settings.get_root().append_file('Test')
+        self.node.remove_node(auth=Auth(self.user))
+
+        assert OsfStorageFileNode.load(child._id) is None
+        assert models.TrashedFileNode.load(child._id) is not None
+
     def test_materialized_path(self):
         child = self.node_settings.get_root().append_file('Test')
         assert_equals('/Test', child.materialized_path)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2818,6 +2818,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         self.deleted_date = date
         self.save()
 
+        # mark node's files as deleted
+        for osfstorage_file in self.files.all():
+            osfstorage_file.delete()
+
         project_signals.node_deleted.send(self)
 
         return True


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When a node is deleted, it was still possible to both visit the landing page and download a deleted file if you had that link saved (or it had been indexed by a search engine).

When a node is deleted, mark those files as deleted as well to avoid this.

## Changes

- When a node is deleted, delete all its osfstorage files
- Change the definition of `is_preprint_primary` to also check if the node has been deleted, and to not count if it has.

## QA Notes

Files on deleted nodes should no longer be able to be viewed or downloaded.

## Documentation

Hotfix, none necessary.

## Side Effects

Not sure if changing that definition of `is_preprint_primary` will have side effects, but should be ok, hopefully.

## Ticket
https://openscience.atlassian.net/browse/PLAT-1199
