### PR TITLE
No longer append provider=OSF to preprint searches on legacy search page [PLAT-1278]

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -287,10 +287,7 @@ var ViewModel = function(params) {
             win.opener = null;
             win.focus();
         } else if (alias.name === 'preprint') {
-            win = window.open(
-                window.location.origin + '/preprints/discover?' + $.param(
-                    {q: self.query(), provider: 'OSF'}
-                ), '_blank');
+            win = window.open(window.location.origin + '/preprints/discover?' + $.param({q: self.query()}), '_blank');
             win.opener = null;
             win.focus();
         } else if (alias.name === 'institution') {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Searching OSF side, you can find results that are preprints from all providers. Clicking "Preprints"in the search sidebar to head to SHARE to narrow down the search limits the search to OSF preprints, thus eliminating some search results you saw on the previous page. Get rid of that to show all Preprints like on the search page, not just limiting to OSF preprints.

## Changes

- Remove `provider=OSF` query param sent to SHARE search

## QA Notes

Steps from the ticket are great!

- Select a preprint from a non-OSF provider (PsyArXiv, SocArXiv, EarthArXiv), copy its title
- Paste into legacy OSF elastic search
- Click 'Preprints' from the menu on the left
- The only parameter should now be be the text search query

## Documentation
None needed
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1278
