### PR TITLE
[PLAT-1208] Add OSF Groups to admin app

### DIFF
--- a/admin/base/urls.py
+++ b/admin/base/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
                                       namespace='metrics')),
             url(r'^desk/', include('admin.desk.urls',
                                    namespace='desk')),
+            url(r'^osf_groups/', include('admin.osf_groups.urls', namespace='osf_groups')),
         ]),
     ),
 ]

--- a/admin/common_auth/forms.py
+++ b/admin/common_auth/forms.py
@@ -24,7 +24,7 @@ class UserRegistrationForm(forms.Form):
 
     # TODO: Moving to guardian, find a better way to distinguish "admin-like" groups from object permission groups
     group_perms = forms.ModelMultipleChoiceField(
-        queryset=Group.objects.exclude(Q(name__startswith='collections_') | Q(name__startswith='preprint_')),
+        queryset=Group.objects.exclude(Q(name__startswith='collections_') | Q(name__startswith='preprint_') | Q(name__startswith='node_')),
         required=False,
         widget=forms.CheckboxSelectMultiple
     )

--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -35,7 +35,8 @@ def serialize_node(node):
         'spam_data': json.dumps(node.spam_data, indent=4),
         'is_public': node.is_public,
         'registrations': [serialize_node(registration) for registration in node.registrations.all()],
-        'registered_from': node.registered_from._id if node.registered_from else None
+        'registered_from': node.registered_from._id if node.registered_from else None,
+        'osf_groups': list(node.osf_groups.all())
     }
 
 def serialize_log(log):

--- a/admin/nodes/templatetags/node_extras.py
+++ b/admin/nodes/templatetags/node_extras.py
@@ -23,3 +23,7 @@ def reverse_user(user_id):
     else:
         user = OSFUser.load(user_id)
     return reverse('users:user', kwargs={'guid': user._id})
+
+@register.filter
+def reverse_osf_group(value):
+    return reverse('osf_groups:osf_group', kwargs={'id': value.id})

--- a/admin/osf_groups/forms.py
+++ b/admin/osf_groups/forms.py
@@ -1,0 +1,6 @@
+from django import forms
+
+
+class OSFGroupSearchForm(forms.Form):
+    name = forms.CharField(label='name', required=False)
+    id = forms.CharField(label='id', required=False)

--- a/admin/osf_groups/serializers.py
+++ b/admin/osf_groups/serializers.py
@@ -1,0 +1,14 @@
+
+
+def serializer_group(osf_group):
+
+    return {
+        'named_id': osf_group._id,
+        'name': osf_group.name,
+        'created': osf_group.created,
+        'modified': osf_group.modified,
+        'creator': osf_group.creator,
+        'managers': list(osf_group.managers.all()),
+        'members': list(osf_group.members.all()),
+        'nodes': osf_group.nodes
+    }

--- a/admin/osf_groups/serializers.py
+++ b/admin/osf_groups/serializers.py
@@ -10,5 +10,5 @@ def serializer_group(osf_group):
         'creator': osf_group.creator,
         'managers': list(osf_group.managers.all()),
         'members': list(osf_group.members.all()),
-        'nodes': osf_group.nodes
+        'nodes': list(osf_group.nodes)
     }

--- a/admin/osf_groups/urls.py
+++ b/admin/osf_groups/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+from admin.osf_groups import views
+
+app_name = 'admin'
+
+urlpatterns = [
+    url(r'^search/$', views.OSFGroupsFormView.as_view(), name='search'),
+    url(r'^(?P<id>[0-9]+)/$', views.OSFGroupsView.as_view(), name='osf_group'),
+    url(r'^$', views.OSFGroupsListView.as_view(), name='osf_groups_list')
+]

--- a/admin/osf_groups/views.py
+++ b/admin/osf_groups/views.py
@@ -38,6 +38,7 @@ class OSFGroupsFormView(PermissionRequiredMixin, FormView):
     def form_valid(self, form):
         id = form.data.get('id').strip()
         name = form.data.get('name').strip()
