### PR TITLE
[PLAT-1254] Fix embargoing pre-registrations

### DIFF
--- a/tests/test_registrations/base.py
+++ b/tests/test_registrations/base.py
@@ -1,3 +1,4 @@
+import copy
 import datetime as dt
 
 from django.utils import timezone
@@ -42,22 +43,34 @@ class RegistrationsTestBase(OsfTestCase):
 
         valid_date = timezone.now() + dt.timedelta(days=180)
         self.embargo_payload = {
-            u'embargoEndDate': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
-            u'registrationChoice': 'embargo'
+            'data': {
+                'attributes': {
+                    'children': [self.node._id],
+                    'draft_registration': self.draft._id,
+                    'lift_embargo': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
+                    'registration_choice': 'embargo',
+                },
+                'type': 'registrations',
+            },
         }
-        self.invalid_embargo_date_payload = {
-            u'embargoEndDate': u'Thu, 01 {month} {year} 05:00:00 GMT'.format(
-                month=current_month,
-                year=str(int(current_year) - 1)
-            ),
-            u'registrationChoice': 'embargo'
-        }
+        self.invalid_embargo_date_payload = copy.deepcopy(self.embargo_payload)
+        self.invalid_embargo_date_payload['data']['attributes']['lift_embargo'] = u'Thu, 01 {month} {year} 05:00:00 GMT'.format(
+            month=current_month,
+            year=str(int(current_year) - 1)
+        )
+
         self.immediate_payload = {
-            'registrationChoice': 'immediate'
+            'data': {
+                'attributes': {
+                    'children': [self.node._id],
+                    'draft_registration': self.draft._id,
+                    'registration_choice': 'immediate',
+                },
+                'type': 'registrations',
+            },
         }
-        self.invalid_payload = {
-            'registrationChoice': 'foobar'
-        }
+        self.invalid_payload = copy.deepcopy(self.immediate_payload)
+        self.invalid_payload['data']['attributes']['registration_choice'] = 'foobar'
 
     def draft_url(self, view_name):
         return self.node.web_url_for(view_name, draft_id=self.draft._id)

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -804,26 +804,34 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         current_year = timezone.now().strftime('%Y')
 
         self.valid_make_public_payload = json.dumps({
-            u'embargoEndDate': u'Fri, 01, {month} {year} 00:00:00 GMT'.format(
-                month=current_month,
-                year=current_year
-            ),
-            u'registrationChoice': 'immediate',
-            u'summary': unicode(fake.sentence())
+            'data': {
+                'attributes': {
+                    u'registration_choice': 'immediate',
+                },
+                'type': 'registrations',
+            }
         })
         valid_date = timezone.now() + datetime.timedelta(days=180)
         self.valid_embargo_payload = json.dumps({
-            u'embargoEndDate': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
-            u'registrationChoice': 'embargo',
-            u'summary': unicode(fake.sentence())
+            'data': {
+                'attributes': {
+                    u'lift_embargo': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
+                    u'registration_choice': 'embargo',
+                },
+                'type': 'registrations',
+            },
         })
         self.invalid_embargo_date_payload = json.dumps({
-            u'embargoEndDate': u'Thu, 01 {month} {year} 05:00:00 GMT'.format(
-                month=current_month,
-                year=str(int(current_year) - 1)
-            ),
-            u'registrationChoice': 'embargo',
-            u'summary': unicode(fake.sentence())
+            'data': {
+                'attributes': {
+                    u'lift_embargo': u'Thu, 01 {month} {year} 05:00:00 GMT'.format(
+                        month=current_month,
+                        year=str(int(current_year) - 1)
+                    ),
+                    u'registration_choice': 'embargo',
+                },
+                'type': 'registrations',
+            }
         })
 
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')

--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -107,8 +107,8 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
         self.draft.reload()
         assert_is_not_none(self.draft.approval)
         assert_equal(self.draft.approval.meta, {
-            u'registration_choice': unicode(self.embargo_payload['registrationChoice']),
-            u'embargo_end_date': unicode(self.embargo_payload['embargoEndDate'])
+            u'registration_choice': 'embargo',
+            u'embargo_end_date': unicode(self.embargo_payload['data']['attributes']['lift_embargo'])
         })
 
     def test_submit_draft_for_review_invalid_registrationChoice(self):
@@ -154,7 +154,11 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
 
         url = self.node.api_url_for('register_draft_registration', draft_id=self.draft._id)
         res = self.app.post_json(url, {
-            'registrationChoice': 'immediate'
+            'data': {
+                'attributes': {
+                    'registration_choice': 'immediate',
+                },
+            },
         }, auth=self.user.auth)
 
         assert_equal(res.status_code, http.ACCEPTED)
@@ -196,8 +200,14 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
         res = self.app.post_json(
             url,
             {
-                'registrationChoice': 'embargo',
-                'embargoEndDate': end_date.strftime('%c'),
+                'data': {
+                    'attributes': {
+                        'children': [self.node._id],
+                        'registration_choice': 'embargo',
+                        'lift_embargo': end_date.strftime('%c'),
+                    },
+                    'type': 'registrations',
+                }
             },
             auth=self.user.auth)
 

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -653,7 +653,9 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
     preRegisterPrompts.unshift('Registrations cannot be modified or deleted once completed.');
 
     var registrationModal = new RegistrationModal.ViewModel(
-        confirm, preRegisterPrompts, validator
+        confirm, preRegisterPrompts, validator, {
+            requiresApproval: self.requiresApproval()
+        }
     );
     registrationModal.show();
 };

--- a/website/static/templates/registration-modal.html
+++ b/website/static/templates/registration-modal.html
@@ -102,7 +102,7 @@
             <button class="btn btn-primary" data-bind="click:embargoPage, disable:invalidSelection">Continue</button>
         </span>
         <span data-bind="if: page() == EMBARGO">
-            <a href="#" class="btn btn-default" data-bind="click: confirmPage, visible: !noComponents()" data-dismiss="modal">Back</a>
+            <a href="#" class="btn btn-default" data-bind="click: confirmPage, visible: !requiresApproval && !noComponents()" data-dismiss="modal">Back</a>
             <button class="btn btn-success" data-bind="click: register, enable: canRegister">Register</button>
         </span>
 


### PR DESCRIPTION
paired with @Johnetordoff

**Purpose**

Embargoing a pre-reg currently doesn't work.

This is because the frontend is sending a v2-formatted
payload to a v1 endpoint.

**Changes**

* Modify the draft registration v1 endpoints to take
  v2-formatted payloads.
* Disallow partial registrations on the frontend for
  preregistrations. This is a hack to avoid adding too
  much new code to the v1 endpoints to support partial
  registrations.

**QA Notes**

I will test this out on staging1 before it goes to prod.
Need to make sure that embargoing a pre-reg works as
expected.

**Side Effects**

Some nasty special-casing that can hopefully
go away in the near future when the Prereg Challenge ends

**Ticket**

https://openscience.atlassian.net/browse/PLAT-1254
