### PR TITLE
Move check for BaseFileNode in get_file, resolves #8888 [PLAT-1309]

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -39,10 +39,10 @@ class FileMixin(object):
             obj = utils.get_object_or_error(BaseFileNode, self.kwargs[self.file_lookup_url_kwarg], self.request, display_name='file')
         except NotFound:
             obj = utils.get_object_or_error(Guid, self.kwargs[self.file_lookup_url_kwarg], self.request).referent
-            if obj.is_deleted:
-                raise Gone(detail='The requested file is no longer available.')
             if not isinstance(obj, BaseFileNode):
                 raise NotFound
+            if obj.is_deleted:
+                raise Gone(detail='The requested file is no longer available.')
 
         if getattr(obj.target, 'deleted', None):
             raise Gone(detail='The requested file is no longer available')

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -130,6 +130,11 @@ class TestFileView:
         assert guid is not None
         assert res.json['data']['attributes']['guid'] == guid._id
 
+    def test_file_with_wrong_guid(self, app, user):
+        url = '/{}files/{}/'.format(API_BASE, user._id)
+        res = app.get(url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 404
+
     @mock.patch('api.base.throttling.CreateGuidThrottle.allow_request')
     def test_file_guid_not_created_with_basic_auth(
             self, mock_allow, app, user, file_url):


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The `get_file` endpoint checked for the `is_deleted` property before making sure it was a `BaseFileNode` object - just move that a little bit!

## Changes

- Move check for `BaseFileNode` above check for `is_deleted`

## QA Notes

Visiting a files detail endpoint like `/v2/files/<real_guid>/` with a guid that's not a file (like a user or a node's guid) returns a 404 not found!

## Documentation
Bug fix, no docs needed!

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/PLAT-1309
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
