### PR TITLE
[EMB-556][Preprints][OSF] Add engagement emails for preprints submitted with no supplemental nodes.

### DIFF
--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -132,7 +132,7 @@ NO_LOGIN = {
 
 NO_SUPPLEMENTAL_NODE = {
     'template': 'no_supplemental_node',
-    'subject': 'Add supplemental files to your ${preprint_word}',
+    'subject': 'Add supplemental materials to your ${preprint_word}',
     'presend': presends.no_supplemental_node,
     'categories': ['engagement', 'engagement-no-supplemental-node'],
     'engagement': True

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -64,13 +64,13 @@ class QueuedMail(ObjectIDMixin, BaseModel):
             self.__class__.delete(self)
             return False
 
-    def find_sent_of_same_type_and_user(self):
+    def sent_email_same_type(self):
         """
         Queries up for all emails of the same type as self, sent to the same user as self.
         Does not look for queue-up emails.
-        :return: a list of those emails
+        :return: a boolean of whether such emails exist
         """
-        return self.__class__.objects.filter(email_type=self.email_type, user=self.user).exclude(sent_at=None)
+        return bool(self.__class__.objects.filter(email_type=self.email_type, user=self.user).exclude(sent_at=None))
 
 
 def queue_mail(to_addr, mail, send_at, user, **context):

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -130,6 +130,14 @@ NO_LOGIN = {
     'engagement': True
 }
 
+NO_SUPPLEMENTAL_NODE = {
+    'template': 'no_supplemental_node',
+    'subject': 'Add supplemental files to your ${preprint_word}',
+    'presend': presends.no_supplemental_node,
+    'categories': ['engagement', 'engagement-no-supplemental-node'],
+    'engagement': True
+}
+
 NEW_PUBLIC_PROJECT = {
     'template': 'new_public_project',
     'subject': 'Now, public. Next, impact.',
@@ -147,6 +155,7 @@ WELCOME_OSF4M = {
     'engagement': True
 }
 
+NO_SUPPLEMENTAL_NODE_TYPE = 'no_supplemental_node'
 NO_ADDON_TYPE = 'no_addon'
 NO_LOGIN_TYPE = 'no_login'
 NEW_PUBLIC_PROJECT_TYPE = 'new_public_project'
@@ -155,6 +164,7 @@ WELCOME_OSF4M_TYPE = 'welcome_osf4m'
 
 # Used to keep relationship from stored string 'email_type' to the predefined queued_email objects.
 queue_mail_types = {
+    NO_SUPPLEMENTAL_NODE_TYPE: NO_SUPPLEMENTAL_NODE,
     NO_ADDON_TYPE: NO_ADDON,
     NO_LOGIN_TYPE: NO_LOGIN,
     NEW_PUBLIC_PROJECT_TYPE: NEW_PUBLIC_PROJECT,

--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -101,9 +101,9 @@ class TestQueuedMail:
             user=user,
             mail=NO_ADDON,
         )
-        assert len(mail.find_sent_of_same_type_and_user()) == 0
+        assert mail.sent_email_same_type() is False
         mail.send_mail()
-        assert len(mail.find_sent_of_same_type_and_user()) == 1
+        assert mail.sent_email_same_type() is True
 
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_user_is_active(self, mock_mail, user):

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -16,6 +16,10 @@ def queue_no_supplemental_node_email(user, preprint):
     with no supplemental nodes.
     """
     from osf.models.queued_mail import queue_mail, NO_SUPPLEMENTAL_NODE
+    if preprint.provider._id == 'osf':
+        logo = settings.OSF_PREPRINTS_LOGO
+    else:
+        logo = preprint.provider._id
     queue_mail(
         to_addr=user.username,
         mail=NO_SUPPLEMENTAL_NODE,
@@ -25,7 +29,8 @@ def queue_no_supplemental_node_email(user, preprint):
         title=preprint.title,
         provider_name=preprint.provider.name,
         preprint_word=preprint.provider.preprint_word,
-        preprint_id=preprint._id
+        preprint_id=preprint._id,
+        logo=logo
     )
 
 @auth_signals.unconfirmed_user_created.connect

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -30,6 +30,7 @@ def queue_no_supplemental_node_email(user, preprint):
         provider_name=preprint.provider.name,
         preprint_word=preprint.provider.preprint_word,
         preprint_id=preprint._id,
+        absolute_url=preprint.absolute_url,
         logo=logo
     )
 

--- a/website/mails/presends.py
+++ b/website/mails/presends.py
@@ -3,6 +3,13 @@ from django.utils import timezone
 
 from website import settings
 
+def no_supplemental_node(email):
+    print(email)
+    from osf.models import Preprint
+    preprint = Preprint.load(email.data['preprint_id'])
+    same_type_emails = email.find_sent_of_same_type_and_user()
+    return preprint.node is None and preprint.machine_state == 'accepted' and not len(same_type_emails)
+
 def no_addon(email):
     return len([addon for addon in email.user.get_addons() if addon.config.short_name != 'osfstorage']) == 0
 

--- a/website/mails/presends.py
+++ b/website/mails/presends.py
@@ -3,15 +3,16 @@ from django.utils import timezone
 
 from website import settings
 
+
 def no_supplemental_node(email):
-    print(email)
     from osf.models import Preprint
     preprint = Preprint.load(email.data['preprint_id'])
-    same_type_emails = email.find_sent_of_same_type_and_user()
-    return preprint.node is None and preprint.machine_state == 'accepted' and not len(same_type_emails)
+    return preprint.node is None and preprint.machine_state == 'accepted' and not email.sent_email_same_type()
+
 
 def no_addon(email):
     return len([addon for addon in email.user.get_addons() if addon.config.short_name != 'osfstorage']) == 0
+
 
 def no_login(email):
     from osf.models.queued_mail import QueuedMail, NO_LOGIN_TYPE
@@ -19,6 +20,7 @@ def no_login(email):
     if sent.exists():
         return False
     return email.user.date_last_login < timezone.now() - settings.NO_LOGIN_WAIT_TIME
+
 
 def new_public_project(email):
     """ Will check to make sure the project that triggered this presend is still public
@@ -36,8 +38,7 @@ def new_public_project(email):
 
     if not node:
         return False
-    public = email.find_sent_of_same_type_and_user()
-    return node.is_public and not len(public)
+    return node.is_public and not email.sent_email_same_type()
 
 
 def welcome_osf4m(email):

--- a/website/preprints/signals.py
+++ b/website/preprints/signals.py
@@ -1,0 +1,4 @@
+import blinker
+
+signals = blinker.Namespace()
+preprint_submitted = signals.signal('preprint-submitted')

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -168,6 +168,7 @@ OSF_HELP_LIST = 'Open Science Framework Help'
 PREREG_AGE_LIMIT = timedelta(weeks=12)
 PREREG_WAIT_TIME = timedelta(weeks=2)
 WAIT_BETWEEN_MAILS = timedelta(days=7)
+NO_SUPPLEMENTAL_NODE_WAIT_TIME = timedelta()
 NO_ADDON_WAIT_TIME = timedelta(weeks=8)
 NO_LOGIN_WAIT_TIME = timedelta(weeks=4)
 WELCOME_OSF4M_WAIT_TIME = timedelta(weeks=2)

--- a/website/signals.py
+++ b/website/signals.py
@@ -5,6 +5,7 @@ from website.project import signals as project
 from addons.base import signals as event
 from website.conferences import signals as conference
 from website.reviews import signals as reviews
+from website.preprints import signals as preprint
 
 ALL_SIGNALS = [
     project.comment_added,
@@ -21,5 +22,6 @@ ALL_SIGNALS = [
     auth.unconfirmed_user_created,
     event.file_updated,
     conference.osf4m_user_created,
-    reviews.reviews_email
+    reviews.reviews_email,
+    preprint.preprint_submitted,
 ]

--- a/website/templates/emails/no_supplemental_node.html.mako
+++ b/website/templates/emails/no_supplemental_node.html.mako
@@ -6,11 +6,17 @@
         Hello ${fullname},
         <br><br>
         Thanks for sharing ${title} on ${provider_name}.
-        Sharing your research doesn’t have to stop there. Add supplemental files such as data, code, protocols, and other materials that comprise your ${preprint_word} to help others get the most from your research.
+        Sharing your research doesn’t have to stop there. Add supplemental materials such as data, code, protocols, and other materials that comprise your ${preprint_word} to help others get the most from your research.
         Supplemental files will be stored in an OSF project that connects to your ${preprint_word}. Just edit your ${preprint_word}, and follow the instructions below:
-        <br>
-        > <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#create-a-new-osf-project">Upload supplemental files to a new OSF project</a>.
-        > <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#connect-an-existing-osf-project">Upload supplemental files to a new OSF project</a>.
+        <br><br>
+        <ul>
+            <li>
+                <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#create-a-new-osf-project">Upload supplemental materials to a new OSF project</a>.
+            </li>
+            <li>
+                <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#connect-an-existing-osf-project">Connect supplemental materials from an existing OSF project</a>.
+            </li>
+        </ul>
         <br><br>
         Sincerely,<br>
         Your ${provider_name} and OSF Team

--- a/website/templates/emails/no_supplemental_node.html.mako
+++ b/website/templates/emails/no_supplemental_node.html.mako
@@ -1,0 +1,23 @@
+## -*- coding: utf-8 -*-
+<%inherit file="notify_base.mako"/>
+<%def name="content()">
+    <div style="margin: 40px;">
+    <br>
+        Hello ${fullname},
+        <br><br>
+        Thanks for sharing ${title} on ${provider_name}.
+        Sharing your research doesn’t have to stop there. Add supplemental files such as data, code, protocols, and other materials that comprise your ${preprint_word} to help others get the most from your research.
+        Supplemental files will be stored in an OSF project that connects to your ${preprint_word}. Just edit your ${preprint_word}, and follow the instructions below:
+        <br>
+        > <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#create-a-new-osf-project">Upload supplemental files to a new OSF project</a>.
+        > <a href="http://help.osf.io/m/preprints/l/664307-edit-your-preprint#connect-an-existing-osf-project">Upload supplemental files to a new OSF project</a>.
+        <br><br>
+        Sincerely,<br>
+        Your ${provider_name} and OSF Team
+
+    </div>
+</%def>
+<%def name="footer()">
+    <br>
+    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="https://cos.io/">Center for Open Science</a>.
+</%def>

--- a/website/templates/emails/no_supplemental_node.html.mako
+++ b/website/templates/emails/no_supplemental_node.html.mako
@@ -5,9 +5,9 @@
     <br>
         Hello ${fullname},
         <br><br>
-        Thanks for sharing ${title} on ${provider_name}.
+        Thanks for sharing <a href="${absolute_url}">${title}</a> on ${provider_name}.
         Sharing your research doesn’t have to stop there. Add supplemental materials such as data, code, protocols, and other materials that comprise your ${preprint_word} to help others get the most from your research.
-        Supplemental files will be stored in an OSF project that connects to your ${preprint_word}. Just edit your ${preprint_word}, and follow the instructions below:
+        Supplemental materials will be stored in an OSF project that connects to your ${preprint_word}. Just edit your ${preprint_word}, and follow the instructions below:
         <br><br>
         <ul>
             <li>


### PR DESCRIPTION
## Purpose

This PR adds engagement emails to be sent to contributors of preprints with no supplemental nodes upon submission (for non-moderated providers) or upon approval (for moderated providers).

## Changes

- Added signals to preprint to be sent
  - When `set_published` is invoked (upon preprint submission) and is not submitted to a moderated service
  - When `run_accept_reject` is invoked (upon approval) and preprint is accepted by the moderator
- Added new `no_supplemental_node` email template.
- Connect to the `preprint_submitted` signal and queue the email to be sent.
- New `presend` hook to determine whether we send the email.

## QA Notes

Engagement emails for preprints with no supplemental nodes will only be sent once per user.
For non-moderated provider, the email will be queued upon submission.
For moderated provider, the email will be queued upon moderator approval.

## Ticket

https://openscience.atlassian.net/browse/EMB-556
