### PR TITLE
Feature/Groups-Guardian Polishing VII [PLAT-1268]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -580,12 +580,7 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     # overrides ListCreateAPIView
     def get_queryset(self):
         node = self.get_node()
-        return DraftRegistration.objects.filter(
-            Q(registered_node=None) |
-            Q(registered_node__is_deleted=True),
-            branched_from=node,
-            deleted__isnull=True,
-        )
+        return node.draft_registrations_active
 
 
 class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, DraftMixin):

--- a/api_tests/osf_groups/views/test_osf_group_members_list.py
+++ b/api_tests/osf_groups/views/test_osf_group_members_list.py
@@ -189,10 +189,9 @@ class TestOSFGroupMembersCreate:
         user = OSFUser.load(data['id'].split('-')[1])
         assert user._id in data['relationships']['users']['links']['related']['href']
         assert osf_group.has_permission(user, MANAGE) is False
-        # unregistered members have no perms until account is claimed
         assert data['attributes']['full_name'] == full_name
         assert data['attributes']['unregistered_member'] == full_name
-        assert osf_group.has_permission(user, MEMBER) is False
+        assert osf_group.has_permission(user, MEMBER) is True
         assert user in osf_group.members_only
         assert user not in osf_group.managers
 
@@ -345,7 +344,7 @@ class TestOSFGroupMembersBulkCreate:
         assert osf_group.has_permission(user, MANAGE) is False
         assert osf_group.has_permission(user, MEMBER) is True
         assert osf_group.has_permission(unreg_user, MANAGE) is False
-        assert osf_group.has_permission(unreg_user, MEMBER) is False
+        assert osf_group.has_permission(unreg_user, MEMBER) is True
         assert osf_group.is_member(unreg_user) is True
         assert osf_group.is_manager(unreg_user) is False
 

--- a/api_tests/requests/views/test_request_list_create.py
+++ b/api_tests/requests/views/test_request_list_create.py
@@ -94,7 +94,7 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
         url = '/{}nodes/{}/requests/'.format(API_BASE, component._id)
         res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
         assert res.status_code == 201
-        assert component.admin_contributors.count() == 2
+        assert component.parent_admin_contributors.count() == 1
         assert component.contributors.count() == 1
         assert mock_mail.call_count == 1
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -884,6 +884,9 @@ class ContributorMixin(models.Model):
         return self.has_permission(user, 'admin') and self.get_group('admin') in user.groups.all()
 
     def active_contributors(self, include=lambda n: True):
+        """
+        Returns active contributors, group members excluded
+        """
         for contrib in self.contributors.filter(is_active=True):
             if include(contrib):
                 yield contrib

--- a/osf_tests/test_osfgroup.py
+++ b/osf_tests/test_osfgroup.py
@@ -68,6 +68,12 @@ class TestOSFGroup:
         assert manager in osf_group.members
         assert manager not in osf_group.members_only
 
+        user_two.is_superuser = True
+        user_two.save()
+
+        # Superusers don't have permission to group
+        assert osf_group.has_permission(user_two, MEMBER) is False
+
     @mock.patch('website.osf_groups.views.mails.send_mail')
     def test_make_manager(self, mock_send_mail, manager, member, user_two, user_three, osf_group):
         # no permissions
@@ -143,8 +149,7 @@ class TestOSFGroup:
         unreg_user = OSFUser.objects.get(username=test_email)
         assert unreg_user in osf_group.members
         assert unreg_user not in osf_group.managers
-        # Unreg user hasn't claimed account, so they have no permissions, even though they belong to member group
-        assert osf_group.has_permission(unreg_user, MEMBER) is False
+        assert osf_group.has_permission(unreg_user, MEMBER) is True
         assert osf_group._id in unreg_user.unclaimed_records
 
         # Attempt to add unreg user as a member
@@ -157,8 +162,7 @@ class TestOSFGroup:
         unreg_manager = OSFUser.objects.get(username=test_manager_email)
         assert unreg_manager in osf_group.members
         assert unreg_manager in osf_group.managers
