### PR TITLE
[fix] Set preprint providers' share_source automatically

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -337,11 +337,10 @@ class ShareSourcePreprintProvider(PermissionRequiredMixin, View):
         preprint_provider = PreprintProvider.objects.get(id=self.kwargs['preprint_provider_id'])
 
         resp_json = self.share_post(preprint_provider)
+        preprint_provider.share_source = resp_json['data']['attributes']['longTitle']
         for data in resp_json['included']:
             if data['type'] == 'ShareUser':
                 preprint_provider.access_token = data['attributes']['token']
-            elif data['type'] == 'SourceConfig':
-                preprint_provider.share_source = data['attributes']['label']
         preprint_provider.save()
         return redirect(reverse_lazy('preprint_providers:detail', kwargs={'preprint_provider_id': preprint_provider.id}))
 

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -59,18 +59,18 @@ class TestShareSourcePreprintProvider(AdminTestCase):
     @mock.patch.object(views.ShareSourcePreprintProvider, 'share_post')
     def test_update_share_token_and_source(self, share_resp):
         token = 'tokennethbranagh'
-        label = 'sir'
+        source_name = 'sir'
         share_resp.return_value = {
+            'data': {
+                'attributes': {
+                    'longTitle': source_name,
+                },
+            },
             'included': [{
                 'attributes': {
                     'token': token,
                 },
                 'type': 'ShareUser',
-            }, {
-                'attributes': {
-                    'label': label
-                },
-                'type': 'SourceConfig',
             }]
         }
 
@@ -78,7 +78,7 @@ class TestShareSourcePreprintProvider(AdminTestCase):
         self.preprint_provider.refresh_from_db()
 
         assert self.preprint_provider.access_token == token
-        assert self.preprint_provider.share_source == label
+        assert self.preprint_provider.share_source == source_name
 
 
 class TestPreprintProviderChangeForm(AdminTestCase):


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
SHARE's API apparently changed out from under the admin app (sorry), and `preprint_provider.share_source` is no longer set when you click "Setup Share Source".

This syncs expectations back up.
<!-- Describe the purpose of your changes -->

## Changes
Set `share_source` based on the SHARE source's `longTitle`
<!-- Briefly describe or list your changes  -->

## QA Notes
Check that `share_source` and `access_token` are both set after clicking "Setup Share Source" for a preprint provider in the admin app.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
n/a
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
