### PR TITLE
Downgrade DRF to 3.8.2

### DIFF
--- a/api_tests/base/test_versioning.py
+++ b/api_tests/base/test_versioning.py
@@ -116,7 +116,7 @@ class TestBaseVersioning:
         url = '/v2/?format=api'
         res = app.get(url)
         assert res.status_code == 200
-        assert '"version": "{}"'.format(
+        assert '&quot;version&quot;: &quot;{}&quot'.format(
             LATEST_VERSIONS[2]
         ) in res.body
 
@@ -124,7 +124,7 @@ class TestBaseVersioning:
         url = '/v2/?format=api&version=2.5'
         res = app.get(url)
         assert res.status_code == 200
-        assert '"version": "2.5"' in res.body
+        assert '&quot;version&quot;: &quot;2.5&quot' in res.body
 
     def test_json_defaults_to_default(self, app):
         url = '/v2/?format=json'

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -2084,7 +2084,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == '"true and false" is not a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
         data = res.json['data']
@@ -2502,7 +2502,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             auth=user.auth,
             expect_errors=True, bulk=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == '"true and false" is not a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
         data = res.json['data']

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -322,7 +322,7 @@ class TestRegistrationUpdate:
             auth=user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == '"Dr.Strange" is not a valid boolean.'
 
     #   test_fields_other_than_public_are_ignored
         attribute_list = {

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -80,7 +80,7 @@ class TestUserSettingsUpdateTwoFactor:
         payload['data']['attributes']['two_factor_enabled'] = 'Yes'
         res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == '"Yes" is not a valid boolean.'
 
         # Already disabled - nothing happens, still disabled
         payload['data']['attributes']['two_factor_enabled'] = False
@@ -194,7 +194,7 @@ class TestUserSettingsUpdateMailingList:
         res = app.patch_json_api(url, bad_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == u'Must be a valid boolean.'
+        assert res.json['errors'][0]['detail'] == u'"22" is not a valid boolean.'
 
     def test_anonymous_patch_401(self, app, url, payload):
         res = app.patch_json_api(url, payload, expect_errors=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ raven==5.32.0
 
 # API requirements
 Django==1.11.15  # pyup: <2.0 # Remove this when we're on Py3
-djangorestframework==3.9.0
+djangorestframework==3.8.2
 django-cors-headers==2.1.0
 djangorestframework-bulk==0.2.1
 hashids==1.2.0


### PR DESCRIPTION
**Purpose**

3.9.0 has a known issue where the browsable API
renders unescaped HTML

https://github.com/encode/django-rest-framework/pull/6191#issuecomment-440687856

**Changes**

Downgrade DRF to latest 3.8.x release

**QA Notes**

Check https://api.osf.io/v2/schemas/registrations/
to make sure that the Browsable API isn't rendering
HTML in the responses

**Ticket**

No ticket
