### PR TITLE
Feature/APIv2 BibliographicContributorsList Endpoints [EMB-579]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -4,7 +4,7 @@ from distutils.version import StrictVersion
 from django_bulk_update.helper import bulk_update
 from django.conf import settings as django_settings
 from django.db import transaction
-from django.db.models import F
+from django.db.models import F, Q
 from django.http import JsonResponse
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import generics
@@ -17,7 +17,7 @@ from rest_framework.response import Response
 
 from api.base import permissions as base_permissions
 from api.base import utils
-from api.base.exceptions import RelationshipPostMakesNoChanges
+from api.base.exceptions import RelationshipPostMakesNoChanges, InvalidFilterValue, InvalidFilterOperator
 from api.base.filters import ListFilterMixin
 from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
@@ -37,6 +37,7 @@ from api.nodes.permissions import ReadOnlyIfRegistration
 from api.users.serializers import UserSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Contributor, MaintenanceState, BaseFileNode
+from osf.utils.permissions import PERMISSIONS
 from waffle.models import Flag, Switch, Sample
 from waffle import flag_is_active, sample_is_active
 
@@ -491,6 +492,21 @@ class BaseContributorList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin
                     raise ValidationError('Contributor identifier incorrectly formatted.')
             queryset[:] = [contrib for contrib in queryset if contrib._id in contrib_ids]
         return queryset
+
+    # overrides FilterMixin
+    def postprocess_query_param(self, key, field_name, operation):
+        if field_name == 'bibliographic':
+            operation['source_field_name'] = 'visible'
+
+    def build_query_from_field(self, field_name, operation):
+        if field_name == 'permission':
+            if operation['op'] != 'eq':
+                raise InvalidFilterOperator(value=operation['op'], valid_operators=['eq'])
+            # operation['value'] should be 'admin', 'write', or 'read'
+            if operation['value'].lower().strip() not in PERMISSIONS:
+                raise InvalidFilterValue(value=operation['value'])
+            return Q(**{operation['value'].lower().strip(): True})
+        return super(BaseContributorList, self).build_query_from_field(field_name, operation)
 
 
 class BaseNodeLinksDetail(JSONAPIBaseView, generics.RetrieveAPIView):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -338,6 +338,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_meta={'count': 'get_contrib_count'},
     )
 
