### PR TITLE
[No ticket] Expose pending embargo terminal (approval) state

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -58,6 +58,10 @@ class RegistrationSerializer(NodeSerializer):
         read_only=True, source='is_pending_embargo',
         help_text='The associated Embargo is awaiting approval by project admins.',
     ))
+    pending_embargo_termination_approval = HideIfWithdrawal(ser.BooleanField(
+        read_only=True, source='is_pending_embargo_termination',
+        help_text='The associated Embargo early termination is awaiting approval by project admins',
+    ))
     embargoed = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_embargoed'))
     pending_registration_approval = HideIfWithdrawal(ser.BooleanField(
         source='is_pending_registration', read_only=True,

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1362,8 +1362,8 @@ class TestRegistrationBulkUpdate:
     def test_bulk_update_embargo_logged_in_contrib(
             self, app, user, registration_one, registration_two,
             public_payload, url):
-        assert registration_one.embargo_termination_approval is None
-        assert registration_two.embargo_termination_approval is None
+        assert registration_one.is_pending_embargo_termination is False
+        assert registration_two.is_pending_embargo_termination is False
 
         res = app.put_json_api(url, public_payload, auth=user.auth, bulk=True)
         assert res.status_code == 200
@@ -1373,13 +1373,15 @@ class TestRegistrationBulkUpdate:
         # Needs confirmation before it will become public
         assert res.json['data'][0]['attributes']['public'] is False
         assert res.json['data'][1]['attributes']['public'] is False
+        assert res.json['data'][0]['attributes']['pending_embargo_termination_approval'] is True
+        assert res.json['data'][1]['attributes']['pending_embargo_termination_approval'] is True
 
         registration_one.refresh_from_db()
         registration_two.refresh_from_db()
 
         # registrations should have pending terminations
-        assert registration_one.embargo_termination_approval and registration_one.embargo_termination_approval.is_pending_approval
-        assert registration_two.embargo_termination_approval and registration_two.embargo_termination_approval.is_pending_approval
+        assert registration_one.is_pending_embargo_termination is True
+        assert registration_two.is_pending_embargo_termination is True
 
 
 class TestRegistrationListFiltering(

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -165,6 +165,12 @@ class Registration(AbstractNode):
         return self.retraction.is_pending_approval
 
     @property
+    def is_pending_embargo_termination(self):
+        return (self.is_embargoed and
+                bool(self.embargo_termination_approval) and
+                self.embargo_termination_approval.is_pending_approval)
+
+    @property
     def is_embargoed(self):
         """A Node is embargoed if:
         - it has an associated Embargo record

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -745,10 +745,7 @@ def _view_project(node, auth, primary=False,
             'embargo_end_date': node.embargo_end_date.strftime('%A, %b %d, %Y') if is_registration and node.embargo_end_date else '',
             'is_pending_embargo': node.is_pending_embargo if is_registration else False,
             'is_embargoed': node.is_embargoed if is_registration else False,
-            'is_pending_embargo_termination': is_registration and node.is_embargoed and (
-                node.embargo_termination_approval and
-                node.embargo_termination_approval.is_pending_approval
-            ),
+            'is_pending_embargo_termination': is_registration and node.is_pending_embargo_termination,
             'registered_from_url': node.registered_from.url if is_registration else '',
             'registered_date': iso8601format(node.registered_date) if is_registration else '',
             'root_id': node.root._id if node.root else None,


### PR DESCRIPTION
## Purpose

Add `pending_embargo_termination_approval` pending to registration detail.
To  allow admins to end embargo early through registries overview page.

## Changes
- Update registration serializer to expose `pending_embargo_termination_approval ` through the API
- Add test

## QA Notes

Will be covered in QA testing for new registries overview page.

## Documentation

## Side Effects

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
