### PR TITLE
[EMB-498][OSF][Collections] Enable search by contributor and by tags.

### DIFF
--- a/api/search/views.py
+++ b/api/search/views.py
@@ -662,7 +662,7 @@ class SearchCollections(BaseSearchView):
         return [
             'abstract',
             'collectedType',
-            'contributors',
+            'contributors.fullname',
             'status',
             'subjects',
             'provider',

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -667,6 +667,7 @@ class SearchCollections(BaseSearchView):
             'subjects',
             'provider',
             'title',
+            'tags',
         ]
 
     def create(self, request, *args, **kwargs):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -677,6 +677,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         try:
             search.search.update_node(self, bulk=False, async_update=True)
+            if self.is_collected and self.is_public:
+                search.search.update_collected_metadata(self._id)
         except search.exceptions.SearchUnavailableError as e:
             logger.exception(e)
             log_exception()

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -544,6 +544,7 @@ def serialize_cgm(cgm):
         'subjects': list(cgm.subjects.values_list('text', flat=True)),
         'title': getattr(obj, 'title', ''),
         'url': getattr(obj, 'url', ''),
+        'tags': list(obj.tag_names),
         'category': 'collectionSubmission',
     }
 


### PR DESCRIPTION
## Purpose

Search by contributors on collections should work.

## Changes

In `search_fields`, we change `contributor` to `contributor.fullname` because `fullname` is a nested attribute in the ES document.
Add `tags` to the ES document. Update the index upon addition/removal of tags.

## Ticket
https://openscience.atlassian.net/browse/EMB-498
