### PR TITLE
[OSF Institutions] Update IdP's EntityID for UCT - Test Server Only [SVCS-960]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1345,7 +1345,7 @@ def main(env):
                 'description': '<a href="http://www.lib.uct.ac.za/">UCT Libraries</a>, <a href="http://www.eresearch.uct.ac.za/">UCT eResearch</a> &amp; <a href="http://www.icts.uct.ac.za/">ICTS</a> present the UCT OSF institutional service to UCT affiliated students, staff and researchers. The UCT OSF facility should be used in conjunction with the institution\'s <a href="http://www.digitalservices.lib.uct.ac.za/dls/rdm-policy">Research Data Management (RDM) Policy</a>, <a href="https://www.uct.ac.za/downloads/uct.ac.za/about/policies/UCTOpenAccessPolicy.pdf">Open Access Policy</a> and <a href="https://www.uct.ac.za/downloads/uct.ac.za/about/policies/UCTOpenAccessPolicy.pdf">IP Policy</a>. Visit the <a href="http://www.digitalservices.lib.uct.ac.za/">UCT Digital Library Services</a> for more information and/or assistance with <a href="http://www.digitalservices.lib.uct.ac.za/dls/rdm">RDM</a> and <a href="http://www.digitalservices.lib.uct.ac.za/dls/data-sharing-guidelines">data sharing</a>. We also encourage the use of UCT Libraries\'s Data Management Planning tool, <a href="http://dmp.lib.uct.ac.za/about_us">DMPonline</a>',
                 'banner_name': 'uct-banner.png',
                 'logo_name': 'uct-shield.png',
-                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('http://sso.uct.ac.za/adfs/services/trust')),
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('http://adfs.uct.ac.za/adfs/services/trust')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
                 'domains': ['test-osf-uct.cos.io'],
                 'email_domains': [],


### PR DESCRIPTION
## Purpose

University of Cape Town (UCT) has migrated their IdP ADFS servers where the main metadata has changed, including the provider's entity ID which is used to build the login URL. This PR targets test server only to test/verify the new changes while keeping prod working with the old one.

## Deployment Notes

More details on the way.

@binoculars 

### Shibboleth

- [x] Modify `shibboleth2.xml`

```xml
<!-- University of Cape Town (UCT) -->
<MetadataProvider type="XML"
                  uri="https://adfs.uct.ac.za/FederationMetadata/2007-06/FederationMetadata.xml"
                  backingFilePath="uct-idp-metadata.xml"
                  reloadInterval="180000" />
```

### CAS

- [x] Modify `institutions-auth.xsl`

```xml
<!-- University of Cape Town (UCT) -->
<xsl:when test="$idp='http://adfs.uct.ac.za/adfs/services/trust'">
...
```

@mfraezz 

### OSF

- [ ] Populate institutions on the test server.

## Ticket

https://openscience.atlassian.net/browse/SVCS-960
