### PR TITLE
Hotfix/Clear Preprint Tags [PLAT-1283]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -237,7 +237,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             save_preprint = True
 
         old_tags = set(preprint.tags.values_list('name', flat=True))
-        if validated_data.get('tags'):
+        if 'tags' in validated_data:
             current_tags = set(validated_data.pop('tags', []))
         elif self.partial:
             current_tags = set(old_tags)

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -628,6 +628,19 @@ class TestPreprintUpdate:
         ) == new_tags
         assert mock_update_doi_metadata.called
 
+        # No tags
+        update_tags_payload = build_preprint_update_payload(
+            preprint._id,
+            attributes={
+                'tags': []
+            }
+        )
+        res = app.patch_json_api(url, update_tags_payload, auth=user.auth)
+
+        assert res.status_code == 200
+        preprint.reload()
+        assert preprint.tags.count() == 0
+
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
     def test_update_contributors(


### PR DESCRIPTION
## Purpose

Fix NPD bug - cannot clear all your preprint tags. You can add a tag, remove a tag, but you can't send in an empty list with your preprint payload to clear all tags.

## Changes

Now you can.

## QA Notes

Rabia's notes in ticket should be fine. Thanks for finding this, Rabia!

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-1283
