### PR TITLE
[hotfix][EMB-466] Include switches and samples in `active_flags` at /v2/

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -36,8 +36,8 @@ from api.nodes.permissions import ReadOnlyIfRegistration
 from api.users.serializers import UserSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Contributor, MaintenanceState, BaseFileNode
-from waffle.models import Flag
-from waffle import flag_is_active
+from waffle.models import Flag, Switch, Sample
+from waffle import flag_is_active, sample_is_active
 
 class JSONAPIBaseView(generics.GenericAPIView):
 
@@ -405,14 +405,18 @@ def root(request, format=None, **kwargs):
         current_user = UserSerializer(user, context={'request': request}).data
     else:
         current_user = None
+
     flags = [name for name in Flag.objects.values_list('name', flat=True) if flag_is_active(request, name)]
+    samples = [name for name in Sample.objects.values_list('name', flat=True) if sample_is_active(name)]
+    switches = list(Switch.objects.filter(active=True).values_list('name', flat=True))
+
     kwargs = request.parser_context['kwargs']
     return_val = {
         'meta': {
             'message': 'Welcome to the OSF API.',
             'version': request.version,
             'current_user': current_user,
-            'active_flags': flags,
+            'active_flags': flags + samples + switches,
         },
         'links': {
             'nodes': utils.absolute_reverse('nodes:node-list', kwargs=kwargs),


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
To change front-end behavior based on a waffle switch (not a flag, e.g. `enable_inactive_schemas` for prereg winddown), switches need to be exposed in `active_flags` at the `/v2/` root endpoint. It only matters to the front end whether a given feature is on or off, not whether it's governed by a switch, sample, or flag.
<!-- Describe the purpose of your changes -->

## Changes
Add switches and samples to the list of `active_flags`. This matches [what's included at `/v2/_waffle`](https://github.com/CenterForOpenScience/osf.io/blob/171b95755238dcd449867983029731e6d834ba89/api/waffle/views.py#L74), if that were filtered to only active waffles.
<!-- Briefly describe or list your changes  -->

## QA Notes
n/a
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
n/a
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
Very slightly slower `/v2/` round trip.
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/EMB-466
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