+        self.redirect_url = reverse('osf_groups:search')
 
         if id:
             self.redirect_url = reverse('osf_groups:osf_group', kwargs={'id': id})
@@ -49,13 +50,13 @@ class OSFGroupsFormView(PermissionRequiredMixin, FormView):
                 self.redirect_url = reverse('osf_groups:osf_groups_list',) + '?name={}'.format(name)
             except OSFGroup.DoesNotExist:
                 messages.error(self.request, 'That OSF Group could not be found')
-                self.redirect_url = reverse('osf_groups:search')
 
         return super(OSFGroupsFormView, self).form_valid(form)
 
     @property
     def success_url(self):
         return self.redirect_url
+
 
 class OSFGroupsListView(PermissionRequiredMixin, ListView):
     """ Allow authorized admin user to view list of registrations

--- a/admin/osf_groups/views.py
+++ b/admin/osf_groups/views.py
@@ -15,7 +15,7 @@ class OSFGroupsView(PermissionRequiredMixin, DetailView):
     """
     template_name = 'osf_groups/osf_groups.html'
     context_object_name = 'group'
-    permission_required = 'osf.view_osf_groups'
+    permission_required = 'osf.groups_read'
     raise_exception = True
 
     def get_object(self, queryset=None):
@@ -27,7 +27,7 @@ class OSFGroupsView(PermissionRequiredMixin, DetailView):
 class OSFGroupsFormView(PermissionRequiredMixin, FormView):
     template_name = 'osf_groups/search.html'
     object_type = 'osf_group'
-    permission_required = 'osf.view_osf_groups'
+    permission_required = 'osf.groups_read'
     raise_exception = True
     form_class = OSFGroupSearchForm
 
@@ -67,7 +67,7 @@ class OSFGroupsListView(PermissionRequiredMixin, ListView):
     paginate_by = 10
     paginate_orphans = 1
     context_object_name = 'osf_groups'
-    permission_required = 'osf.view_osf_groups'
+    permission_required = 'osf.groups_read'
     raise_exception = True
 
     def get_queryset(self):

--- a/admin/osf_groups/views.py
+++ b/admin/osf_groups/views.py
@@ -1,0 +1,75 @@
+from admin.osf_groups.serializers import serializer_group
+
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.views.generic import FormView, DetailView, ListView
+from osf.models import OSFGroup
+from admin.osf_groups.forms import OSFGroupSearchForm
+from django.core.urlresolvers import reverse
+
+
+class OSFGroupsView(PermissionRequiredMixin, DetailView):
+    """ Allow authorized admin user to view nodes
+
+    View of OSF database. No admin models.
+    """
+    template_name = 'osf_groups/osf_groups.html'
+    context_object_name = 'group'
+    permission_required = 'osf.view_osf_groups'
+    raise_exception = True
+
+    def get_object(self, queryset=None):
+        id = self.kwargs.get('id')
+        osf_group = OSFGroup.objects.get(id=id)
+        return serializer_group(osf_group)
+
+
+class OSFGroupsFormView(PermissionRequiredMixin, FormView):
+    template_name = 'osf_groups/search.html'
+    object_type = 'osf_group'
+    permission_required = 'osf.view_osf_groups'
+    raise_exception = True
+    form_class = OSFGroupSearchForm
+
+    @property
+    def success_url(self):
+        id = self.get_form().data.get('id').strip()
+        name = self.get_form().data.get('name').strip()
+
+        if id:
+            return reverse('osf_groups:osf_group', kwargs={'id': id})
+        elif name:
+            groups = OSFGroup.objects.filter(name=name)
+            if len(groups) == 1:
+                return reverse('osf_groups:osf_group', kwargs={'id': groups[0].id})
+            else:
+                return reverse('osf_groups:osf_groups_list',) + '?name={}'.format(name)
+
+class OSFGroupsListView(PermissionRequiredMixin, ListView):
+    """ Allow authorized admin user to view list of registrations
+
+    View of OSF database. No admin models.
+    """
+    template_name = 'osf_groups/osf_groups_list.html'
+    paginate_by = 10
+    paginate_orphans = 1
+    context_object_name = 'osf_groups'
+    permission_required = 'osf.view_osf_groups'
+    raise_exception = True
+
+    def get_queryset(self):
+        name = self.request.GET.get('name')
+        if name:
+            return OSFGroup.objects.filter(name__contains=name)
+
+        return OSFGroup.objects.all()
+
+    def get_context_data(self, **kwargs):
+        query_set = kwargs.pop('object_list', self.object_list)
+        page_size = self.get_paginate_by(query_set)
+        paginator, page, query_set, is_paginated = self.paginate_queryset(
+            query_set, page_size)
+
+        return {
+            'groups': list(query_set),
+            'page': page,
+        }

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -239,6 +239,17 @@
           {% if perms.osf.view_subject%}
             <li><a href="{% url 'subjects:list' %}"><i class='fa fa-link'></i> <span>OSF Subjects</span></a></li>
           {% endif %}
