### PR TITLE
Viewing deleted files improvements [PLAT-1199]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -671,6 +671,7 @@ def addon_deleted_file(auth, target, error_type='BLAME_PROVIDER', **kwargs):
             'file_path': file_path,
             'file_name_title': file_name_title,
             'file_name_ext': file_name_ext,
+            'target_deleted': getattr(target, 'is_deleted', False),
             'version_id': None,
             'file_guid': file_guid,
             'file_id': file_node._id,

--- a/addons/osfstorage/listeners.py
+++ b/addons/osfstorage/listeners.py
@@ -1,10 +1,28 @@
 """
 Listens for actions to be done to OSFstorage file nodes specifically.
 """
-from website.project.signals import contributor_removed
+from django.apps import apps
+
+from website.project.signals import contributor_removed, node_deleted
+from framework.celery_tasks import app
+from framework.celery_tasks.handlers import enqueue_task
+
 
 @contributor_removed.connect
 def checkin_files_by_user(node, user):
     """ Listens to a contributor being removed to check in all of their files
     """
     node.files.filter(checkout=user).update(checkout=None)
+
+
+@node_deleted.connect
+def delete_files(node):
+    enqueue_task(delete_files_task.s(node._id))
+
+
+@app.task(max_retries=5, default_retry_delay=60)
+def delete_files_task(node_id):
+    AbstractNode = apps.get_model('osf.AbstractNode')
+    node = AbstractNode.load(node_id)
+    for osfstorage_file in node.files.all():
+        osfstorage_file.delete()

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -16,6 +16,7 @@ from osf_tests.factories import ProjectFactory, UserFactory, RegionFactory, Node
 
 from addons.osfstorage.tests import factories
 from addons.osfstorage.tests.utils import StorageTestCase
+from addons.osfstorage.listeners import delete_files_task
 
 import datetime
 
@@ -266,12 +267,12 @@ class TestOsfstorageFileNode(StorageTestCase):
 
         assert_is(OsfStorageFileNode.load(child._id), None)
 
-    def test_file_deleted_when_node_deleted(self):
+    @mock.patch('addons.osfstorage.listeners.enqueue_task')
+    def test_file_deleted_when_node_deleted(self, mock_enqueue):
         child = self.node_settings.get_root().append_file('Test')
         self.node.remove_node(auth=Auth(self.user))
 
-        assert OsfStorageFileNode.load(child._id) is None
-        assert models.TrashedFileNode.load(child._id) is not None
+        mock_enqueue.assert_called_with(delete_files_task.s(self.node._id))
 
     def test_materialized_path(self):
         child = self.node_settings.get_root().append_file('Test')

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -318,6 +318,8 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
             AbstractNode.bulk_update_search(resource_object_list)
         for node in nodes:
             project_signals.node_deleted.send(node)
+            for osfstorage_file in node.files.all():
+                osfstorage_file.delete()
 
     # Overrides BulkDestroyJSONAPIView
     def perform_destroy(self, instance):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -318,8 +318,6 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
             AbstractNode.bulk_update_search(resource_object_list)
         for node in nodes:
             project_signals.node_deleted.send(node)
-            for osfstorage_file in node.files.all():
-                osfstorage_file.delete()
 
     # Overrides BulkDestroyJSONAPIView
     def perform_destroy(self, instance):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2818,10 +2818,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         self.deleted_date = date
         self.save()
 
-        # mark node's files as deleted
-        for osfstorage_file in self.files.all():
-            osfstorage_file.delete()
-
         project_signals.node_deleted.send(self)
 
         return True

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -387,6 +387,4 @@ class TestResolveGuid(OsfTestCase):
         pp.node.save()
 
         res = self.app.get(pp.url + 'download', auth=non_contrib.auth, expect_errors=True)
-        # assert res.status_code == 410
-        # This will throw an unauthorized error before it reaches deleted
-        assert res.status_code == 403
+        assert res.status_code == 410

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -209,7 +209,7 @@ def check_can_access(node, user, key=None, api_node=None):
                 return True
 
         if node.is_deleted:
-            raise HTTPError(http.NOT_FOUND)
+            raise HTTPError(http.GONE, data={'message_long': 'The node for this file has been deleted.'})
 
         if key in node.private_link_keys_deleted:
             status.push_status_message('The view-only links you used are expired.', trust=False)

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -208,6 +208,9 @@ def check_can_access(node, user, key=None, api_node=None):
             if check_can_download_preprint_file(user, node):
                 return True
 
+        if node.is_deleted:
+            raise HTTPError(http.NOT_FOUND)
+
         if key in node.private_link_keys_deleted:
             status.push_status_message('The view-only links you used are expired.', trust=False)
 

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -49,10 +49,14 @@
       <div class="osf-panel-body-flex file-page reset-height">
         <div id="grid">
           <div class="spinner-loading-wrapper">
+            % if target_deleted:
+            <p class="m-t-sm fg-load-message">No files</p>
+            %else:
             <div class="ball-scale ball-scale-blue">
                 <div></div>
             </div>
             <p class="m-t-sm fg-load-message"> Loading files...  </p>
+            %endif
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Address things noted by Lauren in https://openscience.atlassian.net/browse/PLAT-1199 - file tree loads forever, deleted files on a private node unexpectedly taking the user to request access, bulk deletes.

## Changes

<!-- Briefly describe or list your changes  -->
- bulk deletes now delete files
- file tree now shows No files instead of infinite loader
- viewing a private file from an unauthorized account 410s, viewing it with perms to the former node shows the graveyard page

<img width="1440" alt="screen shot 2018-11-29 at 11 20 52 am" src="https://user-images.githubusercontent.com/801594/49235814-e4a7a180-f3c8-11e8-9a80-3370fd56f3ae.png">



## QA Notes
Hopefully things noted in the ticket are fixed now!
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
none
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
none anticipated
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1199

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
