### PR TITLE
Feature/Groups-Guardian Polishing IX [PLAT-1268]

### DIFF
--- a/addons/base/tests/models.py
+++ b/addons/base/tests/models.py
@@ -9,6 +9,7 @@ from framework.exceptions import HTTPError
 from nose.tools import (assert_equal, assert_false, assert_in, assert_is,
                         assert_is_none, assert_not_in, assert_raises,
                         assert_true)
+from osf.utils.permissions import ADMIN
 from osf_tests.factories import ProjectFactory, UserFactory
 from tests.utils import mock_auth
 from addons.base import exceptions
@@ -594,7 +595,7 @@ class OAuthCitationsNodeSettingsTestSuiteMixin(
     @mock.patch('framework.status.push_status_message')
     def test_remove_contributor_authorizer(self, mock_push_status):
         contributor = UserFactory()
-        self.node.add_contributor(contributor, permissions='admin')
+        self.node.add_contributor(contributor, permissions=ADMIN)
         self.node.remove_contributor(self.node.creator, auth=Auth(user=contributor))
         self.node_settings.reload()
         self.user_settings.reload()

--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -53,7 +53,8 @@ def get_addons_by_config_type(config_type, user):
 def format_last_known_metadata(auth, node, file, error_type):
     msg = """
     </div>"""  # None is default
-    if error_type != 'FILE_SUSPENDED' and ((auth.user and node.is_contributor_or_group_member(auth.user)) or (auth.private_key and auth.private_key in node.private_link_keys_active)):
+    if error_type != 'FILE_SUSPENDED' and ((auth.user and node.is_contributor_or_group_member(auth.user)) or
+            (auth.private_key and auth.private_key in node.private_link_keys_active)):
         last_meta = file.last_known_metadata
         last_seen = last_meta.get('last_seen', None)
         hashes = last_meta.get('hashes', None)

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -42,6 +42,7 @@ from osf.models import (BaseFileNode, TrashedFileNode,
                         NodeLog, DraftRegistration, RegistrationSchema,
                         Guid, FileVersionUserMetadata, FileVersion)
 from osf.metrics import PreprintView, PreprintDownload
+from osf.utils import permissions
 from website.profile.utils import get_profile_image_url
 from website.project import decorators
 from website.project.decorators import must_be_contributor_or_public, must_be_valid_project, check_contributor_auth
@@ -104,7 +105,7 @@ This content has been removed."""}
 WATERBUTLER_JWE_KEY = jwe.kdf(settings.WATERBUTLER_JWE_SECRET.encode('utf-8'), settings.WATERBUTLER_JWE_SALT.encode('utf-8'))
 
 
-@decorators.must_have_permission('write')
+@decorators.must_have_permission(permissions.WRITE)
 @decorators.must_not_be_registration
 def disable_addon(auth, **kwargs):
     node = kwargs['node'] or kwargs['project']
@@ -135,20 +136,20 @@ def get_addon_user_config(**kwargs):
 
 
 permission_map = {
-    'create_folder': 'write',
-    'revisions': 'read',
-    'metadata': 'read',
-    'download': 'read',
-    'render': 'read',
-    'export': 'read',
-    'upload': 'write',
-    'delete': 'write',
-    'copy': 'write',
-    'move': 'write',
-    'copyto': 'write',
-    'moveto': 'write',
-    'copyfrom': 'read',
-    'movefrom': 'write',
+    'create_folder': permissions.WRITE,
+    'revisions': permissions.READ,
+    'metadata': permissions.READ,
+    'download': permissions.READ,
+    'render': permissions.READ,
+    'export': permissions.READ,
+    'upload': permissions.WRITE,
+    'delete': permissions.WRITE,
+    'copy': permissions.WRITE,
+    'move': permissions.WRITE,
+    'copyto': permissions.WRITE,
+    'moveto': permissions.WRITE,
+    'copyfrom': permissions.READ,
+    'movefrom': permissions.WRITE,
 }
 
 def check_access(node, auth, action, cas_resp):
@@ -160,7 +161,7 @@ def check_access(node, auth, action, cas_resp):
         raise HTTPError(httplib.BAD_REQUEST)
 
     if cas_resp:
-        if permission == 'read':
+        if permission == permissions.READ:
             if node.can_view_files(auth=None):
                 return True
             required_scope = node.file_read_scope
@@ -171,14 +172,14 @@ def check_access(node, auth, action, cas_resp):
            or required_scope not in oauth_scopes.normalize_scopes(cas_resp.attributes['accessTokenScope']):
             raise HTTPError(httplib.FORBIDDEN)
 
-    if permission == 'read':
+    if permission == permissions.READ:
         if node.can_view_files(auth):
             return True
         # The user may have admin privileges on a parent node, in which
         # case they should have read permissions
         if getattr(node, 'is_registration', False) and node.registered_from.can_view(auth):
             return True
-    if permission == 'write' and node.can_edit(auth):
+    if permission == permissions.WRITE and node.can_edit(auth):
         return True
 
     # Users attempting to register projects with components might not have

--- a/addons/bitbucket/views.py
+++ b/addons/bitbucket/views.py
@@ -17,6 +17,7 @@ from website.project.decorators import (
     must_have_permission, must_not_be_registration,
     must_be_contributor_or_public
 )
+from osf.utils.permissions import WRITE
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ bitbucket_deauthorize_node = generic_views.deauthorize_node(
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)
-@must_have_permission('write')
+@must_have_permission(WRITE)
 def bitbucket_set_config(auth, **kwargs):
     node_settings = kwargs.get('node_addon', None)
     node = kwargs.get('node', None)

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -7,6 +7,7 @@ from django.db import models
 from framework.auth.decorators import Auth
 from framework.exceptions import HTTPError
 from osf.models.files import File, Folder, BaseFileNode
+from osf.utils.permissions import WRITE
 from framework.auth.core import _get_current_user
 from addons.base import exceptions
 from addons.dataverse.client import connect_from_settings_or_401
@@ -40,7 +41,7 @@ class DataverseFile(DataverseFileNode, File):
         version.identifier = revision
 
         user = user or _get_current_user()
-        if not user or not self.target.has_permission(user, 'write'):
+        if not user or not self.target.has_permission(user, WRITE):
             try:
                 # Users without edit permission can only see published files
                 if not data['extra']['hasPublishedVersion']:

--- a/addons/dataverse/views.py
+++ b/addons/dataverse/views.py
@@ -17,6 +17,7 @@ from addons.dataverse.settings import DEFAULT_HOSTS
 from addons.dataverse.serializer import DataverseSerializer
 from dataverse.exceptions import VersionJsonNotFoundError, OperationFailedError
 from osf.models import ExternalAccount
+from osf.utils.permissions import WRITE
 from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
     must_have_permission, must_not_be_registration,
@@ -117,7 +118,7 @@ def dataverse_add_user_account(auth, **kwargs):
 
     return {}
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)
@@ -145,7 +146,7 @@ def dataverse_set_config(node_addon, auth, **kwargs):
     return {'dataverse': dataverse.title, 'dataset': dataset.title}, http.OK
 
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 def dataverse_get_datasets(node_addon, **kwargs):
@@ -164,7 +165,7 @@ def dataverse_get_datasets(node_addon, **kwargs):
 ## Crud ##
 
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_not_be_registration
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)

--- a/addons/forward/views/config.py
+++ b/addons/forward/views/config.py
@@ -4,7 +4,7 @@ import httplib as http
 
 from flask import request
 from osf.exceptions import ValidationValueError
-
+from osf.utils.permissions import WRITE
 from framework.exceptions import HTTPError
 
 from website.project.decorators import (
@@ -24,7 +24,7 @@ def forward_config_get(node, node_addon, **kwargs):
     return res
 
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_not_be_registration
 @must_have_addon('forward', 'node')
 def forward_config_put(auth, node_addon, **kwargs):

--- a/addons/github/views.py
+++ b/addons/github/views.py
@@ -16,6 +16,7 @@ from addons.github.serializer import GitHubSerializer
 from addons.github.utils import verify_hook_signature, MESSAGES
 
 from osf.models import NodeLog
+from osf.utils.permissions import WRITE
 from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
     must_have_permission, must_not_be_registration,
@@ -61,7 +62,7 @@ github_deauthorize_node = generic_views.deauthorize_node(
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)
-@must_have_permission('write')
+@must_have_permission(WRITE)
 def github_set_config(auth, **kwargs):
     node_settings = kwargs.get('node_addon', None)
     node = kwargs.get('node', None)
@@ -186,7 +187,7 @@ def github_folder_list(node_addon, **kwargs):
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)
-@must_have_permission('write')
+@must_have_permission(WRITE)
 def github_create_repo(**kwargs):
     repo_name = request.json.get('name')
     if not repo_name:

--- a/addons/gitlab/views.py
+++ b/addons/gitlab/views.py
@@ -18,6 +18,7 @@ from addons.gitlab.serializer import GitLabSerializer
 from addons.gitlab.utils import verify_hook_signature, MESSAGES
 from framework.auth.decorators import must_be_logged_in
 from osf.models import ExternalAccount, NodeLog
+from osf.utils.permissions import WRITE
 from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
     must_have_permission, must_not_be_registration,
@@ -132,7 +133,7 @@ def gitlab_add_user_account(auth, **kwargs):
 @must_have_addon(SHORT_NAME, 'user')
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)
-@must_have_permission('write')
+@must_have_permission(WRITE)
 def gitlab_set_config(auth, **kwargs):
     node_settings = kwargs.get('node_addon', None)
     node = kwargs.get('node', None)

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -11,6 +11,7 @@ from nose.tools import *  # noqa
 from framework.auth import Auth
 from addons.osfstorage.models import OsfStorageFile, OsfStorageFileNode, OsfStorageFolder
 from osf.exceptions import ValidationError
+from osf.utils.permissions import WRITE, ADMIN
 from osf.utils.fields import EncryptedJSONField
 from osf_tests.factories import ProjectFactory, UserFactory, PreprintFactory, RegionFactory, NodeFactory
 
@@ -841,7 +842,7 @@ class TestOsfStorageCheckout(StorageTestCase):
 
     def test_checkout_logs(self):
         non_admin = factories.AuthUserFactory()
-        self.node.add_contributor(non_admin, permissions='write')
+        self.node.add_contributor(non_admin, permissions=WRITE)
         self.node.save()
         self.file.check_in_or_out(non_admin, non_admin, save=True)
         self.file.reload()
@@ -915,7 +916,7 @@ class TestOsfStorageCheckout(StorageTestCase):
             user=user,
             visible=True
         )
-        self.node.add_permission(user, 'admin')
+        self.node.add_permission(user, ADMIN)
         self.file.check_in_or_out(self.user, self.user, save=True)
         self.file.reload()
         assert_equal(self.file.checkout, self.user)

--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -17,6 +17,7 @@ from framework.auth.decorators import must_be_signed, must_be_logged_in
 
 from osf.exceptions import InvalidTagError, TagNotFoundError
 from osf.models import FileVersion, OSFUser
+from osf.utils.permissions import WRITE
 from osf.utils.requests import check_select_for_update
 from website.project.decorators import (
     must_not_be_registration, must_have_permission
@@ -402,7 +403,7 @@ def osfstorage_download(file_node, payload, **kwargs):
     }
 
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @decorators.autoload_filenode(must_be='file')
 def osfstorage_add_tag(file_node, **kwargs):
     data = request.get_json()
@@ -410,7 +411,7 @@ def osfstorage_add_tag(file_node, **kwargs):
         return {'status': 'success'}, httplib.OK
     return {'status': 'failure'}, httplib.BAD_REQUEST
 
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @decorators.autoload_filenode(must_be='file')
 def osfstorage_remove_tag(file_node, **kwargs):
     data = request.get_json()

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -11,6 +11,7 @@ from addons.base import generic_views
 from addons.s3 import utils
 from addons.s3.serializer import S3Serializer
 from osf.models import ExternalAccount
+from osf.utils.permissions import WRITE
 from website.project.decorators import (
     must_have_addon, must_have_permission,
     must_be_addon_authorizer,
@@ -120,7 +121,7 @@ def s3_add_user_account(auth, **kwargs):
 
 @must_be_addon_authorizer(SHORT_NAME)
 @must_have_addon('s3', 'node')
-@must_have_permission('write')
+@must_have_permission(WRITE)
 def create_bucket(auth, node_addon, **kwargs):
     bucket_name = request.json.get('bucket_name', '')
     bucket_location = request.json.get('bucket_location', '')

--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -20,6 +20,7 @@ from osf_tests.factories import (
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 
 from osf.exceptions import NodeStateError
+from osf.utils.permissions import ADMIN, WRITE, READ
 from addons.wiki import settings
 from addons.wiki import views
 from addons.wiki.exceptions import InvalidVersionError
@@ -1002,7 +1003,7 @@ class TestWikiShareJSMongo(OsfTestCase):
         user = UserFactory()
         self.project.add_contributor(
             contributor=user,
-            permissions='admin',
+            permissions=ADMIN,
             auth=Auth(user=self.user),
         )
         self.project.save()
@@ -1010,8 +1011,8 @@ class TestWikiShareJSMongo(OsfTestCase):
         # Removing admin permission does nothing
         self.project.manage_contributors(
             user_dicts=[
-                {'id': user._id, 'permission': 'write', 'visible': True},
-                {'id': self.user._id, 'permission': 'admin', 'visible': True},
+                {'id': user._id, 'permission': WRITE, 'visible': True},
+                {'id': self.user._id, 'permission': ADMIN, 'visible': True},
             ],
             auth=Auth(user=self.user),
             save=True,
@@ -1020,8 +1021,8 @@ class TestWikiShareJSMongo(OsfTestCase):
         # Removing write permission migrates uuid
         self.project.manage_contributors(
             user_dicts=[
-                {'id': user._id, 'permission': 'read', 'visible': True},
-                {'id': self.user._id, 'permission': 'admin', 'visible': True},
+                {'id': user._id, 'permission': READ, 'visible': True},
+                {'id': self.user._id, 'permission': ADMIN, 'visible': True},
             ],
             auth=Auth(user=self.user),
             save=True,
@@ -1259,7 +1260,7 @@ class TestPublicWiki(OsfTestCase):
             'nodeType': 'component',
             'category': 'hypothesis',
             'permissions': {'view': True,
-                            'admin': True}
+                            ADMIN: True}
         }]
 
         assert_equal(data, expected)
@@ -1277,7 +1278,7 @@ class TestPublicWiki(OsfTestCase):
                     'kind': 'folder',
                     'nodeType': 'component',
                     'children': [],
-                    'permissions': {'admin': True,
+                    'permissions': {ADMIN: True,
                                     'view': True}
                     }]
 

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -11,7 +11,7 @@ from django.apps import apps
 
 from addons.wiki import settings as wiki_settings
 from addons.wiki.exceptions import InvalidVersionError
-
+from osf.utils.permissions import ADMIN, READ, WRITE
 # MongoDB forbids field names that begin with "$" or contain ".". These
 # utilities map to and from Mongo field names.
 
@@ -96,7 +96,7 @@ def migrate_uuid(node, wname):
 
     write_contributors = [
         user._id for user in node.contributors
-        if node.has_permission(user, 'write')
+        if node.has_permission(user, WRITE)
     ]
     broadcast_to_sharejs('unlock', old_sharejs_uuid, data=write_contributors)
 
@@ -184,8 +184,8 @@ def serialize_wiki_settings(user, nodes):
     for node in nodes:
         assert node, '{} is not a valid Node.'.format(node._id)
 
-        can_read = node.has_permission(user, 'read')
-        is_admin = node.has_permission(user, 'admin')
+        can_read = node.has_permission(user, READ)
+        is_admin = node.has_permission(user, ADMIN)
         include_wiki_settings = WikiPage.objects.include_wiki_settings(node)
 
         if not include_wiki_settings:
@@ -215,7 +215,7 @@ def serialize_wiki_settings(user, nodes):
                 'is_public': node.is_public
             },
             'children': children_tree,
-            'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, 'read') else 'node',
+            'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, READ) else 'node',
             'nodeType': node.project_or_component,
             'category': node.category,
             'permissions': {

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -30,7 +30,7 @@ from website.project.decorators import (
 )
 
 from osf.exceptions import ValidationError, NodeStateError
-
+from osf.utils.permissions import ADMIN, WRITE
 from .exceptions import (
     NameEmptyError,
     NameInvalidError,
@@ -153,7 +153,7 @@ def wiki_page_content(wname, wver=None, **kwargs):
     return _wiki_page_content(wname, wver=wver, **kwargs)
 
 @must_be_valid_project  # injects project
-@must_have_permission('write')  # injects user, project
+@must_have_permission(WRITE)  # injects user, project
 @must_not_be_registration
 @must_have_addon('wiki', 'node')
 def project_wiki_delete(auth, wname, **kwargs):
@@ -185,7 +185,7 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
     can_edit = (
         auth.logged_in and not
         node.is_registration and (
-            node.has_permission(auth.user, 'write') or
+            node.has_permission(auth.user, WRITE) or
             wiki_settings.is_publicly_editable
         )
     )
@@ -316,7 +316,7 @@ def project_wiki_edit_post(auth, wname, **kwargs):
     return ret, http.FOUND, None, redirect_url
 
 @must_be_valid_project  # injects node or project
-@must_have_permission('admin')
+@must_have_permission(ADMIN)
 @must_not_be_registration
 @must_have_addon('wiki', 'node')
 def edit_wiki_settings(node, auth, **kwargs):
@@ -395,7 +395,7 @@ def project_wiki_compare(wname, wver, **kwargs):
 
 
 @must_not_be_registration
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_have_addon('wiki', 'node')
 def project_wiki_rename(auth, wname, **kwargs):
     """View that handles user the X-editable input for wiki page renaming.
@@ -439,7 +439,7 @@ def project_wiki_rename(auth, wname, **kwargs):
 
 
 @must_be_valid_project  # returns project
-@must_have_permission('write')  # returns user, project
+@must_have_permission(WRITE)  # returns user, project
 @must_not_be_registration
 @must_have_addon('wiki', 'node')
 def project_wiki_validate_name(wname, auth, node, **kwargs):
@@ -501,7 +501,7 @@ def format_home_wiki_page(node):
 
 def format_project_wiki_pages(node, auth):
     pages = []
-    can_edit = node.has_permission(auth.user, 'write') and not node.is_registration
+    can_edit = node.has_permission(auth.user, WRITE) and not node.is_registration
     project_wiki_pages = _get_wiki_pages_latest(node)
     home_wiki_page = format_home_wiki_page(node)
     pages.append(home_wiki_page)
@@ -546,7 +546,7 @@ def serialize_component_wiki(node, auth):
         }
     }
 
-    can_edit = node.has_permission(auth.user, 'write') and not node.is_registration
+    can_edit = node.has_permission(auth.user, WRITE) and not node.is_registration
     if can_edit or home_has_content:
         children.append(component_home_wiki)
 

--- a/addons/zotero/views.py
+++ b/addons/zotero/views.py
@@ -9,6 +9,7 @@ from website.project.decorators import (
     must_be_contributor_or_public
 )
 from api.base.utils import is_truthy
+from osf.utils.permissions import WRITE
 
 
 class ZoteroViews(GenericCitationViews):
@@ -20,7 +21,7 @@ class ZoteroViews(GenericCitationViews):
         @must_have_addon(addon_short_name, 'user')
         @must_have_addon(addon_short_name, 'node')
         @must_be_addon_authorizer(addon_short_name)
-        @must_have_permission('write')
+        @must_have_permission(WRITE)
         def _set_config(node_addon, user_addon, auth, **kwargs):
             """ Changes folder associated with addon.
             Returns serialized node settings

--- a/admin_tests/nodes/test_serializers.py
+++ b/admin_tests/nodes/test_serializers.py
@@ -2,7 +2,7 @@ from nose.tools import *  # noqa: F403
 
 from tests.base import AdminTestCase
 from osf_tests.factories import NodeFactory, UserFactory
-
+from osf.utils.permissions import ADMIN
 from admin.nodes.serializers import serialize_simple_user_and_node_permissions, serialize_node
 
 
@@ -37,4 +37,4 @@ class TestNodeSerializers(AdminTestCase):
         assert_is_instance(info, dict)
         assert_equal(info['id'], user._id)
         assert_equal(info['name'], user.fullname)
-        assert_equal(info['permission'], 'admin')
+        assert_equal(info['permission'], ADMIN)

--- a/admin_tests/osf_groups/test_views.py
+++ b/admin_tests/osf_groups/test_views.py
@@ -9,7 +9,7 @@ from django.test import RequestFactory
 
 from tests.base import AdminTestCase
 from osf_tests.factories import UserFactory, ProjectFactory, OSFGroupFactory
-
+from osf.utils.permissions import WRITE
 from admin.osf_groups.serializers import serialize_node_for_groups
 
 class TestOSFGroupsView(AdminTestCase):
@@ -41,7 +41,7 @@ class TestOSFGroupsView(AdminTestCase):
         nt.assert_equal(group['managers'][0]['id'], self.user._id)
         nt.assert_equal([serialize_node_for_groups(self.project, self.group)], group['nodes'])
         nt.assert_equal(group['nodes'][0]['title'], self.project.title)
-        nt.assert_equal(group['nodes'][0]['permission'], 'write')
+        nt.assert_equal(group['nodes'][0]['permission'], WRITE)
 
 
 class TestOSFGroupsListView(AdminTestCase):

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -3,6 +3,7 @@ from rest_framework import permissions
 from api.base.utils import get_user_auth
 from osf.models import BaseFileNode
 from api.preprints.permissions import PreprintPublishedOrAdmin
+from osf.utils.permissions import ADMIN
 from osf.utils.workflows import DefaultStates
 
 class CheckedOutOrAdmin(permissions.BasePermission):
@@ -18,7 +19,7 @@ class CheckedOutOrAdmin(permissions.BasePermission):
             return False
         return obj.checkout is None \
             or obj.checkout == auth.user \
-            or obj.target.has_permission(auth.user, 'admin')
+            or obj.target.has_permission(auth.user, ADMIN)
 
 
 class IsPreprintFile(PreprintPublishedOrAdmin):

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -24,6 +24,7 @@ from api.files.permissions import CheckedOutOrAdmin
 from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer, QuickFilesDetailSerializer
 from api.files.serializers import FileVersionSerializer
+from osf.utils.permissions import ADMIN
 
 
 class FileMixin(object):
@@ -97,7 +98,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
         if self.request.GET.get('create_guid', False):
             # allows quickfiles to be given guids when another user wants a permanent link to it
-            if (self.get_target().has_permission(user, 'admin') and utils.has_admin_scope(self.request)) or getattr(file.target, 'is_quickfiles', False):
+            if (self.get_target().has_permission(user, ADMIN) and utils.has_admin_scope(self.request)) or getattr(file.target, 'is_quickfiles', False):
                 file.get_guid(create=True)
         return file
 

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -23,7 +23,7 @@ from api.base.utils import get_user_auth, is_deprecated, assert_resource_type
 
 class ContributorOrPublic(permissions.BasePermission):
 
-    acceptable_models = (AbstractNode, NodeRelation, Preprint)
+    acceptable_models = (AbstractNode, NodeRelation, Preprint,)
 
     def has_object_permission(self, request, view, obj):
         from api.nodes.views import NodeStorageProvider
@@ -57,7 +57,7 @@ class IsAdminContributor(permissions.BasePermission):
     admin contributor to make changes.  Admin group membership
     is not sufficient.
     """
-    acceptable_models = (AbstractNode, DraftRegistration)
+    acceptable_models = (AbstractNode, DraftRegistration,)
 
     def has_object_permission(self, request, view, obj):
         assert_resource_type(obj, self.acceptable_models)
@@ -70,7 +70,7 @@ class IsAdminContributor(permissions.BasePermission):
             return obj.is_admin_contributor(auth.user)
 
 class IsAdmin(permissions.BasePermission):
-    acceptable_models = (AbstractNode, PrivateLink)
+    acceptable_models = (AbstractNode, PrivateLink,)
 
     def has_object_permission(self, request, view, obj):
         assert_resource_type(obj, self.acceptable_models)
@@ -131,7 +131,7 @@ class AdminOrPublic(permissions.BasePermission):
 
 class AdminContributorOrPublic(permissions.BasePermission):
 
