### PR TITLE
[PLAT-1286] IE Depreciation Banner

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -59,8 +59,8 @@ a {
     list-style-type: none;
 }
 
-/* Cookie Banner */
-#cookieBanner {
+/* Warning Banner for cookies and browser depreciation goes on bottom of page */
+.warningBanner {
     position:fixed;
     width: 100%;
     z-index: 10;
@@ -75,25 +75,25 @@ a {
     align-items: center;
 }
 
-#cookieText {
+.warningBannerText {
     margin-left: 10%;
     margin-right: 75px;
 }
 
-#cookieAccept {
+.warningBannerAcceptBtn {
    margin-right: 10%
 }
 
-#cookieBanner a {
+.warningBanner a {
     color: white;
     text-decoration: underline;
 }
 
-#cookieBanner a:hover {
+.warningBanner a:hover {
     color: #ADCCE6;
 }
 
-#cookieBanner a:visited {
+.warningBanner a:visited {
     color: #ADCCE6;
 }
 

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -61,18 +61,22 @@ a {
 
 /* Warning Banner for cookies and browser depreciation goes on bottom of page */
 .warningBanner {
+    margin-bottom: 0px;
+    background-color: #263947;
+    color:white;
+    text-align: left;
+    border-width: 1px;
+    border-color: white;
+    display: none;
+    align-items: center;
+}
+
+footBanners {
     position:fixed;
     width: 100%;
     z-index: 10;
     bottom:0;
-    margin-bottom: 0px;
     left:0;
-    background-color: #263947;
-    color:white;
-    text-align: left;
-    border: 0px;
-    display: none;
-    align-items: center;
 }
 
 .warningBannerText {

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -39,18 +39,21 @@ if (String.prototype.endsWith === undefined) {
 
 $('[rel="tooltip"]').tooltip();
 
-// Cookie banner notice for logged out users
 var cookieBannerSelector = '#cookieBanner';
-var CookieBannerViewModel = function(){
-    var self = this;
-    self.elem = $(cookieBannerSelector);
-    var cookieConsentKey = 'osf_cookieconsent';
+var cookieConsentKey = 'osf_cookieconsent';
 
+// IE Depreciation Banner
+var IEDepreciationBannerSelector = '#IEDepreciationBanner';
+var IEcookieConsentKey = 'osf_IEconsent';
+
+var makeWarningBanner = function(selector, cookieKey){
+    var self = this;
+    self.elem = $(selector);
     self.accept = function() {
-        Cookie.set(cookieConsentKey, '1', { expires: 30, path: '/'});
+        Cookie.set(cookieKey, '1', { expires: 30, path: '/'});
     };
 
-    var accepted = Cookie.get(cookieConsentKey) === '1';
+    var accepted = Cookie.get(cookieKey) === '1';
     if (!accepted) {
         self.elem.css({'display': 'flex'});
         self.elem.show();
@@ -211,6 +214,10 @@ function confirmEmails(emailsToAdd) {
 
 
 $(function() {
+    var isIE = /*@cc_on!@*/false || !!document.documentMode;
+    if(isIE){
+        $osf.applyBindings(new makeWarningBanner(IEDepreciationBannerSelector, IEcookieConsentKey), IEDepreciationBannerSelector);
+    }
     if(/MSIE 9.0/.test(window.navigator.userAgent) ||
        /MSIE 8.0/.test(window.navigator.userAgent) ||
        /MSIE 7.0/.test(window.navigator.userAgent) ||
@@ -225,7 +232,7 @@ $(function() {
     }
 
     if ($(cookieBannerSelector).length) {
-        $osf.applyBindings(new CookieBannerViewModel(), cookieBannerSelector);
+        $osf.applyBindings(new makeWarningBanner(cookieBannerSelector, cookieConsentKey), cookieBannerSelector);
     }
 
     var affix = $('.osf-affix');

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -139,46 +139,47 @@
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
 
-<div id="IEDepreciationBanner"  class="alert warningBanner">
-    <div class="warningBannerText">
-        The OSF no longer supports Internet Explorer please switch to another browser or continue at your own risk.
+<footBanners>
+    <div id="IEDepreciationBanner"  class="alert warningBanner">
+        <div class="warningBannerText">
+            OSF does not support the use of Internet Explorer. For optimal performance, please switch to another browser.
+        </div>
+        <div class="warningBannerAcceptBtn">
+            <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
+        </div>
     </div>
-    <div class="warningBannerAcceptBtn">
-        <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
+    % if not user_id:
+    <div id="cookieBanner" class="alert warningBanner">
+        <div id="cookieText" class="warningBannerText">
+            This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information,
+            see our <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md'>Privacy Policy</a>
+            and information on <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect'>cookie use</a>.
+        </div>
+        <div class="warningBannerAcceptBtn">
+            <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
+        </div>
     </div>
-</div>
+    <div id="footerSlideIn">
+        <div class="container">
+            <div class="row">
+                <div class='col-sm-2 hidden-xs'>
+                    <img class="logo" src="/static/img/circle_logo.png">
+                </div>
+                <div class='col-sm-10 col-xs-12'>
+                    <a data-bind="click: dismiss" class="close" href="#">&times;</a>
+                    <h1>Start managing your projects on the OSF today.</h1>
+                    <p>Free and easy to use, the Open Science Framework supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
+                    <div>
+                        <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="${web_url_for('index')}#signUp">Create an Account</a>
 
-% if not user_id:
-<div id="cookieBanner" class="alert warningBanner">
-    <div id="cookieText" class="warningBannerText">
-        This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information,
-        see our <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md'>Privacy Policy</a>
-        and information on <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect'>cookie use</a>.
-    </div>
-    <div class="warningBannerAcceptBtn">
-        <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
-    </div>
-</div>
-<div id="footerSlideIn">
-    <div class="container">
-        <div class="row">
-            <div class='col-sm-2 hidden-xs'>
-                <img class="logo" src="/static/img/circle_logo.png">
-            </div>
-            <div class='col-sm-10 col-xs-12'>
-                <a data-bind="click: dismiss" class="close" href="#">&times;</a>
-                <h1>Start managing your projects on the OSF today.</h1>
-                <p>Free and easy to use, the Open Science Framework supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
-                <div>
-                    <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="${web_url_for('index')}#signUp">Create an Account</a>
-
-                    <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="http://help.osf.io" target="_blank" rel="noreferrer">Learn More</a>
-                    <a data-bind="click: dismiss">Hide this message</a>
+                        <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="http://help.osf.io" target="_blank" rel="noreferrer">Learn More</a>
+                        <a data-bind="click: dismiss">Hide this message</a>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
+</footBanners>
 % endif
 
 

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -141,7 +141,7 @@
 
 <div id="IEDepreciationBanner"  class="alert warningBanner">
     <div class="warningBannerText">
-        The OSF no longer supports Internet Explore please switch to another browser or continue at your own risk.
+        The OSF no longer supports Internet Explorer please switch to another browser or continue at your own risk.
     </div>
     <div class="warningBannerAcceptBtn">
         <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -139,14 +139,23 @@
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
 
+<div id="IEDepreciationBanner"  class="alert warningBanner">
+    <div class="warningBannerText">
+        The OSF no longer supports Internet Explore please switch to another browser or continue at your own risk.
+    </div>
+    <div class="warningBannerAcceptBtn">
+        <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
+    </div>
+</div>
+
 % if not user_id:
-<div id="cookieBanner" class="alert">
-    <div id="cookieText">
+<div id="cookieBanner" class="alert warningBanner">
+    <div id="cookieText" class="warningBannerText">
         This website relies on cookies to help provide a better user experience. By clicking Accept or continuing to use the site, you agree. For more information,
         see our <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md'>Privacy Policy</a>
         and information on <a href='https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md#7-types-of-information-we-collect'>cookie use</a>.
     </div>
-    <div id="cookieAccept">
+    <div class="warningBannerAcceptBtn">
         <div class="btn btn-default" data-dismiss="alert" data-bind="click: accept" aria-label="Accept">Accept</div>
     </div>
 </div>


### PR DESCRIPTION
## Purpose

To indicate we no longer support any version of Internet Explorer.

## Pics
![screen shot 2019-01-09 at 4 10 29 pm](https://user-images.githubusercontent.com/9688518/50973798-be8d1b00-14b7-11e9-9746-cadcfec1d575.png)

## Changes

- Add dismiss-able new banner to base page
- generalizes GDPR "cookie banner" code to work for IE depreciation.

## QA Notes

Setting up IE on a Mac is a real chore. Install virtualbox then go to https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/ to download images to run Windows with IE (These files are huge and take a long time to download.) Also for some reason my IE application wouldn't recognize localhost unless it was written 10.0.2.2 and IE requires you always include the protocol so the full address should read `http://10.0.2.2:5000`.

Also there is a separate ticket for doing this in Ember, so don't go looking for the banner on Emberized pages.

## Documentation

Kinda is docs when you think about it.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1286