-        # Unreg manager hasn't claimed account, so they have no permissions, even though they belong to member group
-        assert osf_group.has_permission(unreg_manager, MEMBER) is False
+        assert osf_group.has_permission(unreg_manager, MEMBER) is True
         assert osf_group._id in unreg_manager.unclaimed_records
 
     def test_remove_member(self, manager, member, user_three, osf_group):
@@ -771,10 +775,10 @@ class TestNodeGroups:
         child = NodeFactory(parent=project, creator=manager)
         project.add_osf_group(osf_group, ADMIN)
         # Manager has explict admin to child, member has implicit admin.
-        # Manager should be in admin_contributors, member should be in parent_admin_contributors
-
-        assert manager in child.admin_users
-        assert member not in child.admin_users
+        # Manager should be in admin_users, member should be in parent_admin_users
+        admin_users = child.get_users_with_perm('admin')
+        assert manager in admin_users
+        assert member not in admin_users
 
         assert manager not in child.parent_admin_users
         assert member in child.parent_admin_users
@@ -782,7 +786,7 @@ class TestNodeGroups:
         user_two.is_superuser = True
         user_two.save()
 
-        assert user_two not in child.admin_users
+        assert user_two not in admin_users
         assert user_two not in child.parent_admin_users
 
 

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -1059,7 +1059,11 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         self.registration.save()
 
         self.registration.set_privacy('public', Auth(self.registration.creator))
-        for admin in self.registration.admin_contributors:
+        admin_contributors = []
+        for contributor in self.registration.contributors:
+            if Contributor.objects.get(user_id=contributor.id, node_id=self.registration.id).permission == 'admin':
+                admin_contributors.append(contributor)
+        for admin in admin_contributors:
             assert_true(any([each[0][0] == admin.username for each in mock_send_mail.call_args_list]))
 
     @mock.patch('osf.models.sanctions.TokenApprovableSanction.ask')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -928,10 +928,10 @@ def _get_children(node, auth):
     children = (Node.objects.get_children(node)
                 .filter(is_deleted=False)
                 .annotate(parentnode_id=Subquery(parent_node_sqs[:1])))
-    admin_nodes = get_objects_for_user(auth.user, 'admin_node', children, with_superuser=False)
+    admin_children = get_objects_for_user(auth.user, 'admin_node', children, with_superuser=False)
 
     nested = defaultdict(list)
-    for child in admin_nodes:
+    for child in admin_children:
         nested[child.parentnode_id].append(child)
 
     return serialize_children(nested[node._id], nested)

--- a/website/registries/utils.py
+++ b/website/registries/utils.py
@@ -26,7 +26,6 @@ def drafts_for_user(user, campaign=None):
         registered_node=None,
         deleted__isnull=True,
         branched_from__in=node_qs,
-        initiator=user
     )
 
     if campaign:

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -945,8 +945,7 @@ def delete_doc(elastic_document_id, node, index=None, category=None):
 @requires_search
 def delete_group_doc(deleted_id, index=None):
     index = index or INDEX
-    category = 'group'
-    client().delete(index=index, doc_type=category, id=deleted_id, refresh=True, ignore=[404])
+    client().delete(index=index, doc_type='group', id=deleted_id, refresh=True, ignore=[404])
 
 @requires_search
 def search_contributor(query, page=0, size=10, exclude=None, current_user=None):


### PR DESCRIPTION
- Use existing Node.draft_registrations_active property to build v2 NodeDraftRegistrationsList query
- Remove initiator from `drafts_for_user` query
- Remove unnecessary 'category' variable.
- rename local variable in _get_children for clarity
- Modify OSFGroup.has_permission to exclude superuser perms
- Remove unused contributor properties on the Node model and add comments for clarity.

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- Use existing Node.draft_registrations_active property to build v2 NodeDraftRegistrationsList query
- Remove initiator from `drafts_for_user` query
- Remove unnecessary 'category' variable.
- rename local variable in _get_children for clarity
- Modify OSFGroup.has_permission to exclude superuser perms
- Remove unused contributor properties on the Node model and add comments for clarity.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