-    acceptable_models = (AbstractNode, DraftRegistration)
+    acceptable_models = (AbstractNode, DraftRegistration,)
 
     def has_object_permission(self, request, view, obj):
         """
@@ -161,7 +161,7 @@ class ExcludeWithdrawals(permissions.BasePermission):
 class ContributorDetailPermissions(permissions.BasePermission):
     """Permissions for contributor detail page."""
 
-    acceptable_models = (AbstractNode, OSFUser, Contributor)
+    acceptable_models = (AbstractNode, OSFUser, Contributor,)
 
     def load_resource(self, context, view):
         return AbstractNode.load(context[view.node_lookup_url_kwarg])
@@ -205,7 +205,7 @@ class NodeGroupDetailPermissions(permissions.BasePermission):
 
 class ContributorOrPublicForPointers(permissions.BasePermission):
 
-    acceptable_models = (AbstractNode, NodeRelation)
+    acceptable_models = (AbstractNode, NodeRelation,)
 
     def has_object_permission(self, request, view, obj):
         assert_resource_type(obj, self.acceptable_models)

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -101,7 +101,7 @@ class IsContributorOrGroupMember(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return obj.is_contributor_or_group_member(auth.user)
         else:
-            return obj.has_permission(auth.user, 'write')
+            return obj.has_permission(auth.user, osf_permissions.WRITE)
 
 
 class IsAdminContributorOrReviewer(IsAdminContributor):

--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -12,6 +12,7 @@ from addons.osfstorage.models import OsfStorageFile, OsfStorageFolder
 from addons.wiki.models import NodeSettings as WikiNodeSettings
 from osf.models import AbstractNode, Preprint, Guid, NodeRelation, Contributor
 from osf.models.node import NodeGroupObjectPermission
+from osf.utils import permissions
 
 from api.base.exceptions import ServiceUnavailableError
 from api.base.utils import get_object_or_error, waterbutler_api_url_for, get_user_auth, has_admin_scope
@@ -84,9 +85,9 @@ class NodeOptimizationMixin(object):
         parent = NodeRelation.objects.annotate(parent__id=Subquery(guid.values('_id')[:1])).filter(child=OuterRef('pk'), is_node_link=False)
         wiki_addon = WikiNodeSettings.objects.filter(owner=OuterRef('pk'), deleted=False)
 
-        admin_permission = Permission.objects.get(codename='admin_node')
-        write_permission = Permission.objects.get(codename='write_node')
-        read_permission = Permission.objects.get(codename='read_node')
+        admin_permission = Permission.objects.get(codename=permissions.ADMIN_NODE)
+        write_permission = Permission.objects.get(codename=permissions.WRITE_NODE)
+        read_permission = Permission.objects.get(codename=permissions.READ_NODE)
         contrib = Contributor.objects.filter(user=auth.user, node=OuterRef('pk'))
         user_group = OSFUserGroup.objects.filter(osfuser_id=auth.user.id if auth.user else None, group_id=OuterRef('group_id'))
         node_group = NodeGroupObjectPermission.objects.annotate(user_group=Subquery(user_group.values_list('group_id')[:1])).filter(user_group__isnull=False, content_object_id=OuterRef('pk'))

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1161,7 +1161,15 @@ class NodeFileDetail(JSONAPIBaseView, generics.RetrieveAPIView, WaterButlerMixin
         return fobj
 
 
-class NodeGroupsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ListFilterMixin, OSFGroupMixin):
+class NodeGroupsBase(JSONAPIBaseView, NodeMixin, OSFGroupMixin):
+    model_class = OSFGroup
+
+    required_read_scopes = [CoreScopes.NODE_OSF_GROUPS_READ]
+    required_write_scopes = [CoreScopes.NODE_OSF_GROUPS_WRITE]
+    view_category = 'nodes'
+
+
+class NodeGroupsList(NodeGroupsBase, generics.ListCreateAPIView, ListFilterMixin):
     """ The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_groups_list)
 
     """
@@ -1170,13 +1178,8 @@ class NodeGroupsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Lis
         AdminOrPublic,
         base_permissions.TokenHasScope,
     )
-    model_class = OSFGroup
 
     serializer_class = NodeGroupsSerializer
-
-    required_read_scopes = [CoreScopes.NODE_OSF_GROUPS_READ]
-    required_write_scopes = [CoreScopes.NODE_OSF_GROUPS_WRITE]
-    view_category = 'nodes'
     view_name = 'node-groups'
 
     def get_default_queryset(self):
@@ -1214,7 +1217,7 @@ class NodeGroupsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Lis
         return context
 
 
-class NodeGroupsDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMixin, OSFGroupMixin):
+class NodeGroupsDetail(NodeGroupsBase, generics.RetrieveUpdateDestroyAPIView):
     """ The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_groups_read)
 
     """
@@ -1226,9 +1229,6 @@ class NodeGroupsDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, N
 
     serializer_class = NodeGroupsDetailSerializer
 
-    required_read_scopes = [CoreScopes.NODE_OSF_GROUPS_READ]
-    required_write_scopes = [CoreScopes.NODE_OSF_GROUPS_WRITE]
-    view_category = 'nodes'
     view_name = 'node-group-detail'
 
     # Overrides RetrieveUpdateDestroyAPIView

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1651,7 +1651,7 @@ class NodeInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestr
 
         for val in data:
             if val['id'] in current_insts:
-                if not user.is_affiliated_with_institution(current_insts[val['id']]) and not node.has_permission(user, 'admin'):
+                if not user.is_affiliated_with_institution(current_insts[val['id']]) and not node.has_permission(user, ADMIN):
                     raise PermissionDenied
                 node.remove_affiliated_institution(inst=current_insts[val['id']], user=user)
         node.save()

--- a/api/osf_groups/serializers.py
+++ b/api/osf_groups/serializers.py
@@ -165,7 +165,6 @@ class GroupMemberCreateSerializer(GroupMemberSerializer):
                 else:
                     user = group.add_unregistered_member(full_name, email, auth, role)
         except ValueError as e:
-            # Making someone a member has the potential to violate the one-manager rule
             raise exceptions.ValidationError(detail=str(e.message))
 
         return user

--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -9,7 +9,7 @@ from api.providers.workflows import Workflows
 from api.base.metrics import MetricsSerializerMixin
 from osf.models.user import Email, OSFUser
 from osf.models.validators import validate_email
-from osf.utils.permissions import REVIEW_GROUPS
+from osf.utils.permissions import REVIEW_GROUPS, ADMIN
 from website import mails
 from website.settings import DOMAIN
 
@@ -255,7 +255,7 @@ class ModeratorSerializer(JSONAPISerializer):
         context['notification_settings_url'] = '{}reviews/preprints/{}/notifications'.format(DOMAIN, provider._id)
         context['provider_name'] = provider.name
         context['is_reviews_moderator_notification'] = True
-        context['is_admin'] = perm_group == 'admin'
+        context['is_admin'] = perm_group == ADMIN
 
         provider.add_to_group(user, perm_group)
         setattr(user, 'permission_group', perm_group)  # Allows reserialization

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -24,7 +24,7 @@ from api.taxonomies.serializers import TaxonomySerializer
 from api.taxonomies.utils import optimize_subject_query
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import AbstractNode, CollectionProvider, CollectionSubmission, NodeLicense, OSFUser, RegistrationProvider, Subject, PreprintRequest, PreprintProvider, WhitelistedSHAREPreprintProvider
-from osf.utils.permissions import REVIEW_PERMISSIONS
+from osf.utils.permissions import REVIEW_PERMISSIONS, ADMIN
 from osf.utils.workflows import RequestTypes
 from osf.metrics import PreprintDownload, PreprintView
 
@@ -453,10 +453,10 @@ class PreprintProviderModeratorsList(ModeratorMixin, JSONAPIBaseView, generics.L
 
     def get_default_queryset(self):
         provider = self.get_provider()
-        admin_group = provider.get_group('admin')
+        admin_group = provider.get_group(ADMIN)
         mod_group = provider.get_group('moderator')
         return (admin_group.user_set.all() | mod_group.user_set.all()).annotate(permission_group=Case(
-            When(groups=admin_group, then=Value('admin')),
+            When(groups=admin_group, then=Value(ADMIN)),
             default=Value('moderator'),
             output_field=CharField(),
         )).order_by('fullname')

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -147,7 +147,7 @@ class UserSerializer(JSONAPISerializer):
     def get_projects_in_common(self, obj):
         user = get_user_auth(self.context['request']).user
         if obj == user:
-            return user.contributor_or_group_member_to.filter(type__in=['osf.node']).count()
+            return user.contributor_or_group_member_to.filter(type='osf.node').count()
         return obj.n_projects_in_common(user)
 
     def absolute_url(self, obj):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -79,6 +79,7 @@ from osf.models import (
     OSFUser,
     Email,
 )
+from osf.utils import permissions
 from website import mails, settings
 from website.project.views.contributor import send_claim_email, send_claim_registered_email
 
@@ -316,7 +317,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, UserNodesFilte
     def get_default_queryset(self):
         user = self.get_user()
         # Nodes the requested user has read_permissions on
-        default_queryset = user.contributor_or_group_member_to.filter(type__in=['osf.node'])
+        default_queryset = user.contributor_or_group_member_to.filter(type='osf.node')
         if user != self.request.user:
             if self.request.user.is_anonymous:
                 # Further restrict UserNodes to public nodes
@@ -502,7 +503,7 @@ class UserDraftRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin):
 
     def get_queryset(self):
         user = self.get_user()
-        node_qs = get_objects_for_user(user, 'admin_node', Node, with_superuser=False).exclude(is_deleted=True)
+        node_qs = get_objects_for_user(user, permissions.ADMIN_NODE, Node, with_superuser=False).exclude(is_deleted=True)
         return DraftRegistration.objects.filter(
             Q(registered_node__isnull=True) |
             Q(registered_node__is_deleted=True),

--- a/api/view_only_links/serializers.py
+++ b/api/view_only_links/serializers.py
@@ -11,7 +11,7 @@ from api.base.serializers import (
 from api.base.utils import absolute_reverse
 
 from osf.models import AbstractNode
-
+from osf.utils.permissions import ADMIN
 
 class ViewOnlyLinkDetailSerializer(JSONAPISerializer):
     key = ser.CharField(read_only=True)
@@ -114,7 +114,7 @@ class ViewOnlyLinkNodesSerializer(BaseAPISerializer):
         eligible_nodes = self.get_eligible_nodes(nodes)
 
         for node in add:
-            if not node.has_permission(user, 'admin'):
+            if not node.has_permission(user, ADMIN):
                 raise PermissionDenied
             if node not in eligible_nodes:
                 raise NonDescendantNodeError(node_id=node._id)
@@ -136,7 +136,7 @@ class ViewOnlyLinkNodesSerializer(BaseAPISerializer):
         )
 
         for node in remove:
-            if not node.has_permission(user, 'admin'):
+            if not node.has_permission(user, ADMIN):
                 raise PermissionDenied
             view_only_link.nodes.remove(node)
         view_only_link.save()
@@ -145,7 +145,7 @@ class ViewOnlyLinkNodesSerializer(BaseAPISerializer):
         eligible_nodes = self.get_eligible_nodes(nodes)
 
         for node in add:
-            if not node.has_permission(user, 'admin'):
+            if not node.has_permission(user, ADMIN):
                 raise PermissionDenied
             if node not in eligible_nodes:
                 raise NonDescendantNodeError(node_id=node._id)

--- a/api/view_only_links/views.py
+++ b/api/view_only_links/views.py
@@ -15,7 +15,7 @@ from api.registrations.serializers import RegistrationSerializer
 from api.view_only_links.serializers import ViewOnlyLinkDetailSerializer, ViewOnlyLinkNodesSerializer
 
 from osf.models import PrivateLink
-
+from osf.utils.permissions import ADMIN
 
 class ViewOnlyLinkDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/view_only_links_read).
@@ -39,7 +39,7 @@ class ViewOnlyLinkDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         user = get_user_auth(self.request).user
 
         for node in view_only_link.nodes.all():
-            if not node.has_permission(user, 'admin'):
+            if not node.has_permission(user, ADMIN):
                 raise PermissionDenied
 
         if not view_only_link:
@@ -83,7 +83,7 @@ class ViewOnlyLinkNodes(JSONAPIBaseView, generics.ListAPIView):
 
         nodes = []
         for node in view_only_link.nodes.all():
-            if not node.has_permission(user, 'admin'):
+            if not node.has_permission(user, ADMIN):
                 raise PermissionDenied
             nodes.append(node)
 

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -17,7 +17,7 @@ from framework.auth.oauth_scopes import public_scopes
 from framework.auth.cas import CasResponse
 from website import settings
 from osf.models import ApiOAuth2PersonalToken, Session
-
+from osf.utils.permissions import ADMIN
 
 @pytest.mark.enable_quickfiles_creation
 class TestWelcomeToApi(ApiTestCase):
@@ -76,12 +76,12 @@ class TestWelcomeToApi(ApiTestCase):
 
         res = self.app.get(self.url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['meta']['admin'], True)
+        assert_equal(res.json['meta'][ADMIN], True)
 
     def test_basic_auth_does_not_have_admin(self):
         res = self.app.get(self.url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
-        assert_not_in('admin', res.json['meta'].keys())
+        assert_not_in(ADMIN, res.json['meta'].keys())
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     # TODO: Remove when available outside of DEV_MODE
@@ -113,7 +113,7 @@ class TestWelcomeToApi(ApiTestCase):
         )
 
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['meta']['admin'], True)
+        assert_equal(res.json['meta'][ADMIN], True)
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     def test_non_admin_scoped_token_does_not_have_admin(self, mock_auth):
@@ -140,4 +140,4 @@ class TestWelcomeToApi(ApiTestCase):
         )
 
         assert_equal(res.status_code, 200)
-        assert_not_in('admin', res.json['meta'].keys())
+        assert_not_in(ADMIN, res.json['meta'].keys())

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -9,7 +9,7 @@ from nose.tools import *  # noqa:
 
 from tests.base import ApiTestCase
 from osf_tests import factories
-
+from osf.utils.permissions import READ, WRITE
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.settings.defaults import API_BASE
@@ -93,12 +93,12 @@ class TestApiBaseViews(ApiTestCase):
                         view.permission_classes,
                         '{0} lacks the appropriate permission classes'.format(view)
                     )
-            for key in ['read', 'write']:
+            for key in [READ, WRITE]:
                 scopes = getattr(view, 'required_{}_scopes'.format(key), None)
                 assert_true(bool(scopes))
                 for scope in scopes:
                     assert_is_not_none(scope)
-                if key == 'write':
+                if key == WRITE:
                     assert_not_in(CoreScopes.ALWAYS_PUBLIC, scopes)
 
     def test_view_classes_support_embeds(self):

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -16,6 +16,7 @@ from osf_tests.factories import (
 )
 from osf.models import Collection
 from osf.utils.sanitize import strip_html
+from osf.utils.permissions import ADMIN
 from tests.utils import assert_items_equal
 from website.project.signals import contributor_removed
 from api_tests.utils import disconnected_from_listeners
@@ -4351,7 +4352,7 @@ class TestCollectedMetaDetail:
         )
         assert res.status_code == 403
 
-        project_one.add_contributor(user_two, permissions='admin', save=True)  # has referent admin perms
+        project_one.add_contributor(user_two, permissions=ADMIN, save=True)  # has referent admin perms
         res = app.delete_json_api(
             url,
             auth=user_two.auth,

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -13,6 +13,7 @@ from api.base.settings.defaults import API_BASE
 from api_tests import utils as api_utils
 from framework.auth.core import Auth
 from osf.models import NodeLog, Session, QuickFilesNode
+from osf.utils.permissions import WRITE, READ
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import (
     AuthUserFactory,
@@ -475,7 +476,7 @@ class TestFileView:
         # test_noncontrib_cannot_checkout
         non_contrib = AuthUserFactory()
         assert file.checkout is None
-        assert not node.has_permission(non_contrib, 'read')
+        assert not node.has_permission(non_contrib, READ)
         res = app.put_json_api(
             file_url, {
                 'data': {
@@ -494,7 +495,7 @@ class TestFileView:
 
         # test_read_contrib_cannot_checkout
         read_contrib = AuthUserFactory()
-        node.add_contributor(read_contrib, permissions='read')
+        node.add_contributor(read_contrib, permissions=READ)
         node.save()
         assert not node.can_edit(user=read_contrib)
         res = app.put_json_api(
@@ -514,7 +515,7 @@ class TestFileView:
 
     def test_write_contrib_can_checkin(self, app, node, file, file_url):
         write_contrib = AuthUserFactory()
-        node.add_contributor(write_contrib, permissions='write')
+        node.add_contributor(write_contrib, permissions=WRITE)
         node.save()
         assert node.can_edit(user=write_contrib)
         file.checkout = write_contrib
@@ -536,7 +537,7 @@ class TestFileView:
     @mock.patch('addons.osfstorage.listeners.enqueue_postcommit_task')
     def test_removed_contrib_files_checked_in(self, mock_enqueue, app, node, file):
         write_contrib = AuthUserFactory()
-        node.add_contributor(write_contrib, permissions='write')
+        node.add_contributor(write_contrib, permissions=WRITE)
         node.save()
         assert node.can_edit(user=write_contrib)
         file.checkout = write_contrib
@@ -801,7 +802,7 @@ class TestPreprintFileView:
         assert res.status_code == 200
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -822,7 +823,7 @@ class TestPreprintFileView:
         assert res.status_code == 403
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -843,7 +844,7 @@ class TestPreprintFileView:
         assert res.status_code == 403
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -864,7 +865,7 @@ class TestPreprintFileView:
         assert res.status_code == 410
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 410
 
@@ -885,7 +886,7 @@ class TestPreprintFileView:
         assert res.status_code == 403
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -906,7 +907,7 @@ class TestPreprintFileView:
         assert res.status_code == 200
 
         # Write contrib
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -927,7 +928,7 @@ class TestPreprintFileView:
         assert res.status_code == 403
 
         # Write contributor
-        preprint.add_contributor(other_user, 'write', save=True)
+        preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
         assert res.status_code == 403
 

--- a/api_tests/identifiers/views/test_identifier_detail.py
+++ b/api_tests/identifiers/views/test_identifier_detail.py
@@ -10,6 +10,7 @@ from osf_tests.factories import (
     NodeFactory,
     PreprintFactory
 )
+from osf.utils.permissions import READ
 from osf.utils.workflows import DefaultStates
 
 
@@ -154,7 +155,7 @@ class TestIdentifierDetail:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -180,7 +181,7 @@ class TestIdentifierDetail:
 
         # test_deleted_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 404
 
@@ -206,7 +207,7 @@ class TestIdentifierDetail:
 
         # test_private_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -232,7 +233,7 @@ class TestIdentifierDetail:
 
         # test_abandoned_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -258,7 +259,7 @@ class TestIdentifierDetail:
 
         # test_orphaned_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -12,6 +12,7 @@ from osf_tests.factories import (
     NodeFactory,
     PreprintFactory,
 )
+from osf.utils.permissions import READ
 from osf.utils.workflows import DefaultStates
 from tests.utils import assert_items_equal
 
@@ -315,7 +316,7 @@ class TestPreprintIdentifierList:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url_preprint_identifier, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -345,7 +346,7 @@ class TestPreprintIdentifierList:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url_preprint_identifier, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -375,7 +376,7 @@ class TestPreprintIdentifierList:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url_preprint_identifier, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 404
 
@@ -399,7 +400,7 @@ class TestPreprintIdentifierList:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url_preprint_identifier, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -423,7 +424,7 @@ class TestPreprintIdentifierList:
 
         # test_unpublished_preprint_identifier_readcontrib_authenticated
         read_user = AuthUserFactory()
-        preprint.add_contributor(read_user, 'read', save=True)
+        preprint.add_contributor(read_user, READ, save=True)
         res = app.get(url_preprint_identifier, auth=read_user.auth, expect_errors=True)
         assert res.status_code == 403
 

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -318,7 +318,7 @@ class TestInstitutionRelationshipNodes:
             self, node_private, user,
             app, url_institution_nodes,
             institution):
-        node_private.add_contributor(user, permissions='read')
+        node_private.add_contributor(user, permissions=permissions.READ)
         node_private.save()
 
         res = app.delete_json_api(

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -3,7 +3,7 @@ import pytest
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
 from osf.models import AbstractNode, NodeLog
-from osf.utils.permisisons import ADMIN, WRITE, READ
+from osf.utils import permissions
 from osf.utils.sanitize import strip_html
 from osf_tests.factories import (
     NodeFactory,
@@ -13,7 +13,6 @@ from osf_tests.factories import (
     AuthUserFactory,
 )
 from tests.base import fake
-from osf.utils import permissions
 
 
 @pytest.fixture()
@@ -104,7 +103,7 @@ class TestNodeChildrenList:
     #   test_return_private_node_children_osf_group_member_admin
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, ADMIN)
+        private_project.add_osf_group(group, permissions.ADMIN)
         res = app.get(private_project_url, auth=group_mem.auth)
         assert res.status_code == 200
         # Can view node children that you have implict admin permissions
@@ -246,14 +245,14 @@ class TestNodeChildCreate:
     #   test_creates_child_group_member_read
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project.add_osf_group(group, READ)
+        project.add_osf_group(group, permissions.READ)
         res = app.post_json_api(
             url, child, auth=group_mem.auth,
             expect_errors=True
         )
         assert res.status_code == 403
 
-        project.update_osf_group(group, WRITE)
+        project.update_osf_group(group, permissions.WRITE)
         res = app.post_json_api(
             url, child, auth=group_mem.auth,
             expect_errors=True

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -3,6 +3,7 @@ import pytest
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
 from osf.models import AbstractNode, NodeLog
+from osf.utils.permisisons import ADMIN, WRITE, READ
 from osf.utils.sanitize import strip_html
 from osf_tests.factories import (
     NodeFactory,
@@ -103,7 +104,7 @@ class TestNodeChildrenList:
     #   test_return_private_node_children_osf_group_member_admin
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'admin')
+        private_project.add_osf_group(group, ADMIN)
         res = app.get(private_project_url, auth=group_mem.auth)
         assert res.status_code == 200
         # Can view node children that you have implict admin permissions
@@ -245,14 +246,14 @@ class TestNodeChildCreate:
     #   test_creates_child_group_member_read
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project.add_osf_group(group, 'read')
+        project.add_osf_group(group, READ)
         res = app.post_json_api(
             url, child, auth=group_mem.auth,
             expect_errors=True
         )
         assert res.status_code == 403
 
-        project.update_osf_group(group, 'write')
+        project.update_osf_group(group, WRITE)
         res = app.post_json_api(
             url, child, auth=group_mem.auth,
             expect_errors=True

--- a/api_tests/nodes/views/test_node_citations.py
+++ b/api_tests/nodes/views/test_node_citations.py
@@ -3,6 +3,7 @@ import pytest
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
 from rest_framework import exceptions
+from osf.utils.permissions import WRITE, READ
 from osf_tests.factories import (
     ProjectFactory,
     AuthUserFactory,
@@ -49,15 +50,15 @@ def private_project(
     private_project = ProjectFactory(creator=admin_contributor)
     private_project.add_contributor(
         write_contrib,
-        permissions='write',
+        permissions=WRITE,
         auth=Auth(admin_contributor))
     private_project.add_contributor(
         read_contrib,
-        permissions='read',
+        permissions=READ,
         auth=Auth(admin_contributor))
     private_project.add_contributor(
         disabled_contrib,
-        permissions='read',
+        permissions=READ,
         auth=Auth(admin_contributor))
     private_project.custom_citation = 'Test Citation Text'
     private_project.save()
@@ -121,7 +122,7 @@ class NodeCitationsMixin:
     #   test_read_group_mem_can_view_private_project_citations
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(private_url, auth=group_mem.auth)
         assert res.status_code == 200
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -7,6 +7,7 @@ from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from framework.auth import core
 from osf.models import Guid
+from osf.utils.permissions import READ
 from osf_tests.factories import (
     ProjectFactory,
     RegistrationFactory,
@@ -358,7 +359,7 @@ class NodeCommentsCreateMixin(object):
         project_dict = project_private_comment_private
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project_dict['project'].add_osf_group(group, 'read')
+        project_dict['project'].add_osf_group(group, READ)
         res = app.post_json_api(
             project_dict['url'],
             project_dict['payload'],
@@ -538,7 +539,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin):
         project_private = ProjectFactory(
             is_public=False, creator=user, comment_level='private')
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -552,7 +553,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_private(self, user, user_read_contrib, payload):
         project_public = ProjectFactory(
             is_public=True, creator=user, comment_level='private')
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -566,7 +567,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_public(self, user, user_read_contrib, payload):
         """ Public project configured so that any logged-in user can comment."""
         project_public = ProjectFactory(is_public=True, creator=user)
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -580,7 +581,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin):
     def project_private_comment_public(self, user, user_read_contrib, payload):
         project_private = ProjectFactory(is_public=False, creator=user)
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -967,7 +968,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin):
         project_private = ProjectFactory(
             is_public=False, creator=user, comment_level='private')
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -983,7 +984,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_private(self, user, user_read_contrib, payload):
         project_public = ProjectFactory(
             is_public=True, creator=user, comment_level='private')
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -999,7 +1000,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_public(self, user, user_read_contrib, payload):
         """ Public project configured so that any logged-in user can comment."""
         project_public = ProjectFactory(is_public=True, creator=user)
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -1015,7 +1016,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin):
     def project_private_comment_public(self, user, user_read_contrib, payload):
         project_private = ProjectFactory(is_public=False, creator=user)
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -1097,7 +1098,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin):
         project_private = ProjectFactory(
             is_public=False, creator=user, comment_level='private')
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -1114,7 +1115,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_private(self, user, user_read_contrib, payload):
         project_public = ProjectFactory(
             is_public=True, creator=user, comment_level='private')
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -1131,7 +1132,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin):
     def project_public_comment_public(self, user, user_read_contrib, payload):
         """ Public project configured so that any logged-in user can comment."""
         project_public = ProjectFactory(is_public=True, creator=user)
-        project_public.add_contributor(user_read_contrib, permissions='read')
+        project_public.add_contributor(user_read_contrib, permissions=READ)
         project_public.save()
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -1148,7 +1149,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin):
     def project_private_comment_public(self, user, user_read_contrib, payload):
         project_private = ProjectFactory(is_public=False, creator=user)
         project_private.add_contributor(
-            user_read_contrib, permissions='read')
+            user_read_contrib, permissions=READ)
         project_private.save()
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -1234,7 +1235,7 @@ class TestCommentRepliesCreate(NodeCommentsCreateMixin):
         project_private = ProjectFactory.create(
             is_public=False, creator=user, comment_level='private')
         project_private.add_contributor(
-            user_read_contrib, permissions='read', save=True)
+            user_read_contrib, permissions=READ, save=True)
         comment_private = CommentFactory(node=project_private, user=user)
         url_private = '/{}nodes/{}/comments/'.format(
             API_BASE, project_private._id)
@@ -1250,7 +1251,7 @@ class TestCommentRepliesCreate(NodeCommentsCreateMixin):
         project_public = ProjectFactory.create(
             is_public=True, creator=user, comment_level='private')
         project_public.add_contributor(
-            user_read_contrib, permissions='read', save=True)
+            user_read_contrib, permissions=READ, save=True)
         comment_public = CommentFactory(node=project_public, user=user)
         url_public = '/{}nodes/{}/comments/'.format(
             API_BASE, project_public._id)
@@ -1265,7 +1266,7 @@ class TestCommentRepliesCreate(NodeCommentsCreateMixin):
     def project_private_comment_public(self, user, user_read_contrib, payload):
         project_private = ProjectFactory(is_public=False, creator=user)
         project_private.add_contributor(
-            user_read_contrib, permissions='read', save=True)
+            user_read_contrib, permissions=READ, save=True)
         comment_private = CommentFactory(node=project_private, user=user)
         comment_reply = CommentFactory(
             node=project_private,
@@ -1285,7 +1286,7 @@ class TestCommentRepliesCreate(NodeCommentsCreateMixin):
     def project_public_comment_public(self, user, user_read_contrib, payload):
         project_public = ProjectFactory(is_public=True, creator=user)
         project_public.add_contributor(
-            user_read_contrib, permissions='read', save=True)
+            user_read_contrib, permissions=READ, save=True)
         comment_public = CommentFactory(node=project_public, user=user)
         comment_reply = CommentFactory(
             node=project_public,

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -162,20 +162,20 @@ class TestContributorDetail:
     def test_node_contributor_detail_serializes_contributor_perms(self, app, user):
         project = ProjectFactory(creator=user, is_public=True)
         user_two = AuthUserFactory()
-        project.add_contributor(user_two, 'write')
+        project.add_contributor(user_two, permissions.WRITE)
         project.save()
 
         osf_group = OSFGroupFactory(creator=user)
         osf_group.make_member(user_two)
-        project.add_osf_group(osf_group, 'admin')
+        project.add_osf_group(osf_group, permissions.ADMIN)
 
         url = '/{}nodes/{}/contributors/{}/'.format(
             API_BASE, project._id, user_two._id)
         res = app.get(url, auth=user.auth)
         # Even though user_two has admin perms through group membership,
         # contributor endpoints return contributor permissions
-        assert res.json['data']['attributes']['permission'] == 'write'
-        assert project.has_permission(user_two, 'admin') is True
+        assert res.json['data']['attributes']['permission'] == permissions.WRITE
+        assert project.has_permission(user_two, permissions.ADMIN) is True
 
     def test_detail_includes_index(
             self,
@@ -652,7 +652,7 @@ class TestNodeContributorUpdate:
     #   test_change_contributor_non_admin_osf_group_member_auth
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project.add_osf_group(group, 'write')
+        project.add_osf_group(group, permissions.WRITE)
         data = {
             'data': {
                 'id': contrib._id,
@@ -737,7 +737,7 @@ class TestNodeContributorUpdate:
             self, app, user, contrib, project, url_contrib):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project.add_osf_group(group, 'admin')
+        project.add_osf_group(group, permissions.ADMIN)
         contrib_id = '{}-{}'.format(project._id, contrib._id)
         data = {
             'data': {
@@ -1176,7 +1176,7 @@ class TestNodeContributorDelete:
             # osf-models
             group_mem = AuthUserFactory()
             group = OSFGroupFactory(creator=group_mem)
-            project.add_osf_group(group, 'admin')
+            project.add_osf_group(group, permissions.ADMIN)
             with disconnected_from_listeners(contributor_removed):
                 res = app.delete(url_user_write_contrib, auth=group_mem.auth)
             assert res.status_code == 204

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -130,9 +130,9 @@ class TestNodeContributorList(NodeCRUDTestCase):
     def test_permissions_work_with_many_users(
             self, app, user, project_private, url_private):
         users = {
-            'admin': [user._id],
-            'write': [],
-            'read': []
+            permissions.ADMIN: [user._id],
+            permissions.WRITE: [],
+            permissions.READ: []
         }
         for i in range(0, 25):
             perm = random.choice(users.keys())
@@ -174,7 +174,7 @@ class TestNodeContributorList(NodeCRUDTestCase):
     #   test_return_private_contributor_list_logged_in_osf_group_member
         res = app.get(url_private, auth=user_two.auth, expect_errors=True)
         osf_group = OSFGroupFactory(creator=user_two)
-        project_private.add_osf_group(osf_group, 'read')
+        project_private.add_osf_group(osf_group, permissions.READ)
         res = app.get(url_private, auth=user_two.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
@@ -688,7 +688,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             self, app, user, user_two, user_three,
             project_public, data_user_three, url_public):
         group = OSFGroupFactory(creator=user_two)
-        project_public.add_osf_group(group, 'write')
+        project_public.add_osf_group(group, permissions.WRITE)
         res = app.post_json_api(url_public, data_user_three,
                                 auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
@@ -724,7 +724,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             self, app, user, user_two, user_three, project_private,
             data_user_two, url_private):
         osf_group = OSFGroupFactory(creator=user_three)
-        project_private.add_osf_group(osf_group, 'admin')
+        project_private.add_osf_group(osf_group, permissions.ADMIN)
         with assert_latest_log(NodeLog.CONTRIB_ADDED, project_private):
             res = app.post_json_api(url_private, data_user_two, auth=user_three.auth)
             assert res.status_code == 201
@@ -788,7 +788,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_private.reload()
             assert user_two in project_private.contributors
             assert project_private.get_permissions(user_two) == [
-                'read', 'write', 'admin']
+                permissions.READ, permissions.WRITE, permissions.ADMIN]
 
     def test_adds_write_contributor_private_project_admin(
             self, app, user, user_two, project_private, url_private):
@@ -818,7 +818,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_private.reload()
             assert user_two in project_private.contributors
             assert project_private.get_permissions(
-                user_two) == ['read', 'write']
+                user_two) == [permissions.READ, permissions.WRITE]
 
     def test_adds_read_contributor_private_project_admin(
             self, app, user, user_two, project_private, url_private):
@@ -848,7 +848,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             project_private.reload()
             assert user_two in project_private.contributors
             assert project_private.get_permissions(user_two) == [
-                'read']
+                permissions.READ]
 
     def test_adds_invalid_permission_contributor_private_project_admin(
             self, app, user, user_two, project_private, url_private):
@@ -902,7 +902,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
             project_private.reload()
             assert user_two in project_private.contributors
-            assert project_private.has_permission(user_two, 'write')
+            assert project_private.has_permission(user_two, permissions.WRITE)
 
     def test_adds_already_existing_contributor_private_project_admin(
             self, app, user, user_two, project_private, data_user_two, url_private):
@@ -1559,7 +1559,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             },
             'relationships': {
                 'users': {
@@ -1577,7 +1577,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'read'
+                'permission': permissions.READ
             },
             'relationships': {
                 'users': {
@@ -1668,7 +1668,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         assert_items_equal([res.json['data'][0]['attributes']['bibliographic'],
                             res.json['data'][1]['attributes']['bibliographic']], [True, False])
         assert_items_equal([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], ['admin', 'read'])
+                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
         assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_public, auth=user.auth)
@@ -1683,7 +1683,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         assert_items_equal([res.json['data'][0]['attributes']['bibliographic'],
                             res.json['data'][1]['attributes']['bibliographic']], [True, False])
         assert_items_equal([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], ['admin', 'read'])
+                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
         assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_private, auth=user.auth)
@@ -1827,7 +1827,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -1838,7 +1838,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -1849,7 +1849,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -1861,7 +1861,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -1904,7 +1904,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_public_projects_logged_out
@@ -1923,7 +1923,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_private_projects_logged_out
@@ -1942,7 +1942,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_update_contributors_private_projects_logged_in_non_contrib
         res = app.put_json_api(
@@ -1961,7 +1961,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_update_contributors_private_projects_logged_in_read_only_contrib
         res = app.put_json_api(
@@ -1980,7 +1980,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_projects_send_dictionary_not_list
@@ -2089,7 +2089,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_invalid_bibliographic
@@ -2119,7 +2119,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor
@@ -2133,7 +2133,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
                         ),
                         'type': 'contributors',
                         'attributes': {
-                            'permission': 'admin',
+                            'permission': permissions.ADMIN,
                             'bibliographic': False
                         }
                     }, {
@@ -2163,7 +2163,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
                     ),
                     'type': 'contributors',
                     'attributes': {
-                            'permission': 'read'
+                            'permission': permissions.READ
                     }
                 }
             ]},
@@ -2185,7 +2185,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write']
+            [permissions.ADMIN, permissions.WRITE]
         )
 
     def test_bulk_update_contributors_private_projects_logged_in_contrib(
@@ -2200,7 +2200,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write']
+            [permissions.ADMIN, permissions.WRITE]
         )
 
 
@@ -2275,7 +2275,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -2286,7 +2286,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -2297,7 +2297,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -2309,7 +2309,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -2346,7 +2346,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_public_projects_logged_out
@@ -2362,7 +2362,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_private_projects_logged_out
@@ -2379,7 +2379,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_contributors_private_projects_logged_in_non_contrib
         res = app.patch_json_api(
@@ -2396,7 +2396,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_private_projects_logged_in_read_only_contrib
@@ -2414,7 +2414,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_contributors_projects_send_dictionary_not_list
         res = app.patch_json_api(
@@ -2511,7 +2511,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_invalid_bibliographic
         res = app.patch_json_api(
@@ -2537,7 +2537,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     def test_bulk_partial_update_contributors_public_projects_logged_in(
             self, app, user, payload_public_one, payload_public_two, url_public):
@@ -2550,7 +2550,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write'])
+            [permissions.ADMIN, permissions.WRITE])
 
     def test_bulk_partial_update_contributors_private_projects_logged_in_contrib(
             self, app, user, payload_private_one, payload_private_two, url_private):
@@ -2563,7 +2563,7 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write'])
+            [permissions.ADMIN, permissions.WRITE])
 
 
 class TestNodeContributorBulkDelete(NodeCRUDTestCase):
@@ -2922,7 +2922,7 @@ class TestNodeContributorFiltering:
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get('permission') == 'admin'
+        assert res.json['data'][0]['attributes'].get('permission') == permissions.ADMIN
 
     #   test_filtering_node_with_only_bibliographic_contributors
         base_url = '/{}nodes/{}/contributors/'.format(API_BASE, project._id)
@@ -2954,13 +2954,13 @@ class TestNodeContributorFiltering:
 
     #   test_filtering_write_contributors
         user_two = AuthUserFactory()
-        project.add_contributor(user_two, 'write')
+        project.add_contributor(user_two, permissions.WRITE)
         url = '/{}nodes/{}/contributors/?filter[permission]=write'.format(
             API_BASE, project._id)
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get('permission') == 'write'
+        assert res.json['data'][0]['attributes'].get('permission') == permissions.WRITE
 
     def test_filtering_node_with_non_bibliographic_contributor(
             self, app, user, project):

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -12,6 +12,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     RegistrationFactory,
 )
+from osf.utils.permissions import WRITE, READ
 from rest_framework import exceptions
 from test_node_draft_registration_list import DraftRegistrationTestCase
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
@@ -89,7 +90,7 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
 
     #   test_group_mem_read_cannot_view
         project_public.remove_osf_group(group)
-        project_public.add_osf_group(group, 'read')
+        project_public.add_osf_group(group, READ)
         res = app.get(url_draft_registrations, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -284,7 +285,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
 
     #   test_osf_group_member_write_cannot_update_draft
         project_public.remove_osf_group(group)
-        project_public.add_osf_group(group, 'write')
+        project_public.add_osf_group(group, WRITE)
         res = app.put_json_api(
             url_draft_registrations,
             payload, expect_errors=True,
@@ -741,7 +742,7 @@ class TestDraftRegistrationDelete(DraftRegistrationTestCase):
 
     #   test_group_member_write_cannot_delete_draft
         project_public.remove_osf_group(group)
-        project_public.add_osf_group(group, 'write')
+        project_public.add_osf_group(group, WRITE)
         res = app.delete_json_api(url_draft_registrations, expect_errors=True, auth=group_mem.auth)
         assert res.status_code == 403
 

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -55,7 +55,7 @@ class DraftRegistrationTestCase:
             user_read_contrib,
             permissions=permissions.READ)
         project_public.save()
-        project_public.add_osf_group(group, 'admin')
+        project_public.add_osf_group(group, permissions.ADMIN)
         return project_public
 
     @pytest.fixture()
@@ -118,7 +118,7 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
     #   test_osf_group_with_admin_permissions
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project_public.add_osf_group(group, 'admin')
+        project_public.add_osf_group(group, permissions.ADMIN)
         res = app.get(url_draft_registrations, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 200
         data = res.json['data']
@@ -157,7 +157,7 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
 
     #   test_osf_group_with_read_permissions
         project_public.remove_osf_group(group)
-        project_public.add_osf_group(group, 'read')
+        project_public.add_osf_group(group, permissions.READ)
         res = app.get(url_draft_registrations, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -325,7 +325,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
 
     #   test_group_write_contrib_cannot_create_draft
         project_public.remove_osf_group(group)
-        project_public.add_osf_group(group, 'write')
+        project_public.add_osf_group(group, permissions.WRITE)
         res = app.post_json_api(
             url_draft_registrations,
             payload,

--- a/api_tests/nodes/views/test_node_embeds.py
+++ b/api_tests/nodes/views/test_node_embeds.py
@@ -7,6 +7,7 @@ from osf_tests.factories import (
     ProjectFactory,
     AuthUserFactory
 )
+from osf.utils.permissions import WRITE
 from rest_framework import exceptions
 
 
@@ -45,10 +46,10 @@ class TestNodeEmbeds:
             write_contrib_two, make_public_node):
         root_node = make_public_node()
         root_node.add_contributor(
-            write_contrib_one, 'write',
+            write_contrib_one, WRITE,
             auth=auth, save=True)
         root_node.add_contributor(
-            write_contrib_two, 'write',
+            write_contrib_two, WRITE,
             auth=auth, save=True)
         return root_node
 
@@ -59,10 +60,10 @@ class TestNodeEmbeds:
             root_node):
         child_one = make_public_node(parent=root_node)
         child_one.add_contributor(
-            write_contrib_one, 'write',
+            write_contrib_one, WRITE,
             auth=auth, save=True)
         child_one.add_contributor(
-            write_contrib_two, 'write',
+            write_contrib_two, WRITE,
             auth=auth, save=True)
         return child_one
 

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -20,6 +20,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     PrivateLinkFactory
 )
+from osf.utils.permissions import READ
 
 
 def prepare_mock_wb_response(
@@ -219,7 +220,7 @@ class TestNodeFilesList(ApiTestCase):
     def test_returns_private_files_logged_in_osf_group_member(self):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        self.project.add_osf_group(group, 'read')
+        self.project.add_osf_group(group, READ)
         res = self.app.get(
             self.private_url,
             auth=group_mem.auth,

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -166,8 +166,8 @@ class TestNodeForksList:
         assert forked_from['id'] == private_project._id
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
-        private_fork.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, permissions.READ)
+        private_fork.add_osf_group(group, permissions.READ)
         res = app.get(
             private_project_url,
             auth=group_mem.auth)
@@ -350,7 +350,7 @@ class TestNodeForkCreate:
     #   test_group_member_read_can_create_fork_of_private_node
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, permissions.READ)
         res = app.post_json_api(
             private_project_url,
             fork_data, auth=user.auth)

--- a/api_tests/nodes/views/test_node_implicit_contributors_list.py
+++ b/api_tests/nodes/views/test_node_implicit_contributors_list.py
@@ -7,6 +7,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     NodeFactory
 )
+from osf.utils.permissions import READ
 
 
 @pytest.fixture()
@@ -63,7 +64,7 @@ class TestNodeImplicitContributors:
     def test_osf_group_members_can_view_implicit_contributors(self, app, component, admin_contributor, implicit_contributor):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        component.add_osf_group(group, 'read')
+        component.add_osf_group(group, READ)
 
         url = '/{}nodes/{}/implicit_contributors/'.format(API_BASE, component._id)
         res = app.get(url, auth=group_mem.auth)

--- a/api_tests/nodes/views/test_node_institutions_list.py
+++ b/api_tests/nodes/views/test_node_institutions_list.py
@@ -1,6 +1,7 @@
 import pytest
 
 from osf_tests.factories import InstitutionFactory, NodeFactory, AuthUserFactory, OSFGroupFactory
+from osf.utils.permissions import READ
 from api.base.settings.defaults import API_BASE
 
 
@@ -51,7 +52,7 @@ class TestNodeInstitutionDetail:
     #   test_osf_group_member_can_view_node_institutions
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_one.add_osf_group(group, 'read')
+        node_one.add_osf_group(group, READ)
         url = '/{0}nodes/{1}/institutions/'.format(API_BASE, node_one._id)
         res = app.get(url)
         assert res.status_code == 200

--- a/api_tests/nodes/views/test_node_linked_nodes.py
+++ b/api_tests/nodes/views/test_node_linked_nodes.py
@@ -7,6 +7,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     AuthUserFactory,
 )
+from osf.utils.permissions import WRITE, READ
 from website.project.signals import contributor_removed
 from api_tests.utils import disconnected_from_listeners
 
@@ -113,7 +114,7 @@ class TestNodeRelationshipNodeLinks:
     #   test_get_private_relationship_linked_nodes_read_group_mem
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_linking_private.add_osf_group(group, 'read')
+        node_linking_private.add_osf_group(group, READ)
         res = app.get(url_private, auth=group_mem.auth)
         assert res.status_code == 200
 
@@ -167,7 +168,7 @@ class TestNodeRelationshipNodeLinks:
     #   test_group_member_can_post_with_write
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_linking_private.add_osf_group(group, 'read')
+        node_linking_private.add_osf_group(group, READ)
         res = app.post_json_api(
             url_private,
             make_payload([node_other._id]),
@@ -175,8 +176,8 @@ class TestNodeRelationshipNodeLinks:
         )
         assert res.status_code == 403
 
-        node_linking_private.update_osf_group(group, 'write')
-        node_other.add_osf_group(group, 'write')
+        node_linking_private.update_osf_group(group, WRITE)
+        node_other.add_osf_group(group, WRITE)
         res = app.post_json_api(
             url_private,
             make_payload([node_other._id]),

--- a/api_tests/nodes/views/test_node_linked_registrations.py
+++ b/api_tests/nodes/views/test_node_linked_registrations.py
@@ -8,6 +8,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     RegistrationFactory,
 )
+from osf.utils.permissions import READ
 from rest_framework import exceptions
 
 
@@ -51,7 +52,7 @@ class LinkedRegistrationsTestCase:
             auth=Auth(user_admin_contrib))
         node_private.add_contributor(
             user_read_contrib,
-            permissions='read',
+            permissions=READ,
             auth=Auth(user_admin_contrib))
         node_private.add_pointer(registration, auth=Auth(user_admin_contrib))
         return node_private
@@ -117,7 +118,7 @@ class TestNodeLinkedRegistrationsList(LinkedRegistrationsTestCase):
     #   test_osf_group_member_read_can_view_linked_reg
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_private.add_osf_group(group, 'read')
+        node_private.add_osf_group(group, READ)
         res = make_request(
             node_id=node_private._id,
             auth=group_mem.auth,
@@ -186,7 +187,7 @@ class TestNodeLinkedRegistrationsRelationshipRetrieve(
     #   test_osf_group_member_can_view_linked_registration_relationship
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_private.add_osf_group(group, 'read')
+        node_private.add_osf_group(group, READ)
         res = make_request(
             node_id=node_private._id,
             auth=group_mem.auth,
@@ -277,7 +278,7 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
     #   test_read_osf_group_mem_cannot_create_linked_registrations_relationship
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        node_private.add_osf_group(group, 'read')
+        node_private.add_osf_group(group, READ)
         registration = RegistrationFactory(is_public=True)
         res = make_request(
             node_id=node_private._id,
@@ -361,7 +362,7 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
         registration.add_contributor(
             user_admin_contrib,
             auth=Auth(registration.creator),
-            permissions='read')
+            permissions=READ)
         registration.save()
         res = make_request(
             node_id=node_private._id,

--- a/api_tests/nodes/views/test_node_links_detail.py
+++ b/api_tests/nodes/views/test_node_links_detail.py
@@ -9,6 +9,7 @@ from osf_tests.factories import (
     RegistrationFactory,
     AuthUserFactory,
 )
+from osf.utils.permissions import WRITE, READ
 from rest_framework import exceptions
 from tests.utils import assert_latest_log
 
@@ -111,7 +112,7 @@ class TestNodeLinkDetail:
     #   test_returns_private_node_pointer_detail_logged_in_group_mem
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(private_url, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -301,10 +302,10 @@ class TestDeleteNodeLink:
             self, app, user_two, private_url, private_project):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.delete(private_url, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
-        private_project.update_osf_group(group, 'write')
+        private_project.update_osf_group(group, WRITE)
         res = app.delete(private_url, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 204
 

--- a/api_tests/nodes/views/test_node_links_list.py
+++ b/api_tests/nodes/views/test_node_links_list.py
@@ -9,6 +9,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     AuthUserFactory
 )
+from osf.utils.permissions import WRITE, READ
 from rest_framework import exceptions
 from tests.utils import assert_latest_log
 
@@ -105,7 +106,7 @@ class TestNodeLinksList:
     #   test_osf_group_member_read_can_view
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(
             private_url,
             auth=group_mem.auth,
@@ -397,7 +398,7 @@ class TestNodeLinkCreate:
 
             group_mem = AuthUserFactory()
             group = OSFGroupFactory(creator=group_mem)
-            public_project.add_osf_group(group, 'read')
+            public_project.add_osf_group(group, READ)
             res = app.post_json_api(
                 public_url, public_payload,
                 auth=group_mem.auth, expect_errors=True)
@@ -423,7 +424,7 @@ class TestNodeLinkCreate:
             self, app, private_project, private_pointer_project, private_url, make_payload):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'write')
+        private_project.add_osf_group(group, WRITE)
         private_payload = make_payload(id=private_pointer_project._id)
         res = app.post_json_api(
             private_url, private_payload, auth=group_mem.auth)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -108,7 +108,7 @@ class TestNodeList:
     #   test_returns_nodes_through_which_you_have_perms_through_osf_groups
         group = OSFGroupFactory(creator=user)
         another_project = ProjectFactory()
-        another_project.add_osf_group(group, 'read')
+        another_project.add_osf_group(group, permissions.READ)
         res = app.get(url, auth=user.auth)
         ids = [each['id'] for each in res.json['data']]
         assert another_project._id in ids
@@ -167,7 +167,7 @@ class TestNodeList:
         assert default_node_permission_queryset(user_2, Node).count() == 0
 
         # Node write contributor
-        private_project.add_contributor(user_2, 'read')
+        private_project.add_contributor(user_2, permissions.READ)
         private_project.save()
         assert default_node_permission_queryset(user_2, Node).count() == 1
 
@@ -179,7 +179,7 @@ class TestNodeList:
         project_3 = ProjectFactory(is_public=False)
         assert default_node_permission_queryset(user_2, Node).count() == 2
         group = OSFGroupFactory(creator=user_2)
-        project_3.add_osf_group(group, 'read')
+        project_3.add_osf_group(group, permissions.READ)
         assert default_node_permission_queryset(user_2, Node).count() == 3
 
     def test_current_user_permissions(self, app, user, url, public_project, non_contrib):
@@ -237,7 +237,7 @@ class TestNodeList:
         # Read group member has "read" permissions
         group_member = AuthUserFactory()
         osf_group = OSFGroupFactory(creator=group_member)
-        public_project.add_osf_group(osf_group, 'read')
+        public_project.add_osf_group(osf_group, permissions.READ)
         res = app.get(url_public, auth=group_member.auth)
         assert public_project.has_permission(group_member, permissions.READ)
         assert permissions.READ in res.json['data'][0]['attributes']['current_user_permissions']
@@ -246,7 +246,7 @@ class TestNodeList:
         # Write group member has "read" and "write" permissions
         group_member = AuthUserFactory()
         osf_group = OSFGroupFactory(creator=group_member)
-        public_project.add_osf_group(osf_group, 'write')
+        public_project.add_osf_group(osf_group, permissions.WRITE)
         res = app.get(url_public, auth=group_member.auth)
         assert res.json['data'][0]['attributes']['current_user_permissions'] == [permissions.WRITE, permissions.READ]
         assert res.json['data'][0]['attributes']['current_user_is_contributor'] is False
@@ -255,7 +255,7 @@ class TestNodeList:
         # Admin group member has "read" and "write" and "admin" permissions
         group_member = AuthUserFactory()
         osf_group = OSFGroupFactory(creator=group_member)
-        public_project.add_osf_group(osf_group, 'admin')
+        public_project.add_osf_group(osf_group, permissions.ADMIN)
         res = app.get(url_public, auth=group_member.auth)
         assert res.json['data'][0]['attributes']['current_user_permissions'] == [permissions.ADMIN, permissions.WRITE, permissions.READ]
         assert res.json['data'][0]['attributes']['current_user_is_contributor'] is False
@@ -951,7 +951,7 @@ class TestNodeFiltering:
         assert unpublished.node._id not in [each['id'] for each in res.json['data']]
 
         # write contrib
-        unpublished.add_contributor(user_two, 'write', save=True)
+        unpublished.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert unpublished.node._id in [each['id'] for each in res.json['data']]
@@ -983,7 +983,7 @@ class TestNodeFiltering:
         assert unpublished.node._id in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        unpublished.add_contributor(user_two, 'write', save=True)
+        unpublished.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert unpublished.node._id not in [each['id'] for each in res.json['data']]
@@ -1015,7 +1015,7 @@ class TestNodeFiltering:
         assert private.node._id not in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        private.add_contributor(user_two, 'write', save=True)
+        private.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert private.node._id in [each['id'] for each in res.json['data']]
@@ -1047,7 +1047,7 @@ class TestNodeFiltering:
         assert private.node._id in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        private.add_contributor(user_two, 'write', save=True)
+        private.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert private.node._id not in [each['id'] for each in res.json['data']]
@@ -1079,7 +1079,7 @@ class TestNodeFiltering:
         assert orphan.node._id not in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        orphan.add_contributor(user_two, 'write', save=True)
+        orphan.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert orphan.node._id in [each['id'] for each in res.json['data']]
@@ -1111,7 +1111,7 @@ class TestNodeFiltering:
         assert orphan.node._id in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        orphan.add_contributor(user_two, 'write', save=True)
+        orphan.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert orphan.node._id not in [each['id'] for each in res.json['data']]
@@ -1143,7 +1143,7 @@ class TestNodeFiltering:
         assert abandoned.node._id not in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        abandoned.add_contributor(user_two, 'write', save=True)
+        abandoned.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert abandoned.node._id not in [each['id'] for each in res.json['data']]
@@ -1175,7 +1175,7 @@ class TestNodeFiltering:
         assert abandoned.node._id in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        abandoned.add_contributor(user_two, 'write', save=True)
+        abandoned.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert abandoned.node._id in [each['id'] for each in res.json['data']]
@@ -1207,7 +1207,7 @@ class TestNodeFiltering:
         assert deleted.node._id not in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        deleted.add_contributor(user_two, 'write', save=True)
+        deleted.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert deleted.node._id not in [each['id'] for each in res.json['data']]
@@ -1239,7 +1239,7 @@ class TestNodeFiltering:
         assert deleted.node._id in [each['id'] for each in res.json['data']]
 
         # write contrib (preprint)
-        deleted.add_contributor(user_two, 'write', save=True)
+        deleted.add_contributor(user_two, permissions.WRITE, save=True)
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200
         assert deleted.node._id in [each['id'] for each in res.json['data']]
@@ -1270,7 +1270,7 @@ class TestNodeFiltering:
             self, app, user_one, user_two):
         project_one = ProjectFactory(creator=user_one, is_public=True)
         preprint_one = PreprintFactory(is_published=False, creator=user_one, project=project_one)
-        project_one.add_contributor(user_two, 'write', save=True)
+        project_one.add_contributor(user_two, permissions.WRITE, save=True)
         preprint_one.date_withdrawn = timezone.now()
         preprint_one.is_public = True
         preprint_one.is_published = True
@@ -1282,7 +1282,7 @@ class TestNodeFiltering:
         preprint_one.save()
 
         project_two = ProjectFactory(creator=user_one, is_public=True)
-        project_two.add_contributor(user_two, 'write', save=True)
+        project_two.add_contributor(user_two, permissions.WRITE, save=True)
         preprint_two = PreprintFactory(creator=user_one, project=project_two)
         preprint_two.date_withdrawn = timezone.now()
         preprint_two.ever_public = True
@@ -1304,8 +1304,8 @@ class TestNodeFiltering:
 
         # Read contribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
-        preprint_one.add_contributor(user2, 'read')
-        preprint_two.add_contributor(user2, 'read')
+        preprint_one.add_contributor(user2, permissions.READ)
+        preprint_two.add_contributor(user2, permissions.READ)
         expected = [project_two._id]
         res = app.get(url, auth=user2.auth)
         actual = [preprint['id'] for preprint in res.json['data']]
@@ -1321,7 +1321,7 @@ class TestNodeFiltering:
             self, app, user_one, user_two):
         project_one = ProjectFactory(creator=user_one, is_public=True)
         preprint_one = PreprintFactory(is_published=False, creator=user_one, project=project_one)
-        project_one.add_contributor(user_two, 'write', save=True)
+        project_one.add_contributor(user_two, permissions.WRITE, save=True)
         preprint_one.date_withdrawn = timezone.now()
         preprint_one.is_public = True
         preprint_one.is_published = True
@@ -1333,7 +1333,7 @@ class TestNodeFiltering:
         preprint_one.save()
 
         project_two = ProjectFactory(creator=user_one, is_public=True)
-        project_two.add_contributor(user_two, 'write', save=True)
+        project_two.add_contributor(user_two, permissions.WRITE, save=True)
         preprint_two = PreprintFactory(creator=user_one, project=project_two)
         preprint_two.date_withdrawn = timezone.now()
         preprint_two.ever_public = True
@@ -1355,8 +1355,8 @@ class TestNodeFiltering:
 
         # Read contribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
-        preprint_one.add_contributor(user2, 'read')
-        preprint_two.add_contributor(user2, 'read')
+        preprint_one.add_contributor(user2, permissions.READ)
+        preprint_two.add_contributor(user2, permissions.READ)
         expected = [project_one._id]
         res = app.get(url, auth=user2.auth)
         actual = [preprint['id'] for preprint in res.json['data']]
@@ -1645,8 +1645,8 @@ class TestNodeCreate:
         second_group = OSFGroupFactory()
         third_group = OSFGroupFactory(creator=user_two)
         third_group.make_member(user_one)
-        parent_project.add_osf_group(group, 'write')
-        parent_project.add_osf_group(second_group, 'write')
+        parent_project.add_osf_group(group, permissions.WRITE)
+        parent_project.add_osf_group(second_group, permissions.WRITE)
         url = '/{}nodes/{}/children/?inherit_contributors=true'.format(
             API_BASE, parent_project._id)
         component_data = {
@@ -1702,7 +1702,7 @@ class TestNodeCreate:
         osf_group = OSFGroupFactory(creator=user_one)
         osf_group.add_unregistered_member(fullname='far', email='foo@bar.baz', auth=Auth(user_one))
         osf_group.save()
-        parent_project.add_osf_group(osf_group, 'admin')
+        parent_project.add_osf_group(osf_group, permissions.ADMIN)
         url = '/{}nodes/{}/children/?inherit_contributors=true'.format(
             API_BASE, parent_project._id)
         component_data = {
@@ -1724,7 +1724,7 @@ class TestNodeCreate:
         assert len(
             new_component.contributors
         ) == len(parent_project.contributors)
-        expected_perms = set(['read', 'admin'])
+        expected_perms = set([permissions.READ, permissions.ADMIN])
         actual_perms = set([contributor.permission for contributor in new_component.contributor_set.all()])
         assert actual_perms == expected_perms
 
@@ -3792,9 +3792,9 @@ class TestNodeBulkDeleteSkipUneditable:
             self, app, public_project_one, public_project_three, url):
         group_member = AuthUserFactory()
         group = OSFGroupFactory(creator=group_member)
-        public_project_one.add_osf_group(group, 'admin')
+        public_project_one.add_osf_group(group, permissions.ADMIN)
         public_project_one.save()
-        public_project_three.add_osf_group(group, 'write')
+        public_project_three.add_osf_group(group, permissions.WRITE)
         public_project_three.save()
         payload = {
             'data': [

--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -11,6 +11,7 @@ from osf_tests.factories import (
     RegistrationFactory,
     EmbargoFactory,
 )
+from osf.utils.permissions import READ
 from tests.base import assert_datetime_equal
 from api_tests.utils import disconnected_from_listeners
 from website.project.signals import contributor_removed
@@ -79,7 +80,7 @@ class TestNodeLogList:
     def test_can_view_osf_group_log(self, app, private_project, private_url):
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(private_url, auth=group_mem.auth)
         assert res.status_code == 200
 

--- a/api_tests/nodes/views/test_node_preprints.py
+++ b/api_tests/nodes/views/test_node_preprints.py
@@ -91,8 +91,8 @@ class TestNodePreprintsListFiltering(PreprintsListFilteringMixin):
 
         # contribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
-        preprint_one.add_contributor(user2, 'read')
-        preprint_two.add_contributor(user2, 'read')
+        preprint_one.add_contributor(user2, permissions.READ)
+        preprint_two.add_contributor(user2, permissions.READ)
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
         actual = [preprint['id'] for preprint in res.json['data']]

--- a/api_tests/nodes/views/test_node_registrations_list.py
+++ b/api_tests/nodes/views/test_node_registrations_list.py
@@ -8,6 +8,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     AuthUserFactory,
 )
+from osf.utils.permissions import READ
 
 
 def node_url_for(n_id):
@@ -87,7 +88,7 @@ class TestNodeRegistrationList:
     #   test_return_private_registration_group_mem_read
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(private_url, expect_errors=True, auth=group_mem.auth)
         assert res.status_code == 200
 

--- a/api_tests/nodes/views/test_node_wiki_list.py
+++ b/api_tests/nodes/views/test_node_wiki_list.py
@@ -14,6 +14,7 @@ from osf_tests.factories import (
     OSFGroupFactory,
     RegistrationFactory,
 )
+from osf.utils.permissions import WRITE, READ
 from tests.base import fake
 
 
@@ -126,7 +127,7 @@ class TestNodeWikiList:
     #   test_return_private_node_wikis_logged_in_osf_group_member
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        private_project.add_osf_group(group, 'read')
+        private_project.add_osf_group(group, READ)
         res = app.get(private_url, auth=group_mem.auth)
         assert res.status_code == 200
         wiki_ids = [wiki['id'] for wiki in res.json['data']]
@@ -349,7 +350,7 @@ class TestNodeWikiCreate(WikiCRUDTestCase):
         # test_osf_group_member_write
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project_public.add_osf_group(group, 'write')
+        project_public.add_osf_group(group, WRITE)
         res = app.post_json_api(url_node_public, create_wiki_payload(fake.word()), auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 201
 
@@ -386,7 +387,7 @@ class TestNodeWikiCreate(WikiCRUDTestCase):
         # test_do_not_create_public_wiki_page_as_read_osf_group_member
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project_public.add_osf_group(group, 'read')
+        project_public.add_osf_group(group, READ)
         res = app.post_json_api(url_node_public, create_wiki_payload(fake.word()), auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
 

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -179,7 +179,7 @@ class TestNodeDetailViewOnlyLinks:
             {'view_only': private_node_one_private_link.key})
         assert res_linked.status_code == 200
         assert res_linked.json['data']['attributes']['current_user_permissions'] == [
-            'read']
+            permissions.READ]
 
         # Remove any keys that will be different for view-only responses
         res_normal_json = res_normal.json

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from nose.tools import *  # noqa:
 from osf_tests.factories import AuthUserFactory, PreprintFactory
 from tests.base import ApiTestCase
+from osf.utils.permissions import WRITE
 from osf.utils.workflows import DefaultStates
 
 
@@ -89,7 +90,7 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.unpublished_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
         assert_equal(res.status_code, 403)
@@ -111,7 +112,7 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 200)
@@ -133,7 +134,7 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
         assert_equal(res.status_code, 404)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 404)
@@ -155,7 +156,7 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 403)
@@ -177,7 +178,7 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 200)
@@ -234,7 +235,7 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.unpublished_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
         assert_equal(res.status_code, 403)
@@ -256,7 +257,7 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 200)
@@ -278,7 +279,7 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
         assert_equal(res.status_code, 404)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 404)
@@ -300,7 +301,7 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 403)
@@ -322,7 +323,7 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
         assert_equal(res.status_code, 403)
 
         # Write contrib
-        self.published_preprint.add_contributor(self.other_contrib, 'write', save=True)
+        self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth)
         # Really because preprint is in initial machine state
         assert_equal(res.status_code, 200)

--- a/api_tests/preprints/views/test_preprint_contributors_detail.py
+++ b/api_tests/preprints/views/test_preprint_contributors_detail.py
@@ -684,7 +684,7 @@ class TestPreprintContributorUpdate:
             auth=user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert preprint.get_permissions(contrib) == ['read', 'write']
+        assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE]
         assert preprint.get_visible(contrib)
 
     #   test_change_contributor_not_logged_in
@@ -702,7 +702,7 @@ class TestPreprintContributorUpdate:
         assert res.status_code == 401
 
         preprint.reload()
-        assert preprint.get_permissions(contrib) == ['read', 'write']
+        assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE]
         assert preprint.get_visible(contrib)
 
     #   test_change_contributor_non_admin_auth
@@ -723,7 +723,7 @@ class TestPreprintContributorUpdate:
         assert res.status_code == 403
 
         preprint.reload()
-        assert preprint.get_permissions(contrib) == ['read', 'write']
+        assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE]
         assert preprint.get_visible(contrib)
 
     def test_change_admin_self_without_other_admin(
@@ -746,7 +746,7 @@ class TestPreprintContributorUpdate:
         assert res.status_code == 400
 
         preprint.reload()
-        assert preprint.get_permissions(user) == ['read', 'write', 'admin']
+        assert preprint.get_permissions(user) == [permissions.READ, permissions.WRITE, permissions.ADMIN]
 
     def test_node_update_invalid_data(self, app, user, url_creator):
         res = app.put_json_api(
@@ -827,7 +827,7 @@ class TestPreprintContributorUpdate:
             assert attributes['permission'] == permissions.ADMIN
 
             preprint.reload()
-            assert preprint.get_permissions(contrib) == ['read', 'write', 'admin']
+            assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE, permissions.ADMIN]
 
         with assert_latest_log(PreprintLog.PERMISSIONS_UPDATED, preprint):
             data = {
@@ -846,7 +846,7 @@ class TestPreprintContributorUpdate:
             assert attributes['permission'] == permissions.WRITE
 
             preprint.reload()
-            assert preprint.get_permissions(contrib) == ['read', 'write']
+            assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE]
 
         with assert_latest_log(PreprintLog.PERMISSIONS_UPDATED, preprint):
             data = {
@@ -865,7 +865,7 @@ class TestPreprintContributorUpdate:
             assert attributes['permission'] == permissions.READ
 
             preprint.reload()
-            assert preprint.get_permissions(contrib) == ['read']
+            assert preprint.get_permissions(contrib) == [permissions.READ]
 
     def test_change_contributor_bibliographic(
             self, app, user, contrib, preprint, url_contrib):
@@ -927,7 +927,7 @@ class TestPreprintContributorUpdate:
             assert not attributes['bibliographic']
 
             preprint.reload()
-            assert preprint.get_permissions(contrib) == ['read']
+            assert preprint.get_permissions(contrib) == [permissions.READ]
             assert not preprint.get_visible(contrib)
 
     # @assert_not_logs(PreprintLog.PERMISSIONS_UPDATED, 'preprint')
@@ -952,7 +952,7 @@ class TestPreprintContributorUpdate:
             assert attributes['bibliographic']
 
             preprint.reload()
-            assert preprint.get_permissions(contrib) == ['read', 'write']
+            assert preprint.get_permissions(contrib) == [permissions.READ, permissions.WRITE]
             assert preprint.get_visible(contrib)
 
     def test_change_admin_self_with_other_admin(
@@ -976,7 +976,7 @@ class TestPreprintContributorUpdate:
             assert attributes['permission'] == permissions.WRITE
 
             preprint.reload()
-            assert preprint.get_permissions(user) == ['read', 'write']
+            assert preprint.get_permissions(user) == [permissions.READ, permissions.WRITE]
 
 
 @pytest.mark.django_db
@@ -1021,7 +1021,7 @@ class TestPreprintContributorPartialUpdate:
         res = app.patch_json_api(url_creator, data, auth=user.auth)
         assert res.status_code == 200
         preprint.reload()
-        assert preprint.get_permissions(user) == ['read', 'write', 'admin']
+        assert preprint.get_permissions(user) == [permissions.READ, permissions.WRITE, permissions.ADMIN]
         assert not preprint.get_visible(user)
 
     def test_patch_permission_only(self, app, user, preprint):
@@ -1046,7 +1046,7 @@ class TestPreprintContributorPartialUpdate:
         res = app.patch_json_api(url_read_contrib, data, auth=user.auth)
         assert res.status_code == 200
         preprint.reload()
-        assert preprint.get_permissions(user_read_contrib) == ['read']
+        assert preprint.get_permissions(user_read_contrib) == [permissions.READ]
         assert not preprint.get_visible(user_read_contrib)
 
 

--- a/api_tests/preprints/views/test_preprint_contributors_list.py
+++ b/api_tests/preprints/views/test_preprint_contributors_list.py
@@ -105,9 +105,9 @@ class TestPreprintContributorList(NodeCRUDTestCase):
     def test_permissions_work_with_many_users(
             self, app, user, preprint_unpublished, url_unpublished):
         users = {
-            'admin': [user._id],
-            'write': [],
-            'read': []
+            permissions.ADMIN: [user._id],
+            permissions.WRITE: [],
+            permissions.READ: []
         }
         for i in range(0, 25):
             perm = random.choice(users.keys())
@@ -147,7 +147,7 @@ class TestPreprintContributorList(NodeCRUDTestCase):
 
     #   test_return_unpublished_contributor_list_logged_in_read_contributor
         read_contrib = AuthUserFactory()
-        preprint_unpublished.add_contributor(read_contrib, permissions='read', save=True)
+        preprint_unpublished.add_contributor(read_contrib, permissions=permissions.READ, save=True)
         res = app.get(url_unpublished, auth=read_contrib.auth, expect_errors=True)
         assert res.status_code == 403
         assert 'detail' in res.json['errors'][0]
@@ -193,7 +193,7 @@ class TestPreprintContributorList(NodeCRUDTestCase):
         assert res.status_code == 403
 
         # test private_preprint_contributors_read_contrib_logged_out
-        preprint_published.add_contributor(user_two, 'read', save=True)
+        preprint_published.add_contributor(user_two, permissions.READ, save=True)
         res = app.get(url_published, auth=user_two.auth)
         assert res.status_code == 200
 
@@ -215,7 +215,7 @@ class TestPreprintContributorList(NodeCRUDTestCase):
         assert res.status_code == 404
 
         # test_deleted_preprint_contributors_read_contrib_logged_out
-        preprint_published.add_contributor(user_two, 'read', save=True)
+        preprint_published.add_contributor(user_two, permissions.READ, save=True)
         res = app.get(url_published, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 404
 
@@ -237,7 +237,7 @@ class TestPreprintContributorList(NodeCRUDTestCase):
         assert res.status_code == 403
 
         # test_abandoned_preprint_contributors_read_contrib_logged_out
-        preprint_published.add_contributor(user_two, 'read', save=True)
+        preprint_published.add_contributor(user_two, permissions.READ, save=True)
         res = app.get(url_published, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -259,7 +259,7 @@ class TestPreprintContributorList(NodeCRUDTestCase):
         assert res.status_code == 403
 
         # test_orphaned_preprint_contributors_read_contrib_logged_out
-        preprint_published.add_contributor(user_two, 'read', save=True)
+        preprint_published.add_contributor(user_two, permissions.READ, save=True)
         res = app.get(url_published, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 200
 
@@ -723,7 +723,7 @@ class TestPreprintContributorAdd(NodeCRUDTestCase):
             preprint_published, data_user_three, url_published):
         preprint_published.add_contributor(
             user_two,
-            permissions='write',
+            permissions=permissions.WRITE,
             auth=Auth(user),
             save=True)
         res = app.post_json_api(url_published, data_user_three,
@@ -810,7 +810,7 @@ class TestPreprintContributorAdd(NodeCRUDTestCase):
 
             preprint_unpublished.reload()
             assert user_two in preprint_unpublished.contributors
-            assert preprint_unpublished.get_permissions(user_two) == ['read', 'write', 'admin']
+            assert preprint_unpublished.get_permissions(user_two) == [permissions.READ, permissions.WRITE, permissions.ADMIN]
 
     def test_adds_write_contributor_unpublished_preprint_admin(
             self, app, user, user_two, preprint_unpublished, url_unpublished):
@@ -840,7 +840,7 @@ class TestPreprintContributorAdd(NodeCRUDTestCase):
             preprint_unpublished.reload()
             assert user_two in preprint_unpublished.contributors
             assert preprint_unpublished.get_permissions(
-                user_two) == ['read', 'write']
+                user_two) == [permissions.READ, permissions.WRITE]
 
     def test_adds_read_contributor_unpublished_preprint_admin(
             self, app, user, user_two, preprint_unpublished, url_unpublished):
@@ -869,7 +869,7 @@ class TestPreprintContributorAdd(NodeCRUDTestCase):
 
             preprint_unpublished.reload()
             assert user_two in preprint_unpublished.contributors
-            assert preprint_unpublished.get_permissions(user_two) == ['read']
+            assert preprint_unpublished.get_permissions(user_two) == [permissions.READ]
 
     def test_adds_invalid_permission_contributor_unpublished_preprint_admin(
             self, app, user, user_two, preprint_unpublished, url_unpublished):
@@ -923,8 +923,8 @@ class TestPreprintContributorAdd(NodeCRUDTestCase):
 
             preprint_unpublished.reload()
             assert user_two in preprint_unpublished.contributors
-            assert preprint_unpublished.has_permission(user_two, 'write')
-            assert preprint_unpublished.has_permission(user_two, 'read')
+            assert preprint_unpublished.has_permission(user_two, permissions.WRITE)
+            assert preprint_unpublished.has_permission(user_two, permissions.READ)
 
     def test_adds_already_existing_contributor_unpublished_preprint_admin(
             self, app, user, user_two, preprint_unpublished, data_user_two, url_unpublished):
@@ -1526,7 +1526,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
             self, mock_update, mock_mail, app, user, url_preprint_contribs, preprint_unpublished):
         url = '/{}preprints/{}/'.format(API_BASE, preprint_unpublished._id)
         user_two = AuthUserFactory()
-        preprint_unpublished.add_contributor(user_two, permissions='write', save=True)
+        preprint_unpublished.add_contributor(user_two, permissions=permissions.WRITE, save=True)
         payload = {
             'data': {
                 'id': preprint_unpublished._id,
@@ -1603,7 +1603,7 @@ class TestPreprintContributorBulkCreate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             },
             'relationships': {
                 'users': {
@@ -1621,7 +1621,7 @@ class TestPreprintContributorBulkCreate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'read'
+                'permission': permissions.READ
             },
             'relationships': {
                 'users': {
@@ -1712,7 +1712,7 @@ class TestPreprintContributorBulkCreate(NodeCRUDTestCase):
         assert_items_equal([res.json['data'][0]['attributes']['bibliographic'],
                             res.json['data'][1]['attributes']['bibliographic']], [True, False])
         assert_items_equal([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], ['admin', 'read'])
+                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
         assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_published, auth=user.auth)
@@ -1727,7 +1727,7 @@ class TestPreprintContributorBulkCreate(NodeCRUDTestCase):
         assert_items_equal([res.json['data'][0]['attributes']['bibliographic'],
                             res.json['data'][1]['attributes']['bibliographic']], [True, False])
         assert_items_equal([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], ['admin', 'read'])
+                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
         assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_unpublished, auth=user.auth)
@@ -1870,7 +1870,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -1881,7 +1881,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -1892,7 +1892,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -1904,7 +1904,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -1947,7 +1947,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_published_preprints_logged_out
@@ -1966,7 +1966,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_unpublished_preprints_logged_out
@@ -1985,7 +1985,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_update_contributors_unpublished_preprints_logged_in_non_contrib
         res = app.put_json_api(
@@ -2004,7 +2004,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_update_contributors_unpublished_preprints_logged_in_read_only_contrib
         res = app.put_json_api(
@@ -2023,7 +2023,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_preprints_send_dictionary_not_list
@@ -2132,7 +2132,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_invalid_bibliographic
@@ -2162,7 +2162,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor
@@ -2176,7 +2176,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
                         ),
                         'type': 'contributors',
                         'attributes': {
-                            'permission': 'admin',
+                            'permission': permissions.ADMIN,
                             'bibliographic': False
                         }
                     }, {
@@ -2206,7 +2206,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
                     ),
                     'type': 'contributors',
                     'attributes': {
-                            'permission': 'read'
+                            'permission': permissions.READ
                     }
                 }
             ]},
@@ -2228,7 +2228,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write']
+            [permissions.ADMIN, permissions.WRITE]
         )
 
     def test_bulk_update_contributors_unpublished_preprints_logged_in_contrib(
@@ -2243,7 +2243,7 @@ class TestPreprintContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write']
+            [permissions.ADMIN, permissions.WRITE]
         )
 
 
@@ -2317,7 +2317,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -2328,7 +2328,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -2339,7 +2339,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': True,
-                'permission': 'admin'
+                'permission': permissions.ADMIN
             }
         }
 
@@ -2351,7 +2351,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             'type': 'contributors',
             'attributes': {
                 'bibliographic': False,
-                'permission': 'write'
+                'permission': permissions.WRITE
             }
         }
 
@@ -2388,7 +2388,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_published_preprints_logged_out
@@ -2404,7 +2404,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_unpublished_preprints_logged_out
@@ -2421,7 +2421,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_contributors_unpublished_preprints_logged_in_non_contrib
         res = app.patch_json_api(
@@ -2438,7 +2438,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read']
+            [permissions.ADMIN, permissions.READ, permissions.READ]
         )
 
     #   test_bulk_partial_update_contributors_unpublished_preprints_logged_in_read_only_contrib
@@ -2456,7 +2456,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_contributors_preprints_send_dictionary_not_list
         res = app.patch_json_api(
@@ -2553,7 +2553,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     #   test_bulk_partial_update_invalid_bibliographic
         res = app.patch_json_api(
@@ -2579,7 +2579,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission'],
              data[2]['attributes']['permission']],
-            ['admin', 'read', 'read'])
+            [permissions.ADMIN, permissions.READ, permissions.READ])
 
     def test_bulk_partial_update_contributors_published_preprints_logged_in(
             self, app, user, payload_published_one, payload_published_two, url_published):
@@ -2592,7 +2592,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write'])
+            [permissions.ADMIN, permissions.WRITE])
 
     def test_bulk_partial_update_contributors_unpublished_preprints_logged_in_contrib(
             self, app, user, payload_unpublished_one, payload_unpublished_two, url_unpublished):
@@ -2605,7 +2605,7 @@ class TestPreprintContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert_items_equal(
             [data[0]['attributes']['permission'],
              data[1]['attributes']['permission']],
-            ['admin', 'write'])
+            [permissions.ADMIN, permissions.WRITE])
 
 @pytest.mark.enable_quickfiles_creation
 class TestPreprintContributorBulkDelete(NodeCRUDTestCase):
@@ -2965,7 +2965,7 @@ class TestPreprintContributorFiltering:
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get('permission') == 'admin'
+        assert res.json['data'][0]['attributes'].get('permission') == permissions.ADMIN
 
     #   test_filtering_node_with_only_bibliographic_contributors
         base_url = '/{}preprints/{}/contributors/'.format(API_BASE, preprint._id)

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -7,10 +7,12 @@ from rest_framework import exceptions
 from waffle.testutils import override_switch
 
 from osf import features
+from osf.utils.permissions import READ
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from framework.auth.core import Auth
 from osf.models import NodeLicense, PreprintContributor
+from osf.utils.permissions import WRITE
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import (
     PreprintFactory,
@@ -264,7 +266,7 @@ class TestPreprintUpdate:
         assert res.status_code == 401
 
         read_contrib = AuthUserFactory()
-        preprint.add_contributor(read_contrib, 'read', save=True)
+        preprint.add_contributor(read_contrib, READ, save=True)
         res = app.patch_json_api(
             url,
             update_doi_payload,
@@ -276,7 +278,7 @@ class TestPreprintUpdate:
     def test_update_original_publication_date_to_none(self, app, preprint, url):
         # Original pub date accidentally set, need to remove
         write_contrib = AuthUserFactory()
-        preprint.add_contributor(write_contrib, 'write', save=True)
+        preprint.add_contributor(write_contrib, WRITE, save=True)
         preprint.original_publication_date = '2013-12-11 10:09:08.070605+00:00'
         preprint.save()
         update_payload = build_preprint_update_payload(
@@ -297,7 +299,7 @@ class TestPreprintUpdate:
 
     def test_update_preprint_permission_write_contrib(self, app, preprint, url):
         write_contrib = AuthUserFactory()
-        preprint.add_contributor(write_contrib, 'write', save=True)
+        preprint.add_contributor(write_contrib, WRITE, save=True)
 
         doi = '10.123/456/789'
         original_publication_date = '2013-12-11 10:09:08.070605+00:00'
@@ -351,7 +353,7 @@ class TestPreprintUpdate:
         preprint.save()
 
         write_contrib = AuthUserFactory()
-        preprint.add_contributor(write_contrib, 'write', save=True)
+        preprint.add_contributor(write_contrib, WRITE, save=True)
 
         update_payload = build_preprint_update_payload(
             preprint._id, attributes={
@@ -650,7 +652,7 @@ class TestPreprintUpdate:
             'data': {
                 'attributes': {
                     'bibliographic': True,
-                    'permission': 'write',
+                    'permission': WRITE,
                     'send_email': False
                 },
                 'type': 'contributors',
@@ -674,7 +676,7 @@ class TestPreprintUpdate:
 
         assert res.status_code == 201
         assert new_user in preprint.contributors
-        assert preprint.has_permission(new_user, 'write')
+        assert preprint.has_permission(new_user, WRITE)
         assert PreprintContributor.objects.get(preprint=preprint, user=new_user).visible is True
         assert mock_update_doi_metadata.called
 
@@ -685,7 +687,7 @@ class TestPreprintUpdate:
         read_write_contrib = AuthUserFactory()
         preprint.add_contributor(
             read_write_contrib,
-            permissions='write',
+            permissions=WRITE,
             auth=Auth(user), save=True)
         new_file = test_utils.create_test_preprint_file(
             preprint, user, filename='lovechild_reason.pdf')
@@ -747,7 +749,7 @@ class TestPreprintUpdate:
         write_contrib = AuthUserFactory()
         preprint.add_contributor(
             write_contrib,
-            permissions='write',
+            permissions=WRITE,
             auth=Auth(user), save=True)
 
         assert not preprint.subjects.filter(_id=subject._id).exists()
@@ -769,7 +771,7 @@ class TestPreprintUpdate:
         read_contrib = AuthUserFactory()
         preprint.add_contributor(
             read_contrib,
-            permissions='read',
+            permissions=READ,
             auth=Auth(user), save=True)
 
         assert not preprint.subjects.filter(_id=subject._id).exists()
@@ -881,11 +883,11 @@ class TestPreprintUpdateLicense:
         preprint = PreprintFactory(
             creator=admin_contrib,
             provider=preprint_provider)
-        preprint.add_contributor(write_contrib, permissions='write', auth=Auth(admin_contrib))
+        preprint.add_contributor(write_contrib, permissions=WRITE, auth=Auth(admin_contrib))
         preprint.add_contributor(
             read_contrib,
             auth=Auth(admin_contrib),
-            permissions='read')
+            permissions=READ)
         preprint.save()
         return preprint
 
@@ -1364,7 +1366,7 @@ class TestPreprintDetailPermissions:
             is_published=True,
             is_public=False,
             machine_state='accepted')
-        fact.add_contributor(write_contrib, permissions='write')
+        fact.add_contributor(write_contrib, permissions=WRITE)
         fact.is_public = False
         fact.save()
         return fact
@@ -1379,7 +1381,7 @@ class TestPreprintDetailPermissions:
             is_published=True,
             is_public=True,
             machine_state='accepted')
-        fact.add_contributor(write_contrib, permissions='write')
+        fact.add_contributor(write_contrib, permissions=WRITE)
         return fact
 
     @pytest.fixture()
@@ -1562,7 +1564,7 @@ class TestPreprintDetailPermissions:
         res = app.get(url, expect_errors=True)
         assert res.status_code == 401
 
-        unpublished.add_contributor(write_contrib, permissions='write', save=True)
+        unpublished.add_contributor(write_contrib, permissions=WRITE, save=True)
         res = app.get(url, auth=write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -1608,7 +1610,7 @@ class TestReviewsPreprintDetailPermissions:
             subjects=[[subject._id]],
             is_published=False,
             machine_state=DefaultStates.PENDING.value)
-        preprint.add_contributor(write_contrib, permissions='write')
+        preprint.add_contributor(write_contrib, permissions=WRITE)
         preprint.save()
         return preprint
 
@@ -1634,7 +1636,7 @@ class TestReviewsPreprintDetailPermissions:
             is_published=False,
             is_public=False,
             machine_state=DefaultStates.PENDING.value)
-        preprint.add_contributor(write_contrib, permissions='write')
+        preprint.add_contributor(write_contrib, permissions=WRITE)
         return preprint
 
     @pytest.fixture()

--- a/api_tests/preprints/views/test_preprint_files_list.py
+++ b/api_tests/preprints/views/test_preprint_files_list.py
@@ -9,6 +9,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     PreprintFactory
 )
+from osf.utils.permissions import WRITE
 from osf.utils.workflows import DefaultStates
 from addons.osfstorage.models import OsfStorageFile
 
@@ -31,7 +32,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 200
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -52,7 +53,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -73,7 +74,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -94,7 +95,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -115,7 +116,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -136,7 +137,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 404
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 404
 
@@ -157,7 +158,7 @@ class TestPreprintProvidersList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -238,7 +239,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 200
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -259,7 +260,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -280,7 +281,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -301,7 +302,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -322,7 +323,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth)
         assert res.status_code == 200
 
@@ -343,7 +344,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 404
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 404
 
@@ -364,7 +365,7 @@ class TestPreprintFilesList(ApiTestCase):
         assert res.status_code == 403
 
         # Write contributor
-        self.preprint.add_contributor(self.user_two, 'write', save=True)
+        self.preprint.add_contributor(self.user_two, WRITE, save=True)
         res = self.app.get(self.url, auth=self.user_two.auth, expect_errors=True)
         assert res.status_code == 403
 

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -339,8 +339,8 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
 
         # Read contribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
-        preprint_one.add_contributor(user2, 'read')
-        preprint_two.add_contributor(user2, 'read')
+        preprint_one.add_contributor(user2, permissions.READ)
+        preprint_two.add_contributor(user2, permissions.READ)
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
         actual = [preprint['id'] for preprint in res.json['data']]
@@ -478,7 +478,7 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
 
     def test_read_user_on_supplemental_node(self):
-        self.public_project.set_permissions(self.other_user, 'read', save=True)
+        self.public_project.set_permissions(self.other_user, permissions.READ, save=True)
         assert_in(self.other_user, self.public_project.contributors)
         public_project_payload = build_preprint_create_payload(
             self.public_project._id, self.provider._id)
@@ -793,7 +793,7 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
                                project=project_public,
                                machine_state='pending',
                                is_published=False)
-        preprint.add_contributor(user_write_contrib, permissions='write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_visible_to_admins(
@@ -883,7 +883,7 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
                                project=project_public,
                                is_published=False,
                                machine_state=DefaultStates.PENDING.value)
-        preprint.add_contributor(user_write_contrib, permissions='write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_visible_to_admins(
@@ -958,7 +958,7 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
                                project=project_public,
                                is_published=False,
                                machine_state=DefaultStates.INITIAL.value)
-        preprint.add_contributor(user_write_contrib, permissions='write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_not_visible_to_admins(
@@ -1040,7 +1040,7 @@ class TestPreprintIsPublishedListMatchesDetail(
                                subjects=[[subject._id]],
                                project=project_public,
                                is_published=False)
-        preprint.add_contributor(user_write_contrib, 'write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()
@@ -1125,7 +1125,7 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(
                                project=project_public,
                                is_published=False,
                                machine_state=DefaultStates.INITIAL.value)
-        preprint.add_contributor(user_write_contrib, 'write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()
@@ -1210,7 +1210,7 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(
                                project=project_public,
                                is_published=False,
                                machine_state=DefaultStates.PENDING.value)
-        preprint.add_contributor(user_write_contrib, 'write', save=True)
+        preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -8,6 +8,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     SubjectFactory,
 )
+from osf.utils.permissions import WRITE
 from osf.utils.workflows import DefaultStates
 
 
@@ -256,7 +257,7 @@ class PreprintIsValidListMixin:
             subjects=[[subject._id]],
             project=project,
             is_published=True)
-        preprint.add_contributor(user_write_contrib, 'write', save=True)
+        preprint.add_contributor(user_write_contrib, WRITE, save=True)
         return preprint
 
     def test_preprint_is_preprint_orphan_invisible_no_auth(

--- a/api_tests/preprints/views/test_preprint_node_relationship.py
+++ b/api_tests/preprints/views/test_preprint_node_relationship.py
@@ -2,6 +2,7 @@ import pytest
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
+from osf.utils.permissions import READ, WRITE
 from osf_tests.factories import (
     PreprintFactory,
     AuthUserFactory,
@@ -94,13 +95,13 @@ class TestPreprintNodeRelationship:
         assert res.status_code == 403
 
         # read-contributor
-        preprint.add_contributor(user_two, 'read')
+        preprint.add_contributor(user_two, READ)
         preprint.save()
         res = app.patch_json_api(url, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
         # write-contributor
-        preprint.update_contributor(user_two, 'write', True, auth=Auth(user), save=True)
+        preprint.update_contributor(user_two, WRITE, True, auth=Auth(user), save=True)
         res = app.patch_json_api(url, {'data': None}, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 200
         assert res.json['data'] is None

--- a/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
@@ -6,6 +6,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     PreprintProviderFactory,
 )
+from osf.utils import permissions
 
 
 @pytest.mark.django_db
@@ -25,7 +26,7 @@ class TestPreprintProviderModeratorList:
     @pytest.fixture()
     def admin(self, provider):
         user = AuthUserFactory()
-        provider.get_group('admin').user_set.add(user)
+        provider.get_group(permissions.ADMIN).user_set.add(user)
         return user
 
     @pytest.fixture()
@@ -77,7 +78,7 @@ class TestPreprintProviderModeratorList:
         assert res.status_code == 200
         assert len(res.json['data']) == 1
         assert res.json['data'][0]['id'] == admin._id
-        assert res.json['data'][0]['attributes']['permission_group'] == 'admin'
+        assert res.json['data'][0]['attributes']['permission_group'] == permissions.ADMIN
 
     @mock.patch('framework.auth.views.mails.send_mail')
     def test_list_post_unauthorized(self, mock_mail, app, url, nonmoderator, moderator, provider):

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -308,7 +308,7 @@ class TestRegistrationUpdate:
     #   test_osf_group_member_write_cannot_update_registration
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        public_project.add_osf_group(group, 'write')
+        public_project.add_osf_group(group, permissions.WRITE)
         res = app.put_json_api(
             public_url,
             public_to_private_payload,
@@ -318,7 +318,7 @@ class TestRegistrationUpdate:
 
     #   test_osf_group_member_admin_cannot_update_registration
         public_project.remove_osf_group(group)
-        public_project.add_osf_group(group, 'admin')
+        public_project.add_osf_group(group, permissions.ADMIN)
         res = app.put_json_api(
             public_url,
             public_to_private_payload,

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -6,6 +6,7 @@ from framework.auth.core import Auth
 
 from api.base.settings.defaults import API_BASE
 from tests.base import ApiTestCase
+from osf.utils.permissions import WRITE
 from osf_tests.factories import (
     ProjectFactory,
     AuthUserFactory,
@@ -30,9 +31,9 @@ class TestRegistrationEmbeds(ApiTestCase):
         self.contribs = [AuthUserFactory() for i in range(2)]
         for contrib in self.contribs:
             self.root_node.add_contributor(
-                contrib, 'write', auth=self.auth, save=True)
+                contrib, WRITE, auth=self.auth, save=True)
             self.child1.add_contributor(
-                contrib, 'write', auth=self.auth, save=True)
+                contrib, WRITE, auth=self.auth, save=True)
 
         self.contrib1 = self.contribs[0]
         self.contrib2 = self.contribs[1]

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -9,6 +9,7 @@ from osf_tests.factories import (
     NodeFactory,
     RegistrationFactory,
 )
+from osf.utils.permissions import READ
 from tests.base import ApiTestCase, get_default_metaschema
 
 
@@ -37,7 +38,7 @@ class LinkedRegistrationsTestCase(ApiTestCase):
             self.rw_contributor, auth=Auth(self.admin_contributor))
         public_node.add_contributor(
             self.read_contributor,
-            permissions='read',
+            permissions=READ,
             auth=Auth(self.admin_contributor))
         public_node.add_pointer(
             self.public_linked_registration,
@@ -57,7 +58,7 @@ class LinkedRegistrationsTestCase(ApiTestCase):
             auth=Auth(self.admin_contributor))
         private_node.add_contributor(
             self.read_contributor,
-            permissions='read',
+            permissions=READ,
             auth=Auth(self.admin_contributor))
         private_node.add_pointer(
             self.public_linked_registration,

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -677,7 +677,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
         # admin via a group cannot create registration
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        project_public.add_osf_group(group, 'admin')
+        project_public.add_osf_group(group, permissions.ADMIN)
         res = app.post_json_api(url_registrations, payload, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
 

--- a/api_tests/requests/mixins.py
+++ b/api_tests/requests/mixins.py
@@ -110,7 +110,7 @@ class PreprintRequestTestMixin(object):
         pre.save()
         pre.add_contributor(
             contributor=write_contrib,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True
         )
         pre.is_public = True
@@ -128,7 +128,7 @@ class PreprintRequestTestMixin(object):
         pre.save()
         pre.add_contributor(
             contributor=write_contrib,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True
         )
         return pre
@@ -142,7 +142,7 @@ class PreprintRequestTestMixin(object):
         post.save()
         post.add_contributor(
             contributor=write_contrib,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True
         )
         return post
@@ -156,7 +156,7 @@ class PreprintRequestTestMixin(object):
         preprint.save()
         preprint.add_contributor(
             contributor=write_contrib,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True
         )
         return preprint

--- a/api_tests/requests/views/test_request_actions_create.py
+++ b/api_tests/requests/views/test_request_actions_create.py
@@ -229,7 +229,7 @@ class TestCreateNodeRequestAction(NodeRequestTestMixin):
 
     def test_set_permissions_on_approve(self, app, admin, url, node_request):
         assert node_request.creator not in node_request.target.contributors
-        payload = self.create_payload(node_request._id, trigger='accept', permissions='admin')
+        payload = self.create_payload(node_request._id, trigger='accept', permissions=permissions.ADMIN)
         res = app.post_json_api(url, payload, auth=admin.auth)
         assert res.status_code == 201
         node_request.reload()

--- a/api_tests/reviews/mixins/comment_settings.py
+++ b/api_tests/reviews/mixins/comment_settings.py
@@ -6,6 +6,7 @@ from osf_tests.factories import (
     PreprintFactory,
     PreprintProviderFactory,
 )
+from osf.utils import permissions
 
 
 @pytest.mark.django_db
@@ -30,7 +31,7 @@ class ReviewActionCommentSettingsMixin(object):
     @pytest.fixture()
     def provider_admin(self, provider):
         user = AuthUserFactory()
-        user.groups.add(provider.get_group('admin'))
+        user.groups.add(provider.get_group(permissions.ADMIN))
         return user
 
     @pytest.fixture()
@@ -44,7 +45,7 @@ class ReviewActionCommentSettingsMixin(object):
         user = AuthUserFactory()
         preprint.add_contributor(
             user,
-            'admin'
+            permissions.ADMIN
         )
         return user
 

--- a/api_tests/reviews/mixins/filter_mixins.py
+++ b/api_tests/reviews/mixins/filter_mixins.py
@@ -10,6 +10,7 @@ from osf_tests.factories import (
     PreprintProviderFactory,
     ProjectFactory,
 )
+from osf.utils import permissions
 
 
 def get_actual(app, url, user=None, sort=None, expect_errors=False, **filters):
@@ -225,7 +226,7 @@ class ReviewProviderFilterMixin(object):
     def admin_pair(self, expected_providers):
         user = AuthUserFactory()
         provider = expected_providers[1]
-        user.groups.add(provider.get_group('admin'))
+        user.groups.add(provider.get_group(permissions.ADMIN))
         return (user, provider)
 
     def test_review_provider_filters(

--- a/api_tests/users/views/test_user_can_review.py
+++ b/api_tests/users/views/test_user_can_review.py
@@ -5,7 +5,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     PreprintProviderFactory,
 )
-
+from osf.utils.permissions import ADMIN
 
 @pytest.mark.django_db
 class TestUserCanReview:
@@ -17,7 +17,7 @@ class TestUserCanReview:
     @pytest.fixture()
     def moderator(self, provider):
         user = AuthUserFactory()
-        provider.add_to_group(user, 'admin')
+        provider.add_to_group(user, ADMIN)
         return user
 
     @pytest.fixture()

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -14,6 +14,7 @@ from osf_tests.factories import (
     UserFactory,
 )
 from website.views import find_bookmark_collection
+from osf.utils import permissions
 from osf.utils.workflows import DefaultStates
 
 
@@ -181,7 +182,7 @@ class TestUserNodes:
         assert len(res.json['data']) == 0
 
         group = OSFGroupFactory(creator=group_mem)
-        private_project_user_one.add_osf_group(group, 'read')
+        private_project_user_one.add_osf_group(group, permissions.READ)
         res = app.get(url, auth=group_mem.auth)
         assert len(res.json['data']) == 1
 
@@ -292,19 +293,19 @@ class TestNodeListPermissionFiltering:
     @pytest.fixture()
     def read_node(self, creator, contrib):
         node = ProjectFactory(creator=creator)
-        node.add_contributor(contrib, permissions='read', save=True)
+        node.add_contributor(contrib, permissions=permissions.READ, save=True)
         return node
 
     @pytest.fixture()
     def write_node(self, creator, contrib):
         node = ProjectFactory(creator=creator)
-        node.add_contributor(contrib, permissions='write', save=True)
+        node.add_contributor(contrib, permissions=permissions.WRITE, save=True)
         return node
 
     @pytest.fixture()
     def admin_node(self, creator, contrib):
         node = ProjectFactory(creator=creator)
-        node.add_contributor(contrib, permissions='admin', save=True)
+        node.add_contributor(contrib, permissions=permissions.ADMIN, save=True)
         return node
 
     @pytest.fixture()
@@ -333,9 +334,9 @@ class TestNodeListPermissionFiltering:
 
         user2 = AuthUserFactory()
         osf_group = OSFGroupFactory(creator=user2)
-        read_node.add_osf_group(osf_group, 'read')
-        write_node.add_osf_group(osf_group, 'write')
-        admin_node.add_osf_group(osf_group, 'admin')
+        read_node.add_osf_group(osf_group, permissions.READ)
+        write_node.add_osf_group(osf_group, permissions.WRITE)
+        admin_node.add_osf_group(osf_group, permissions.ADMIN)
 
         # test filter group member read
         res = app.get('{}read'.format(url), auth=user2.auth)
@@ -361,7 +362,7 @@ class TestNodeListPermissionFiltering:
         res = app.get('{}read'.format(url), auth=me.auth)
         assert len(res.json['data']) == 0
 
-        read_node.add_contributor(me, 'read')
+        read_node.add_contributor(me, permissions.READ)
         read_node.save()
         res = app.get('{}read'.format(url), auth=me.auth)
         assert len(res.json['data']) == 1
@@ -370,7 +371,7 @@ class TestNodeListPermissionFiltering:
         # test filter write
         res = app.get('{}write'.format(url), auth=me.auth)
         assert len(res.json['data']) == 0
-        write_node.add_contributor(me, 'write')
+        write_node.add_contributor(me, permissions.WRITE)
         write_node.save()
         res = app.get('{}write'.format(url), auth=me.auth)
         assert len(res.json['data']) == 1
@@ -381,7 +382,7 @@ class TestNodeListPermissionFiltering:
         assert len(res.json['data']) == 0
 
         res = app.get('{}admin'.format(url), auth=me.auth)
-        admin_node.add_contributor(me, 'admin')
+        admin_node.add_contributor(me, permissions.ADMIN)
         admin_node.save()
         res = app.get('{}admin'.format(url), auth=me.auth)
         assert len(res.json['data']) == 1

--- a/api_tests/users/views/test_user_preprints_list.py
+++ b/api_tests/users/views/test_user_preprints_list.py
@@ -176,8 +176,8 @@ class TestUserPreprintsListFiltering(PreprintsListFilteringMixin):
         # Read contribs - contrib=False on UserPreprints filter so read contribs can only see
         # withdrawn preprints that were once public
         user2 = AuthUserFactory()
-        preprint_one.add_contributor(user2, 'read', save=True)
-        preprint_two.add_contributor(user2, 'read', save=True)
+        preprint_one.add_contributor(user2, permissions.READ, save=True)
+        preprint_two.add_contributor(user2, permissions.READ, save=True)
         url = '/{}users/{}/preprints/?version=2.2&'.format(API_BASE, user2._id)
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)

--- a/api_tests/users/views/test_user_registrations_list.py
+++ b/api_tests/users/views/test_user_registrations_list.py
@@ -12,6 +12,7 @@ from osf_tests.factories import (
     RegistrationFactory,
     OSFGroupFactory
 )
+from osf.utils import permissions
 from tests.base import ApiTestCase
 from website.views import find_bookmark_collection
 
@@ -73,7 +74,7 @@ class TestUserRegistrations:
             is_public=False,
             creator=user_one
         )
-        project.add_osf_group(osf_group, 'admin')
+        project.add_osf_group(osf_group, permissions.ADMIN)
         return project
 
     @pytest.fixture()

--- a/osf/models/collection.py
+++ b/osf/models/collection.py
@@ -15,6 +15,7 @@ from osf.models.base import BaseModel, GuidMixin
 from osf.models.mixins import GuardianMixin, TaxonomizableMixin
 from osf.models.validators import validate_title
 from osf.utils.fields import NonNaiveDateTimeField
+from osf.utils.permissions import ADMIN
 from osf.exceptions import NodeStateError
 from website.util import api_v2_url
 from website.search.exceptions import SearchUnavailableError
@@ -177,7 +178,7 @@ class Collection(DirtyFieldsMixin, GuidMixin, BaseModel, GuardianMixin):
             self.collected_types = ContentType.objects.filter(app_label='osf', model__in=['abstractnode', 'collection', 'preprint'])
             # Set up initial permissions
             self.update_group_permissions()
-            self.get_group('admin').user_set.add(self.creator)
+            self.get_group(ADMIN).user_set.add(self.creator)
 
         elif 'is_public' in saved_fields:
             from website.collections.tasks import on_collection_updated

--- a/osf/models/contributor.py
+++ b/osf/models/contributor.py
@@ -2,6 +2,7 @@ from django.db import models
 from include import IncludeManager
 
 from osf.utils.fields import NonNaiveDateTimeField
+from osf.utils import permissions
 
 
 class AbstractBaseContributor(models.Model):
@@ -87,10 +88,10 @@ def get_contributor_permission(contributor, object_id, model_type):
     # Checking for django group membership allows you to also get the intended permissions of unregistered contributors
     user_groups = contributor.user.groups.filter(name__in=[read, write, admin]).values_list('name', flat=True)
     if admin in user_groups:
-        return 'admin'
+        return permissions.ADMIN
     elif write in user_groups:
-        return 'write'
+        return permissions.WRITE
     elif read in user_groups:
-        return 'read'
+        return permissions.READ
     else:
         return None

--- a/osf/models/osf_group.py
+++ b/osf/models/osf_group.py
@@ -15,7 +15,7 @@ from osf.models import base
 from osf.models.mixins import GuardianMixin, Loggable
 from osf.models import Node, OSFUser, NodeLog
 from osf.models.osf_grouplog import OSFGroupLog
-from osf.utils.permissions import ADMIN, MANAGER, MEMBER, MANAGE, reduce_permissions
+from osf.utils.permissions import ADMIN, WRITE, MANAGER, MEMBER, MANAGE, reduce_permissions
 from osf.utils import sanitize
 from website.project import signals as project_signals
 from website.osf_groups import signals as group_signals
@@ -314,7 +314,7 @@ class OSFGroup(GuardianMixin, Loggable, base.ObjectIDMixin, base.BaseModel):
         for node in self.nodes:
             node.update_search()
 
-    def add_group_to_node(self, node, permission='write', auth=None):
+    def add_group_to_node(self, node, permission=WRITE, auth=None):
         """Gives the OSF Group permissions to the node.  Called from node model.
 
         :param obj Node