+          {% if perms.osf.view_osf_groups %}
+              <li><a role="button" data-toggle="collapse" href="#collapseOSFGroups">
+                  <i class='fa fa-caret-down'></i> OSF Groups
+              </a></li>
+              <div class="collapse" id="collapseOSFGroups">
+                  <ul class="sidebar-menu sidebar-menu-inner">
+                      <li><a href="{% url 'osf_groups:search' %}"><i class='fa fa-link'></i><span> Search</span> </a></li>
+                      <li><a href="{% url 'osf_groups:osf_groups_list' %}"><i class='fa fa-link'></i><span> List</span> </a></li>
+                  </ul>
+              </div>
+          {% endif %}
           {% if perms.osf.view_scheduledbanner %}
               <li><a role="button" data-toggle="collapse" href="#collapseBanners">
                   <i class='fa fa-caret-down'></i> Banners

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -175,6 +175,19 @@
 
             </tr>
             <tr>
+                <td>
+                    OSF Groups
+                </td>
+                <td>
+                    <select class="form-control" style="width:90%; display:inherit;" id="groups-select">
+                        {% for group in node.osf_groups %}
+                            <option value="{{ group | reverse_osf_group }}">{{group.name}} ({{group.id}})</option>
+                        {% endfor %}
+                    </select>
+                    <input type="submit" class="pull-right btn btn-default"  value="Go to" onclick="document.location.href = document.getElementById('groups-select').value;" />
+                </td>
+            </tr>
+            <tr>
                 <td>Contributors</td>
                 <td>
                     <table class="table table-bordered table-hover">

--- a/admin/templates/osf_groups/osf_groups.html
+++ b/admin/templates/osf_groups/osf_groups.html
@@ -1,0 +1,94 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+{% load node_extras %}
+<title>OSF Group</title>
+{% endblock title %}
+{% block content %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="btn-group" role="group">
+                <a href="{% url 'osf_groups:search' %}" class="btn btn-default"><i class="fa fa-search"></i></a>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>OSF Group details</h3>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Field</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>_id</td>
+                        <td colspan="2">{{ group.named_id }}</td>
+                    </tr>
+                    <tr>
+                        <td>Name</td>
+                        <td colspan="2">{{ group.name }}</td>
+                    </tr>
+                    <tr>
+                        <td>Date Created</td>
+                        <td colspan="2">{{ group.created }}</td>
+                    </tr>
+                    <tr>
+                        <td>Date Modified</td>
+                        <td colspan="2">{{ group.modified }}</td>
+                    </tr>
+                    <tr>
+                        <td>Creator</td>
+                        <td colspan="2"><a href="{{ group.creator.id | reverse_user }}">{{ group.creator }}</a></td>
+                    </tr>
+                    <tr>
+                        <td>Manager</td>
+                        <td>
+                            <select class="form-control" id="manager-select">
+                                {% for manager in group.managers %}
+                                    <option value="{{ manager.id | reverse_user }}">{{manager}}</option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                        <td>
+                            <input type="submit" class="pull-right btn btn-default"  value="Go to" onclick="document.location.href = document.getElementById('manager-select').value;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Members</td>
+                        <td>
+                            <select class="form-control" id="member-select">
+                                {% for member in group.members %}
+                                    <option value="{{ member.id | reverse_user }}">{{member}}</option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                        <td>
+                            <input type="submit" class="pull-right btn btn-default"  value="Go to" onclick="document.location.href = document.getElementById('member-select').value;" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Nodes</td>
+                        <td>
+                            <select class="form-control" id="node-select">
+                                {% for node in group.nodes %}
+                                    <option value="{{ node | reverse_node }}">{{node.title}}</option>
+                                {% endfor %}
+                            </select>
+                        </td>
+                        <td>
+                            <input type="submit" class="pull-right btn btn-default" value="Go to" onclick="document.location.href = document.getElementById('node-select').value;" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock content %}