+    bibliographic_contributors = RelationshipField(
+        related_view='nodes:node-bibliographic-contributors',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
+
     implicit_contributors = RelationshipField(
         related_view='nodes:node-implicit-contributors',
         related_view_kwargs={'node_id': '<_id>'},

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/addons/$', views.NodeAddonList.as_view(), name=views.NodeAddonList.view_name),
     url(r'^(?P<node_id>\w+)/addons/(?P<provider>\w+)/$', views.NodeAddonDetail.as_view(), name=views.NodeAddonDetail.view_name),
     url(r'^(?P<node_id>\w+)/addons/(?P<provider>\w+)/folders/$', views.NodeAddonFolderList.as_view(), name=views.NodeAddonFolderList.view_name),
+    url(r'^(?P<node_id>\w+)/bibliographic_contributors/$', views.NodeBibliographicContributorsList.as_view(), name=views.NodeBibliographicContributorsList.view_name),
     url(r'^(?P<node_id>\w+)/children/$', views.NodeChildrenList.as_view(), name=views.NodeChildrenList.view_name),
     url(r'^(?P<node_id>\w+)/citation/$', views.NodeCitationDetail.as_view(), name=views.NodeCitationDetail.view_name),
     url(r'^(?P<node_id>\w+)/citation/(?P<style_id>[-\w]+)/$', views.NodeCitationStyleDetail.as_view(), name=views.NodeCitationStyleDetail.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -20,8 +20,6 @@ from api.base.exceptions import (
     InvalidModelValueError,
     JSONAPIException,
     Gone,
-    InvalidFilterOperator,
-    InvalidFilterValue,
     RelationshipPostMakesNoChanges,
     EndpointNotImplementedError,
     InvalidQueryStringError,
@@ -119,7 +117,7 @@ from osf.models import NodeRelation, Guid
 from osf.models import BaseFileNode
 from osf.models.files import File, Folder
 from addons.osfstorage.models import Region
-from osf.utils.permissions import ADMIN, PERMISSIONS
+from osf.utils.permissions import ADMIN
 from website import mails
 
 # This is used to rethrow v1 exceptions as v2
@@ -389,21 +387,6 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
     def get_resource(self):
         return self.get_node()
 
-    # overrides FilterMixin
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'bibliographic':
-            operation['source_field_name'] = 'visible'
-
-    def build_query_from_field(self, field_name, operation):
-        if field_name == 'permission':
-            if operation['op'] != 'eq':
-                raise InvalidFilterOperator(value=operation['op'], valid_operators=['eq'])
-            # operation['value'] should be 'admin', 'write', or 'read'
-            if operation['value'].lower().strip() not in PERMISSIONS:
-                raise InvalidFilterValue(value=operation['value'])
-            return Q(**{operation['value'].lower().strip(): True})
-        return super(NodeContributorsList, self).build_query_from_field(field_name, operation)
-
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView, BulkDeleteJSONAPIView
     def get_serializer_class(self):
         """
@@ -534,6 +517,31 @@ class NodeImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView, ListFi
     def get_queryset(self):
         queryset = self.get_queryset_from_request()
         return queryset
+
+
+class NodeBibliographicContributorsList(BaseContributorList, NodeMixin):
+    permission_classes = (
+        AdminOrPublic,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    model_class = OSFUser
+
+    throttle_classes = (UserRateThrottle, NonCookieAuthThrottle,)
+
+    pagination_class = NodeContributorPagination
+    serializer_class = NodeContributorsSerializer
+    view_category = 'nodes'
+    view_name = 'node-bibliographic-contributors'
+    ordering = ('_order',)  # default ordering
+
+    def get_default_queryset(self):
+        contributors = super(NodeBibliographicContributorsList, self).get_default_queryset()
+        return contributors.filter(visible=True)
 
 
 class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin):

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -128,6 +128,11 @@ class RegistrationSerializer(NodeSerializer):
         related_meta={'count': 'get_contrib_count'},
     )
 
+    bibliographic_contributors = RelationshipField(
+        related_view='registrations:registration-bibliographic-contributors',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
+
     implicit_contributors = RelationshipField(
         related_view='registrations:registration-implicit-contributors',
         related_view_kwargs={'node_id': '<_id>'},

--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     # url(r'^blog/', include('blog.urls')),
     url(r'^$', views.RegistrationList.as_view(), name=views.RegistrationList.view_name),
     url(r'^(?P<node_id>\w+)/$', views.RegistrationDetail.as_view(), name=views.RegistrationDetail.view_name),
+    url(r'^(?P<node_id>\w+)/bibliographic_contributors/$', views.RegistrationBibliographicContributorsList.as_view(), name=views.RegistrationBibliographicContributorsList.view_name),
     url(r'^(?P<node_id>\w+)/children/$', views.RegistrationChildrenList.as_view(), name=views.RegistrationChildrenList.view_name),
     url(r'^(?P<node_id>\w+)/comments/$', views.RegistrationCommentsList.as_view(), name=views.RegistrationCommentsList.view_name),
     url(r'^(?P<node_id>\w+)/contributors/$', views.RegistrationContributorsList.as_view(), name=views.RegistrationContributorsList.view_name),

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -16,7 +16,7 @@ from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
 from api.base.utils import get_user_auth, default_node_list_permission_queryset, is_bulk_request, is_truthy
 from api.comments.serializers import RegistrationCommentSerializer, CommentCreateSerializer
 from api.identifiers.serializers import RegistrationIdentifierSerializer
-from api.nodes.views import NodeIdentifierList
+from api.nodes.views import NodeIdentifierList, NodeBibliographicContributorsList
 from api.users.views import UserMixin
 from api.users.serializers import UserSerializer
 
@@ -226,6 +226,15 @@ class RegistrationContributorDetail(BaseContributorDetail, RegistrationMixin, Us
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
     )
+
+
+class RegistrationBibliographicContributorsList(NodeBibliographicContributorsList, RegistrationMixin):
+
+    pagination_class = NodeContributorPagination
+    serializer_class = RegistrationContributorsSerializer
+
+    view_category = 'registrations'
+    view_name = 'registration-bibliographic-contributors'
 
 
 class RegistrationImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, RegistrationMixin):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -122,6 +122,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
         # fields that are visible for withdrawals
         visible_on_withdrawals = [
             'contributors',
+            'bibliographic_contributors',
             'implicit_contributors',
             'date_created',
             'date_modified',

--- a/api_tests/nodes/views/test_node_bibliographic_contributors_list.py
+++ b/api_tests/nodes/views/test_node_bibliographic_contributors_list.py
@@ -1,0 +1,88 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    ProjectFactory,
+    AuthUserFactory,
+)
+from osf.utils.permissions import READ, WRITE, ADMIN
+
+
+@pytest.mark.django_db
+@pytest.mark.enable_quickfiles_creation
+class TestNodeBibliographicContributors:
+    @pytest.fixture()
+    def admin_contributor_bib(self):
+        return AuthUserFactory(given_name='Oranges')
+
+    @pytest.fixture()
+    def write_contributor_non_bib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def read_contributor_bib(self):
+        return AuthUserFactory(given_name='Grapes')
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def project(self, admin_contributor_bib, write_contributor_non_bib, read_contributor_bib):
+        project = ProjectFactory(
+            creator=admin_contributor_bib
+        )
+        project.add_contributor(write_contributor_non_bib, [READ, WRITE], visible=False)
+        project.add_contributor(read_contributor_bib, [READ])
+        project.save()
+        return project
+
+    @pytest.fixture()
+    def url(self, project):
+        return '/{}nodes/{}/bibliographic_contributors/'.format(API_BASE, project._id)
+
+    def test_list_and_filter_bibliographic_contributors(self, app, url, project, admin_contributor_bib,
+            write_contributor_non_bib, read_contributor_bib, non_contributor):
+
+        # Test GET unauthenticated
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 401
+
+        # Test GET non_contributor
+        res = app.get(url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Test GET read contrib
+        res = app.get(url, auth=read_contributor_bib.auth, expect_errors=True)
+        assert res.status_code == 200
+
+        # Test GET write contrib
+        res = app.get(url, auth=write_contributor_non_bib.auth, expect_errors=True)
+        assert res.status_code == 200
+
+        # Test POST not allowed
+        res = app.post_json_api(url, auth=write_contributor_non_bib.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # Test GET contributor, only bibliographic contribs included
+        res = app.get(url, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        actual = [contrib['id'].split('-')[1] for contrib in res.json['data']]
+        assert admin_contributor_bib._id in actual
+        assert write_contributor_non_bib._id not in actual
+        assert read_contributor_bib._id in actual
+
+        # Test filter contributors on perms
+        perm_filter = '{}?filter[permission]={}'.format(url, READ)
+        res = app.get(perm_filter, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 2
+
+        perm_filter = '{}?filter[permission]={}'.format(url, ADMIN)
+        res = app.get(perm_filter, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == '{}-{}'.format(project._id, admin_contributor_bib._id)

--- a/api_tests/registrations/views/test_registration_bibliographic_contributors_list.py
+++ b/api_tests/registrations/views/test_registration_bibliographic_contributors_list.py
@@ -1,0 +1,30 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.nodes.views.test_node_bibliographic_contributors_list import TestNodeBibliographicContributors
+from osf_tests.factories import (
+    RegistrationFactory,
+    ProjectFactory
+)
+from osf.utils.permissions import READ, WRITE
+
+
+@pytest.mark.django_db
+@pytest.mark.enable_quickfiles_creation
+class TestRegistrationBibliographicContributors(TestNodeBibliographicContributors):
+
+    @pytest.fixture()
+    def project(self, admin_contributor_bib, write_contributor_non_bib, read_contributor_bib):
+        project = ProjectFactory(creator=admin_contributor_bib)
+        reg = RegistrationFactory(
+            creator=admin_contributor_bib,
+            project=project
+        )
+        reg.add_contributor(write_contributor_non_bib, [READ, WRITE], visible=False)
+        reg.add_contributor(read_contributor_bib, [READ])
+        reg.save()
+        return reg
+
+    @pytest.fixture()
+    def url(self, project):
+        return '/{}registrations/{}/bibliographic_contributors/'.format(API_BASE, project._id)


### PR DESCRIPTION
## Purpose

- Add NodeBibliographicContributorsList and RegistrationBibliographicContributorsList.  Requesting bibliographic contributors only is a much more common use case so it's getting its own endpoint

## Changes

- Two new endpoints: `nodes/<node_id>/bibliographic_contributors` and `registrations/<registration_id>/bibliographic_contributors`.  Only return contributors where visible=True
- Can filter these endpoints on same fields as NodeContributors

## QA Notes

No QA needed API only - will be tested with Registries

## Documentation

incoming..

## Side Effects

You can now filter RegistrationContributors on permission and bibliographic now that code is being shared a little differently. 

## Ticket
https://openscience.atlassian.net/browse/EMB-579
