### PR TITLE
Prevent AttributeErrors checking auth on preprints

### DIFF
--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -251,7 +251,7 @@ def check_key_expired(key, node, url):
         :param str url: the url redirect to
         :return: url with pushed message added if key expired else just url
     """
-    if key in node.private_link_keys_deleted:
+    if getattr(node, 'private_link_keys_deleted', False) and key in node.private_link_keys_deleted:
         url = furl(url).add({'status': 'expired'}).url
 
     return url


### PR DESCRIPTION
## Purpose
Fix edge case when using private link keys or directly hitting download urls for private preprints if you don't have access

## Changes
* LBYL

## QA Notes
To reproduce, make a private preprint, and as a different user, hit `<domain>/<preprint_guid>/download`.

## Side Effects
None expected

## Ticket
None