### PR TITLE
[Hotfix] Transact async file deletes

### DIFF
--- a/addons/osfstorage/listeners.py
+++ b/addons/osfstorage/listeners.py
@@ -2,10 +2,11 @@
 Listens for actions to be done to OSFstorage file nodes specifically.
 """
 from django.apps import apps
+from django.db import transaction
 
 from website.project.signals import contributor_removed, node_deleted
 from framework.celery_tasks import app
-from framework.celery_tasks.handlers import enqueue_task
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 
 
 @contributor_removed.connect
@@ -17,12 +18,17 @@ def checkin_files_by_user(node, user):
 
 @node_deleted.connect
 def delete_files(node):
-    enqueue_task(delete_files_task.s(node._id))
+    enqueue_postcommit_task(delete_files_task, (node._id, ), {}, celery=True)
 
 
 @app.task(max_retries=5, default_retry_delay=60)
 def delete_files_task(node_id):
-    AbstractNode = apps.get_model('osf.AbstractNode')
-    node = AbstractNode.load(node_id)
-    for osfstorage_file in node.files.all():
-        osfstorage_file.delete()
+    with transaction.atomic():
+        Guid = apps.get_model('osf.Guid')
+        OsfStorageFolder = apps.get_model('osf.OsfStorageFolder')
+        guid = Guid.objects.filter(_id=node_id).values('content_type_id', 'object_id').get()
+        OsfStorageFolder.objects.get(
+            target_object_id=guid['object_id'],
+            target_content_type=guid['content_type_id'],
+            is_root=True
+        ).delete(save=True)

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -267,12 +267,12 @@ class TestOsfstorageFileNode(StorageTestCase):
 
         assert_is(OsfStorageFileNode.load(child._id), None)
 
-    @mock.patch('addons.osfstorage.listeners.enqueue_task')
+    @mock.patch('addons.osfstorage.listeners.enqueue_postcommit_task')
     def test_file_deleted_when_node_deleted(self, mock_enqueue):
         child = self.node_settings.get_root().append_file('Test')
         self.node.remove_node(auth=Auth(self.user))
 
-        mock_enqueue.assert_called_with(delete_files_task.s(self.node._id))
+        mock_enqueue.assert_called_with(delete_files_task, (self.node._id, ), {}, celery=True)
 
     def test_materialized_path(self):
         child = self.node_settings.get_root().append_file('Test')


### PR DESCRIPTION
## Purpose
One of the (unwritten?) assumptions of celery tasks is that you shouldn't be performing `UPDATE` queries within tasks, unless they're transacted.

## Changes
* Add transaction to async updates.
* Optimize query / workflow
* Enqueue task postcommit

## QA Notes
Not user facing

## Side Effects
None expected

## Ticket
None known