### PR TITLE
[hotfix] Update registration schema options to allow "" values [PLAT-1265] 

### DIFF
--- a/website/project/metadata/aspredicted.json
+++ b/website/project/metadata/aspredicted.json
@@ -13,7 +13,8 @@
             "format": "singleselect",
             "options": [
                 "Yes, at least some data have been collected for this study already",
-                "No, no data have been collected for this study yet"
+                "No, no data have been collected for this study yet",
+                ""
             ],
             "description": "Please choose"
         },{

--- a/website/project/metadata/brandt-postcomp-2.json
+++ b/website/project/metadata/brandt-postcomp-2.json
@@ -32,14 +32,14 @@
             "type": "choose",
             "format": "singleselect",
             "title": "The replication effect size is",
-            "options": ["significantly different from the original effect size", "not significantly different from the original effect size"],
+            "options": ["Significantly different from the original effect size", "Not significantly different from the original effect size", ""],
             "nav": "Difference in effect size"
         },{
             "qid": "item33",
             "type": "choose",
             "format": "singleselect",
             "title": "I judge the replication to be a(n)",
-            "options": ["success", "informative failure to replicate", "practical failure to replicate", "inconclusive"],
+            "options": ["Success", "Informative failure to replicate", "Practical failure to replicate", "Inconclusive", ""],
             "nav": "Outcome"
         },{
             "qid": "item34",

--- a/website/project/metadata/brandt-prereg-2.json
+++ b/website/project/metadata/brandt-prereg-2.json
@@ -68,7 +68,7 @@
             "title": "Are the original materials for the study available from the author?",
             "type": "choose",
             "format": "singleselect",
-            "options": ["yes", "no"],
+            "options": ["Yes", "No", ""],
             "nav": "Materials available?"
         }, {
             "qid": "item11",
@@ -115,49 +115,49 @@
             "title": "The similarities/differences in the instructions are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in instructions"
         }, {
             "qid": "item18",
             "title": "The similarities/differences in the measures are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in measures"
         }, {
             "qid": "item19",
             "title": "The similarities/differences in the stimuli are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in stimuli"
         }, {
             "qid": "item20",
             "title": "The similarities/differences in the procedure are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in procedure"
         }, {
             "qid": "item21",
             "title": "The similarities/differences in the location (e.g., lab vs. online; alone vs. in groups) are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in location"
         }, {
             "qid": "item22",
             "title": "The similarities/difference in remuneration are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in remuneration"
         }, {
             "qid": "item23",
             "title": "The similarities/differences between participant populations are",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Exact", "Close", "Different"],
+            "options": ["Exact", "Close", "Different", ""],
             "nav": "Differences in populations"
         }, {
             "qid": "item24",

--- a/website/project/metadata/osf-standard-2.json
+++ b/website/project/metadata/osf-standard-2.json
@@ -11,7 +11,7 @@
             "nav": "Data Completion",
             "type": "choose",
             "format": "singleselect",
-            "options": ["No, data collection has not begun", "Yes, data collection is underway or complete"],
+            "options": ["No, data collection has not begun", "Yes, data collection is underway or complete", ""],
             "description": "Please choose"
         },{
             "qid": "looked",
@@ -19,7 +19,7 @@
             "nav": "Looked at Data",
             "type": "choose",
             "format": "singleselect",
-            "options": ["Yes", "No"],
+            "options": ["Yes", "No", ""],
             "description": "Please choose"
         },{
             "qid": "comments",

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -173,6 +173,11 @@ var Question = function(questionSchema, data) {
 
     self.data = data || {};
 
+    var options = [];
+    if (questionSchema.options) {
+        options = questionSchema.options.filter(function(el) { return el !== ''; });
+    }
+
     self.id = questionSchema.qid;
     self.title = questionSchema.title || 'Untitled';
     self.nav = questionSchema.nav || 'Untitled';
@@ -181,7 +186,7 @@ var Question = function(questionSchema, data) {
     self.required = questionSchema.required || false;
     self.description = questionSchema.description || '';
     self.help = questionSchema.help;
-    self.options = questionSchema.options || [];
+    self.options = options;
     self.fileLimit = questionSchema.fileLimit;
     self.fileDescription = questionSchema.fileDescription;
     self.properties = questionSchema.properties || [];


### PR DESCRIPTION
### Purpose
Previously, attempting to create registrations of the following types would fail if any of the optional single select questions were left blank: 
* OSF Standard
* AsPredicted
* Replication Recipe Preregistration
* Replication Recipe Post-completion 

3c9af481a18d1b8db4fe66fbeac4b5d0be3bec08 prevented the registrations from failing. This PR attempts to prevent ValidationErrors from being logged to sentry (in hopes that we can re-enable the validation check). 


### Changes
* Add "" as a valid value to the enum of all optional single select questions. 
* Filter question options on the frontend so "" is not shown as an option.

### (DEV) QA Notes
Confirm that you can create the following registrations when leaving all optional single select questions blank and that `ValidationErrors` are not logged to sentry: 
* OSF Standard
* AsPredicted
* Replication Recipe Preregistration
* Replication Recipe Post-completion 

### Notes 
> This is a hack. The appropriate fix would be for the value key to
be ommitted when optional questions are left blank, however this would
prevent legacy registrations from being registered.

### Ticket
https://openscience.atlassian.net/browse/PLAT-1265
