### PR TITLE
Use verification token detail to determine is_merged [PLAT-1125]

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -832,10 +832,9 @@ class UserEmailsList(JSONAPIBaseView, generics.ListAPIView, generics.CreateAPIVi
             hashed_id = hashids.encode(email.id)
             serialized_email = UserEmail(email_id=hashed_id, address=email.address, confirmed=True, verified=True, primary=primary)
             serialized_emails.append(serialized_email)
-        email_verifications = user.email_verifications or []
-        for token in email_verifications:
-            is_merge = Email.objects.filter(address=email.address).exists()
-            detail = user.email_verifications[token]
+        email_verifications = user.email_verifications or {}
+        for token, detail in email_verifications.iteritems():
+            is_merge = Email.objects.filter(address=detail['email']).exists()
             serialized_unconfirmed_email = UserEmail(
                 email_id=token,
                 address=detail['email'],


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For the `UserEmailsList` view, `get_default_queryset` was using the email from `user.emails.all()` to determine `is_merged` for emails in `email_verifications`. Whoops!

## Changes
- Properly iterate over the items stored in `email_verifications`
- Use the `email` key in the detail to determine `is_merge`


<!-- Briefly describe or list your changes  -->

## QA Notes
This is a bug fix for [a ticket already in QA](https://openscience.atlassian.net/browse/PLAT-1125), so see that one for the actual notes!

## Documentation

None (yet!)

## Side Effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/PLAT-1125
