### PR TITLE
Feature/APIv2 Minting DOI's for Nodes and Registrations [EMB-570]

### DIFF
--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -14,12 +14,14 @@ from api.identifiers.serializers import NodeIdentifierSerializer, RegistrationId
 from api.nodes.permissions import (
     IsPublic,
     ExcludeWithdrawals,
+    AdminOrPublic,
+    EditIfPublic,
 )
 
 from osf.models import Node, Registration, Preprint, Identifier
 
 
-class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixin):
     """List of identifiers for a specified node. *Read-only*.
 
     ##Identifier Attributes
@@ -55,6 +57,8 @@ class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     permission_classes = (
         IsPublic,
+        EditIfPublic,
+        AdminOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ExcludeWithdrawals,

--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -22,39 +22,6 @@ from osf.models import Node, Registration, Preprint, Identifier
 
 
 class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixin):
-    """List of identifiers for a specified node. *Read-only*.
-
-    ##Identifier Attributes
-
-    OSF Identifier entities have the "identifiers" `type`.
-
-        name           type                   description
-        ----------------------------------------------------------------------------
-        category       string                 e.g. 'ark', 'doi'
-        value          string                 the identifier value itself
-
-    ##Links
-
-        self: this identifier's detail page
-
-    ##Relationships
-
-    ###Referent
-
-    The identifier is refers to this node.
-
-    ##Actions
-
-    *None*.
-
-    ##Query Params
-
-     Identifiers may be filtered by their category.
-
-    #This Request/Response
-
-    """
-
     permission_classes = (
         IsPublic,
         EditIfPublic,
@@ -65,7 +32,7 @@ class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixi
     )
 
     required_read_scopes = [CoreScopes.IDENTIFIERS_READ]
-    required_write_scopes = [CoreScopes.NULL]
+    required_write_scopes = [CoreScopes.IDENTIFIERS_WRITE]
 
     view_category = 'identifiers'
     view_name = 'identifier-list'

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -50,6 +50,17 @@ class IsPublic(permissions.BasePermission):
         return obj.is_public or obj.can_view(auth)
 
 
+class EditIfPublic(permissions.BasePermission):
+
+    acceptable_models = (AbstractNode,)
+
+    def has_object_permission(self, request, view, obj):
+        assert_resource_type(obj, self.acceptable_models)
+        if request.method not in permissions.SAFE_METHODS:
+            return obj.is_public
+        return True
+
+
 class IsAdmin(permissions.BasePermission):
     acceptable_models = (AbstractNode, PrivateLink)
 

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -1,4 +1,6 @@
+import mock
 import pytest
+import responses
 from urlparse import urlparse
 from django.utils import timezone
 from framework.auth.core import Auth
@@ -11,9 +13,12 @@ from osf_tests.factories import (
     IdentifierFactory,
     NodeFactory,
     PreprintFactory,
+    WithdrawnRegistrationFactory,
 )
 from osf.utils.workflows import DefaultStates
 from tests.utils import assert_items_equal
+from website.identifiers.clients import DataCiteClient
+from website import settings
 
 
 @pytest.fixture()
@@ -135,6 +140,14 @@ class TestRegistrationIdentifierList:
         res = app.get(url, expect_errors=True)
         assert res.status_code == 404
 
+    def test_do_not_return_deleted_identifier(
+            self, app, registration):
+        registration.is_deleted = True
+        registration.save()
+        url = '/{}registrations/{}/identifiers/'.format(API_BASE, registration._id)
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 410
+
 
 @pytest.mark.django_db
 class TestNodeIdentifierList:
@@ -235,6 +248,14 @@ class TestNodeIdentifierList:
         url = '/{}nodes/{}/identifiers/'.format(API_BASE, registration._id)
         res = app.get(url, expect_errors=True)
         assert res.status_code == 404
+
+    def test_do_not_return_deleted_identifier(
+            self, app, node):
+        node.is_deleted = True
+        node.save()
+        url = '/{}nodes/{}/identifiers/'.format(API_BASE, node._id)
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 410
 
 
 @pytest.mark.django_db
@@ -430,3 +451,133 @@ class TestPreprintIdentifierList:
         # test_unpublished_preprint_identifier_admin_authenticated
         res = app.get(url_preprint_identifier, auth=user.auth)
         assert res.status_code == 200
+
+
+@pytest.mark.django_db
+class TestNodeIdentifierCreate:
+
+    @pytest.fixture()
+    def resource(self, user):
+        return NodeFactory(creator=user, is_public=True)
+
+    @pytest.fixture()
+    def write_contributor(self, resource):
+        user = AuthUserFactory()
+        resource.add_contributor(user, ['read', 'write'])
+        resource.save()
+        return user
+
+    @pytest.fixture()
+    def read_contributor(self, resource):
+        user = AuthUserFactory()
+        resource.add_contributor(user, ['read'])
+        resource.save()
+        return user
+
+    @pytest.fixture()
+    def identifier_url(self, resource):
+        return '/{}{}s/{}/identifiers/'.format(API_BASE, resource.__class__.__name__.lower(), resource._id)
+
+    @pytest.fixture()
+    def identifier_payload(self):
+        return {
+            'data': {
+                'type': 'identifiers',
+                'attributes': {
+                    'category': 'doi'
+                }
+            }
+        }
+
+    @pytest.fixture()
+    def ark_payload(self):
+        return {
+            'data': {
+                'type': 'identifiers',
+                'attributes': {
+                    'category': 'ark'
+                }
+            }
+        }
+
+    @pytest.fixture()
+    def client(self):
+        return DataCiteClient(base_url='https://mds.fake.datacite.org', prefix=settings.DATACITE_PREFIX)
+
+    @responses.activate
+    def test_create_identifier(self, app, resource, client, identifier_url, identifier_payload, user,
+            write_contributor, read_contributor, ark_payload):
+        responses.add(
+            responses.Response(
+                responses.POST,
+                client.base_url + '/metadata',
+                body='OK (10.5072/FK2osf.io/dp438)',
+                status=201,
+            )
+        )
+        responses.add(
+            responses.Response(
+                responses.POST,
+                client.base_url + '/doi',
+                body='OK (10.5072/FK2osf.io/dp438)',
+                status=201,
+            )
+        )
+
+        # Can only mint DOI's
+        res = app.post_json_api(identifier_url, ark_payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'You can only mint a DOI, not a different type of identifier.'
+
+        # Cannot connect to DOI service
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 503
+        assert res.json['errors'][0]['detail'] == 'Service is unavailable at this time.'
+
+        with mock.patch('osf.models.AbstractNode.get_doi_client') as mock_get_doi:
+            mock_get_doi.return_value = client
+            res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth)
+
+        resource.reload()
+        assert res.status_code == 201
+        assert res.json['data']['attributes']['category'] == 'doi'
+        assert res.json['data']['attributes']['value'] == resource.get_identifier_value('doi')
+        assert res.json['data']['id'] == resource.identifiers.first()._id
+        assert res.json['data']['type'] == 'identifiers'
+        assert resource.logs.first().action == 'external_ids_added'
+        assert resource.identifiers.count() == 1
+
+        # write contributor cannot create identifier
+        res = app.post_json_api(identifier_url, identifier_payload, auth=write_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # read contributor cannot create identifier
+        res = app.post_json_api(identifier_url, identifier_payload, auth=read_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # cannot request a DOI when one already exists
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'A DOI already exists for this resource.'
+
+        # cannot request a DOI for a private resource
+        resource.is_public = False
+        resource.save()
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 403
+
+
+@pytest.mark.django_db
+class TestRegistrationIdentifierCreate(TestNodeIdentifierCreate):
+
+    @pytest.fixture()
+    def resource(self, user):
+        return RegistrationFactory(creator=user, is_public=True)
+
+    @pytest.fixture()
+    def retraction(self, resource, user):
+        return WithdrawnRegistrationFactory(registration=resource)
+
+    def test_create_doi_for_withdrawn_registration(self, app, user, retraction, identifier_url, identifier_payload):
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 403

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -158,6 +158,7 @@ class CoreScopes(object):
     WIKI_BASE_WRITE = 'wikis.base_write'
 
     IDENTIFIERS_READ = 'identifiers.data_read'
+    IDENTIFIERS_WRITE = 'identifiers.data_write'
 
 
 class ComposedScopes(object):
@@ -195,6 +196,7 @@ class ComposedScopes(object):
 
     # Identifier views
     IDENTIFIERS_READ = (CoreScopes.IDENTIFIERS_READ, )
+    IDENTIFIERS_WRITE = (CoreScopes.IDENTIFIERS_WRITE, )
 
     # Comment reports collection
     COMMENT_REPORTS_READ = (CoreScopes.COMMENT_REPORTS_READ,)
@@ -207,7 +209,7 @@ class ComposedScopes(object):
                           CoreScopes.NODE_FORKS_READ, CoreScopes.WIKI_BASE_READ, CoreScopes.LICENSE_READ,
                           CoreScopes.IDENTIFIERS_READ, CoreScopes.NODE_PREPRINTS_READ, CoreScopes.PREPRINT_REQUESTS_READ)
     NODE_METADATA_WRITE = NODE_METADATA_READ + \
-                    (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE,
+                    (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE, CoreScopes.IDENTIFIERS_WRITE,
                      CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE,
                      CoreScopes.NODE_PREPRINTS_WRITE, CoreScopes.PREPRINT_REQUESTS_WRITE, CoreScopes.WIKI_BASE_WRITE)
 

--- a/website/identifiers/views.py
+++ b/website/identifiers/views.py
@@ -17,6 +17,8 @@ from osf.utils.permissions import ADMIN
 def node_identifiers_post(auth, node, **kwargs):
     """Create identifier pair for a node. Node must be a public registration.
     """
+    # TODO this functionality exists in APIv2. When front end is entirely using
+    # v2 for minting DOI's, remove this view.
     if not node.is_public or node.is_retracted:
         raise HTTPError(http.BAD_REQUEST)
     if node.get_identifier('doi') or node.get_identifier('ark'):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow POSTing to nodes' and registrations' identifiers relationship to request minting a DOI.

/v2/nodes/<guid>/identifiers/
/v2/registrations/<guid>/identifiers/
Right now, only valid to POST with category: 'doi'. Error if the node already has a DOI.

## Changes

-Added route to v2 that does the same things v1 route did

## QA Notes

API only, moves same code that allows us to create a DOI for a project/registration in v1 to v2.

## Documentation

https://github.com/CenterForOpenScience/developer.osf.io/pull/42
## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/EMB-570