### PR TITLE
Script to create CSV with top 100 preprints by download [PLAT-1288]

### DIFF
--- a/scripts/remove_after_use/top_100_preprints.py
+++ b/scripts/remove_after_use/top_100_preprints.py
@@ -1,0 +1,41 @@
+import datetime
+import pytz
+import csv
+import sys
+
+from website.app import setup_django
+setup_django()
+
+from osf.models import Preprint
+from osf.metrics import PreprintDownload, PreprintView
+
+TWENTY_EIGHTEEN = datetime.datetime(2018, 1, 1, tzinfo=pytz.UTC)
+
+def main():
+    public_preprints = Preprint.objects.filter(is_published=True, is_public=True)
+
+    # Get the top 100 Preprints by download count
+    top_preprints = PreprintDownload.get_top_by_count(
+        qs=public_preprints,
+        model_field='guids___id',
+        metric_field='preprint_id',
+        annotation='download_count',
+        size=500,
+        after=TWENTY_EIGHTEEN,
+    )[:100]
+
+    fieldnames = ['provider', 'url', 'title', '2018_download_count', '2018_view_count']
+    writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
+    writer.writeheader()
+    for preprint in top_preprints:
+        row = {
+            'provider': preprint.provider._id,
+            'url': preprint.absolute_url,
+            'title': preprint.title.encode('utf-8'),
+            '2018_download_count': preprint.download_count,
+            '2018_view_count': PreprintView.get_count_for_preprint(preprint, after=TWENTY_EIGHTEEN)
+        }
+        writer.writerow(row)
+
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
[#PLAT-1288]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

We'd like to know the top 100 downloaded preprints from 2018. Use the nifty new elasticsearch metrics to get those!

**Usage**:
`python -m scripts.remove_after_use.top_100_preprints > top_preprints.csv`

## Changes

- script to output a CSV 

## QA Notes

No QA needed!
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

Internal one time script, none needed
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
Nope!
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1288
