### PR TITLE
Hotfix/Delete Node Perms [PLAT-1293]

### DIFF
--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -61,6 +61,26 @@ class IsAdmin(permissions.BasePermission):
         return obj.has_permission(auth.user, osf_permissions.ADMIN)
 
 
+class NodeDetailPermissions(permissions.BasePermission):
+    """Permissions for contributor detail page."""
+
+    acceptable_models = (AbstractNode,)
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Write members can edit nodes, but you must be admins to delete
+        """
+        assert_resource_type(obj, self.acceptable_models)
+        auth = get_user_auth(request)
+
+        if request.method in permissions.SAFE_METHODS:
+            return obj.is_public or obj.can_view(auth)
+        elif request.method == 'DELETE':
+            return obj.has_permission(auth.user, osf_permissions.ADMIN)
+        else:
+            return obj.can_edit(auth)
+
+
 class IsContributor(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         assert isinstance(obj, AbstractNode), 'obj must be an Node, got {}'.format(obj)

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -62,13 +62,11 @@ class IsAdmin(permissions.BasePermission):
 
 
 class NodeDetailPermissions(permissions.BasePermission):
-    """Permissions for contributor detail page."""
-
     acceptable_models = (AbstractNode,)
 
     def has_object_permission(self, request, view, obj):
         """
-        Write members can edit nodes, but you must be admins to delete
+        Write members can edit nodes, but you must be an admin to delete
         """
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -74,6 +74,7 @@ from api.nodes.permissions import (
     ReadOnlyIfRegistration,
     IsAdminOrReviewer,
     IsContributor,
+    NodeDetailPermissions,
     WriteOrPublicForRelationshipInstitutions,
     ExcludeWithdrawals,
     NodeLinksShowIfVersion,
@@ -334,7 +335,7 @@ class NodeDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMix
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
-        ContributorOrPublic,
+        NodeDetailPermissions,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
         ExcludeWithdrawals,

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1263,6 +1263,17 @@ class TestNodeDelete(NodeCRUDTestCase):
         assert project_private.is_deleted is False
         assert 'detail' in res.json['errors'][0]
 
+    def test_deletes_private_node_logged_in_write_contributor(
+            self, app, user_two, project_private, url_private):
+        project_private.add_contributor(
+            user_two, permissions=[permissions.WRITE, permissions.READ])
+        project_private.save()
+        res = app.delete(url_private, auth=user_two.auth, expect_errors=True)
+        project_private.reload()
+        assert res.status_code == 403
+        assert project_private.is_deleted is False
+        assert 'detail' in res.json['errors'][0]
+
     def test_delete_project_with_component_returns_error(self, app, user):
         project = ProjectFactory(creator=user)
         NodeFactory(parent=project, creator=user)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -3358,6 +3358,23 @@ class TestNodeBulkDelete:
         res = app.get(user_one_private_project_url, auth=user_one.auth)
         assert res.status_code == 200
 
+    def test_bulk_delete_private_projects_logged_in_write_contributor(
+            self, app, user_one, user_two,
+            user_one_private_project,
+            private_payload, url,
+            user_one_private_project_url):
+        user_one_private_project.add_contributor(
+            user_two, permissions=[permissions.READ, permissions.WRITE], save=True)
+        res = app.delete_json_api(
+            url, private_payload,
+            auth=user_two.auth,
+            expect_errors=True, bulk=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == exceptions.PermissionDenied.default_detail
+
+        res = app.get(user_one_private_project_url, auth=user_one.auth)
+        assert res.status_code == 200
+
     def test_bulk_delete_all_or_nothing(
             self, app, user_one, user_two,
             user_one_private_project,


### PR DESCRIPTION
## Purpose

Fix inconsistencies regarding deleting nodes permissions.

## Changes

- Add new permission class for the NodeDetail view that still allows write contribs to update, but requires admin perms to delete
- Adds test for deleting nodes and bulk deleting nodes as write contribs (bulk delete already requires admin)

## QA Notes

- Verify read and write contributors cannot delete or bulk delete nodes via API v2.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1293