### PR TITLE
Feature/Fix Dataverse Error [PLAT-1328]

### DIFF
--- a/addons/dataverse/requirements.txt
+++ b/addons/dataverse/requirements.txt
@@ -1,4 +1,4 @@
 # Allow for optional timeout parameter.
 # https://github.com/IQSS/dataverse-client-python/pull/27
 #-e git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse
--e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@48dd0edfa396a51d28e08518d72e4fa825427073#egg=dataverse
+-e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@5a9a8cabc9a521bd86efc0105075c5a4816a2ca5#egg=dataverse


### PR DESCRIPTION
## Purpose

Fix issue in `dataverse-client-python` where dataverses within dataverses can cause a KeyError: 'protocol', because dataverses don't have the protocol key.


## Changes

Points to latest osf fork of dataverse-client-python since this PR was merged https://github.com/CenterForOpenScience/dataverse-client-python/pull/4

## QA Notes

Create a test dataverse on https://demo.dataverse.org/, and then add both a dataverse and a dataset to that top-level dataverse.  (Create the nested dataverse first).   

So I had dataverse Grapes Dataverse, with a Raisins Dataverse and a strawberries dataset.
<img width="1219" alt="screen shot 2019-02-08 at 12 17 59 pm" src="https://user-images.githubusercontent.com/9755598/52500536-daadd600-2ba3-11e9-973d-a131744d4aa3.png">

On the OSF connect your Grapes Dataverse, select your strawberries dataset and hit save.  Before, you would get a key error when the _id property would loop through all the content in Grapes Dataverse (Raisins Dataverse and strawberries dataset). If it hit a dataverse before finding the matching dataset, it would get an error when looking for the `protocol` key which doesn't exist on a dataverse.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1328