### PR TITLE
Add user affiliations when forking or templating [PLAT-159]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1487,9 +1487,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         return False
 
     def add_affiliations(self, user, new):
-        # add affiliations from the original to the forked or templated node
-        user_affils = user.affiliated_institutions.values_list('id', flat=True)
-        for affiliation in self.affiliated_institutions.filter(id__in=user_affils):
+        # add all of the user's affiliations to the forked or templated node
+        for affiliation in user.affiliated_institutions.all():
             new.affiliated_institutions.add(affiliation)
 
     # TODO: Optimize me (e.g. use bulk create)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -119,6 +119,17 @@ class TestParentNode:
     def template(self, project, auth):
         return project.use_as_template(auth=auth)
 
+    @pytest.fixture()
+    def project_with_affiliations(self, user):
+        institution = InstitutionFactory()
+        another_institution = InstitutionFactory()
+        user.affiliated_institutions.add(institution)
+        user.save()
+        original = ProjectFactory(creator=user)
+        original.affiliated_institutions.add(*[institution, another_institution])
+        original.save()
+        return original
+
     def test_top_level_node_has_parent_node_none(self):
         project = ProjectFactory()
         assert project.parent_node is None
@@ -355,6 +366,11 @@ class TestParentNode:
         fork = project.fork_node(auth=auth)
         assert fork.parent_node is None
 
+    def test_fork_has_correct_affiliations(self, user, auth, project_with_affiliations):
+        fork = project_with_affiliations.fork_node(auth=auth)
+        assert project_with_affiliations.affiliated_institutions.count() == 2
+        assert fork.affiliated_institutions.count() == 1
+
     def test_fork_child_has_parent(self, project, auth):
         fork = project.fork_node(auth=auth)
         fork_child = NodeFactory(parent=fork)
@@ -380,6 +396,11 @@ class TestParentNode:
 
     def test_template_has_no_parent(self, template):
         assert template.parent_node is None
+
+    def test_template_has_correct_affiliations(self, user, auth, project_with_affiliations):
+        template = project_with_affiliations.use_as_template(auth=auth)
+        assert project_with_affiliations.affiliated_institutions.count() == 2
+        assert template.affiliated_institutions.count() == 1
 
     def test_teplate_project_child_has_correct_parent(self, template):
         template_child = NodeFactory(parent=template)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -368,8 +368,11 @@ class TestParentNode:
 
     def test_fork_has_correct_affiliations(self, user, auth, project_with_affiliations):
         fork = project_with_affiliations.fork_node(auth=auth)
-        assert project_with_affiliations.affiliated_institutions.count() == 2
-        assert fork.affiliated_institutions.count() == 1
+        user_affiliations = user.affiliated_institutions.values_list('id', flat=True)
+        project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
+        fork_affiliations = fork.affiliated_institutions.values_list('id', flat=True)
+        assert set(project_affiliations) != set(user_affiliations)
+        assert set(fork_affiliations) == set(user_affiliations)
 
     def test_fork_child_has_parent(self, project, auth):
         fork = project.fork_node(auth=auth)
@@ -399,8 +402,11 @@ class TestParentNode:
 
     def test_template_has_correct_affiliations(self, user, auth, project_with_affiliations):
         template = project_with_affiliations.use_as_template(auth=auth)
-        assert project_with_affiliations.affiliated_institutions.count() == 2
-        assert template.affiliated_institutions.count() == 1
+        user_affiliations = user.affiliated_institutions.values_list('id', flat=True)
+        project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
+        template_affiliations = template.affiliated_institutions.values_list('id', flat=True)
+        assert set(project_affiliations) != set(user_affiliations)
+        assert set(template_affiliations) == set(user_affiliations)
 
     def test_teplate_project_child_has_correct_parent(self, template):
         template_child = NodeFactory(parent=template)


### PR DESCRIPTION
[#PLAT-159]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Forking a project or using a project as a template was not copying over the current users' affiliations. Fix it!
<!-- Describe the purpose of your changes -->

## Changes

- Add method that copies affiliations from the node to the one it's forking or templating
- Tests to make sure forked and templated nodes have correct affilations

## QA Notes

- Have a user with an institutional affiliation
- Be a contributor on a project with at least one affiliation that matches yours, and one that doesn't
- From the project overview page:
	- fork the project
	- use the project as a template
- Ensure both the fork and template have your affiliations, but not the ones your user doesn't have
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

This was expected behavior in the first place, so no changes needed

## Side Effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/PLAT-159
