### PR TITLE
Fix relationship types

### DIFF
--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -7,6 +7,7 @@ from rest_framework import serializers as ser
 from api.base import utils
 from api.base.exceptions import Conflict
 from api.base.exceptions import JSONAPIAttributeException
+from api.base.serializers import get_meta_type
 from api.base.serializers import JSONAPISerializer
 from api.base.serializers import LinksField
 from api.base.serializers import RelationshipField
@@ -73,7 +74,10 @@ class TargetRelationshipField(RelationshipField):
 class PreprintRequestTargetRelationshipField(TargetRelationshipField):
     def to_representation(self, value):
         ret = super(TargetRelationshipField, self).to_representation(value)
-        ret['data']['type'] = PreprintRequestSerializer.Meta.type_
+        ret['data']['type'] = get_meta_type(
+            PreprintRequestSerializer,
+            self.context.get('request'),
+        )
         return ret
 
 class BaseActionSerializer(JSONAPISerializer):

--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -4,6 +4,7 @@ from rest_framework_bulk import generics as bulk_generics
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from django.db.models import Q
 
+from api.base.serializers import get_meta_type
 from api.base.settings import BULK_SETTINGS
 from api.base.exceptions import Conflict, JSONAPIException, Gone
 from api.base.utils import is_bulk_request
@@ -139,7 +140,7 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
             )
 
         user = self.request.user
-        object_type = self.serializer_class.Meta.type_
+        object_type = get_meta_type(self.serializer_class, self.request)
 
         resource_object_list = self.get_requested_resources(request=request, request_data=data)
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1584,7 +1584,11 @@ class LinkedNode(JSONAPIRelationshipSerializer):
     id = ser.CharField(source='_id', required=False, allow_null=True)
 
     class Meta:
-        type_ = 'linked_nodes'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_nodes'
+            return 'nodes'
 
 
 class LinkedRegistration(JSONAPIRelationshipSerializer):
@@ -1613,7 +1617,11 @@ class LinkedNodesRelationshipSerializer(BaseAPISerializer):
         return obj['self'].linked_nodes_related_url
 
     class Meta:
-        type_ = 'linked_nodes'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_nodes'
+            return 'nodes'
 
     def get_pointers_to_add_remove(self, pointers, new_pointers):
         diff = relationship_diff(

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1604,7 +1604,11 @@ class LinkedRegistration(JSONAPIRelationshipSerializer):
 
 class LinkedPreprint(LinkedNode):
     class Meta:
-        type_ = 'linked_preprints'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_preprints'
+            return 'preprints'
 
 
 class LinkedNodesRelationshipSerializer(BaseAPISerializer):
@@ -1763,7 +1767,11 @@ class LinkedPreprintsRelationshipSerializer(LinkedNodesRelationshipSerializer):
         return obj['self'].linked_preprints_related_url
 
     class Meta:
-        type_ = 'linked_preprints'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_preprints'
+            return 'preprints'
 
     def make_instance_obj(self, obj):
         # Convenience method to format instance based on view's get_object

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1595,7 +1595,11 @@ class LinkedRegistration(JSONAPIRelationshipSerializer):
     id = ser.CharField(source='_id', required=False, allow_null=True)
 
     class Meta:
-        type_ = 'linked_registrations'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_registrations'
+            return 'registrations'
 
 
 class LinkedPreprint(LinkedNode):
@@ -1690,7 +1694,11 @@ class LinkedRegistrationsRelationshipSerializer(BaseAPISerializer):
         return obj['self'].linked_registrations_related_url
 
     class Meta:
-        type_ = 'linked_registrations'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.13'):
+                return 'linked_registrations'
+            return 'registrations'
 
     def get_pointers_to_add_remove(self, pointers, new_pointers):
         diff = relationship_diff(

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -163,6 +163,7 @@ REST_FRAMEWORK = {
         '2.10',
         '2.11',
         '2.12',
+        '2.13',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -23,6 +23,7 @@ from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
 from api.base.requests import EmbeddedRequest
 from api.base.serializers import (
+    get_meta_type,
     MaintenanceStateSerializer,
     LinkedNodesRelationshipSerializer,
     LinkedRegistrationsRelationshipSerializer,
@@ -147,9 +148,10 @@ class JSONAPIBaseView(generics.GenericAPIView):
             embeds = self.request.query_params.getlist('embed') or self.request.query_params.getlist('embed[]')
 
         fields_check = self.get_serializer_class()._declared_fields.copy()
-        if 'fields[{}]'.format(self.serializer_class.Meta.type_) in self.request.query_params:
+        serializer_class_type = get_meta_type(self.serializer_class, self.request)
+        if 'fields[{}]'.format(serializer_class_type) in self.request.query_params:
             # Check only requested and mandatory fields
-            sparse_fields = self.request.query_params['fields[{}]'.format(self.serializer_class.Meta.type_)]
+            sparse_fields = self.request.query_params['fields[{}]'.format(serializer_class_type)]
             for field in fields_check.copy().keys():
                 if field not in ('type', 'id', 'links') and field not in sparse_fields:
                     fields_check.pop(field)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -302,7 +302,7 @@ class LinkedRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDe
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -320,7 +320,7 @@ class LinkedRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDe
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -341,7 +341,7 @@ class LinkedRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDe
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -196,7 +196,7 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -214,7 +214,7 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -235,7 +235,7 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -364,6 +364,3 @@ class CollectedPreprintsRelationshipSerializer(CollectedAbstractNodeRelationship
                 list(self.context['view'].collection_preprints(obj, user=get_user_auth(self.context['request']).user)),
             'self': obj,
         }
-
-    class Meta:
-        type_ = 'linked_preprints'

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -857,7 +857,7 @@ class CollectionLinkedRegistrationsRelationship(LinkedRegistrationsRelationship,
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -875,7 +875,7 @@ class CollectionLinkedRegistrationsRelationship(LinkedRegistrationsRelationship,
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_regisrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -896,7 +896,7 @@ class CollectionLinkedRegistrationsRelationship(LinkedRegistrationsRelationship,
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -733,7 +733,7 @@ class CollectionLinkedNodesRelationship(LinkedNodesRelationship, CollectionMixin
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -751,7 +751,7 @@ class CollectionLinkedNodesRelationship(LinkedNodesRelationship, CollectionMixin
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -772,7 +772,7 @@ class CollectionLinkedNodesRelationship(LinkedNodesRelationship, CollectionMixin
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1686,7 +1686,7 @@ class NodeLinkedRegistrationsRelationship(LinkedRegistrationsRelationship, NodeM
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -1704,7 +1704,7 @@ class NodeLinkedRegistrationsRelationship(LinkedRegistrationsRelationship, NodeM
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -1725,7 +1725,7 @@ class NodeLinkedRegistrationsRelationship(LinkedRegistrationsRelationship, NodeM
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_registrations",   # required
+                           "type": "registrations",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1597,7 +1597,7 @@ class NodeLinkedNodesRelationship(LinkedNodesRelationship, NodeMixin):
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -1615,7 +1615,7 @@ class NodeLinkedNodesRelationship(LinkedNodesRelationship, NodeMixin):
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }
@@ -1636,7 +1636,7 @@ class NodeLinkedNodesRelationship(LinkedNodesRelationship, NodeMixin):
         Query Params:  <none>
         Body (JSON):   {
                          "data": [{
-                           "type": "linked_nodes",   # required
+                           "type": "nodes",   # required
                            "id": <node_id>   # required
                          }]
                        }

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -1,4 +1,5 @@
 import re
+from distutils.version import StrictVersion
 
 from rest_framework import generics
 from django.db.models import Q
@@ -218,8 +219,9 @@ class PreprintNodeRelationship(JSONAPIBaseView, generics.RetrieveUpdateAPIView, 
     def get_object(self):
         preprint = self.get_preprint()
         auth = get_user_auth(self.request)
+        type_ = 'linked_preprint_nodes' if StrictVersion(self.request.version) < StrictVersion('2.13') else 'nodes'
         obj = {
-            'data': {'id': preprint.node._id, 'type': 'linked_preprint_nodes'} if preprint.node and preprint.node.can_view(auth) else None,
+            'data': {'id': preprint.node._id, 'type': type_} if preprint.node and preprint.node.can_view(auth) else None,
             'self': preprint,
         }
         return obj

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -11,7 +11,7 @@ from api.base.parsers import (
     JSONAPIRelationshipParser,
     JSONAPIRelationshipParserForRegularJSON,
 )
-from api.base.serializers import AddonAccountSerializer
+from api.base.serializers import get_meta_type, AddonAccountSerializer
 from api.base.utils import (
     default_node_list_queryset,
     default_node_list_permission_queryset,
@@ -509,7 +509,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
         # DELETEs normally dont get type checked
         # not the best way to do it, should be enforced everywhere, maybe write a test for it
         for val in data:
-            if val['type'] != self.serializer_class.Meta.type_:
+            if val['type'] != get_meta_type(self.serializer_class, self.request):
                 raise Conflict()
         for val in data:
             if val['id'] in current_institutions:

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -93,7 +93,9 @@ class TestSerializerMetaType(ApiTestCase):
             ), 'Serializer {} has no Meta'.format(ser)
             assert hasattr(
                 ser.Meta, 'type_'
-            ), 'Serializer {} has no Meta.type_'.format(ser)
+            ) or hasattr(
+                ser.Meta, 'get_type'
+            ), 'Serializer {} has no Meta.type_ or Meta.get_type()'.format(ser)
 
 
 class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -3024,6 +3024,19 @@ class TestCollectionRelationshipNodeLinks:
         assert collection_private.linked_registrations_self_url in res.json['links']['self']
         assert collection_private.linked_registrations_related_url in res.json['links']['html']
         assert res.json['data'][0]['id'] == registration_private._id
+        assert res.json['data'][0]['type'] == 'linked_registrations'
+
+    def test_get_relationship_linked_registrations_2_13(
+            self, app, registration_private,
+            url_private_linked_regs, user_one,
+            collection_private
+    ):
+        res = app.get('{}?version=2.13'.format(url_private_linked_regs), auth=user_one.auth)
+        assert res.status_code == 200
+        assert collection_private.linked_registrations_self_url in res.json['links']['self']
+        assert collection_private.linked_registrations_related_url in res.json['links']['html']
+        assert res.json['data'][0]['id'] == registration_private._id
+        assert res.json['data'][0]['type'] == 'registrations'
 
     def test_get_public_relationship_linked_nodes_logged_out(
             self, app, url_public_linked_nodes, node_public):

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -2985,9 +2985,9 @@ class TestCollectionRelationshipNodeLinks:
 
     @pytest.fixture()
     def make_payload(self, node_admin):
-        def payload(node_ids=None, deprecatedType=True):
+        def payload(node_ids=None, deprecated_type=True):
             node_ids = node_ids or [node_admin._id]
-            env_linked_nodes = [{'type': 'linked_nodes' if deprecatedType else 'nodes',
+            env_linked_nodes = [{'type': 'linked_nodes' if deprecated_type else 'nodes',
                                  'id': node_id} for node_id in node_ids]
             return {'data': env_linked_nodes}
         return payload
@@ -3469,9 +3469,9 @@ class TestCollectionRelationshipPreprintLinks:
 
     @pytest.fixture()
     def make_payload(self, preprint_admin):
-        def payload(preprint_ids=None, deprecatedType=True):
+        def payload(preprint_ids=None, deprecated_type=True):
             preprint_ids = preprint_ids or [preprint_admin._id]
-            env_linked_preprints = [{'type': 'linked_preprints' if deprecatedType else 'preprints',
+            env_linked_preprints = [{'type': 'linked_preprints' if deprecated_type else 'preprints',
                                  'id': preprint_id} for preprint_id in preprint_ids]
             return {'data': env_linked_preprints}
         return payload

--- a/api_tests/nodes/views/test_node_linked_nodes.py
+++ b/api_tests/nodes/views/test_node_linked_nodes.py
@@ -70,11 +70,11 @@ class TestNodeRelationshipNodeLinks:
 
     @pytest.fixture()
     def make_payload(self, node_admin):
-        def payload(node_ids=None):
+        def payload(node_ids=None, deprecatedType=True):
             node_ids = node_ids or [node_admin._id]
             env_linked_nodes = [
                 {
-                    'type': 'linked_nodes',
+                    'type': 'linked_nodes' if deprecatedType else 'nodes',
                     'id': node_id
                 } for node_id in node_ids]
             return {'data': env_linked_nodes}
@@ -132,6 +132,21 @@ class TestNodeRelationshipNodeLinks:
         res = app.post_json_api(
             url_private,
             make_payload([node_public._id]),
+            auth=user.auth
+        )
+
+        assert res.status_code == 201
+
+        ids = [data['id'] for data in res.json['data']]
+        assert node_public._id in ids
+        assert node_private._id in ids
+
+    def test_post_public_node_2_13(
+            self, app, user, node_private, node_public,
+            make_payload, url_private):
+        res = app.post_json_api(
+            '{}?version=2.13'.format(url_private),
+            make_payload([node_public._id], False),
             auth=user.auth
         )
 
@@ -343,6 +358,36 @@ class TestNodeRelationshipNodeLinks:
 
         assert res.status_code == 409
 
+    #   test_type_nodes_not_acceptable_below_2_13
+        res = app.post_json_api(
+            url_private,
+            {
+                'data': [{
+                    'type': 'nodes',
+                    'id': node_contrib._id
+                }]
+            },
+            auth=user.auth,
+            expect_errors=True
+        )
+
+        assert res.status_code == 409
+
+    #   test_type_linked_nodes_not_acceptable_as_of_2_13
+        res = app.post_json_api(
+            '{}?version=2.13'.format(url_private),
+            {
+                'data': [{
+                    'type': 'linked_nodes',
+                    'id': node_contrib._id
+                }]
+            },
+            auth=user.auth,
+            expect_errors=True
+        )
+
+        assert res.status_code == 409
+
     #   test_creates_public_linked_node_relationship_logged_out
         res = app.post_json_api(
             url_public, make_payload([node_public._id]),
@@ -460,6 +505,25 @@ class TestNodeLinkedNodes:
 
         for node_id in node_ids:
             assert node_id in nodes_returned
+
+    def test_linked_nodes_returns_everything_2_13(
+            self, app, user, node_ids, url_linked_nodes):
+        res = app.get('{}?version=2.13'.format(url_linked_nodes), auth=user.auth)
+
+        assert res.status_code == 200
+        nodes_returned = [
+            linked_node['id'] for linked_node in res.json['data']
+        ]
+        assert len(nodes_returned) == len(node_ids)
+
+        for node_id in node_ids:
+            assert node_id in nodes_returned
+
+        node_types = [
+            linked_node['type'] for linked_node in res.json['data']
+        ]
+        assert 'nodes' in node_types
+        assert 'linked_nodes' not in node_types
 
     def test_linked_nodes_only_return_viewable_nodes(
             self, app, user, node_one, node_two, node_public, node_ids):

--- a/api_tests/nodes/views/test_node_linked_nodes.py
+++ b/api_tests/nodes/views/test_node_linked_nodes.py
@@ -70,11 +70,11 @@ class TestNodeRelationshipNodeLinks:
 
     @pytest.fixture()
     def make_payload(self, node_admin):
-        def payload(node_ids=None, deprecatedType=True):
+        def payload(node_ids=None, deprecated_type=True):
             node_ids = node_ids or [node_admin._id]
             env_linked_nodes = [
                 {
-                    'type': 'linked_nodes' if deprecatedType else 'nodes',
+                    'type': 'linked_nodes' if deprecated_type else 'nodes',
                     'id': node_id
                 } for node_id in node_ids]
             return {'data': env_linked_nodes}

--- a/api_tests/nodes/views/test_node_linked_registrations.py
+++ b/api_tests/nodes/views/test_node_linked_registrations.py
@@ -188,10 +188,10 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None, deprecatedType=True):
+        def payload(registration_id=None, deprecated_type=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations' if deprecatedType else 'registrations',
+                    'type': 'linked_registrations' if deprecated_type else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -199,7 +199,7 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecated_type=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
             if version:
@@ -207,11 +207,11 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
             if auth:
                 return app.post_json_api(
                     url,
-                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                    make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                     auth=auth, expect_errors=expect_errors)
             return app.post_json_api(
                 url,
-                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                 expect_errors=expect_errors)
         return request
 
@@ -235,7 +235,7 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
             reg_id=registration._id,
             auth=user_admin_contrib.auth,
             version='2.13',
-            deprecatedType=False,
+            deprecated_type=False,
         )
         assert res.status_code == 201
         linked_registrations = [r['id'] for r in res.json['data']]
@@ -371,10 +371,10 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None, deprecatedType=True):
+        def payload(registration_id=None, deprecated_type=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations' if deprecatedType else 'registrations',
+                    'type': 'linked_registrations' if deprecated_type else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -382,7 +382,7 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecated_type=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
             if version:
@@ -390,11 +390,11 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
             if auth:
                 return app.put_json_api(
                     url,
-                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                    make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                     auth=auth, expect_errors=expect_errors)
             return app.put_json_api(
                 url,
-                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                 expect_errors=expect_errors)
         return request
 
@@ -419,7 +419,7 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
             reg_id=registration_two._id,
             auth=user_admin_contrib.auth,
             version='2.13',
-            deprecatedType=False,
+            deprecated_type=False,
         )
         assert res.status_code == 200
         linked_registrations = [r['id'] for r in res.json['data']]
@@ -490,10 +490,10 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None, deprecatedType=True):
+        def payload(registration_id=None, deprecated_type=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations' if deprecatedType else 'registrations',
+                    'type': 'linked_registrations' if deprecated_type else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -501,7 +501,7 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecated_type=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
             if version:
@@ -509,11 +509,11 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
             if auth:
                 return app.delete_json_api(
                     url,
-                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                    make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                     auth=auth, expect_errors=expect_errors)
             return app.delete_json_api(
                 url,
-                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
+                make_payload(registration_id=reg_id, deprecated_type=deprecated_type),
                 expect_errors=expect_errors)
         return request
 
@@ -533,7 +533,7 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
             auth=user_admin_contrib.auth,
             reg_id=registration._id,
             version='2.13',
-            deprecatedType=False,
+            deprecated_type=False,
         )
         assert res.status_code == 204
 

--- a/api_tests/nodes/views/test_node_linked_registrations.py
+++ b/api_tests/nodes/views/test_node_linked_registrations.py
@@ -120,9 +120,11 @@ class TestNodeLinkedRegistrationsRelationshipRetrieve(
 
     @pytest.fixture()
     def make_request(self, app):
-        def request(node_id=None, auth=None, expect_errors=False):
+        def request(node_id=None, auth=None, expect_errors=False, version=None):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
+            if version:
+                url = '{}?version={}'.format(url, version)
             if auth:
                 return app.get(url, auth=auth, expect_errors=expect_errors)
             return app.get(url, expect_errors=expect_errors)
@@ -137,6 +139,13 @@ class TestNodeLinkedRegistrationsRelationshipRetrieve(
         res = make_request(node_id=node_public._id)
         assert res.status_code == 200
         assert res.json['data'][0]['id'] == registration._id
+        assert res.json['data'][0]['type'] == 'linked_registrations'
+
+        #   test_public_node_unauthenticated_user_can_view_linked_registrations_relationship_2_13
+        res = make_request(node_id=node_public._id, version='2.13')
+        assert res.status_code == 200
+        assert res.json['data'][0]['id'] == registration._id
+        assert res.json['data'][0]['type'] == 'registrations'
 
     #   test_private_node_admin_contributor_can_view_linked_registrations_relationship
         res = make_request(
@@ -179,10 +188,10 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None):
+        def payload(registration_id=None, deprecatedType=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations',
+                    'type': 'linked_registrations' if deprecatedType else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -190,16 +199,19 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
+            if version:
+                url = '{}?version={}'.format(url, version)
             if auth:
                 return app.post_json_api(
-                    url, make_payload(registration_id=reg_id),
+                    url,
+                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                     auth=auth, expect_errors=expect_errors)
             return app.post_json_api(
                 url,
-                make_payload(registration_id=reg_id),
+                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                 expect_errors=expect_errors)
         return request
 
@@ -210,6 +222,20 @@ class TestNodeLinkedRegistrationsRelationshipCreate(
             node_id=node_private._id,
             reg_id=registration._id,
             auth=user_admin_contrib.auth
+        )
+        assert res.status_code == 201
+        linked_registrations = [r['id'] for r in res.json['data']]
+        assert registration._id in linked_registrations
+
+    def test_admin_contributor_can_create_linked_registrations_relationship_2_13(
+            self, make_request, user_admin_contrib, node_private):
+        registration = RegistrationFactory(is_public=True)
+        res = make_request(
+            node_id=node_private._id,
+            reg_id=registration._id,
+            auth=user_admin_contrib.auth,
+            version='2.13',
+            deprecatedType=False,
         )
         assert res.status_code == 201
         linked_registrations = [r['id'] for r in res.json['data']]
@@ -345,10 +371,10 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None):
+        def payload(registration_id=None, deprecatedType=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations',
+                    'type': 'linked_registrations' if deprecatedType else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -356,17 +382,19 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
+            if version:
+                url = '{}?version={}'.format(url, version)
             if auth:
                 return app.put_json_api(
                     url,
-                    make_payload(registration_id=reg_id),
+                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                     auth=auth, expect_errors=expect_errors)
             return app.put_json_api(
                 url,
-                make_payload(registration_id=reg_id),
+                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                 expect_errors=expect_errors)
         return request
 
@@ -377,6 +405,21 @@ class TestNodeLinkedRegistrationsRelationshipUpdate(
             node_id=node_private._id,
             reg_id=registration_two._id,
             auth=user_admin_contrib.auth
+        )
+        assert res.status_code == 200
+        linked_registrations = [r['id'] for r in res.json['data']]
+        assert registration._id not in linked_registrations
+        assert registration_two._id in linked_registrations
+
+    def test_admin_contributor_can_update_linked_registrations_relationship_2_13(
+            self, make_request, registration, user_admin_contrib, node_private):
+        registration_two = RegistrationFactory(is_public=True)
+        res = make_request(
+            node_id=node_private._id,
+            reg_id=registration_two._id,
+            auth=user_admin_contrib.auth,
+            version='2.13',
+            deprecatedType=False,
         )
         assert res.status_code == 200
         linked_registrations = [r['id'] for r in res.json['data']]
@@ -447,10 +490,10 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
 
     @pytest.fixture()
     def make_payload(self):
-        def payload(registration_id=None):
+        def payload(registration_id=None, deprecatedType=True):
             return {
                 'data': [{
-                    'type': 'linked_registrations',
+                    'type': 'linked_registrations' if deprecatedType else 'registrations',
                     'id': registration_id
                 }]
             }
@@ -458,15 +501,19 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
 
     @pytest.fixture()
     def make_request(self, app, make_payload):
-        def request(node_id=None, auth=None, reg_id=None, expect_errors=False):
+        def request(node_id=None, auth=None, reg_id=None, expect_errors=False, version=None, deprecatedType=True):
             url = '/{}nodes/{}/relationships/linked_registrations/'.format(
                 API_BASE, node_id)
+            if version:
+                url = '{}?version={}'.format(url, version)
             if auth:
                 return app.delete_json_api(
-                    url, make_payload(reg_id),
+                    url,
+                    make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                     auth=auth, expect_errors=expect_errors)
             return app.delete_json_api(
-                url, make_payload(reg_id),
+                url,
+                make_payload(registration_id=reg_id, deprecatedType=deprecatedType),
                 expect_errors=expect_errors)
         return request
 
@@ -476,6 +523,17 @@ class TestNodeLinkedRegistrationsRelationshipDelete(
             node_id=node_private._id,
             auth=user_admin_contrib.auth,
             reg_id=registration._id
+        )
+        assert res.status_code == 204
+
+    def test_admin_contributor_can_delete_linked_registrations_relationship_2_13(
+            self, make_request, registration, user_admin_contrib, node_private):
+        res = make_request(
+            node_id=node_private._id,
+            auth=user_admin_contrib.auth,
+            reg_id=registration._id,
+            version='2.13',
+            deprecatedType=False,
         )
         assert res.status_code == 204
 

--- a/api_tests/preprints/views/test_preprint_node_relationship.py
+++ b/api_tests/preprints/views/test_preprint_node_relationship.py
@@ -68,6 +68,12 @@ class TestPreprintNodeRelationship:
         assert res.json['data']['id'] == supplemental_project._id
         assert url in res.json['links']['self']
 
+        res = app.get('{}?version=2.13'.format(url), auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['type'] == 'nodes'
+        assert res.json['data']['id'] == supplemental_project._id
+        assert url in res.json['links']['self']
+
         # No permission to the supplemental node
         res = app.get(url, auth=user_two.auth)
         assert res.status_code == 200

--- a/api_tests/registrations/views/test_registration_linked_nodes.py
+++ b/api_tests/registrations/views/test_registration_linked_nodes.py
@@ -110,6 +110,16 @@ class TestNodeRelationshipNodeLinks:
         assert linking_node.linked_nodes_self_url in res.json['links']['self']
         assert linking_node.linked_nodes_related_url in res.json['links']['html']
         assert private_node._id in [e['id'] for e in res.json['data']]
+        assert res.json['data'][0]['type'] == 'linked_nodes'
+
+        #   get_relationship_linked_nodes_2_13
+        res = app.get('{}?version=2.13'.format(url), auth=user.auth)
+
+        assert res.status_code == 200
+        assert linking_node.linked_nodes_self_url in res.json['links']['self']
+        assert linking_node.linked_nodes_related_url in res.json['links']['html']
+        assert private_node._id in [e['id'] for e in res.json['data']]
+        assert res.json['data'][0]['type'] == 'nodes'
 
     #   get_linked_nodes_related_counts
         res = app.get(

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -168,9 +168,11 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             API_BASE, self.public_registration._id)
 
     def make_request(
-            self, registration_id=None, auth=None, expect_errors=False):
+            self, registration_id=None, auth=None, expect_errors=False, version=None):
         url = '/{}registrations/{}/relationships/linked_registrations/'.format(
             API_BASE, registration_id)
+        if version:
+            url = '{}?version={}'.format(url, version)
         if auth:
             return self.app.get(url, auth=auth, expect_errors=expect_errors)
         return self.app.get(url, expect_errors=expect_errors)
@@ -184,6 +186,18 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert_not_in(
             self.private_linked_registration._id,
             linked_registration_ids)
+        assert res.json['data'][0]['type'] == 'linked_registrations'
+
+    def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship_2_13(
+            self):
+        res = self.make_request(registration_id=self.public_registration._id, version='2.13')
+        assert_equal(res.status_code, 200)
+        linked_registration_ids = [r['id'] for r in res.json['data']]
+        assert_in(self.public_linked_registration._id, linked_registration_ids)
+        assert_not_in(
+            self.private_linked_registration._id,
+            linked_registration_ids)
+        assert res.json['data'][0]['type'] == 'registrations'
 
     def test_private_registration_admin_contributor_can_view_linked_registrations_relationship(
             self):


### PR DESCRIPTION
## Purpose

Endpoints pointed to by relationship self urls should return Resource Identifier Objects consisting of the resource id and type. In several cases in the API, the resource types are set to the relationship name rather than the type of the related resource. This PR deprecates and versions out the incorrect resource type names.

## Changes

* add a `get_meta_type()` helper method that will first look for `Meta.type_`, and, if not found, look for `Meta.get_type()` and pass it the current request
* `s/linked_nodes/nodes/` type for node.linked_nodes relationship self endpoint (including tests)
* `s/linked_registrations/registrations/` type for node.linked_registrations relationship self endpoint (including tests)
* add tests for new resource types for registrations relationships 
* `s/linked_preprints/preprints/` type for collection.linked_preprints relationship self endpoint (including tests)
* `s/linked_preprint_nodes/nodes/` type for preprint.node relationship self endpoint (including tests)

## QA Notes

API testing should be performed on these endpoints before and after `version=2.13`:
* `/v2/nodes/{}/relationships/linked_nodes`
* `/v2/nodes/{}/relationships/linked_registrations`
* `/v2/registrations/{}/relationships/linked_nodes`
* `/v2/registrations/{}/relationships/linked_registrations`
* `/v2/collections/{}/relationships/linked_nodes`
* `/v2/collections/{}/relationships/linked_registrations`
* `/v2/collections/{}/relationships/linked_preprints`
* `/v2/preprints/{}/relationships/node`

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/41

## Side Effects

None expected.

## Ticket

N/A