@@ -351,7 +351,7 @@ class OSFGroup(GuardianMixin, Loggable, base.ObjectIDMixin, base.BaseModel):
         for user in self.members:
             group_signals.group_added_to_node.send(self, node=node, user=user, permission=permission, auth=auth)
 
-    def update_group_permissions_to_node(self, node, permission='write', auth=None):
+    def update_group_permissions_to_node(self, node, permission=WRITE, auth=None):
         """Updates the OSF Group permissions to the node.  Called from node model.
 
         :param obj Node

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -105,7 +105,7 @@ class ReviewsMachine(BaseMachine):
         # Returns True if the submitter of the request is a moderator or admin for the provider.
         provider = self.machineable.provider
         return provider.get_group('moderator').user_set.filter(id=submitter.id).exists() or \
-               provider.get_group('admin').user_set.filter(id=submitter.id).exists()
+               provider.get_group(permissions.ADMIN).user_set.filter(id=submitter.id).exists()
 
     def perform_withdraw(self, ev):
         self.machineable.date_withdrawn = self.action.created if self.action is not None else timezone.now()
@@ -215,7 +215,7 @@ class NodeRequestMachine(BaseMachine):
         context['contributors_url'] = '{}contributors/'.format(self.machineable.target.absolute_url)
         context['project_settings_url'] = '{}settings/'.format(self.machineable.target.absolute_url)
 
-        for admin in self.machineable.target.get_users_with_perm('admin'):
+        for admin in self.machineable.target.get_users_with_perm(permissions.ADMIN):
             mails.send_mail(
                 admin.username,
                 mails.ACCESS_REQUEST_SUBMITTED,

--- a/osf/utils/permissions.py
+++ b/osf/utils/permissions.py
@@ -5,8 +5,11 @@ READ = 'read'
 WRITE = 'write'
 ADMIN = 'admin'
 # NOTE: Ordered from most-restrictive to most permissive
-PERMISSIONS = ['read_node', 'write_node', 'admin_node']
-CONTRIB_PERMISSIONS = {'admin_node': 'admin', 'write_node': 'write', 'read_node': 'read'}
+READ_NODE = 'read_node'
+WRITE_NODE = 'write_node'
+ADMIN_NODE = 'admin_node'
+PERMISSIONS = [READ_NODE, WRITE_NODE, ADMIN_NODE]
+CONTRIB_PERMISSIONS = {ADMIN_NODE: ADMIN, WRITE_NODE: WRITE, READ_NODE: READ}
 API_CONTRIBUTOR_PERMISSIONS = [READ, WRITE, ADMIN]
 CREATOR_PERMISSIONS = ADMIN
 DEFAULT_CONTRIBUTOR_PERMISSIONS = WRITE

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -7,6 +7,7 @@ from django.core.exceptions import MultipleObjectsReturned
 from osf.models import Guid, NodeLicenseRecord, OSFUser
 from osf_tests.factories import AuthUserFactory, UserFactory, NodeFactory, NodeLicenseRecordFactory, \
     RegistrationFactory, PreprintFactory, PreprintProviderFactory
+from osf.utils.permissions import ADMIN
 from tests.base import OsfTestCase
 from tests.test_websitefiles import TestFile
 from website.settings import MFR_SERVER_URL, WATERBUTLER_URL
@@ -278,14 +279,14 @@ class TestResolveGuid(OsfTestCase):
 
         # test_provider_admin_can_download_unpublished
         admin = AuthUserFactory()
-        provider.add_to_group(admin, 'admin')
+        provider.add_to_group(admin, ADMIN)
         provider.save()
 
         res = self.app.get('{}download'.format(pp.url), auth=admin.auth)
         assert res.status_code == 302
         assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
-        branded_provider.add_to_group(admin, 'admin')
+        branded_provider.add_to_group(admin, ADMIN)
         branded_provider.save()
 
         res = self.app.get('{}download'.format(pp_branded.url), auth=admin.auth)

--- a/osf_tests/test_osfgroup.py
+++ b/osf_tests/test_osfgroup.py
@@ -781,7 +781,7 @@ class TestNodeGroups:
         project.add_osf_group(osf_group, ADMIN)
         # Manager has explict admin to child, member has implicit admin.
         # Manager should be in admin_users, member should be in parent_admin_users
-        admin_users = child.get_users_with_perm('admin')
+        admin_users = child.get_users_with_perm(ADMIN)
         assert manager in admin_users
         assert member not in admin_users
 

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -553,9 +553,9 @@ class TestDraftRegistrations:
         member = factories.AuthUserFactory()
         osf_group = factories.OSFGroupFactory(creator=user)
         osf_group.make_member(member, auth=auth)
-        project.add_osf_group(osf_group, 'admin')
+        project.add_osf_group(osf_group, ADMIN)
         draft_2 = factories.DraftRegistrationFactory(branched_from=project)
-        assert project.has_permission(member, 'admin')
+        assert project.has_permission(member, ADMIN)
         with pytest.raises(PermissionsError):
             draft_2.register(Auth(member))
         assert not draft_2.registered_node

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -341,11 +341,11 @@ class TestMustBeContributorDecorator(AuthAppTestCase):
         self.non_contrib = AuthUserFactory()
         admin = UserFactory()
         self.public_project = ProjectFactory(is_public=True)
-        self.public_project.add_contributor(admin, auth=Auth(self.public_project.creator), permissions='admin')
+        self.public_project.add_contributor(admin, auth=Auth(self.public_project.creator), permissions=permissions.ADMIN)
         self.private_project = ProjectFactory(is_public=False)
         self.public_project.add_contributor(self.contrib, auth=Auth(self.public_project.creator))
         self.private_project.add_contributor(self.contrib, auth=Auth(self.private_project.creator))
-        self.private_project.add_contributor(admin, auth=Auth(self.private_project.creator), permissions='admin')
+        self.private_project.add_contributor(admin, auth=Auth(self.private_project.creator), permissions=permissions.ADMIN)
         self.public_project.save()
         self.private_project.save()
 
@@ -421,7 +421,7 @@ class TestMustBeContributorDecorator(AuthAppTestCase):
     def test_must_be_contributor_parent_write_public_project(self):
         user = UserFactory()
         node = NodeFactory(parent=self.public_project, creator=user)
-        self.public_project.set_permissions(self.public_project.creator, 'write')
+        self.public_project.set_permissions(self.public_project.creator, permissions.WRITE)
         self.public_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor(
@@ -434,7 +434,7 @@ class TestMustBeContributorDecorator(AuthAppTestCase):
     def test_must_be_contributor_parent_write_private_project(self):
         user = UserFactory()
         node = NodeFactory(parent=self.private_project, creator=user)
-        self.private_project.set_permissions(self.private_project.creator, 'write')
+        self.private_project.set_permissions(self.private_project.creator, permissions.WRITE)
         self.private_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor(
@@ -530,7 +530,7 @@ class TestMustBeContributorOrPublicDecorator(AuthAppTestCase):
         user = UserFactory()
         node = NodeFactory(parent=self.public_project, creator=user)
         contrib = UserFactory()
-        self.public_project.add_contributor(contrib, auth=Auth(self.public_project.creator), permissions='write')
+        self.public_project.add_contributor(contrib, auth=Auth(self.public_project.creator), permissions=permissions.WRITE)
         self.public_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor_or_public(
@@ -544,7 +544,7 @@ class TestMustBeContributorOrPublicDecorator(AuthAppTestCase):
         user = UserFactory()
         node = NodeFactory(parent=self.private_project, creator=user)
         contrib = UserFactory()
-        self.private_project.add_contributor(contrib, auth=Auth(self.private_project.creator), permissions='write')
+        self.private_project.add_contributor(contrib, auth=Auth(self.private_project.creator), permissions=permissions.WRITE)
         self.private_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor_or_public(
@@ -567,9 +567,9 @@ class TestMustBeContributorOrPublicButNotAnonymizedDecorator(AuthAppTestCase):
         self.non_contrib = AuthUserFactory()
         admin = UserFactory()
         self.public_project = ProjectFactory(is_public=True)
-        self.public_project.add_contributor(admin, auth=Auth(self.public_project.creator), permissions='admin')
+        self.public_project.add_contributor(admin, auth=Auth(self.public_project.creator), permissions=permissions.ADMIN)
         self.private_project = ProjectFactory(is_public=False)
-        self.private_project.add_contributor(admin, auth=Auth(self.private_project.creator), permissions='admin')
+        self.private_project.add_contributor(admin, auth=Auth(self.private_project.creator), permissions=permissions.ADMIN)
         self.public_project.add_contributor(self.contrib, auth=Auth(self.public_project.creator))
         self.private_project.add_contributor(self.contrib, auth=Auth(self.private_project.creator))
         self.public_project.save()
@@ -654,7 +654,7 @@ class TestMustBeContributorOrPublicButNotAnonymizedDecorator(AuthAppTestCase):
     def test_must_be_contributor_parent_write_public_project(self):
         user = UserFactory()
         node = NodeFactory(parent=self.public_project, creator=user)
-        self.public_project.set_permissions(self.public_project.creator, 'write')
+        self.public_project.set_permissions(self.public_project.creator, permissions.WRITE)
         self.public_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor_or_public_but_not_anonymized(
@@ -667,7 +667,7 @@ class TestMustBeContributorOrPublicButNotAnonymizedDecorator(AuthAppTestCase):
     def test_must_be_contributor_parent_write_private_project(self):
         user = UserFactory()
         node = NodeFactory(parent=self.private_project, creator=user)
-        self.private_project.set_permissions(self.private_project.creator, 'write')
+        self.private_project.set_permissions(self.private_project.creator, permissions.WRITE)
         self.private_project.save()
         with assert_raises(HTTPError) as exc_info:
             view_that_needs_contributor_or_public_but_not_anonymized(
@@ -698,7 +698,7 @@ def protected(**kwargs):
     return 'open sesame'
 
 
-@must_have_permission('admin')
+@must_have_permission(permissions.ADMIN)
 def thriller(**kwargs):
     return 'chiller'
 

--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -6,6 +6,7 @@ from nose.tools import *  # noqa; PEP8 asserts
 
 from osf_tests.factories import ProjectFactory, NodeFactory, AuthUserFactory, NodeRequestFactory
 from osf.utils import workflows
+from osf.utils import permissions
 from tests.base import OsfTestCase
 
 from framework.auth.decorators import Auth
@@ -22,7 +23,7 @@ class TestContributorUtils(OsfTestCase):
     def test_serialize_user(self):
         serialized = utils.serialize_user(self.project.creator, self.project)
         assert_true(serialized['visible'])
-        assert_equal(serialized['permission'], 'admin')
+        assert_equal(serialized['permission'], permissions.ADMIN)
 
     def test_serialize_user_full_does_not_include_emails_by_default(self):
         serialized = utils.serialize_user(self.project.creator, self.project, full=True)
@@ -40,7 +41,7 @@ class TestContributorUtils(OsfTestCase):
     def test_serialize_user_admin(self):
         serialized = utils.serialize_user(self.project.creator, self.project, admin=True)
         assert_false(serialized['visible'])
-        assert_equal(serialized['permission'], 'read')
+        assert_equal(serialized['permission'], permissions.READ)
 
     def test_serialize_access_requests(self):
         new_user = AuthUserFactory()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -12,6 +12,7 @@ from website.notifications.events import utils
 from addons.base import signals
 from framework.auth import Auth
 from osf_tests import factories
+from osf.utils.permissions import WRITE
 from tests.base import OsfTestCase, NotificationTestCase
 
 email_transactional = 'email_transactional'
@@ -386,13 +387,13 @@ class TestFileMoved(NotificationTestCase):
         # Move Event: Tests that store_emails is called 3 times, one in
         # each category
         self.sub.email_transactional.add(self.user_1)
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.private_node.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
-        self.project.add_contributor(self.user_4, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_4, permissions=WRITE, auth=self.auth)
         self.project.save()
         self.file_sub.email_digest.add(self.user_4)
         self.file_sub.save()
@@ -402,7 +403,7 @@ class TestFileMoved(NotificationTestCase):
     @mock.patch('website.notifications.emails.store_emails')
     def test_remove_user_sent_once(self, mock_store):
         # Move Event: Tests removed user is removed once. Regression
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
         self.file_sub.email_digest.add(self.user_3)
         self.file_sub.save()
@@ -468,13 +469,13 @@ class TestFileCopied(NotificationTestCase):
         # Copy Event: Tests that store_emails is called 2 times, two with
         # permissions, one without
         self.sub.email_transactional.add(self.user_1)
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.private_node.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
-        self.project.add_contributor(self.user_4, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_4, permissions=WRITE, auth=self.auth)
         self.project.save()
         self.file_sub.email_digest.add(self.user_4)
         self.file_sub.save()
@@ -539,9 +540,9 @@ class TestCategorizeUsers(NotificationTestCase):
         # Tests that a user with a sub in the origin node gets a warning that
         # they are no longer tracking the file.
         self.sub.email_transactional.add(self.user_1)
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.private_node.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
@@ -557,9 +558,9 @@ class TestCategorizeUsers(NotificationTestCase):
     def test_moved_user(self):
         # Doesn't warn a user with two different subs, but does send a
         # moved email
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.private_node.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
@@ -573,7 +574,7 @@ class TestCategorizeUsers(NotificationTestCase):
         assert_equal({email_transactional: [self.user_3._id], email_digest: [], 'none': []}, moved)
 
     def test_remove_user(self):
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=WRITE, auth=self.auth)
         self.project.save()
         self.file_sub.email_transactional.add(self.user_3)
         self.file_sub.save()
@@ -584,7 +585,7 @@ class TestCategorizeUsers(NotificationTestCase):
         assert_equal({email_transactional: [self.user_3._id], email_digest: [], 'none': []}, removed)
 
     def test_node_permissions(self):
-        self.private_node.add_contributor(self.user_3, permissions='write')
+        self.private_node.add_contributor(self.user_3, permissions=WRITE)
         self.private_sub.email_digest.add(self.user_3, self.user_4)
         remove = {email_transactional: [], email_digest: [], 'none': []}
         warn = {email_transactional: [], email_digest: [self.user_3._id, self.user_4._id], 'none': []}
@@ -812,5 +813,3 @@ def file_renamed_payload():
         (u'time', 1441905340.876648),
         ('node', u'wp6xv'),
         ('project', None)])
-
-

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,6 +22,7 @@ from website.util import web_url_for
 from website import settings
 
 from osf_tests import factories
+from osf.utils import permissions
 from tests.base import capture_signals
 from tests.base import OsfTestCase, NotificationTestCase
 
@@ -40,7 +41,7 @@ class TestNotificationsModels(OsfTestCase):
     def test_has_permission_on_children(self):
         non_admin_user = factories.UserFactory()
         parent = factories.ProjectFactory()
-        parent.add_contributor(contributor=non_admin_user, permissions='read')
+        parent.add_contributor(contributor=non_admin_user, permissions=permissions.READ)
         parent.save()
 
         node = factories.NodeFactory(parent=parent, category='project')
@@ -50,13 +51,13 @@ class TestNotificationsModels(OsfTestCase):
         sub_component2 = factories.NodeFactory(parent=node)
 
         assert_true(
-            node.has_permission_on_children(non_admin_user, 'read')
+            node.has_permission_on_children(non_admin_user, permissions.READ)
         )
 
     def test_check_user_has_permission_excludes_deleted_components(self):
         non_admin_user = factories.UserFactory()
         parent = factories.ProjectFactory()
-        parent.add_contributor(contributor=non_admin_user, permissions='read')
+        parent.add_contributor(contributor=non_admin_user, permissions=permissions.READ)
         parent.save()
 
         node = factories.NodeFactory(parent=parent, category='project')
@@ -67,30 +68,30 @@ class TestNotificationsModels(OsfTestCase):
         sub_component2 = factories.NodeFactory(parent=node)
 
         assert_false(
-            node.has_permission_on_children(non_admin_user,'read')
+            node.has_permission_on_children(non_admin_user,permissions.READ)
         )
 
     def test_check_user_does_not_have_permission_on_private_node_child(self):
         non_admin_user = factories.UserFactory()
         parent = factories.ProjectFactory()
-        parent.add_contributor(contributor=non_admin_user, permissions='read')
+        parent.add_contributor(contributor=non_admin_user, permissions=permissions.READ)
         parent.save()
         node = factories.NodeFactory(parent=parent, category='project')
         sub_component = factories.NodeFactory(parent=node)
 
         assert_false(
-            node.has_permission_on_children(non_admin_user,'read')
+            node.has_permission_on_children(non_admin_user,permissions.READ)
         )
 
     def test_check_user_child_node_permissions_false_if_no_children(self):
         non_admin_user = factories.UserFactory()
         parent = factories.ProjectFactory()
-        parent.add_contributor(contributor=non_admin_user, permissions='read')
+        parent.add_contributor(contributor=non_admin_user, permissions=permissions.READ)
         parent.save()
         node = factories.NodeFactory(parent=parent, category='project')
 
         assert_false(
-            node.has_permission_on_children(non_admin_user,'read')
+            node.has_permission_on_children(non_admin_user,permissions.READ)
         )
 
     def test_check_admin_has_permissions_on_private_component(self):
@@ -99,7 +100,7 @@ class TestNotificationsModels(OsfTestCase):
         sub_component = factories.NodeFactory(parent=node)
 
         assert_true(
-            node.has_permission_on_children(parent.creator,'read')
+            node.has_permission_on_children(parent.creator,permissions.READ)
         )
 
     def test_check_user_private_node_child_permissions_excludes_pointers(self):
@@ -110,7 +111,7 @@ class TestNotificationsModels(OsfTestCase):
         parent.save()
 
         assert_false(
-            parent.has_permission_on_children(user,'read')
+            parent.has_permission_on_children(user,permissions.READ)
         )
 
     def test_new_project_creator_is_subscribed(self):
@@ -501,7 +502,7 @@ class TestRemoveContributor(OsfTestCase):
         super(OsfTestCase, self).setUp()
         self.project = factories.ProjectFactory()
         self.contributor = factories.UserFactory()
-        self.project.add_contributor(contributor=self.contributor, permissions='read')
+        self.project.add_contributor(contributor=self.contributor, permissions=permissions.READ)
         self.project.save()
 
         self.subscription = NotificationSubscription.objects.get(
@@ -510,7 +511,7 @@ class TestRemoveContributor(OsfTestCase):
         )
 
         self.node = factories.NodeFactory(parent=self.project)
-        self.node.add_contributor(contributor=self.project.creator, permissions='admin')
+        self.node.add_contributor(contributor=self.project.creator, permissions=permissions.ADMIN)
         self.node.save()
 
         self.node_subscription = NotificationSubscription.objects.get(
@@ -1072,9 +1073,9 @@ class TestNotificationUtils(OsfTestCase):
 
     def test_serialize_node_level_event_that_adopts_parent_settings(self):
         user = factories.UserFactory()
-        self.project.add_contributor(contributor=user, permissions='read')
+        self.project.add_contributor(contributor=user, permissions=permissions.READ)
         self.project.save()
-        self.node.add_contributor(contributor=user, permissions='read')
+        self.node.add_contributor(contributor=user, permissions=permissions.READ)
         self.node.save()
 
         # set up how it was in original test - remove existing subscriptions
@@ -1144,9 +1145,9 @@ class TestCompileSubscriptions(NotificationTestCase):
         self.private_node = factories.NodeFactory(parent=self.base_project, is_public=False, creator=self.user_1)
         # Adding contributors
         for node in [self.base_project, self.shared_node, self.private_node]:
-            node.add_contributor(self.user_2, permissions='admin')
-        self.base_project.add_contributor(self.user_3, permissions='write')
-        self.shared_node.add_contributor(self.user_3, permissions='write')
+            node.add_contributor(self.user_2, permissions=permissions.ADMIN)
+        self.base_project.add_contributor(self.user_3, permissions=permissions.WRITE)
+        self.shared_node.add_contributor(self.user_3, permissions=permissions.WRITE)
         # Setting basic subscriptions
         self.base_sub = factories.NotificationSubscriptionFactory(
             _id=self.base_project._id + '_file_updated',
@@ -1277,8 +1278,8 @@ class TestMoveSubscription(NotificationTestCase):
         self.file_sub.save()
 
     def test_separate_users(self):
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         subbed, removed = utils.separate_users(
             self.private_node, [self.user_2._id, self.user_3._id, self.user_4._id]
@@ -1289,8 +1290,8 @@ class TestMoveSubscription(NotificationTestCase):
     def test_event_subs_same(self):
         self.file_sub.email_transactional.add(self.user_2, self.user_3, self.user_4)
         self.file_sub.save()
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         results = utils.users_to_remove('xyz42_file_updated', self.project, self.private_node)
         assert_equal({'email_transactional': [self.user_4._id], 'email_digest': [], 'none': []}, results)
@@ -1298,8 +1299,8 @@ class TestMoveSubscription(NotificationTestCase):
     def test_event_nodes_same(self):
         self.file_sub.email_transactional.add(self.user_2, self.user_3, self.user_4)
         self.file_sub.save()
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         results = utils.users_to_remove('xyz42_file_updated', self.project, self.project)
         assert_equal({'email_transactional': [], 'email_digest': [], 'none': []}, results)
@@ -1314,7 +1315,7 @@ class TestMoveSubscription(NotificationTestCase):
 
     def test_move_sub_with_none(self):
         # Attempt to reproduce an error that is seen when moving files
-        self.project.add_contributor(self.user_2, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_2, permissions=permissions.WRITE, auth=self.auth)
         self.project.save()
         self.file_sub.none.add(self.user_2)
         self.file_sub.save()
@@ -1325,17 +1326,17 @@ class TestMoveSubscription(NotificationTestCase):
         # One user doesn't have permissions on the node the sub is moved to. Should be listed.
         self.file_sub.email_transactional.add(self.user_2, self.user_3, self.user_4)
         self.file_sub.save()
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         results = utils.users_to_remove('xyz42_file_updated', self.project, self.private_node)
         assert_equal({'email_transactional': [self.user_4._id], 'email_digest': [], 'none': []}, results)
 
     def test_remove_one_user_warn_another(self):
         # Two users do not have permissions on new node, but one has a project sub. Both should be listed.
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
         self.private_node.save()
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.project.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
@@ -1348,9 +1349,9 @@ class TestMoveSubscription(NotificationTestCase):
 
     def test_warn_user(self):
         # One user with a project sub does not have permission on new node. User should be listed.
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
         self.private_node.save()
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.project.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
@@ -1361,9 +1362,9 @@ class TestMoveSubscription(NotificationTestCase):
         assert_in(self.user_3, self.sub.email_digest.all())  # Is not removed from the project subscription.
 
     def test_user_node_subbed_and_not_removed(self):
-        self.project.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.project.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.project.save()
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         self.sub.email_digest.add(self.user_3)
         self.sub.save()
@@ -1374,8 +1375,8 @@ class TestMoveSubscription(NotificationTestCase):
     def test_garrulous_event_name(self):
         self.file_sub.email_transactional.add(self.user_2, self.user_3, self.user_4)
         self.file_sub.save()
-        self.private_node.add_contributor(self.user_2, permissions='admin', auth=self.auth)
-        self.private_node.add_contributor(self.user_3, permissions='write', auth=self.auth)
+        self.private_node.add_contributor(self.user_2, permissions=permissions.ADMIN, auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=permissions.WRITE, auth=self.auth)
         self.private_node.save()
         results = utils.users_to_remove('complicated/path_to/some/file/ASDFASDF.txt_file_updated', self.project, self.private_node)
         assert_equal({'email_transactional': [], 'email_digest': [], 'none': []}, results)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -8,22 +8,22 @@ from osf.utils import permissions
 
 def test_reduce_permissions():
     result = permissions.reduce_permissions(['read_node', 'write_node', 'admin_node'])
-    assert_equal(result, 'admin')
+    assert_equal(result, permissions.ADMIN)
 
     result2 = permissions.reduce_permissions(['read_node', 'write_node'])
-    assert_equal(result2, 'write')
+    assert_equal(result2, permissions.WRITE)
 
     result3 = permissions.reduce_permissions(['read_node'])
-    assert_equal(result3, 'read')
+    assert_equal(result3, permissions.READ)
 
-    result = permissions.reduce_permissions(['read', 'write', 'admin'])
-    assert_equal(result, 'admin')
+    result = permissions.reduce_permissions([permissions.READ, permissions.WRITE, permissions.ADMIN])
+    assert_equal(result, permissions.ADMIN)
 
-    result2 = permissions.reduce_permissions(['read', 'write'])
-    assert_equal(result2, 'write')
+    result2 = permissions.reduce_permissions([permissions.READ, permissions.WRITE])
+    assert_equal(result2, permissions.WRITE)
 
-    result3 = permissions.reduce_permissions(['read'])
-    assert_equal(result3, 'read')
+    result3 = permissions.reduce_permissions([permissions.READ])
+    assert_equal(result3, permissions.READ)
 
 
 def test_reduce_permissions_with_empty_list_raises_error():
@@ -38,7 +38,7 @@ def test_reduce_permissions_with_unknown_permission_raises_error():
 
 def test_default_contributor_permissions():
     assert_equal(permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS,
-        'write')
+        permissions.WRITE)
 
 
 if __name__ == '__main__':

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -7,13 +7,13 @@ from osf.utils import permissions
 
 
 def test_reduce_permissions():
-    result = permissions.reduce_permissions(['read_node', 'write_node', 'admin_node'])
+    result = permissions.reduce_permissions([permissions.READ_NODE, permissions.WRITE_NODE, permissions.ADMIN_NODE])
     assert_equal(result, permissions.ADMIN)
 
-    result2 = permissions.reduce_permissions(['read_node', 'write_node'])
+    result2 = permissions.reduce_permissions([permissions.READ_NODE, permissions.WRITE_NODE])
     assert_equal(result2, permissions.WRITE)
 
-    result3 = permissions.reduce_permissions(['read_node'])
+    result3 = permissions.reduce_permissions([permissions.READ_NODE])
     assert_equal(result3, permissions.READ)
 
     result = permissions.reduce_permissions([permissions.READ, permissions.WRITE, permissions.ADMIN])

--- a/tests/test_registrations/base.py
+++ b/tests/test_registrations/base.py
@@ -28,7 +28,7 @@ class RegistrationsTestBase(OsfTestCase):
         self.non_contrib = AuthUserFactory()
         self.group_mem = AuthUserFactory()
         self.group = OSFGroupFactory(creator=self.group_mem)
-        self.node.add_osf_group(self.group, 'admin')
+        self.node.add_osf_group(self.group, permissions.ADMIN)
 
         self.meta_schema = RegistrationSchema.objects.get(name='Open-Ended Registration', schema_version=2)
 

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -64,8 +64,8 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test__initiate_embargo_does_not_create_tokens_for_unregistered_admin(self):
         unconfirmed_user = UnconfirmedUserFactory()
         contrib = Contributor.objects.create(user=unconfirmed_user, node=self.registration)
-        self.registration.add_permission(unconfirmed_user, 'admin', save=True)
-        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, 'admin')
+        self.registration.add_permission(unconfirmed_user, permissions.ADMIN, save=True)
+        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, permissions.ADMIN)
 
         embargo = self.registration._initiate_embargo(
             self.user,
@@ -115,7 +115,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
 
     # Node#embargo_registration tests
     def test_embargo_from_non_admin_raises_PermissionsError(self):
-        self.registration.remove_permission(self.user, 'admin')
+        self.registration.remove_permission(self.user, permissions.ADMIN)
         self.registration.save()
         self.registration.reload()
         with assert_raises(PermissionsError):
@@ -218,7 +218,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_one_approval_with_two_admins_stays_pending(self):
         admin2 = UserFactory()
         Contributor.objects.create(user=admin2, node=self.registration)
-        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
         self.registration.embargo_registration(
             self.user,
             timezone.now() + datetime.timedelta(days=10)
@@ -550,7 +550,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_with_wrong_token_returns_HTTPBad_Request(self):
         admin2 = UserFactory()
         Contributor.objects.create(user=admin2, node=self.registration)
-        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
         self.registration.embargo_registration(
             self.user,
             timezone.now() + datetime.timedelta(days=10)
@@ -569,7 +569,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_with_wrong_admins_token_returns_HTTPBad_Request(self):
         admin2 = UserFactory()
         Contributor.objects.create(user=admin2, node=self.registration)
-        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
         self.registration.embargo_registration(
             self.user,
             timezone.now() + datetime.timedelta(days=10)
@@ -634,7 +634,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_disapprove_with_wrong_admins_token_returns_HTTPBad_Request(self):
         admin2 = UserFactory()
         Contributor.objects.create(user=admin2, node=self.registration)
-        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
         self.registration.embargo_registration(
             self.user,
             timezone.now() + datetime.timedelta(days=10)
@@ -1061,7 +1061,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         self.registration.set_privacy('public', Auth(self.registration.creator))
         admin_contributors = []
         for contributor in self.registration.contributors:
-            if Contributor.objects.get(user_id=contributor.id, node_id=self.registration.id).permission == 'admin':
+            if Contributor.objects.get(user_id=contributor.id, node_id=self.registration.id).permission == permissions.ADMIN:
                 admin_contributors.append(contributor)
         for admin in admin_contributors:
             assert_true(any([each[0][0] == admin.username for each in mock_send_mail.call_args_list]))

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -47,8 +47,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
     def test__initiate_approval_does_not_create_tokens_for_unregistered_admin(self):
         unconfirmed_user = UnconfirmedUserFactory()
         Contributor.objects.create(node=self.registration, user=unconfirmed_user)
-        self.registration.add_permission(unconfirmed_user, permissions.ADMIN, save=True)
-        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, permissions.ADMIN)
+        self.registration.add_permission(unconfirmed_user, ADMIN, save=True)
+        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, ADMIN)
 
         approval = self.registration._initiate_approval(
             self.user
@@ -82,7 +82,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         assert_not_in(child_non_admin._id, approval.approval_state)
 
     def test_require_approval_from_non_admin_raises_PermissionsError(self):
-        self.registration.remove_permission(self.user, permissions.ADMIN)
+        self.registration.remove_permission(self.user, ADMIN)
         self.registration.save()
         self.registration.reload()
         with assert_raises(PermissionsError):
@@ -128,7 +128,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
     def test_one_approval_with_two_admins_stays_pending(self):
         admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=admin2)
-        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
+        self.registration.add_permission(admin2, ADMIN, save=True)
         self.registration.require_approval(
             self.user
         )

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -21,7 +21,7 @@ from osf.models.sanctions import (
 )
 from framework.auth import Auth
 from osf.models import Contributor, SpamStatus
-
+from osf.utils.permissions import ADMIN
 
 DUMMY_TOKEN = tokens.encode({
     'dummy': 'token'
@@ -47,8 +47,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
     def test__initiate_approval_does_not_create_tokens_for_unregistered_admin(self):
         unconfirmed_user = UnconfirmedUserFactory()
         Contributor.objects.create(node=self.registration, user=unconfirmed_user)
-        self.registration.add_permission(unconfirmed_user, 'admin', save=True)
-        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, 'admin')
+        self.registration.add_permission(unconfirmed_user, permissions.ADMIN, save=True)
+        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, permissions.ADMIN)
 
         approval = self.registration._initiate_approval(
             self.user
@@ -82,7 +82,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         assert_not_in(child_non_admin._id, approval.approval_state)
 
     def test_require_approval_from_non_admin_raises_PermissionsError(self):
-        self.registration.remove_permission(self.user, 'admin')
+        self.registration.remove_permission(self.user, permissions.ADMIN)
         self.registration.save()
         self.registration.reload()
         with assert_raises(PermissionsError):
@@ -128,7 +128,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
     def test_one_approval_with_two_admins_stays_pending(self):
         admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=admin2)
-        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.add_permission(admin2, permissions.ADMIN, save=True)
         self.registration.require_approval(
             self.user
         )

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -23,7 +23,7 @@ from osf.exceptions import (
     NodeStateError,
 )
 from osf.models import Contributor, Retraction
-from osf.utils.permissions import ADMIN
+from osf.utils import permissions
 
 
 @pytest.mark.enable_bookmark_creation

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -23,6 +23,7 @@ from osf.exceptions import (
     NodeStateError,
 )
 from osf.models import Contributor, Retraction
+from osf.utils.permissions import ADMIN
 
 
 @pytest.mark.enable_bookmark_creation
@@ -51,8 +52,8 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
     def test__initiate_retraction_does_not_create_tokens_for_unregistered_admin(self):
         unconfirmed_user = UnconfirmedUserFactory()
         Contributor.objects.create(node=self.registration, user=unconfirmed_user)
-        self.registration.add_permission(unconfirmed_user, 'admin', save=True)
-        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, 'admin')
+        self.registration.add_permission(unconfirmed_user, permissions.ADMIN, save=True)
+        assert_equal(Contributor.objects.get(node=self.registration, user=unconfirmed_user).permission, permissions.ADMIN)
 
         retraction = self.registration._initiate_retraction(self.user)
         assert_true(self.user._id in retraction.approval_state)
@@ -200,7 +201,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         # group admin on node cannot retract registration
         group_mem = AuthUserFactory()
         group = OSFGroupFactory(creator=group_mem)
-        self.registration.registered_from.add_osf_group(group, 'admin')
+        self.registration.registered_from.add_osf_group(group, permissions.ADMIN)
         with assert_raises(PermissionsError):
             self.registration.retraction.approve_retraction(group_mem, approval_token)
         assert_true(self.registration.is_pending_retraction)
@@ -297,7 +298,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
     def test_two_approvals_with_two_admins_retracts(self):
         self.admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=self.admin2)
-        self.registration.add_permission(self.admin2, 'admin', save=True)
+        self.registration.add_permission(self.admin2, permissions.ADMIN, save=True)
         self.registration.retract_registration(self.user)
         self.registration.save()
         self.registration.reload()
@@ -319,7 +320,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
     def test_one_approval_with_two_admins_stays_pending(self):
         self.admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=self.admin2)
-        self.registration.add_permission(self.admin2, 'admin', save=True)
+        self.registration.add_permission(self.admin2, permissions.ADMIN, save=True)
 
         self.registration.retract_registration(self.user)
         self.registration.save()
@@ -788,7 +789,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
 
         self.group_mem = AuthUserFactory()
         self.group = OSFGroupFactory(creator=self.group_mem)
-        self.registration.registered_from.add_osf_group(self.group, 'admin')
+        self.registration.registered_from.add_osf_group(self.group, permissions.ADMIN)
 
     def test_GET_retraction_page_when_pending_retraction_returns_HTTPError_BAD_REQUEST(self):
         self.registration.retract_registration(self.user)
@@ -822,7 +823,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
             unreg.fullname,
             unreg.email,
             auth=Auth(self.user),
-            permissions='admin',
+            permissions=permissions.ADMIN,
             existing_user=unreg
         )
         self.registration.save()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -126,21 +126,21 @@ class TestNodeSerializers(OsfTestCase):
         user = UserFactory()
         admin_project = ProjectFactory()
         admin_project.add_contributor(user, auth=Auth(admin_project.creator),
-                                      permissions='admin')
+                                      permissions=permissions.ADMIN)
         admin_project.save()
 
         admin_component = NodeFactory(parent=admin_project)
         admin_component.add_contributor(user, auth=Auth(admin_component.creator),
-                                        permissions='admin')
+                                        permissions=permissions.ADMIN)
         admin_component.save()
 
         read_and_write = NodeFactory(parent=admin_project)
         read_and_write.add_contributor(user, auth=Auth(read_and_write.creator),
-                                       permissions='write')
+                                       permissions=permissions.WRITE)
         read_and_write.save()
         read_only = NodeFactory(parent=admin_project)
         read_only.add_contributor(user, auth=Auth(read_only.creator),
-                                  permissions='read')
+                                  permissions=permissions.READ)
         read_only.save()
 
         non_contributor = NodeFactory(parent=admin_project)
@@ -196,7 +196,7 @@ class TestNodeSerializers(OsfTestCase):
         project = ProjectFactory()
         user = UserFactory()
         group = OSFGroupFactory(creator=user)
-        project.add_osf_group(group, 'write')
+        project.add_osf_group(group, permissions.WRITE)
 
         res = _view_project(
             project, auth=Auth(user),
@@ -206,7 +206,7 @@ class TestNodeSerializers(OsfTestCase):
         assert_false(res['user']['is_admin'])
         assert_true(res['user']['can_edit'])
         assert_true(res['user']['has_read_permissions'])
-        assert_equal(set(res['user']['permissions']), set(['read', 'write']))
+        assert_equal(set(res['user']['permissions']), set([permissions.READ, permissions.WRITE]))
         assert_true(res['user']['can_comment'])
 
     def test_serialize_node_search_returns_only_visible_contributors(self):
@@ -356,34 +356,34 @@ class TestGetReadableDescendants(OsfTestCase):
         userB = UserFactory(fullname='User B')
 
         project1 = ProjectFactory(creator=self.user, title='One')
-        project1.add_contributor(userA, auth=Auth(self.user), permissions='read')
-        project1.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        project1.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
+        project1.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         component2 = ProjectFactory(creator=self.user, title='Two')
-        component2.add_contributor(userA, auth=Auth(self.user), permissions='read')
+        component2.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
 
         component3 = ProjectFactory(creator=self.user, title='Three')
-        component3.add_contributor(userA, auth=Auth(self.user), permissions='read')
-        component3.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        component3.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
+        component3.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         component4 = ProjectFactory(creator=self.user, title='Four')
-        component4.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        component4.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         component5 = ProjectFactory(creator=self.user, title='Five')
-        component5.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        component5.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         component6 = ProjectFactory(creator=self.user, title='Six')
-        component6.add_contributor(userA, auth=Auth(self.user), permissions='read')
+        component6.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
 
         component7 = ProjectFactory(creator=self.user, title='Seven')
-        component7.add_contributor(userA, auth=Auth(self.user), permissions='read')
+        component7.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
 
         component8 = ProjectFactory(creator=self.user, title='Eight')
-        component8.add_contributor(userA, auth=Auth(self.user), permissions='read')
-        component8.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        component8.add_contributor(userA, auth=Auth(self.user), permissions=permissions.READ)
+        component8.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         component9 = ProjectFactory(creator=self.user, title='Nine')
-        component9.add_contributor(userB, auth=Auth(self.user), permissions='read')
+        component9.add_contributor(userB, auth=Auth(self.user), permissions=permissions.READ)
 
         project1.add_pointer(component2, Auth(self.user))
         NodeRelation.objects.create(parent=project1, child=component4)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -242,7 +242,7 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
     def test_check_can_access_osf_group_member_valid(self):
         user = AuthUserFactory()
         group = OSFGroupFactory(creator=user)
-        self.project.add_osf_group(group, 'read')
+        self.project.add_osf_group(group, permissions.READ)
         self.project.save()
         assert_true(check_can_access(self.project, user))
 
@@ -441,11 +441,11 @@ class TestProjectViews(OsfTestCase):
         dict2 = add_contributor_json(user2)
         dict3 = add_contributor_json(user3)
         dict2.update({
-            'permission': 'admin',
+            'permission': permissions.ADMIN,
             'visible': True,
         })
         dict3.update({
-            'permission': 'write',
+            'permission': permissions.WRITE,
             'visible': False,
         })
 
@@ -464,13 +464,13 @@ class TestProjectViews(OsfTestCase):
         assert_equal(project.logs.latest().action, 'contributor_added')
         assert_equal(len(project.contributors), 3)
 
-        assert project.has_permission(user2, 'admin') is True
-        assert project.has_permission(user2, 'write') is True
-        assert project.has_permission(user2, 'read') is True
+        assert project.has_permission(user2, permissions.ADMIN) is True
+        assert project.has_permission(user2, permissions.WRITE) is True
+        assert project.has_permission(user2, permissions.READ) is True
 
-        assert project.has_permission(user3, 'admin') is False
-        assert project.has_permission(user3, 'write') is True
-        assert project.has_permission(user3, 'read') is True
+        assert project.has_permission(user3, permissions.ADMIN) is False
+        assert project.has_permission(user3, permissions.WRITE) is True
+        assert project.has_permission(user3, permissions.READ) is True
 
     def test_manage_permissions(self):
         url = self.project.api_url + 'contributors/manage/'
@@ -478,11 +478,11 @@ class TestProjectViews(OsfTestCase):
             url,
             {
                 'contributors': [
-                    {'id': self.project.creator._id, 'permission': 'admin',
+                    {'id': self.project.creator._id, 'permission': permissions.ADMIN,
                         'registered': True, 'visible': True},
-                    {'id': self.user1._id, 'permission': 'read',
+                    {'id': self.user1._id, 'permission': permissions.READ,
                         'registered': True, 'visible': True},
-                    {'id': self.user2._id, 'permission': 'admin',
+                    {'id': self.user2._id, 'permission': permissions.ADMIN,
                         'registered': True, 'visible': True},
                 ]
             },
@@ -491,13 +491,13 @@ class TestProjectViews(OsfTestCase):
 
         self.project.reload()
 
-        assert self.project.has_permission(self.user1, 'admin') is False
-        assert self.project.has_permission(self.user1, 'write') is False
-        assert self.project.has_permission(self.user1, 'read') is True
+        assert self.project.has_permission(self.user1, permissions.ADMIN) is False
+        assert self.project.has_permission(self.user1, permissions.WRITE) is False
+        assert self.project.has_permission(self.user1, permissions.READ) is True
 
-        assert self.project.has_permission(self.user2, 'admin') is True
-        assert self.project.has_permission(self.user2, 'write') is True
-        assert self.project.has_permission(self.user2, 'read') is True
+        assert self.project.has_permission(self.user2, permissions.ADMIN) is True
+        assert self.project.has_permission(self.user2, permissions.WRITE) is True
+        assert self.project.has_permission(self.user2, permissions.READ) is True
 
     def test_manage_permissions_again(self):
         url = self.project.api_url + 'contributors/manage/'
@@ -505,9 +505,9 @@ class TestProjectViews(OsfTestCase):
             url,
             {
                 'contributors': [
-                    {'id': self.user1._id, 'permission': 'admin',
+                    {'id': self.user1._id, 'permission': permissions.ADMIN,
                      'registered': True, 'visible': True},
-                    {'id': self.user2._id, 'permission': 'admin',
+                    {'id': self.user2._id, 'permission': permissions.ADMIN,
                      'registered': True, 'visible': True},
                 ]
             },
@@ -519,9 +519,9 @@ class TestProjectViews(OsfTestCase):
             url,
             {
                 'contributors': [
-                    {'id': self.user1._id, 'permission': 'admin',
+                    {'id': self.user1._id, 'permission': permissions.ADMIN,
                      'registered': True, 'visible': True},
-                    {'id': self.user2._id, 'permission': 'read',
+                    {'id': self.user2._id, 'permission': permissions.READ,
                      'registered': True, 'visible': True},
                 ]
             },
@@ -530,13 +530,13 @@ class TestProjectViews(OsfTestCase):
 
         self.project.reload()
 
-        assert self.project.has_permission(self.user2, 'admin') is False
-        assert self.project.has_permission(self.user2, 'write') is False
-        assert self.project.has_permission(self.user2, 'read') is True
+        assert self.project.has_permission(self.user2, permissions.ADMIN) is False
+        assert self.project.has_permission(self.user2, permissions.WRITE) is False
+        assert self.project.has_permission(self.user2, permissions.READ) is True
 
-        assert self.project.has_permission(self.user1, 'admin') is True
-        assert self.project.has_permission(self.user1, 'write') is True
-        assert self.project.has_permission(self.user1, 'read') is True
+        assert self.project.has_permission(self.user1, permissions.ADMIN) is True
+        assert self.project.has_permission(self.user1, permissions.WRITE) is True
+        assert self.project.has_permission(self.user1, permissions.READ) is True
 
     def test_contributor_manage_reorder(self):
 
@@ -545,8 +545,8 @@ class TestProjectViews(OsfTestCase):
         reg_user1, reg_user2 = UserFactory(), UserFactory()
         project.add_contributors(
             [
-                {'user': reg_user1, 'permissions': 'admin', 'visible': True},
-                {'user': reg_user2, 'permissions': 'admin', 'visible': False},
+                {'user': reg_user1, 'permissions': permissions.ADMIN, 'visible': True},
+                {'user': reg_user2, 'permissions': permissions.ADMIN, 'visible': False},
             ]
         )
         # Add a non-registered user
@@ -561,13 +561,13 @@ class TestProjectViews(OsfTestCase):
             url,
             {
                 'contributors': [
-                    {'id': reg_user2._id, 'permission': 'admin',
+                    {'id': reg_user2._id, 'permission': permissions.ADMIN,
                         'registered': True, 'visible': False},
-                    {'id': project.creator._id, 'permission': 'admin',
+                    {'id': project.creator._id, 'permission': permissions.ADMIN,
                         'registered': True, 'visible': True},
-                    {'id': unregistered_user._id, 'permission': 'admin',
+                    {'id': unregistered_user._id, 'permission': permissions.ADMIN,
                         'registered': False, 'visible': True},
-                    {'id': reg_user1._id, 'permission': 'admin',
+                    {'id': reg_user1._id, 'permission': permissions.ADMIN,
                         'registered': True, 'visible': True},
                 ]
             },
@@ -700,8 +700,8 @@ class TestProjectViews(OsfTestCase):
         reg_user1, reg_user2 = UserFactory(), UserFactory()
         project.add_contributors(
             [
-                {'user': reg_user1, 'permissions': 'admin', 'visible': True},
-                {'user': reg_user2, 'permissions': 'admin', 'visible': True},
+                {'user': reg_user1, 'permissions': permissions.ADMIN, 'visible': True},
+                {'user': reg_user2, 'permissions': permissions.ADMIN, 'visible': True},
             ]
         )
 
@@ -845,7 +845,7 @@ class TestProjectViews(OsfTestCase):
         non_admin = AuthUserFactory()
         node.add_contributor(
             non_admin,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True,
         )
 
@@ -1851,9 +1851,9 @@ class TestAddingContributorViews(OsfTestCase):
             serialize_unregistered(fake.name(), unreg.username),
             unreg_no_record
         ]
-        contrib_data[0]['permission'] = 'admin'
-        contrib_data[1]['permission'] = 'write'
-        contrib_data[2]['permission'] = 'read'
+        contrib_data[0]['permission'] = permissions.ADMIN
+        contrib_data[1]['permission'] = permissions.WRITE
+        contrib_data[2]['permission'] = permissions.READ
         contrib_data[0]['visible'] = True
         contrib_data[1]['visible'] = True
         contrib_data[2]['visible'] = True
@@ -1875,7 +1875,7 @@ class TestAddingContributorViews(OsfTestCase):
         email = fake_email()
         unreg_no_record = serialize_unregistered(name, email)
         contrib_data = [unreg_no_record]
-        contrib_data[0]['permission'] = 'admin'
+        contrib_data[0]['permission'] = permissions.ADMIN
         contrib_data[0]['visible'] = True
 
         with assert_raises(ValidationError):
@@ -1890,7 +1890,7 @@ class TestAddingContributorViews(OsfTestCase):
         email = '!@#$%%^&*'
         unreg_no_record = serialize_unregistered(name, email)
         contrib_data = [unreg_no_record]
-        contrib_data[0]['permission'] = 'admin'
+        contrib_data[0]['permission'] = permissions.ADMIN
         contrib_data[0]['visible'] = True
 
         with assert_raises(ValidationError):
@@ -1925,11 +1925,11 @@ class TestAddingContributorViews(OsfTestCase):
             'registered': False,
             'fullname': name,
             'email': email,
-            'permission': 'admin',
+            'permission': permissions.ADMIN,
             'visible': True,
         }
         reg_dict = add_contributor_json(reg_user)
-        reg_dict['permission'] = 'admin'
+        reg_dict['permission'] = permissions.ADMIN
         reg_dict['visible'] = True
         payload = {
             'users': [reg_dict, pseudouser],
@@ -1966,7 +1966,7 @@ class TestAddingContributorViews(OsfTestCase):
             'registered': False,
             'fullname': fake.name(),
             'email': fake_email(),
-            'permission': 'admin',
+            'permission': permissions.ADMIN,
             'visible': True,
         }
         payload = {
@@ -1994,7 +1994,7 @@ class TestAddingContributorViews(OsfTestCase):
             'id': user._id,
             'fullname': user.fullname,
             'email': user.username,
-            'permission': 'write',
+            'permission': permissions.WRITE,
             'visible': True}
 
         payload = {
@@ -2022,7 +2022,7 @@ class TestAddingContributorViews(OsfTestCase):
             'id': user._id,
             'fullname': user.fullname,
             'email': user.username,
-            'permission': 'write',
+            'permission': permissions.WRITE,
             'visible': True}
 
         payload = {
@@ -2046,7 +2046,7 @@ class TestAddingContributorViews(OsfTestCase):
             'registered': False,
             'fullname': name,
             'email': email,
-            'permission': 'admin',
+            'permission': permissions.ADMIN,
             'visible': True,
         }
         payload = {
@@ -2064,7 +2064,7 @@ class TestAddingContributorViews(OsfTestCase):
         contributors = [{
             'user': contributor,
             'visible': True,
-            'permissions': 'write'
+            'permissions': permissions.WRITE
         }]
         project = ProjectFactory(creator=self.auth.user)
         project.add_contributors(contributors, auth=self.auth)
@@ -2180,11 +2180,11 @@ class TestAddingContributorViews(OsfTestCase):
             'registered': False,
             'fullname': name,
             'email': fake_email(),
-            'permission': 'write',
+            'permission': permissions.WRITE,
             'visible': True,
         }
         reg_dict = add_contributor_json(reg_user)
-        reg_dict['permission'] = 'admin'
+        reg_dict['permission'] = permissions.ADMIN
         reg_dict['visible'] = True
         payload = {
             'users': [reg_dict, pseudouser],
@@ -2205,11 +2205,11 @@ class TestAddingContributorViews(OsfTestCase):
             'registered': False,
             'fullname': name,
             'email': email,
-            'permission': 'admin',
+            'permission': permissions.ADMIN,
             'visible': True,
         }
         reg_dict = add_contributor_json(reg_user)
-        reg_dict['permission'] = 'admin'
+        reg_dict['permission'] = permissions.ADMIN
         reg_dict['visible'] = True
         payload = {
             'users': [reg_dict, pseudouser],
@@ -4400,12 +4400,12 @@ class TestWikiWidgetViews(OsfTestCase):
         # project with no home wiki page
         self.project = ProjectFactory()
         self.read_only_contrib = AuthUserFactory()
-        self.project.add_contributor(self.read_only_contrib, permissions='read')
+        self.project.add_contributor(self.read_only_contrib, permissions=permissions.READ)
         self.noncontributor = AuthUserFactory()
 
         # project with no home wiki content
         self.project2 = ProjectFactory(creator=self.project.creator)
-        self.project2.add_contributor(self.read_only_contrib, permissions='read')
+        self.project2.add_contributor(self.read_only_contrib, permissions=permissions.READ)
         WikiPage.objects.create_for_node(self.project2, 'home', '', Auth(self.project.creator))
 
     def test_show_wiki_for_contributors_when_no_wiki_or_content(self):
@@ -4421,12 +4421,12 @@ class TestWikiWidgetViews(OsfTestCase):
 
     def test_show_wiki_for_osf_group_members(self):
         group = OSFGroupFactory(creator=self.noncontributor)
-        self.project.add_osf_group(group, 'read')
+        self.project.add_osf_group(group, permissions.READ)
         assert_false(_should_show_wiki_widget(self.project, self.noncontributor))
         assert_false(_should_show_wiki_widget(self.project2, self.noncontributor))
 
         self.project.remove_osf_group(group)
-        self.project.add_osf_group(group, 'write')
+        self.project.add_osf_group(group, permissions.WRITE)
         assert_true(_should_show_wiki_widget(self.project, self.noncontributor))
         assert_false(_should_show_wiki_widget(self.project2, self.noncontributor))
 
@@ -4530,9 +4530,9 @@ class TestProjectCreation(OsfTestCase):
         non_admin = AuthUserFactory()
         read_user = AuthUserFactory()
         group = OSFGroupFactory(creator=read_user)
-        self.project.add_contributor(non_admin, permissions='write')
-        self.project.add_contributor(read_user, permissions='read')
-        self.project.add_osf_group(group, 'admin')
+        self.project.add_contributor(non_admin, permissions=permissions.WRITE)
+        self.project.add_contributor(read_user, permissions=permissions.READ)
+        self.project.add_osf_group(group, permissions.ADMIN)
         self.project.save()
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=non_admin.auth)
@@ -4543,14 +4543,14 @@ class TestProjectCreation(OsfTestCase):
         assert_in(self.user1, child.contributors)
         assert_in(self.user2, child.contributors)
         assert_in(read_user, child.contributors)
-        assert child.has_permission(non_admin, 'admin') is True
-        assert child.has_permission(non_admin, 'write') is True
-        assert child.has_permission(non_admin, 'read') is True
+        assert child.has_permission(non_admin, permissions.ADMIN) is True
+        assert child.has_permission(non_admin, permissions.WRITE) is True
+        assert child.has_permission(non_admin, permissions.READ) is True
         # read_user was a read contrib on the parent, but was an admin group member
         # read contrib perms copied over
-        assert child.has_permission(read_user, 'admin') is False
-        assert child.has_permission(read_user, 'write') is False
-        assert child.has_permission(read_user, 'read') is True
+        assert child.has_permission(read_user, permissions.ADMIN) is False
+        assert child.has_permission(read_user, permissions.WRITE) is False
+        assert child.has_permission(read_user, permissions.READ) is True
         # User creating the component was not a manager on the group
         assert group not in child.osf_groups
         # check redirect url
@@ -4561,9 +4561,9 @@ class TestProjectCreation(OsfTestCase):
         non_admin = AuthUserFactory()
         write_user = AuthUserFactory()
         group = OSFGroupFactory(creator=write_user)
-        self.project.add_contributor(non_admin, permissions='write')
-        self.project.add_contributor(write_user, permissions='write')
-        self.project.add_osf_group(group, 'admin')
+        self.project.add_contributor(non_admin, permissions=permissions.WRITE)
+        self.project.add_contributor(write_user, permissions=permissions.WRITE)
+        self.project.add_osf_group(group, permissions.ADMIN)
         self.project.save()
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=write_user.auth)
@@ -4574,13 +4574,13 @@ class TestProjectCreation(OsfTestCase):
         assert_in(self.user1, child.contributors)
         assert_in(self.user2, child.contributors)
         assert_in(write_user, child.contributors)
-        assert child.has_permission(non_admin, 'admin') is False
-        assert child.has_permission(non_admin, 'write') is True
-        assert child.has_permission(non_admin, 'read') is True
+        assert child.has_permission(non_admin, permissions.ADMIN) is False
+        assert child.has_permission(non_admin, permissions.WRITE) is True
+        assert child.has_permission(non_admin, permissions.READ) is True
         # Component creator gets admin
-        assert child.has_permission(write_user, 'admin') is True
-        assert child.has_permission(write_user, 'write') is True
-        assert child.has_permission(write_user, 'read') is True
+        assert child.has_permission(write_user, permissions.ADMIN) is True
+        assert child.has_permission(write_user, permissions.WRITE) is True
+        assert child.has_permission(write_user, permissions.READ) is True
         # User creating the component was a manager of the group, so group copied
         assert group in child.osf_groups
         # check redirect url
@@ -4589,7 +4589,7 @@ class TestProjectCreation(OsfTestCase):
     def test_create_component_with_contributors_read(self):
         url = web_url_for('project_new_node', pid=self.project._id)
         non_admin = AuthUserFactory()
-        self.project.add_contributor(non_admin, permissions='read')
+        self.project.add_contributor(non_admin, permissions=permissions.READ)
         self.project.save()
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=non_admin.auth, expect_errors=True)

--- a/tests/test_webtests.py
+++ b/tests/test_webtests.py
@@ -32,6 +32,7 @@ from osf_tests.factories import (
     UnconfirmedUserFactory,
     UnregUserFactory,
 )
+from osf.utils import permissions
 from addons.wiki.models import WikiPage, WikiVersion
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 from website import settings, language
@@ -130,7 +131,7 @@ class TestAUser(OsfTestCase):
         project = ProjectFactory(creator=self.user)
         project.add_contributor(
             self.user,
-            permissions='admin',
+            permissions=permissions.ADMIN,
             save=True)
         res = self.app.get('/{0}/addons/'.format(project._primary_key), auth=self.auth, auto_follow=True)
         assert_in('OSF Storage', res)
@@ -146,7 +147,7 @@ class TestAUser(OsfTestCase):
         project = ProjectFactory()
         project.add_contributor(
             self.user,
-            permissions='admin',
+            permissions=permissions.ADMIN,
             save=True)
         # User goes to the project page
         res = self.app.get(project.url, auth=self.auth).maybe_follow()
@@ -157,7 +158,7 @@ class TestAUser(OsfTestCase):
         project = ProjectFactory()
         project.add_contributor(
             self.user,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True)
         # User goes to the project page
         res = self.app.get(project.url, auth=self.auth).maybe_follow()
@@ -168,7 +169,7 @@ class TestAUser(OsfTestCase):
         project = ProjectFactory(is_public=True)
         project.add_contributor(
             self.user,
-            permissions='admin',
+            permissions=permissions.ADMIN,
             save=True)
         # User goes to the project page
         res = self.app.get(project.url, auth=self.auth).maybe_follow()
@@ -179,7 +180,7 @@ class TestAUser(OsfTestCase):
         project = ProjectFactory(is_public=True)
         project.add_contributor(
             self.user,
-            permissions='write',
+            permissions=permissions.WRITE,
             save=True)
         # User goes to the project page
         res = self.app.get(project.url, auth=self.auth).maybe_follow()
@@ -300,7 +301,7 @@ class TestComponents(OsfTestCase):
         non_admin = AuthUserFactory()
         self.component.add_contributor(
             non_admin,
-            permissions='write',
+            permissions=permissions.WRITE,
             auth=self.consolidate_auth,
             save=True,
         )
@@ -324,7 +325,7 @@ class TestComponents(OsfTestCase):
         non_admin = AuthUserFactory()
         self.component.add_contributor(
             non_admin,
-            permissions='write',
+            permissions=permissions.WRITE,
             auth=self.consolidate_auth,
             save=True,
         )
@@ -366,7 +367,7 @@ class TestPrivateLinkView(OsfTestCase):
         link2.save()
         self.project.add_contributor(
             self.user,
-            permissions='read',
+            permissions=permissions.READ,
             save=True,
         )
         res = self.app.get(self.project_url, {'view_only': link2.key},
@@ -381,7 +382,7 @@ class TestPrivateLinkView(OsfTestCase):
     def test_no_warning_for_read_only_user_with_invalid_link(self):
         self.project.add_contributor(
             self.user,
-            permissions='read',
+            permissions=permissions.READ,
             save=True,
         )
         res = self.app.get(self.project_url, {'view_only': 'not_valid'},
@@ -1019,13 +1020,13 @@ class TestPreprintBannerView(OsfTestCase):
         self.non_contrib = AuthUserFactory()
         self.provider_one = PreprintProviderFactory()
         self.project_one = ProjectFactory(creator=self.admin, is_public=True)
-        self.project_one.add_contributor(self.write_contrib, 'write')
-        self.project_one.add_contributor(self.read_contrib, 'read')
+        self.project_one.add_contributor(self.write_contrib, permissions.WRITE)
+        self.project_one.add_contributor(self.read_contrib, permissions.READ)
 
         self.subject_one = SubjectFactory()
         self.preprint = PreprintFactory(creator=self.admin, filename='mgla.pdf', provider=self.provider_one, subjects=[[self.subject_one._id]], project=self.project_one, is_published=True)
-        self.preprint.add_contributor(self.write_contrib, 'write')
-        self.preprint.add_contributor(self.read_contrib, 'read')
+        self.preprint.add_contributor(self.write_contrib, permissions.WRITE)
+        self.preprint.add_contributor(self.read_contrib, permissions.READ)
 
     def test_public_project_published_preprint(self):
         url = self.project_one.web_url_for('view_project')
@@ -1221,7 +1222,7 @@ class TestPreprintBannerView(OsfTestCase):
     def test_implicit_admins_can_see_project_status(self):
         project = ProjectFactory(creator=self.admin)
         component = NodeFactory(creator=self.admin, parent=project)
-        project.add_contributor(self.write_contrib, 'admin')
+        project.add_contributor(self.write_contrib, permissions.ADMIN)
         project.save()
 
         preprint = PreprintFactory(creator=self.admin, filename='mgla.pdf', provider=self.provider_one, subjects=[[self.subject_one._id]], project=component, is_published=True)

--- a/website/citations/views.py
+++ b/website/citations/views.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from framework.auth.decorators import must_be_logged_in
 
 from osf.models.citation import CitationStyle
+from osf.utils.permissions import WRITE
 from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
     must_have_permission, must_not_be_registration,
@@ -80,7 +81,7 @@ class GenericCitationViews(object):
         @must_be_logged_in
         @must_have_addon(addon_short_name, 'node')
         @must_be_valid_project
-        @must_have_permission('write')
+        @must_have_permission(WRITE)
         def _get_config(auth, node_addon, **kwargs):
             """ Returns the serialized node settings,
             with a boolean indicator for credential validity.
