### PR TITLE
[feature fix] Fix error in local development environment setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -359,6 +359,8 @@ services:
 
   requirements:
     image: quay.io/centerforopenscience/osf:develop
+    # Need to allocate tty to be able to call invoke for requirements task
+    tty: true
     command:
       - /bin/bash
       - -c


### PR DESCRIPTION
## Purpose

Currently, local development environment is not being able to be up
because the requirements container fails to run invoke requirements
task. The problem is the command in the docker-compose.yml is getting
Inappropriate ioctl for device error. This PR fixes the error by
allocating tty in docker-compose.yml.

Fix Issue https://github.com/CenterForOpenScience/osf.io/issues/8905

## Changes

Adds `tty: true` under requirements service in `docker-compose.yml`.


## Side Effects

It is only tested for docker-compose version 1.23.2, docker version 18.09.1.