--- a/admin/templates/osf_groups/osf_groups_list.html
+++ b/admin/templates/osf_groups/osf_groups_list.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% load node_extras %}
+
+{% load static %}
+{% block title %}
+    <title>OSF Groups</title>
+{% endblock title %}
+{% block content %}
+<h2>List of Groups</h2>
+{% include "util/pagination.html" with items=page status=status %}
+<table class="table table-striped table-hover table-responsive">
+    <thead>
+        <tr>
+            <td>Name</td>
+            <td>Date Created</td>
+            <td>Date Modified</td>
+            <td>Creator</td>
+        </tr>
+    </thead>
+    <tbody>
+        {% for group in groups %}
+        <tr>
+            <td>
+                <a href="{{ group | reverse_osf_group }}">{{ group.name }}</a>
+            </td>
+            <td>
+                {{ group.created }}
+            </td>
+            <td>
+                {{ group.modified }}
+            </td>
+            <td>
+                <a href="{{ group.creator.id | reverse_user }}">{{ group.creator }}</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endblock content %}

--- a/admin/templates/osf_groups/search.html
+++ b/admin/templates/osf_groups/search.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+<title>OSF Groups Search</title>
+{% endblock title %}
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            <ul class="messages">
+            {% for message in messages %}
+                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        </div>
+        <div class="row">
+            <form action="{% url 'osf_groups:search' %}" method="post">
+                {% csrf_token %}
+                {% if form.errors %}
+                    <div class="alert alert-danger">{{ form.errors }}</div>
+                {% endif %}
+                <div class="form-group">
+                    <label for="id">id:</label>
+                    {{ form.id }}
+                </div>
+                <div class="form-group">
+                    <label for="name">name:</label>
+                    {{ form.name }}
+                </div>
+                <input type="submit" class="btn btn-primary" value="Submit" />
+            </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -219,6 +219,19 @@
                     </td>
                 </tr>
                 <tr>
+                <td>
+                    OSF Groups
+                </td>
+                <td>
+                    <select class="form-control" style="width:90%; display:inherit;" id="groups-select">
+                        {% for group in user.osf_groups %}
+                            <option value="{{ group | reverse_osf_group }}">{{group.name}} ({{group.id}})</option>
+                        {% endfor %}
+                    </select>
+                    <input type="submit" class="pull-right btn btn-default"  value="Go to" onclick="document.location.href = document.getElementById('groups-select').value;" />
+                </td>
+                </tr>
+                <tr>
                     <td>Nodes</td>
                     <td>
                         <table class="table table-hover table-bordered">

--- a/admin/users/serializers.py
+++ b/admin/users/serializers.py
@@ -18,7 +18,9 @@ def serialize_user(user):
         'osf_link': user.absolute_url,
         'system_tags': user.system_tags,
         'unclaimed': bool(user.unclaimed_records),
-        'requested_deactivation': bool(user.requested_deactivation)
+        'requested_deactivation': bool(user.requested_deactivation),
+        'osf_groups': list(user.osf_groups.all())
+
     }
 
 

