### PR TITLE
[PLAT-1200] Include withdrawal date, justification for registered children

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -74,11 +74,11 @@ class RegistrationSerializer(NodeSerializer):
     )
 
     date_registered = VersionedDateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
-    date_withdrawn = VersionedDateTimeField(source='retraction.date_retracted', read_only=True, help_text='Date time of when this registration was retracted.')
+    date_withdrawn = VersionedDateTimeField(read_only=True, help_text='Date time of when this registration was retracted.')
     embargo_end_date = HideIfWithdrawal(ser.SerializerMethodField(help_text='When the embargo on this registration will be lifted.'))
     custom_citation = HideIfWithdrawal(ser.CharField(allow_blank=True, required=False))
 
-    withdrawal_justification = ser.CharField(source='retraction.justification', read_only=True)
+    withdrawal_justification = ser.CharField(read_only=True)
     template_from = HideIfWithdrawal(ser.CharField(
         read_only=True, allow_blank=False, allow_null=False,
         help_text='Specify a node id for a node you would like to use as a template for the '

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -189,6 +189,18 @@ class Registration(AbstractNode):
         job = self.archive_job
         return job and not job.done and not job.archive_tree_finished()
 
+    @property
+    def date_withdrawn(self):
+        if self.root.retraction is None:
+            return None
+        return self.root.retraction.date_retracted
+
+    @property
+    def withdrawal_justification(self):
+        if self.root.retraction is None:
+            return None
+        return self.root.retraction.justification
+
     def _initiate_embargo(self, user, end_date, for_existing_registration=False,
                           notify_initiator_on_complete=False):
         """Initiates the retraction process for a registration

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -191,15 +191,11 @@ class Registration(AbstractNode):
 
     @property
     def date_withdrawn(self):
-        if self.root.retraction is None:
-            return None
-        return self.root.retraction.date_retracted
+        return getattr(self.root.retraction, 'date_retracted', None)
 
     @property
     def withdrawal_justification(self):
-        if self.root.retraction is None:
-            return None
-        return self.root.retraction.justification
+        return getattr(self.root.retraction, 'justification', None)
 
     def _initiate_embargo(self, user, end_date, for_existing_registration=False,
                           notify_initiator_on_complete=False):


### PR DESCRIPTION
## Purpose

Currently the tombstone pages for retracted child registrations don't have the info for their parent's retractions. This PR serializes the children so they return the retraction info of the parent.

## Changes

- makes `withdrawal_justification` and `date_withdrawn` serializer methods
- adds a test 

## QA Notes

You should be able to create a multi-node registration, retract that, and then view the children's tombstone with complete info.

## Documentation

None needed.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1200