### PR TITLE
[Hotfix][PLAT-1265] Fix validation of registration schemas 

### DIFF
--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -340,7 +340,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'u\'Nope, data collection has not begun\' is not one of [u\'No, data collection has not begun\', u\'Yes, data collection is underway or complete\']'
+        assert errors['detail'] == 'u\'Nope, data collection has not begun\' is not one of [u\'No, data collection has not begun\', u\'Yes, data collection is underway or complete\', \'\']'
 
     def test_cannot_update_registration_schema(
             self, app, user, schema, payload,

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -539,7 +539,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'u\'Nope, data collection has not begun\' is not one of [u\'No, data collection has not begun\', u\'Yes, data collection is underway or complete\']'
+        assert errors['detail'] == 'u\'Nope, data collection has not begun\' is not one of [u\'No, data collection has not begun\', u\'Yes, data collection is underway or complete\', \'\']'
 
     def test_reviewer_cannot_create_draft_registration(
             self, app, user_read_contrib, project_public,

--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -162,7 +162,7 @@ def get_options_jsonschema(options, required):
             options[item] = option.get('text')
     value = {'enum': options}
 
-    if not required:  # Non-required fields need to accept empty strings as a value.
+    if not required and '' not in value['enum']:  # Non-required fields need to accept empty strings as a value.
         value['enum'].append('')
 
     return value


### PR DESCRIPTION
## Purpose

Currently our jsonschema validator will occasionally throw errors, this PR fixes that.

## Changes

- Makes it so optional singleselect fields work when left empty.

## QA Notes

There should be no user-facing changes, but sentry errors should caused by registration's jsonschema validation should cease.

## Documentation

Not user-facing, no docs.

## Side Effects

Note: many jsonschema validator errors that appear on Sentry were caused by the Prereg challenge registration and weren't addressed because that schema is no longer being used.

None that I know of.

## Ticket

https://openscience.atlassian.net/projects/PLAT/issues/PLAT-1265