### PR TITLE
Feature/Updates to v2 Withdrawal Initiation [EMB-578][PLAT-1333]

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -353,15 +353,15 @@ class RegistrationSerializer(NodeSerializer):
                     raise exceptions.PermissionDenied()
             else:
                 raise exceptions.ValidationError('Registrations can only be turned from private to public.')
-        if 'withdrawal_justification' in validated_data or 'is_retracted' in validated_data:
+        if 'withdrawal_justification' in validated_data or 'is_pending_retraction' in validated_data:
             if user_is_admin:
-                is_retracted = validated_data.get('is_retracted', None)
+                is_pending_retraction = validated_data.get('is_pending_retraction', None)
                 withdrawal_justification = validated_data.get('withdrawal_justification', None)
-                if withdrawal_justification and not is_retracted:
+                if withdrawal_justification and not is_pending_retraction:
                     raise exceptions.ValidationError(
                         'You cannot provide a withdrawal_justification without a concurrent withdrawal request.',
                     )
-                if is_truthy(is_retracted):
+                if is_truthy(is_pending_retraction):
                     if registration.is_pending_retraction:
                         raise exceptions.ValidationError('This registration is already pending withdrawal')
                     try:
@@ -369,8 +369,8 @@ class RegistrationSerializer(NodeSerializer):
                     except NodeStateError as err:
                         raise exceptions.ValidationError(str(err))
                     retraction.ask(registration.get_active_contributors_recursive(unique_users=True))
-                elif is_retracted is not None:
-                    raise exceptions.ValidationError('You cannot set withdrawn to False.')
+                elif is_pending_retraction is not None:
+                    raise exceptions.ValidationError('You cannot set is_pending_withdrawal to False.')
             else:
                 raise exceptions.PermissionDenied()
         return registration
@@ -452,15 +452,15 @@ class RegistrationCreateSerializer(RegistrationSerializer):
 
 class RegistrationDetailSerializer(RegistrationSerializer):
     """
-    Overrides RegistrationSerializer to make id required, and to make withdrawn and withdrawal_justification writable.
+    Overrides RegistrationSerializer make _id required and other fields writeable
     """
 
     id = IDField(source='_id', required=True)
 
-    withdrawn = ser.BooleanField(
-        source='is_retracted', required=False,
-        help_text='The registration has been withdrawn.',
-    )
+    pending_withdrawal = HideIfWithdrawal(ser.BooleanField(
+        source='is_pending_retraction', required=False,
+        help_text='The registration is awaiting withdrawal approval by project admins.',
+    ))
     withdrawal_justification = ser.CharField(required=False)
 
 


### PR DESCRIPTION
## Purpose

Modify how we're initiating a withdrawal in v2.  Recent PR https://github.com/CenterForOpenScience/osf.io/pull/8868 sets `withdrawn` field to True to start the withdrawal process, but Registries has reported this causes issues Ember-side. We should patch the field that we have the ability to change instantly, "pending_withdrawal".

## Changes
Update the `pending_withdrawal` field instead of `withdrawn`.  Set `withdrawn` back to read-only. 


## QA Notes
None needed - this will be tested front-end with registries

## Documentation
Need to update Erin's documentation here https://github.com/CenterForOpenScience/developer.osf.io/pull/36

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/EMB-578