### PR TITLE
Feature/Follow-Up for Withdrawals via APIv2 [PLAT-1275]

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -353,17 +353,17 @@ class RegistrationSerializer(NodeSerializer):
                     raise exceptions.PermissionDenied()
             else:
                 raise exceptions.ValidationError('Registrations can only be turned from private to public.')
-        if 'retraction' in validated_data or 'is_retracted' in validated_data:
+        if 'withdrawal_justification' in validated_data or 'is_retracted' in validated_data:
             if user_is_admin:
                 is_retracted = validated_data.get('is_retracted', None)
-                if validated_data.get('retraction') and not is_retracted:
+                withdrawal_justification = validated_data.get('withdrawal_justification', None)
+                if withdrawal_justification and not is_retracted:
                     raise exceptions.ValidationError(
                         'You cannot provide a withdrawal_justification without a concurrent withdrawal request.',
                     )
                 if is_truthy(is_retracted):
                     if registration.is_pending_retraction:
                         raise exceptions.ValidationError('This registration is already pending withdrawal')
-                    withdrawal_justification = validated_data['retraction']['justification'] if validated_data.get('retraction') else None
                     try:
                         retraction = registration.retract_registration(user, withdrawal_justification, save=True)
                     except NodeStateError as err:
@@ -461,7 +461,7 @@ class RegistrationDetailSerializer(RegistrationSerializer):
         source='is_retracted', required=False,
         help_text='The registration has been withdrawn.',
     )
-    withdrawal_justification = ser.CharField(source='retraction.justification', required=False)
+    withdrawal_justification = ser.CharField(required=False)
 
 
 class RegistrationNodeLinksSerializer(NodeLinksSerializer):


### PR DESCRIPTION
## Purpose

Fixes failing test caused by https://github.com/CenterForOpenScience/osf.io/pull/8868 going in after https://github.com/CenterForOpenScience/osf.io/pull/8836.

## Changes

Make sure you can still see withdrawal_justification on Registration children.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1275