--- a/admin_tests/osf_groups/test_views.py
+++ b/admin_tests/osf_groups/test_views.py
@@ -1,0 +1,100 @@
+from admin.osf_groups.views import (
+    OSFGroupsView,
+    OSFGroupsListView,
+    OSFGroupsFormView
+)
+from admin_tests.utilities import setup_log_view
+from nose import tools as nt
+from django.test import RequestFactory
+
+from tests.base import AdminTestCase
+from osf_tests.factories import UserFactory, ProjectFactory, OSFGroupFactory
+
+
+class TestOSFGroupsView(AdminTestCase):
+
+    def setUp(self):
+        super(TestOSFGroupsView, self).setUp()
+        self.user = UserFactory()
+        self.project = ProjectFactory()
+        self.group = OSFGroupFactory(name='', creator=self.user)
+        self.group.add_group_to_node(self.project)
+        self.group.save()
+        self.request = RequestFactory().post('/fake_path')
+
+    def test_get_object(self):
+        view = OSFGroupsView()
+        view = setup_log_view(view, self.request, id=self.group.id)
+
+        group = view.get_object()
+
+        nt.assert_equal(self.group.name, group['name'])
+        nt.assert_equal(self.group.creator, group['creator'])
+        nt.assert_equal(list(self.group.members.all()), group['members'])
+        nt.assert_equal(list(self.group.managers.all()), group['managers'])
+        nt.assert_equal(list(self.group.nodes), group['nodes'])
+
+
+class TestOSFGroupsListView(AdminTestCase):
+
+    def setUp(self):
+        super(TestOSFGroupsListView, self).setUp()
+        self.user = UserFactory()
+        self.group = OSFGroupFactory(name='Brian Dawkins', creator=self.user)
+        self.group2 = OSFGroupFactory(name='Brian Westbrook', creator=self.user)
+        self.group3 = OSFGroupFactory(name='Darren Sproles', creator=self.user)
+        self.request = RequestFactory().post('/fake_path')
+        self.view = OSFGroupsListView()
+
+    def test_get_default_queryset(self):
+        view = setup_log_view(self.view, self.request)
+
+        queryset = view.get_queryset()
+
+        nt.assert_equal(len(queryset), 3)
+
+        nt.assert_in(self.group, queryset)
+        nt.assert_in(self.group2, queryset)
+        nt.assert_in(self.group3, queryset)
+
+    def test_get_queryset_by_name(self):
+        request = RequestFactory().post('/fake_path/?name=Brian')
+        view = setup_log_view(self.view, request)
+
+        queryset = view.get_queryset()
+
+        nt.assert_equal(len(queryset), 2)
+
+        nt.assert_in(self.group, queryset)
+        nt.assert_in(self.group2, queryset)
+
+
+class TestOSFGroupsFormView(AdminTestCase):
+
+    def setUp(self):
+        super(TestOSFGroupsFormView, self).setUp()
+        self.user = UserFactory()
+        self.group = OSFGroupFactory(name='Brian Dawkins', creator=self.user)
+        self.group2 = OSFGroupFactory(name='Brian Westbrook', creator=self.user)
+        self.view = OSFGroupsFormView()
+
+    def test_post_id(self):
+        request = RequestFactory().post('/fake_path', data={'id': self.group.id, 'name': ''})
+        view = setup_log_view(self.view, request)
+
+        redirect = view.post(request)
+        assert redirect.url == '/osf_groups/{}/'.format(self.group.id)
+
+    def test_post_name_single_object(self):
+        request = RequestFactory().post('/fake_path', data={'id': '', 'name': self.group.name})
+        view = setup_log_view(self.view, request)
+
+        redirect = view.post(request)
+        assert redirect.url == '/osf_groups/{}/'.format(self.group.id)
+
+    def test_post_name_multiple_objects(self):
+        request = RequestFactory().post('/fake_path', data={'id': '', 'name': 'Brian'})
+        view = setup_log_view(self.view, request)
+
+        redirect = view.post(request)
+        assert redirect.url == '/osf_groups/?name=Brian'

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
 from django.contrib.auth.models import Group