@@ -103,7 +104,7 @@ class GenericCitationViews(object):
         @must_have_addon(addon_short_name, 'user')
         @must_have_addon(addon_short_name, 'node')
         @must_be_addon_authorizer(addon_short_name)
-        @must_have_permission('write')
+        @must_have_permission(WRITE)
         def _set_config(node_addon, user_addon, auth, **kwargs):
             """ Changes folder associated with addon.
             Returns serialized node settings
@@ -135,7 +136,7 @@ class GenericCitationViews(object):
         @must_not_be_registration
         @must_have_addon(addon_short_name, 'user')
         @must_have_addon(addon_short_name, 'node')
-        @must_have_permission('write')
+        @must_have_permission(WRITE)
         def _import_auth(auth, node_addon, user_addon, **kwargs):
             """
             Import addon credentials from the currently logged-in user to a node.
@@ -152,7 +153,7 @@ class GenericCitationViews(object):
 
         @must_not_be_registration
         @must_have_addon(addon_short_name, 'node')
-        @must_have_permission('write')
+        @must_have_permission(WRITE)
         def _deauthorize_node(auth, node_addon, **kwargs):
             """ Removes addon authorization from node.
             """

--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -7,6 +7,7 @@ from website import settings
 from osf.models import MailRecord
 from api.base.utils import waterbutler_api_url_for
 from osf.exceptions import NodeStateError
