### PR TITLE
Make sure version coming back from WB is an int

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -289,8 +289,6 @@ def get_auth(auth, **kwargs):
             raise HTTPError(httplib.BAD_REQUEST)
 
     path = data.get('path')
-    version = data.get('version')
-
     credentials = None
     waterbutler_settings = None
     fileversion = None
@@ -301,7 +299,7 @@ def get_auth(auth, **kwargs):
             filenode = OsfStorageFileNode.load(path.strip('/'))
             if filenode and filenode.is_file:
                 # default to most recent version if none is provided in the response
-                version = int(version) if version else filenode.versions.count()
+                version = int(data.get('version', filenode.versions.count()))
                 try:
                     fileversion = FileVersion.objects.filter(
                         basefilenode___id=file_id,

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -301,7 +301,7 @@ def get_auth(auth, **kwargs):
             filenode = OsfStorageFileNode.load(path.strip('/'))
             if filenode and filenode.is_file:
                 # default to most recent version if none is provided in the response
-                version = version or filenode.versions.count()
+                version = int(version) if version else filenode.versions.count()
                 try:
                     fileversion = FileVersion.objects.filter(
                         basefilenode___id=file_id,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

OSF was not always getting an int back as the version from WB for metrics tracking for osfstorage files

## Changes

cast the version to an int before using it to update analytics!
<!-- Briefly describe or list your changes  -->

## QA Notes
Should just make things work as expected
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
None necessary
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket
Staging sentry error: 
https://staging-sentry.cos.io/cos/osf-back-end-vu/issues/5054/
