### PR TITLE
Limit upload sizes for addons DV, GD, S3, and OC [PLAT-1232]

### DIFF
--- a/addons/dataverse/apps.py
+++ b/addons/dataverse/apps.py
@@ -1,6 +1,7 @@
 import os
 
 from addons.base.apps import BaseAddonAppConfig
+from addons.dataverse.settings import MAX_UPLOAD_SIZE
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(
@@ -25,6 +26,7 @@ class DataverseAddonAppConfig(BaseAddonAppConfig):
     has_hgrid_files = True
     node_settings_template = os.path.join(TEMPLATE_PATH, 'dataverse_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'dataverse_user_settings.mako')
+    max_file_size = MAX_UPLOAD_SIZE
 
     @property
     def get_hgrid_data(self):

--- a/addons/dataverse/settings/defaults.py
+++ b/addons/dataverse/settings/defaults.py
@@ -4,3 +4,6 @@ DEFAULT_HOSTS = [
 ]
 
 REQUEST_TIMEOUT = 60
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 2 * 1024  # 2 GB

--- a/addons/googledrive/apps.py
+++ b/addons/googledrive/apps.py
@@ -1,4 +1,5 @@
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.googledrive.settings import MAX_UPLOAD_SIZE
 
 googledrive_root_folder = generic_root_folder('googledrive')
 
@@ -12,6 +13,7 @@ class GoogleDriveAddonConfig(BaseAddonAppConfig):
     configs = ['accounts', 'node']
     categories = ['storage']
     has_hgrid_files = True
+    max_file_size = MAX_UPLOAD_SIZE
 
     @property
     def get_hgrid_data(self):

--- a/addons/googledrive/settings/defaults.py
+++ b/addons/googledrive/settings/defaults.py
@@ -14,3 +14,6 @@ OAUTH_SCOPE = [
 ]
 OAUTH_BASE_URL = 'https://accounts.google.com/o/oauth2/'
 API_BASE_URL = 'https://www.googleapis.com/'
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 5 * 1024  # 5 GB

--- a/addons/owncloud/apps.py
+++ b/addons/owncloud/apps.py
@@ -1,5 +1,6 @@
 import os
 from addons.base.apps import BaseAddonAppConfig, generic_root_folder
+from addons.owncloud.settings import MAX_UPLOAD_SIZE
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(
@@ -21,6 +22,7 @@ class OwnCloudAddonAppConfig(BaseAddonAppConfig):
     has_hgrid_files = True
     node_settings_template = os.path.join(TEMPLATE_PATH, 'owncloud_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'owncloud_user_settings.mako')
+    max_file_size = MAX_UPLOAD_SIZE
 
     @property
     def get_hgrid_data(self):

--- a/addons/owncloud/settings/defaults.py
+++ b/addons/owncloud/settings/defaults.py
@@ -1,2 +1,5 @@
 DEFAULT_HOSTS = []
 USE_SSL = True
+
+# Max file size permitted by frontend in megabytes
+MAX_UPLOAD_SIZE = 512

--- a/addons/s3/settings/defaults.py
+++ b/addons/s3/settings/defaults.py
@@ -10,7 +10,7 @@ STATIC_PATH = os.path.join(parent_dir(HERE), 'static')
 MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 # Max file size permitted by frontend in megabytes
-MAX_UPLOAD_SIZE = 128
+MAX_UPLOAD_SIZE = 5 * 1024  # 5 GB
 
 ALLOWED_ORIGIN = '*'
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2977,8 +2977,9 @@ tbOptions = {
                 size = file.size / 1000000;
                 maxSize = item.data.accept.maxSize;
                 if (size > maxSize) {
-                    displaySize = Math.round(file.size / 10000) / 100;
-                    msgText = 'This file is too large (' + displaySize + ' MB). Max file size is ' + item.data.accept.maxSize + ' MB.';
+                    displaySize = $osf.humanFileSize(file.size, true);
+                    maxSize = $osf.humanFileSize(maxSize * 1000000, true);
+                    msgText = 'This file is too large (' + displaySize + '). Max file size is ' + maxSize + '.';
                     $osf.growl(msgText);
                     addFileStatus(treebeard, file, false, msgText, '');
                     removeFromUI(file, treebeard);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The providers mentioned in this ticket need a file size limit to prevent against users taking down OSF with large uploads. Also update the UI for this file size error to be more noticeable in a growler.

<img width="1077" alt="screen shot 2018-12-11 at 2 29 11 pm" src="https://user-images.githubusercontent.com/801594/49825146-b4a9b800-fd51-11e8-83d4-b38db1383cff.png">


**note**: screen shot has a 1GB filesize limit for GD just for demo purposes only, there really is a 5GB limit!


## Changes

- Add `MAX_UPLOAD_SIZE` for addons as specified in the ticket
- Change max upload size error to Growler rather than file widget error bar
- Remove failed file from UI on file size error

## QA Notes

- The new growler should now be universal among all providers that currently already have upload limits.

These are the settings that are defaults for all providers with limits, though they could be different on the staging servers/production!
- box: 250 MB
- dataverse: 2 GB (new)
- dropbox: 150 MB
- figshare: 50 MB
- github: 100 MB
- googledrive: 5 GB (new)
- osfstorage: 5 GB
- owncloud: 512 MB (new)
- s3: 5 GB (updated)

## Documentation

Good question, anyone know where this documentation would go? Is it somewhere in the help docs?

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-1232