+from osf.utils.permissions import ADMIN
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 
@@ -55,7 +56,7 @@ def prepare_contributors(admins):
     return [
         {
             'user': admin,
-            'permissions': 'admin',
+            'permissions': ADMIN,
             'visible': False,
         }
         for admin in admins

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -1,7 +1,7 @@
 from babel import dates, core, Locale
 
 from osf.models import AbstractNode, OSFUser, NotificationDigest, NotificationSubscription
-
+from osf.utils.permissions import READ
 from website import mails
 from website.notifications import constants
 from website.notifications import utils
@@ -155,7 +155,7 @@ def check_node(node, event):
             users = getattr(subscription, notification_type, [])
             if users:
                 for user in users.exclude(date_disabled__isnull=False):
-                    if node.has_permission(user, 'read'):
+                    if node.has_permission(user, READ):
                         node_subscriptions[notification_type].append(user._id)
     return node_subscriptions
 

--- a/website/notifications/tasks.py
+++ b/website/notifications/tasks.py
@@ -9,6 +9,7 @@ from framework.celery_tasks import app as celery_app
 from framework.sentry import log_exception
 from osf.models import OSFUser, AbstractNode, AbstractProvider
 from osf.models import NotificationDigest
+from osf.utils.permissions import ADMIN
 from website import mails, settings
 from website.notifications.utils import NotificationsDict
 
@@ -76,7 +77,7 @@ def _send_reviews_moderator_emails(send_type):
                 reviews_submissions_url='{}reviews/preprints/{}'.format(settings.DOMAIN, provider._id),
                 notification_settings_url='{}reviews/preprints/{}/notifications'.format(settings.DOMAIN, provider._id),
                 is_reviews_moderator_notification=True,
-                is_admin=provider.get_group('admin').user_set.filter(id=user.id).exists()
+                is_admin=provider.get_group(ADMIN).user_set.filter(id=user.id).exists()
             )
         remove_notifications(email_notification_ids=notification_ids)
 