+from django.db.models import Q
 from osf.models import *  # noqa
 
 
@@ -18,7 +19,7 @@ class OSFUserAdmin(admin.ModelAdmin):
         Restricts preprint django groups from showing up in the user's groups list in the admin app
         """
         if db_field.name == 'groups':
-            kwargs['queryset'] = Group.objects.exclude(name__startswith='preprint_')
+            kwargs['queryset'] = Group.objects.exclude(Q(name__startswith='preprint_') | Q(name__startswith='node_'))
         return super(OSFUserAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
     def save_related(self, request, form, formsets, change):
@@ -26,7 +27,7 @@ class OSFUserAdmin(admin.ModelAdmin):
         Since m2m fields overridden with new form data in admin app, preprint groups (which are now excluded from being selections)
         are removed.  Manually re-adds preprint groups after adding new groups in form.
         """
-        preprint_groups = list(form.instance.groups.filter(name__startswith='preprint_'))
+        preprint_groups = list(form.instance.groups.filter(Q(name__startswith='preprint_') | Q(name__startswith='node_')))
         super(OSFUserAdmin, self).save_related(request, form, formsets, change)
         if 'groups' in form.cleaned_data:
             for group in preprint_groups:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -771,7 +771,8 @@ def _view_project(node, auth, primary=False,
             'access_requests_enabled': node.access_requests_enabled,
             'storage_location': node.osfstorage_region.name,
             'waterbutler_url': node.osfstorage_region.waterbutler_url,
-            'mfr_url': node.osfstorage_region.mfr_url
+            'mfr_url': node.osfstorage_region.mfr_url,
+            'groups': list(node.osf_groups.values_list('name', flat=True)),
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -160,6 +160,14 @@
                     </ol>
                 % endif
                 </div>
+                % if node['groups']:
+                    <div>
+                        Groups:
+                        %for group_name in node['groups']:
+                            <ol>${group_name}</ol>
+                        %endfor
+                    </div>
+                % endif
                 % if enable_institutions and not node['anonymous']:
                     % if ('admin' in user['permissions'] and not node['is_registration']) and (len(node['institutions']) != 0 or len(user['institutions']) != 0):
                         <a class="link-dashed" href="${node['url']}settings/#configureInstitutionAnchor" id="institution">Affiliated Institutions:</a>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -6,7 +6,7 @@
   <li role="presentation" class="active">
     <a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
   </li>
-  % if 'admin' in user['permissions'] and node['has_draft_registrations']:
+  % if 'admin' in user['permissions'] and user['is_contributor'] and node['has_draft_registrations']:
   <li role="presentation" data-bind="visible: hasDrafts">
       <a id="draftsControl" aria-controls="drafts" href="#drafts">Draft Registrations</a>
   </li>
@@ -26,7 +26,7 @@
     ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
     ##      %endif
         % else:
-          % if 'admin' in user['permissions']:
+          % if 'admin' in user['permissions'] and user['is_contributor']:
             <p>There have been no completed registrations of this project.
             You can start a new registration by clicking the “New registration” button, and you have the option of saving as a draft registration before submission.</p>
           % else:
@@ -41,7 +41,7 @@
         To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
         %endif
       </div>
-      % if 'admin' in user['permissions'] and not disk_saving_mode:
+      % if 'admin' in user['permissions'] and user['is_contributor'] and not disk_saving_mode:
       <div class="col-xs-3 col-sm-4">
         <a id="registerNode" class="btn btn-success disabled" type="button">
           Loading ...


### PR DESCRIPTION
## Purpose

Adding guardian on nodes will clutter admin app, also this is a nice time to add OSF groups stuff to the admin app.
 
## Changes

- OSF Group admin detail view
- OSF Group admin list view
- OSF Group search form
- adds OSF Groups links to admin home page
- adds tests
- excludes cluttered groups from groups lists

## QA Notes

Try searching for groups by name and id, the info and links on the detail/list page should be correct.

## Documentation

None necessary 

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1208