### PR TITLE
[EMB-401] Add rounded institutions logo to api

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -164,6 +164,7 @@ REST_FRAMEWORK = {
         '2.11',
         '2.12',
         '2.13',
+        '2.14',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -5,7 +5,7 @@ from osf.models import Node, Registration
 from osf.utils import permissions as osf_permissions
 
 from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField, JSONAPIRelationshipSerializer, \
-    BaseAPISerializer
+    BaseAPISerializer, ShowIfVersion
 from api.base.exceptions import RelationshipPostMakesNoChanges
 
 
@@ -19,7 +19,6 @@ class InstitutionSerializer(JSONAPISerializer):
 
     name = ser.CharField(read_only=True)
     id = ser.CharField(read_only=True, source='_id')
-    logo_path = ser.CharField(read_only=True)
     description = ser.CharField(read_only=True)
     auth_url = ser.CharField(read_only=True)
     assets = ser.SerializerMethodField(read_only=True)
@@ -58,6 +57,11 @@ class InstitutionSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'institutions'
 
+    # Deprecated fields
+    logo_path = ShowIfVersion(
+        ser.CharField(read_only=True, default=''),
+        min_version='2.0', max_version='2.11',
+    )
 
 class NodeRelated(JSONAPIRelationshipSerializer):
     id = ser.CharField(source='_id', required=False, allow_null=True)

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -22,6 +22,7 @@ class InstitutionSerializer(JSONAPISerializer):
     logo_path = ser.CharField(read_only=True)
     description = ser.CharField(read_only=True)
     auth_url = ser.CharField(read_only=True)
+    assets = ser.SerializerMethodField(read_only=True)
     links = LinksField({
         'self': 'get_api_url',
         'html': 'get_absolute_html_url',
@@ -47,6 +48,12 @@ class InstitutionSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return obj.absolute_api_v2_url
+
+    def get_assets(self, obj):
+        return {
+            'logo': obj.logo_path,
+            'logo_rounded': obj.logo_path_rounded_corners,
+        }
 
     class Meta:
         type_ = 'institutions'

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -60,7 +60,7 @@ class InstitutionSerializer(JSONAPISerializer):
     # Deprecated fields
     logo_path = ShowIfVersion(
         ser.CharField(read_only=True, default=''),
-        min_version='2.0', max_version='2.11',
+        min_version='2.0', max_version='2.13',
     )
 
 class NodeRelated(JSONAPIRelationshipSerializer):

--- a/api_tests/institutions/views/test_institution_detail.py
+++ b/api_tests/institutions/views/test_institution_detail.py
@@ -20,3 +20,13 @@ class TestInstitutionDetail:
         res = app.get(url)
         assert res.status_code == 200
         assert res.json['data']['attributes']['name'] == institution.name
+        assert 'logo_path' in res.json['data']['attributes']
+        assert 'assets' in res.json['data']['attributes']
+        assert 'logo' in res.json['data']['attributes']['assets']
+        assert 'logo_rounded' in res.json['data']['attributes']['assets']
+
+        # test_return_without_logo_path
+        url = '/{}institutions/{}/?version=2.14&'.format(API_BASE, institution._id)
+        res = app.get(url)
+        assert res.status_code == 200
+        assert 'logo_path' not in res.json['data']['attributes']


### PR DESCRIPTION
## Purpose
Add `logo_rounded` url path for institutions to the api.

## Changes

- Add `logo_rounded` asset path to institutions.

## QA Notes

N/A

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/40

## Side Effects


## Ticket

https://openscience.atlassian.net/browse/EMB-401