--- a/website/notifications/views.py
+++ b/website/notifications/views.py
@@ -7,6 +7,7 @@ from framework.auth.decorators import must_be_logged_in
 from framework.exceptions import HTTPError
 
 from osf.models import AbstractNode, NotificationSubscription
+from osf.utils.permissions import READ
 from website.notifications import utils
 from website.notifications.constants import NOTIFICATION_TYPES
 from website.project.decorators import must_be_valid_project
@@ -69,7 +70,7 @@ def configure_subscription(auth):
             raise HTTPError(http.BAD_REQUEST)
         owner = user
     else:
-        if not node.has_permission(user, 'read'):
+        if not node.has_permission(user, READ):
             sentry.log_message('{!r} attempted to subscribe to private node, {}'.format(user, target_id))
             raise HTTPError(http.FORBIDDEN)
 

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -5,7 +5,7 @@ from website import settings
 from osf.models import Contributor
 from addons.osfstorage.models import Region
 from website.filters import profile_image_url
-
+from osf.utils.permissions import READ
 from osf.utils import workflows
 from website.ember_osf_web.decorators import storage_i18n_flag_active
 
@@ -41,7 +41,7 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
         if admin:
             flags = {
                 'visible': False,
-                'permission': 'read',
+                'permission': READ,
             }
         else:
             if not contrib:

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -13,6 +13,7 @@ from framework.auth.decorators import collect_auth
 from framework.database import get_or_http_error
 
 from osf.models import AbstractNode, Guid, Preprint, OSFGroup
