### PR TITLE
[PLAT-300] Fix Institutions settings 'FAQ' link

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -431,7 +431,7 @@
                             <li>institutional logos to be displayed on public projects</li>
                             <li>public projects to be discoverable on specific institutional landing pages</li>
                             <li>single sign-on to the OSF with institutional credentials</li>
-                            <li><a href="http://help.osf.io/m/os4i">FAQ</a></li>
+                            <li><a href="http://help.osf.io/m/institutions">FAQ</a></li>
                          </ul>
                          <!-- /ko -->
                      </div>


### PR DESCRIPTION
## Purpose

The institution link just points to the help page, this change points it specifically to the institution's help page.

## Changes

- simple HTML change

## QA Notes

You should be able to click the link pictured on the ticket and go to http://help.osf.io/m/institutions

## Documentation

Doc related.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/PLAT-300