### PR TITLE
Feature/Fix CollectionSubmission APIv2 Query  [PLAT-1305][EMB-554]

### DIFF
--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -1,5 +1,6 @@
 from guardian.core import ObjectPermissionChecker
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import ValidationError, PermissionDenied
 
@@ -346,7 +347,7 @@ class CollectedMetaDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView
     def get_object(self):
         cgm = get_object_or_error(
             CollectionSubmission,
-            self.kwargs['cgm_id'],
+            Q(collection=Collection.load(self.kwargs['collection_id']), guid___id=self.kwargs['cgm_id']),
             self.request,
             'submission',
         )


### PR DESCRIPTION
## Purpose

A request to the CollectedMetaDetail API v2 endpoint will fail `/v2/collections/<collection_id>/collected_metadata/<cgm_id>/` if the cgm belongs to multiple collections. 

## Changes
Update the CollectionSubmission query on the view (CollectedMetaDetail.get_object()) to query the CollectionSubmission on both the collection and the guid so the query returns one result.

<!-- Briefly describe or list your changes  -->

## QA Notes
This fixes both descriptions noted in https://openscience.atlassian.net/browse/EMB-554
https://openscience.atlassian.net/browse/PLAT-1305.  Scenarios described there should be sufficient for testing.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/EMB-554
https://openscience.atlassian.net/browse/PLAT-1305