+from osf.utils.permissions import WRITE
 from website import settings, language
 from website.util import web_url_for
 
@@ -432,7 +433,7 @@ def must_have_write_permission_or_public_wiki(func):
         if wiki and wiki.is_publicly_editable:
             return func(*args, **kwargs)
         else:
-            return must_have_permission('write')(func)(*args, **kwargs)
+            return must_have_permission(WRITE)(func)(*args, **kwargs)
 
     # Return decorated function
     return wrapped

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -331,7 +331,7 @@ def project_remove_contributor(auth, **kwargs):
         node = AbstractNode.load(node_id)
 
         # Forbidden unless user is removing herself
-        if not node.has_permission(auth.user, 'admin'):
+        if not node.has_permission(auth.user, ADMIN):
             if auth.user != contributor:
                 raise HTTPError(http.FORBIDDEN)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -45,7 +45,7 @@ from addons.wiki.models import WikiPage
 from osf.models import AbstractNode, Collection, Contributor, Guid, PrivateLink, Node, NodeRelation, Preprint
 from osf.models.licenses import serialize_node_license_record
 from osf.utils.sanitize import strip_html
-from osf.utils.permissions import ADMIN, READ, WRITE, CREATOR_PERMISSIONS
+from osf.utils.permissions import ADMIN, READ, WRITE, CREATOR_PERMISSIONS, ADMIN_NODE
 from website import settings
 from website.views import find_bookmark_collection, validate_page_num
 from website.views import serialize_node_summary, get_storage_region_list
