### PR TITLE
Return twofactor secret in API v2 [PLAT-1280]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -389,10 +389,9 @@ class UserSettingsSerializer(JSONAPISerializer):
             return False
 
     def get_secret(self, obj):
-        if self.context['request'].method in ('PUT', 'PATCH'):
-            two_factor_addon = obj.get_addon('twofactor')
-            if two_factor_addon and not two_factor_addon.is_confirmed:
-                return two_factor_addon.totp_secret_b32
+        two_factor_addon = obj.get_addon('twofactor')
+        if two_factor_addon and not two_factor_addon.is_confirmed:
+            return two_factor_addon.totp_secret_b32
 
     def get_subscribe_osf_general_email(self, obj):
         return obj.mailchimp_mailing_lists.get(MAILCHIMP_GENERAL_LIST, False)

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -382,6 +382,10 @@ class UserSettingsSerializer(JSONAPISerializer):
     subscribe_osf_help_email = ser.SerializerMethodField()
     secret = ser.SerializerMethodField(read_only=True)
 
+    def to_representation(self, instance):
+        self.context['twofactor_addon'] = instance.get_addon('twofactor')
+        return super(UserSettingsSerializer, self).to_representation(instance)
+
     def get_two_factor_enabled(self, obj):
         try:
             two_factor = TwoFactorUserSettings.objects.get(owner_id=obj.id)
@@ -390,13 +394,13 @@ class UserSettingsSerializer(JSONAPISerializer):
             return False
 
     def get_two_factor_confirmed(self, obj):
-        two_factor_addon = obj.get_addon('twofactor')
+        two_factor_addon = self.context['twofactor_addon']
         if two_factor_addon and two_factor_addon.is_confirmed:
             return True
         return False
 
     def get_secret(self, obj):
-        two_factor_addon = obj.get_addon('twofactor')
+        two_factor_addon = self.context['twofactor_addon']
         if two_factor_addon and not two_factor_addon.is_confirmed:
             return two_factor_addon.totp_secret_b32
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -377,6 +377,7 @@ class UserSettingsSerializer(JSONAPISerializer):
     id = IDField(source='_id', read_only=True)
     type = TypeField()
     two_factor_enabled = ser.SerializerMethodField()
+    two_factor_confirmed = ser.SerializerMethodField(read_only=True)
     subscribe_osf_general_email = ser.SerializerMethodField()
     subscribe_osf_help_email = ser.SerializerMethodField()
     secret = ser.SerializerMethodField(read_only=True)
@@ -387,6 +388,12 @@ class UserSettingsSerializer(JSONAPISerializer):
             return not two_factor.deleted
         except TwoFactorUserSettings.DoesNotExist:
             return False
+
+    def get_two_factor_confirmed(self, obj):
+        two_factor_addon = obj.get_addon('twofactor')
+        if two_factor_addon and two_factor_addon.is_confirmed:
+            return True
+        return False
 
     def get_secret(self, obj):
         two_factor_addon = obj.get_addon('twofactor')

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -373,6 +373,7 @@ class UserSettingsSerializer(JSONAPISerializer):
     two_factor_enabled = ser.SerializerMethodField()
     subscribe_osf_general_email = ser.SerializerMethodField()
     subscribe_osf_help_email = ser.SerializerMethodField()
+    secret = ser.SerializerMethodField(read_only=True)
 
     def get_two_factor_enabled(self, obj):
         try:
@@ -380,6 +381,12 @@ class UserSettingsSerializer(JSONAPISerializer):
             return not two_factor.deleted
         except TwoFactorUserSettings.DoesNotExist:
             return False
+
+    def get_secret(self, obj):
+        if self.context['request'].method in ('PUT', 'PATCH'):
+            two_factor_addon = obj.get_addon('twofactor')
+            if two_factor_addon and not two_factor_addon.is_confirmed:
+                return two_factor_addon.totp_secret_b32
 
     def get_subscribe_osf_general_email(self, obj):
         return obj.mailchimp_mailing_lists.get(MAILCHIMP_GENERAL_LIST, False)

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -136,6 +136,12 @@ class UserSerializer(JSONAPISerializer):
         read_only=True,
     ))
 
+    settings = ShowIfCurrentUser(RelationshipField(
+        related_view='users:user_settings',
+        related_view_kwargs={'user_id': '<_id>'},
+        read_only=True,
+    ))
+
     class Meta:
         type_ = 'users'
 

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -133,6 +133,20 @@ class TestUserDetail:
         res = app.get(url)
         assert 'emails' not in res.json['data']['relationships'].keys()
 
