### PR TITLE
OSF Groups legacy UI [PLAT-1194]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -771,7 +771,8 @@ def _view_project(node, auth, primary=False,
             'access_requests_enabled': node.access_requests_enabled,
             'storage_location': node.osfstorage_region.name,
             'waterbutler_url': node.osfstorage_region.waterbutler_url,
-            'mfr_url': node.osfstorage_region.mfr_url
+            'mfr_url': node.osfstorage_region.mfr_url,
+            'groups': list(node.osf_groups.values_list('name', flat=True)),
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -160,6 +160,14 @@
                     </ol>
                 % endif
                 </div>
+                % if node['groups']:
+                    <div>
+                        Groups:
+                        %for group_name in node['groups']:
+                            <ol>${group_name}</ol>
+                        %endfor
+                    </div>
+                % endif
                 % if enable_institutions and not node['anonymous']:
                     % if ('admin' in user['permissions'] and not node['is_registration']) and (len(node['institutions']) != 0 or len(user['institutions']) != 0):
                         <a class="link-dashed" href="${node['url']}settings/#configureInstitutionAnchor" id="institution">Affiliated Institutions:</a>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -6,7 +6,7 @@
   <li role="presentation" class="active">
     <a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
   </li>
-  % if 'admin' in user['permissions'] and node['has_draft_registrations']:
+  % if 'admin' in user['permissions'] and user['is_contributor'] and node['has_draft_registrations']:
   <li role="presentation" data-bind="visible: hasDrafts">
       <a id="draftsControl" aria-controls="drafts" href="#drafts">Draft Registrations</a>
   </li>
@@ -26,7 +26,7 @@
     ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
     ##      %endif
         % else:
-          % if 'admin' in user['permissions']:
+          % if 'admin' in user['permissions'] and user['is_contributor']:
             <p>There have been no completed registrations of this project.
             You can start a new registration by clicking the “New registration” button, and you have the option of saving as a draft registration before submission.</p>
           % else:
@@ -41,7 +41,7 @@
         To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
         %endif
       </div>
-      % if 'admin' in user['permissions'] and not disk_saving_mode:
+      % if 'admin' in user['permissions'] and user['is_contributor'] and not disk_saving_mode:
       <div class="col-xs-3 col-sm-4">
         <a id="registerNode" class="btn btn-success disabled" type="button">
           Loading ...


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Some basic UI changes ahead of groups coming to the OSF. The rest of this ticket was to do some analysis on what else probably should be changed legacy UI wise.

## Changes

- If there are groups attached to the node, list their names under "Contributors" on the detail page
- If a user is just an admin through a group, do not show actions related to registrations or draft registrations on a node's registration page.

## QA Notes

Part of a larger feature, no individual QA needed
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
Part of a larger feature, no individual docs needed
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1194