@@ -927,7 +927,7 @@ def _get_children(node, auth):
     children = (Node.objects.get_children(node)
                 .filter(is_deleted=False)
                 .annotate(parentnode_id=Subquery(parent_node_sqs[:1])))
-    admin_children = get_objects_for_user(auth.user, 'admin_node', children, with_superuser=False)
+    admin_children = get_objects_for_user(auth.user, ADMIN_NODE, children, with_superuser=False)
 
     nested = defaultdict(list)
     for child in admin_children:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -666,7 +666,7 @@ def _should_show_wiki_widget(node, user):
     has_wiki = bool(node.get_addon('wiki'))
     wiki_page = WikiVersion.objects.get_for_node(node, 'home')
 
-    if node.has_permission(user, 'write') and not node.is_registration:
+    if node.has_permission(user, WRITE) and not node.is_registration:
         return has_wiki
     else:
         return has_wiki and wiki_page and wiki_page.html(node)
@@ -981,7 +981,7 @@ def _get_readable_descendants(auth, node, permission=None):
             descendants.append(child)
         # Child is a node link and user has write permission
         elif node.linked_nodes.filter(id=child.id).exists():
-            if node.has_permission(auth.user, 'write'):
+            if node.has_permission(auth.user, WRITE):
                 descendants.append(child)
             else:
                 all_readable = False
@@ -1017,7 +1017,7 @@ def serialize_child_tree(child_list, user, nested):
                     'title': child.title,
                     'is_public': child.is_public,
                     'contributors': contributors,
-                    'is_admin': child.has_permission(user, 'admin'),
+                    'is_admin': child.has_permission(user, ADMIN),
                     'is_supplemental_project': child.has_linked_published_preprints,
                 },
                 'user_id': user._id,
@@ -1026,7 +1026,7 @@ def serialize_child_tree(child_list, user, nested):
                 'category': child.category,
                 'permissions': {
                     'view': True,
-                    'is_admin': child.has_permission(user, 'admin')
+                    'is_admin': child.has_permission(user, ADMIN)
                 }
             })
 
@@ -1077,7 +1077,7 @@ def node_child_tree(user, node):
             },
             'user_id': user._id,
             'children': serialize_child_tree(nested.get(node._id), user, nested) if node._id in nested.keys() else [],
-            'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, 'read') else 'node',
+            'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, READ) else 'node',
             'nodeType': node.project_or_component,
             'category': node.category,
             'permissions': {

--- a/website/project/views/tag.py
+++ b/website/project/views/tag.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 
 from framework.auth.decorators import collect_auth
 from osf.models import AbstractNode
+from osf.utils.permissions import WRITE
 from osf.exceptions import InvalidTagError, NodeStateError, TagNotFoundError
 from website.project.decorators import (
     must_be_valid_project, must_have_permission, must_not_be_registration
@@ -29,7 +30,7 @@ def project_tag(tag, auth, **kwargs):
 
 
 @must_be_valid_project  # injects project
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_not_be_registration
 def project_add_tag(auth, node, **kwargs):
 
@@ -44,7 +45,7 @@ def project_add_tag(auth, node, **kwargs):
 
 
 @must_be_valid_project  # injects project
-@must_have_permission('write')
+@must_have_permission(WRITE)
 @must_not_be_registration
 def project_remove_tag(auth, node, **kwargs):
     data = request.get_json()

--- a/website/registries/views.py
+++ b/website/registries/views.py
@@ -2,6 +2,7 @@
 from flask import request
 from framework.auth import Auth, decorators
 from framework.utils import iso8601format
+from osf.utils.permissions import ADMIN
 from website.registries import utils
 
 
@@ -15,7 +16,7 @@ def _view_registries_landing_page(campaign=None, **kwargs):
         registerable_nodes = [
             node for node
             in auth.user.contributor_to
-            if node.has_permission(user=auth.user, permission='admin')
+            if node.has_permission(user=auth.user, permission=ADMIN)
         ]
         has_projects = bool(registerable_nodes)
     else:

--- a/website/routes.py
+++ b/website/routes.py
@@ -33,6 +33,7 @@ from framework.auth.core import _get_current_user
 from osf import features
 from osf.models import Institution
 from osf.utils import sanitize
+from osf.utils import permissions
 from website import util
 from website import prereg
 from website import settings
@@ -160,6 +161,7 @@ def get_globals():
         'features': features,
         'waffle': waffle,
         'csrf_cookie_name': api_settings.CSRF_COOKIE_NAME,
+        'permissions': permissions
     }
 
 

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -1,4 +1,4 @@
-% if complete or 'write' in user['permissions']:
+% if complete or permissions.WRITE in user['permissions']:
     <div class="panel panel-default" name="${short_name}">
         <div class="panel-heading clearfix">
             <h3 class="panel-title">${full_name}</h3>

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -5,7 +5,7 @@
     <span id="selectAddonsAnchor" class="anchor"></span>
 
     <!-- Begin left column -->
-    % if 'write' in user['permissions'] and any(addon['enabled'] for addon in addon_settings):
+    % if permissions.WRITE in user['permissions'] and any(addon['enabled'] for addon in addon_settings):
         <div class="col-sm-3 affix-parent scrollspy">
 
 
@@ -23,7 +23,7 @@
     % endif
 
     <!-- End left column -->
-        % if 'write' in user['permissions']:  ## Begin Select Addons
+        % if permissions.WRITE in user['permissions']:  ## Begin Select Addons
 
             % if not node['is_registration']:
                 <div class="panel panel-default" id="selectAddon">

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -59,7 +59,7 @@
             <!-- /ko -->
         </h3>
 
-        % if 'admin' in user['permissions'] and not node['is_registration']:
+        % if permissions.ADMIN in user['permissions'] and not node['is_registration']:
             <p class="m-b-xs">Drag and drop contributors to change listing order.</p>
         % endif
 
@@ -138,7 +138,7 @@
         ${buttonGroup()}
     </div>
 
-    % if 'admin' in user['permissions'] and access_requests and node['access_requests_enabled']:
+    % if permissions.ADMIN in user['permissions'] and access_requests and node['access_requests_enabled']:
     <div id="manageAccessRequests">
         <h3> Requests for Access</h3>
         <p class="m-b-xs">The following users have requested access to this project.</p>
@@ -155,7 +155,7 @@
     </div>
     % endif
 
-    % if 'admin' in user['permissions']:
+    % if permissions.ADMIN in user['permissions']:
         <h3 class="m-t-xl">View-only Links
             <a href="#addPrivateLink" data-toggle="modal" class="btn btn-success btn-sm m-l-md">
               <i class="fa fa-plus"></i> Add
@@ -385,7 +385,7 @@
 </script>
 
 <%def name="buttonGroup()">
-    % if 'admin' in user['permissions']:
+    % if permissions.ADMIN in user['permissions']:
         <div class="m-b-sm">
             <a class="btn btn-danger contrib-button" data-bind="click: cancel, visible: changed">Discard Changes</a>
             <a class="btn btn-success contrib-button" data-bind="click: submit, visible: canSubmit">Save Changes</a>

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -4,7 +4,7 @@
 <div class="page-header  visible-xs">
   <h2 class="text-300">Files</h2>
 </div>
-% if not node['is_registration'] and not node['anonymous'] and 'write' in user['permissions']:
+% if not node['is_registration'] and not node['anonymous'] and permissions.WRITE in user['permissions']:
     <span class="f-w-xl">Click on a storage provider or drag and drop to upload</span>
 %endif
 
@@ -27,7 +27,7 @@
     <script src=${"/static/public/js/files-page.js" | webpack_asset}></script>
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
-        % if 'write' in user['permissions'] and not node['is_registration']:
+        % if permissions.WRITE in user['permissions'] and not node['is_registration']:
             window.contextVars.diskSavingMode = !${ disk_saving_mode | sjson, n };
         % endif
         window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -38,7 +38,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class="btn btn-default disabled">Private</button>
-                        % if 'admin' in user['permissions'] and not (node['is_pending_registration'] or node['is_pending_embargo']) and not (node['is_embargoed'] and parent_node['exists']):
+                        % if permissions.ADMIN in user['permissions'] and not (node['is_pending_registration'] or node['is_pending_embargo']) and not (node['is_embargoed'] and parent_node['exists']):
                         <a disabled data-bind="attr: {'disabled': false}, css: {'disabled': nodeIsPendingEmbargoTermination}" class="btn btn-default" href="#nodesPrivacy" data-toggle="modal">
                           Make Public
                           <!-- ko if: nodeIsPendingEmbargoTermination -->
@@ -47,7 +47,7 @@
                         </a>
                         % endif
                     % else:
-                        % if 'admin' in user['permissions'] and not node['is_registration']:
+                        % if permissions.ADMIN in user['permissions'] and not node['is_registration']:
                             <a class="btn btn-default" href="#nodesPrivacy" data-toggle="modal">Make Private</a>
                         % endif
                         <button class="btn btn-default disabled">Public</button>
@@ -111,7 +111,7 @@
                                         Remove from bookmarks
                                     </a>
                                 </li>
-                                % if 'admin' in user['permissions'] and not node['is_registration']:  ## Create view-only link
+                                % if permissions.ADMIN in user['permissions'] and not node['is_registration']:  ## Create view-only link
                                     <li>
                                         <a href="${node['url']}settings/#createVolsAnchor">
                                             Create view-only link
@@ -175,7 +175,7 @@
                     </div>
                 % endif
                 % if enable_institutions and not node['anonymous']:
-                    % if ('admin' in user['permissions'] and not node['is_registration']) and (len(node['institutions']) != 0 or len(user['institutions']) != 0):
+                    % if (permissions.ADMIN in user['permissions'] and not node['is_registration']) and (len(node['institutions']) != 0 or len(user['institutions']) != 0):
                         <a class="link-dashed" href="${node['url']}settings/#configureInstitutionAnchor" id="institution">Affiliated Institutions:</a>
                         % if node['institutions'] != []:
                             % for inst in node['institutions']:
@@ -189,7 +189,7 @@
                             <span> None </span>
                         % endif
                     % endif
-                    % if not ('admin' in user['permissions'] and not node['is_registration']) and node['institutions'] != []:
+                    % if not (permissions.ADMIN in user['permissions'] and not node['is_registration']) and node['institutions'] != []:
                         Affiliated institutions:
                         % for inst in node['institutions']:
                             % if inst != node['institutions'][-1]:
@@ -246,7 +246,7 @@
                     <span id="nodeCategoryEditable">${node['category']}</span>
                 </p>
 
-                % if (node['description']) or (not node['description'] and 'write' in user['permissions'] and not node['is_registration']):
+                % if (node['description']) or (not node['description'] and permissions.WRITE in user['permissions'] and not node['is_registration']):
                     <p>
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">
                         ${node['description']}</span>
@@ -258,7 +258,7 @@
                     % else:
                         <div class="col-xs-6">
                     % endif
-                            % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
+                            % if (permissions.ADMIN in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                                 <p>
                                   <license-picker params="saveUrl: '${node['update_url']}',
                                                           saveMethod: 'PUT',
@@ -315,7 +315,7 @@
             <div style="margin-top: 5px;">
                 Included in <a href="${collection['url']}" target="_blank">${collection['title']}</a>
                 <img style="margin: 0px 0px 2px 5px;" height="16", width="16" src="${collection['logo']}">
-                % if 'admin' in user['permissions']:
+                % if permissions.ADMIN in user['permissions']:
                   <a href="${collection['url']}${node['id']}/edit"><i class="fa fa-edit" aria-label="Edit in Collection"></i></a>
                 % endif
             &nbsp;<span id="metadata${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadata${i}"></span>
@@ -429,7 +429,7 @@
                    <a href="${node['url']}files/"> <i class="fa fa-external-link"></i> </a>
                 </div>
             </div>
-            % if not node['is_registration'] and not node['anonymous'] and 'write' in user['permissions']:
+            % if not node['is_registration'] and not node['anonymous'] and permissions.WRITE in user['permissions']:
                 <div class="row">
                     <div class="col-sm-12 m-t-sm m-l-md">
                         <span class="f-w-xl">Click on a storage provider or drag and drop to upload</span>
@@ -491,7 +491,7 @@
                         </div>
                      </div>
                      <div data-bind="visible: page() == 'standard'" style="display: none;">
-                         % if not node['anonymous'] and 'admin' in user['permissions']:
+                         % if not node['anonymous'] and permissions.ADMIN in user['permissions']:
                              <a data-bind="click: showEditBox" class="pull-right"><i class="glyphicon glyphicon-pencil"></i> Customize</a>
                          % endif
                          <div class="m-b-md">
@@ -511,7 +511,7 @@
                          <pre id="citationText" class="formatted-citation"></pre>
                      </div>
                      <div data-bind="visible: page() == 'custom'" style="display: none;">
-                         % if not node['anonymous'] and 'admin' in user['permissions']:
+                         % if not node['anonymous'] and permissions.ADMIN in user['permissions']:
                             <a data-bind="click: showEditBox" class="pull-right"><i class="glyphicon glyphicon-pencil"></i> Edit</a>
                          % endif
 
@@ -557,7 +557,7 @@
         % endif
 
 
-        %if node['tags'] or 'write' in user['permissions']:
+        %if node['tags'] or permissions.WRITE in user['permissions']:
          <div class="tags panel panel-default">
             <div class="panel-heading clearfix">
                 <h3 class="panel-title">Tags </h3>
@@ -593,12 +593,12 @@
 </div>
 
 <%def name="children()">
-% if ('write' in user['permissions'] and not node['is_registration']) or node['children']:
+% if (permissions.WRITE in user['permissions'] and not node['is_registration']) or node['children']:
     <div class="components panel panel-default">
         <div class="panel-heading clearfix">
             <h3 class="panel-title" style="padding-bottom: 5px; padding-top: 5px;">Components </h3>
             <div class="pull-right">
-                % if 'write' in user['permissions'] and not node['is_registration']:
+                % if permissions.WRITE in user['permissions'] and not node['is_registration']:
                     <span id="newComponent">
                         <button class="btn btn-sm btn-default" disabled="true">Add Component</button>
                     </span>

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -68,11 +68,11 @@
                             <li><a href="${node['url']}contributors/">Contributors</a></li>
                         % endif
 
-                        % if 'write' in user['permissions'] and not node['is_registration']:
+                        % if permissions.WRITE in user['permissions'] and not node['is_registration']:
                             <li><a href="${node['url']}addons/">Add-ons</a></li>
                         % endif
 
-                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'write' in user['permissions']):
+                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and permissions.WRITE in user['permissions']):
                             <li><a href="${node['url']}settings/">Settings</a></li>
                         % endif
                     % endif
@@ -124,7 +124,7 @@
                 <div class="alert alert-info">
                     <div>This is a pending registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>, awaiting approval from project administrators. This registration will be final when all project administrators approve the registration or 48 hours pass, whichever comes first.</div>
 
-                    % if 'admin' in user['permissions']:
+                    % if 'permissions.ADMIN' in user['permissions']:
                         <div>
                             <br>
                             <button type="button" id="registrationCancelButton" class="btn btn-danger" data-toggle="modal" data-target="#registrationCancel">
@@ -156,7 +156,7 @@
         % if node['is_pending_embargo']:
             <div
                 class="alert alert-info">This ${node['node_type']} is currently pending registration, awaiting approval from project administrators. This registration will be final and enter the embargo period when all project administrators approve the registration or 48 hours pass, whichever comes first. The embargo will keep the registration private until the embargo period ends.
-                % if 'admin' in user['permissions']:
+                % if permissions.ADMIN in user['permissions']:
                         <div>
                             <br>
                             <button type="button" id="registrationCancelButton" class="btn btn-danger" data-toggle="modal" data-target="#registrationCancel">

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -6,7 +6,7 @@
   <li role="presentation" class="active">
     <a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
   </li>
-  % if 'admin' in user['permissions'] and user['is_contributor'] and node['has_draft_registrations']:
+  % if permissions.ADMIN in user['permissions'] and user['is_contributor'] and node['has_draft_registrations']:
   <li role="presentation" data-bind="visible: hasDrafts">
       <a id="draftsControl" aria-controls="drafts" href="#drafts">Draft Registrations</a>
   </li>
@@ -26,7 +26,7 @@
     ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
     ##      %endif
         % else:
-          % if 'admin' in user['permissions'] and user['is_contributor']:
+          % if permissions.ADMIN in user['permissions'] and user['is_contributor']:
             <p>There have been no completed registrations of this project.
             You can start a new registration by clicking the “New registration” button, and you have the option of saving as a draft registration before submission.</p>
           % else:
@@ -41,7 +41,7 @@
         To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
         %endif
       </div>
-      % if 'admin' in user['permissions'] and user['is_contributor'] and not disk_saving_mode:
+      % if permissions.ADMIN in user['permissions'] and user['is_contributor'] and not disk_saving_mode:
       <div class="col-xs-3 col-sm-4">
         <a id="registerNode" class="btn btn-success disabled" type="button">
           Loading ...

--- a/website/templates/project/retracted_registration.mako
+++ b/website/templates/project/retracted_registration.mako
@@ -54,7 +54,7 @@
 
                 % if parent_node['id']:
                     <br />Category: <span class="node-category">${ node['category'] }</span>
-                % elif node['description'] or 'write' in user['permissions']:
+                % elif node['description'] or permissions.WRITE in user['permissions']:
                     <br /><span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${ node['description'] }</span>
                 % endif
             </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -9,7 +9,7 @@
     <!-- Begin left column -->
     <div class="col-md-3 col-xs-12 affix-parent scrollspy">
 
-        % if 'write' in user['permissions']:
+        % if permissions.WRITE in user['permissions']:
 
             <div class="panel panel-default osf-affix" data-spy="affix" data-offset-top="0" data-offset-bottom="263"><!-- Begin sidebar -->
                 <ul class="nav nav-stacked nav-pills">
@@ -23,14 +23,14 @@
                     % endif
 
                     % if not node['is_registration']:
-                        % if 'admin' in user['permissions']:
+                        % if permissions.ADMIN in user['permissions']:
                             <li><a href="#createVolsAnchor">View-only Links</a></li>
                             <li><a href="#enableRequestAccessAnchor">Access Requests</a></li>
                         % endif
 
                         <li><a href="#configureWikiAnchor">Wiki</a></li>
 
-                        % if 'admin' in user['permissions']:
+                        % if permissions.ADMIN in user['permissions']:
                             <li><a href="#configureCommentingAnchor">Commenting</a></li>
                         % endif
 
@@ -42,7 +42,7 @@
 
                     % if node['is_registration']:
 
-                        % if (node['is_public'] or node['embargo_end_date']) and 'admin' in user['permissions']:
+                        % if (node['is_public'] or node['embargo_end_date']) and permissions.ADMIN in user['permissions']:
                             <li><a href="#withdrawRegistrationAnchor">Withdraw Public Registration</a></li>
                         % endif
 
@@ -62,7 +62,7 @@
     <!-- Begin right column -->
     <div class="col-md-9 col-xs-12">
 
-        % if 'write' in user['permissions']:  ## Begin Configure Project
+        % if permissions.WRITE in user['permissions']:  ## Begin Configure Project
 
             % if not node['is_registration']:
                 <div class="panel panel-default">
@@ -111,7 +111,7 @@
                         <div class="help-block">
                             <span data-bind="css: messageClass, html: message"></span>
                         </div>
-                    % if 'admin' in user['permissions']:
+                    % if permissions.ADMIN in user['permissions']:
                         <hr />
                             <span data-bind="stopBinding: true">
                                 <span id="deleteNode">
@@ -148,7 +148,7 @@
 
         % endif  ## End Configure Project
 
-        % if 'admin' in user['permissions']:  ## Begin create VOLS
+        % if permissions.ADMIN in user['permissions']:  ## Begin create VOLS
             % if not node['is_registration']:
                 <div class="panel panel-default">
                     <span id="createVolsAnchor" class="anchor"></span>
@@ -168,7 +168,7 @@
             % endif
         % endif ## End create vols
 
-        % if 'admin' in user['permissions']:  ## Begin enable request access
+        % if permissions.ADMIN in user['permissions']:  ## Begin enable request access
             % if not node['is_registration']:
                 <div class="panel panel-default">
                     <span id="enableRequestAccessAnchor" class="anchor"></span>
@@ -200,7 +200,7 @@
             % endif
         % endif ## End enable request access
 
-        % if 'write' in user['permissions']:  ## Begin Wiki Config
+        % if permissions.WRITE in user['permissions']:  ## Begin Wiki Config
             % if not node['is_registration']:
                 <div class="panel panel-default">
                     <span id="configureWikiAnchor" class="anchor"></span>
@@ -259,7 +259,7 @@
             %endif
         %endif ## End Wiki Config
 
-        % if 'admin' in user['permissions']:  ## Begin Configure Commenting
+        % if permissions.ADMIN in user['permissions']:  ## Begin Configure Commenting
 
             % if not node['is_registration']:
 
@@ -333,7 +333,7 @@
 
         % endif ## End Configure Email Notifications
 
-        % if 'write' in user['permissions']:  ## Begin Redirect Link Config
+        % if permissions.WRITE in user['permissions']:  ## Begin Redirect Link Config
             % if not node['is_registration']:
 
                 <div class="panel panel-default">
@@ -365,7 +365,7 @@
             %endif
         %endif ## End Redirect Link Config
 
-        % if 'admin' in user['permissions']:  ## Begin Retract Registration
+        % if permissions.ADMIN in user['permissions']:  ## Begin Retract Registration
 
             % if node['is_registration']:
 
@@ -421,7 +421,7 @@
                  </div>
                  <div class="panel-body">
                      <div class="help-block">
-                         % if 'write' not in user['permissions']:
+                         % if permissions.WRITE not in user['permissions']:
                              <p class="text-muted">Contributors with read-only permissions to this project cannot add or remove institutional affiliations.</p>
                          % endif:
                          <!-- ko if: affiliatedInstitutions().length == 0 -->
@@ -445,9 +445,9 @@
                                  <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path_rounded_corners}"></td>
                                  <td><span data-bind="text: item.name"></span></td>
                                  <td>
-                                     % if 'admin' in user['permissions']:
+                                     % if permissions.ADMIN in user['permissions']:
                                          <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
-                                     % elif 'write' in user['permissions']:
+                                     % elif permissions.WRITE in user['permissions']:
                                          <!-- ko if: $parent.userInstitutionsIds.indexOf(item.id) !== -1 -->
                                             <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
                                          <!-- /ko -->
@@ -466,7 +466,7 @@
                              <tr>
                                  <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path_rounded_corners}"></td>
                                  <td><span data-bind="text: item.name"></span></td>
-                                 % if 'write' in user['permissions']:
+                                 % if permissions.WRITE in user['permissions']:
                                      <td><button
                                              data-bind="disable: $parent.loading(),
                                              click: $parent.submitInst"

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -57,7 +57,7 @@
               </div>
           </div>
       </div>
-      %if (file_tags or 'write' in user['permissions']) and provider == 'osfstorage' and not error:
+      %if (file_tags or permissions.WRITE in user['permissions']) and provider == 'osfstorage' and not error:
        <div class="panel panel-default">
         <div class="panel-heading clearfix">
             <h3 class="panel-title">Tags</h3>

--- a/website/templates/util/render_addon_widget.mako
+++ b/website/templates/util/render_addon_widget.mako
@@ -1,6 +1,6 @@
 <%def name="render_addon_widget(addon_name, addon_data)">
 
-    % if addon_data['complete'] or 'write' in user['permissions']:
+    % if addon_data['complete'] or permissions.WRITE in user['permissions']:
         <div class="panel panel-default" name="${addon_data['short_name']}">
             <div class="panel-heading clearfix">
                 <h3 class="panel-title">${addon_data['full_name']}</h3>

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -53,7 +53,7 @@
 
             % if not summary['archiving']:
             <div class="pull-right">
-                % if not summary['primary'] and 'write' in user['permissions'] and not node['is_registration']:
+                % if not summary['primary'] and permissions.WRITE in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
                     <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Create a fork of ${summary['title']}"></i>
                 % endif
@@ -146,7 +146,7 @@
             %else:
                 Private Component
             %endif
-            % if not summary['primary'] and 'write' in user['permissions'] and not node['is_registration']:
+            % if not summary['primary'] and permissions.WRITE in user['permissions'] and not node['is_registration']:
                 ## Allow deletion of pointers, even if user doesn't know what they are deleting
                 <span class="pull-right">
                     <i class="fa fa-times remove-pointer pointer" data-id="${summary['id']}"

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -3,7 +3,7 @@
 <%def name="render_nodes(nodes, sortable, user, pluralized_node_type, show_path, include_js=True)">
 
     % if len(nodes):
-        <ul data-bind="stopBinding: true" class="list-group m-md ${'sortable' if sortable and 'write' in user['permissions'] else ''}">
+        <ul data-bind="stopBinding: true" class="list-group m-md ${'sortable' if sortable and permissions.WRITE in user['permissions'] else ''}">
             ## TODO: Add .scripted when JS is hooked up
             <span id='${pluralized_node_type if pluralized_node_type is not UNDEFINED else 'osfNodeList'}' class="render-nodes-list">
                 % for each in nodes:
@@ -12,7 +12,7 @@
                 <%include file="../project/nodes_delete.mako"/>
             </span>
         </ul>
-        % if sortable and 'write' in user['permissions'] and not node['is_registration']:
+        % if sortable and permissions.WRITE in user['permissions'] and not node['is_registration']:
         <script>
             $(function(){
                 $('.sortable').sortable({


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- Mostly a big find and replace for the ADMIN/WRITE/READ constants.  We're not consistent about using them (I certainly haven't been consistent), but adding them here from John's recommendation
- Remove an inaccurate comment
- Consolidate some of the new API group-related views into a base view
- clean up some type_in filters where the array had one element

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