+    def test_user_settings_relationship(self, app, user_one, user_two):
+        # settings relationship does not show for anonymous request
+        url = '/{}users/{}/'.format(API_BASE, user_one._id)
+        res = app.get(url)
+        assert 'settings' not in res.json['data']['relationships'].keys()
+
+        # settings does not appear for a different user
+        res = app.get(url, auth=user_two.auth)
+        assert 'settings' not in res.json['data']['relationships'].keys()
+
+        # settings is present for the current user
+        res = app.get(url, auth=user_one.auth)
+        assert 'settings' in res.json['data']['relationships'].keys()
+
     # Regression test for https://openscience.atlassian.net/browse/OSF-8966
     def test_browsable_api_for_user_detail(self, app, user_one):
         url = '/{}users/{}/?format=api'.format(API_BASE, user_one._id)

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -48,11 +48,11 @@ class TestUserSettingsGet:
         assert res.json['data']['attributes']['secret'] is None
         assert res.json['data']['type'] == 'user_settings'
 
-        # unconfirmed two_factor does not include secret
-        user_one.add_addon('twofactor')
+        # unconfirmed two_factor includes secret
+        addon = user_one.add_addon('twofactor')
         res = app.get(url, auth=user_one.auth)
         assert res.json['data']['attributes']['two_factor_enabled'] is True
-        assert res.json['data']['attributes']['secret'] is None
+        assert res.json['data']['attributes']['secret'] == addon.totp_secret_b32
 
 @pytest.mark.django_db
 class TestUserSettingsUpdateTwoFactor:

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -45,6 +45,7 @@ class TestUserSettingsGet:
         assert res.json['data']['attributes']['subscribe_osf_help_email'] is True
         assert res.json['data']['attributes']['subscribe_osf_general_email'] is False
         assert res.json['data']['attributes']['two_factor_enabled'] is False
+        assert res.json['data']['attributes']['two_factor_confirmed'] is False
         assert res.json['data']['attributes']['secret'] is None
         assert res.json['data']['type'] == 'user_settings'
 
@@ -52,6 +53,7 @@ class TestUserSettingsGet:
         addon = user_one.add_addon('twofactor')
         res = app.get(url, auth=user_one.auth)
         assert res.json['data']['attributes']['two_factor_enabled'] is True
+        assert res.json['data']['attributes']['two_factor_confirmed'] is False
         assert res.json['data']['attributes']['secret'] == addon.totp_secret_b32
 
 @pytest.mark.django_db
@@ -94,6 +96,7 @@ class TestUserSettingsUpdateTwoFactor:
         assert res.status_code == 200
         assert res.json['data']['attributes']['two_factor_enabled'] is False
         assert res.json['data']['attributes']['secret'] is None
+        assert res.json['data']['attributes']['two_factor_confirmed'] is False
 
         # Test enabling two factor
         payload['data']['attributes']['two_factor_enabled'] = True
@@ -105,6 +108,7 @@ class TestUserSettingsUpdateTwoFactor:
         assert addon.deleted is False
         assert addon.is_confirmed is False
         assert res.json['data']['attributes']['secret'] == addon.totp_secret_b32
+        assert res.json['data']['attributes']['two_factor_confirmed'] is False
 
         # Test already enabled - nothing happens, still enabled
         res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
@@ -117,6 +121,7 @@ class TestUserSettingsUpdateTwoFactor:
         res = app.patch_json_api(url, payload, auth=user_one.auth, expect_errors=True)
         assert res.status_code == 200
         assert res.json['data']['attributes']['two_factor_enabled'] is False
+        assert res.json['data']['attributes']['two_factor_confirmed'] is False
         assert res.json['data']['attributes']['secret'] is None
         user_one.reload()
         addon = user_one.get_addon('twofactor')
@@ -155,6 +160,7 @@ class TestUserSettingsUpdateTwoFactor:
 
         assert res.json['data']['attributes']['two_factor_enabled'] is True
         assert res.json['data']['attributes']['secret'] is None
+        assert res.json['data']['attributes']['two_factor_confirmed'] is True
         assert res.status_code == 200
         user_one.reload()
         addon = user_one.get_addon('twofactor')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

As it stands, it's not possible to complete two factor authentication using the API alone, as the secret you need to provide to a two factor authenticator isn't returned. Let's return it!

## Changes

- Include the `totp_secret_b32` property in the user settings response whenever two factor is enabled but not confirmed
- Tests for this
- **Bonus:** include user settings relationship on the user serializer so the frontend can get to it!
- **Bonus tests for that too!**

## QA Notes

Pretty sure this will be a "tested by the frontend as they make stuff" ticket and won't require anything else fancy!

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/37
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

None anticipated
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1280
