### PR TITLE
Feature/Add URL to Parse Token/Run Registration Handlers [EMB-583]

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -377,8 +377,8 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_EMBARGO_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
-    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
-    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
+    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
+    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
 
     initiated_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
     for_existing_registration = models.BooleanField(default=False)
@@ -567,8 +567,8 @@ class Retraction(EmailApprovableSanction):
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_RETRACTION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
-    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
-    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
+    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
+    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
 
     initiated_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
     justification = models.CharField(max_length=2048, null=True, blank=True)
@@ -703,8 +703,8 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
-    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
-    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
+    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
+    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
 
     initiated_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
 
@@ -922,8 +922,8 @@ class EmbargoTerminationApproval(EmailApprovableSanction):
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_EMBARGO_TERMINATION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
-    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
-    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'project/{node_id}/?token={token}'
+    APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
+    REJECT_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
 
     embargoed_registration = models.ForeignKey('Registration', null=True, blank=True, on_delete=models.CASCADE)
     initiated_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -526,7 +526,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_registration_without_embargo_raises_HTTPBad_Request(self):
         assert_false(self.registration.is_pending_embargo)
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            self.registration.web_url_for('token_action', token=DUMMY_TOKEN),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -541,7 +541,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert_true(self.registration.is_pending_embargo)
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            self.registration.web_url_for('token_action', token=DUMMY_TOKEN),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -560,7 +560,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         wrong_approval_token = self.registration.embargo.approval_state[admin2._id]['approval_token']
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=wrong_approval_token),
+            self.registration.web_url_for('token_action', token=wrong_approval_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -579,7 +579,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         wrong_approval_token = self.registration.embargo.approval_state[admin2._id]['approval_token']
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=wrong_approval_token),
+            self.registration.web_url_for('token_action', token=wrong_approval_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -597,7 +597,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         approval_token = self.registration.embargo.approval_state[self.user._id]['approval_token']
         self.app.get(
-            self.registration.web_url_for('view_project', token=approval_token),
+            self.registration.web_url_for('token_action', token=approval_token),
             auth=self.user.auth,
         )
         self.registration.embargo.reload()
@@ -608,7 +608,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_disapprove_registration_without_embargo_HTTPBad_Request(self):
         assert_false(self.registration.is_pending_embargo)
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            self.registration.web_url_for('token_action', token=DUMMY_TOKEN),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -623,7 +623,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert_true(self.registration.is_pending_embargo)
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            self.registration.web_url_for('token_action', token=DUMMY_TOKEN),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -644,7 +644,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         wrong_rejection_token = self.registration.embargo.approval_state[admin2._id]['rejection_token']
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=wrong_rejection_token),
+            self.registration.web_url_for('token_action', token=wrong_rejection_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -664,14 +664,14 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         rejection_token = registration.embargo.approval_state[self.user._id]['rejection_token']
 
         res = self.app.get(
-            registration.registered_from.web_url_for('view_project', token=rejection_token),
+            registration.registered_from.web_url_for('token_action', token=rejection_token),
             auth=self.user.auth,
         )
         registration.embargo.reload()
         assert_equal(registration.embargo.state, Embargo.REJECTED)
         assert_false(registration.is_pending_embargo)
-        assert_equal(res.status_code, 200)
-        assert_equal(project.web_url_for('view_project'), res.request.path)
+        assert_equal(res.status_code, 302)
+        assert_equal(project.web_url_for('token_action'), res.request.path)
 
     def test_GET_disapprove_for_existing_registration_returns_200(self):
         self.registration.embargo_registration(
@@ -684,14 +684,14 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         rejection_token = self.registration.embargo.approval_state[self.user._id]['rejection_token']
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=rejection_token),
+            self.registration.web_url_for('token_action', token=rejection_token),
             auth=self.user.auth,
         )
         self.registration.embargo.reload()
         assert_equal(self.registration.embargo.state, Embargo.REJECTED)
         assert_false(self.registration.is_pending_embargo)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.request.path, self.registration.web_url_for('view_project'))
+        assert_equal(res.status_code, 302)
+        assert_equal(res.request.path, self.registration.web_url_for('token_action'))
 
     def test_GET_from_unauthorized_user_with_registration_token(self):
         unauthorized_user = AuthUserFactory()
@@ -705,7 +705,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         # Test unauth user cannot approve
         res = self.app.get(
             # approval token goes through registration
-            self.registration.web_url_for('view_project', token=app_token),
+            self.registration.web_url_for('token_action', token=app_token),
             auth=unauthorized_user.auth,
             expect_errors=True,
         )
@@ -714,7 +714,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         # Test unauth user cannot reject
         res = self.app.get(
             # rejection token goes through registration parent
-            self.project.web_url_for('view_project', token=rej_token),
+            self.project.web_url_for('token_action', token=rej_token),
             auth=unauthorized_user.auth,
             expect_errors=True,
         )
@@ -726,7 +726,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         # Test unauth user cannot approve deleted node
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=app_token),
+            self.registration.web_url_for('token_action', token=app_token),
             auth=unauthorized_user.auth,
             expect_errors=True,
         )
@@ -734,7 +734,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         # Test unauth user cannot reject
         res = self.app.get(
-            self.project.web_url_for('view_project', token=rej_token),
+            self.project.web_url_for('token_action', token=rej_token),
             auth=unauthorized_user.auth,
             expect_errors=True,
         )
@@ -742,10 +742,10 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
 
         # Test auth user can approve registration with deleted parent
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=app_token),
+            self.registration.web_url_for('token_action', token=app_token),
             auth=self.user.auth,
         )
-        assert_equal(res.status_code, 200)
+        assert_equal(res.status_code, 302)
 
     def test_GET_from_authorized_user_with_registration_app_token(self):
         self.registration.require_approval(self.user)
@@ -753,10 +753,10 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         app_token = self.registration.registration_approval.approval_state[self.user._id]['approval_token']
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=app_token),
+            self.registration.web_url_for('token_action', token=app_token),
             auth=self.user.auth,
         )
-        assert_equal(res.status_code, 200)
+        assert_equal(res.status_code, 302)
 
     def test_GET_from_authorized_user_with_registration_rej_token(self):
         self.registration.require_approval(self.user)
@@ -764,10 +764,10 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         rej_token = self.registration.registration_approval.approval_state[self.user._id]['rejection_token']
 
         res = self.app.get(
-            self.project.web_url_for('view_project', token=rej_token),
+            self.project.web_url_for('token_action', token=rej_token),
             auth=self.user.auth,
         )
-        assert_equal(res.status_code, 200)
+        assert_equal(res.status_code, 302)
 
     def test_GET_from_authorized_user_with_registration_rej_token_deleted_node(self):
         self.registration.require_approval(self.user)
@@ -778,13 +778,13 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.project.save()
 
         res = self.app.get(
-            self.project.web_url_for('view_project', token=rej_token),
+            self.project.web_url_for('token_action', token=rej_token),
             auth=self.user.auth,
             expect_errors=True,
         )
         assert_equal(res.status_code, 410)
         res = self.app.get(
-            self.registration.web_url_for('view_project'),
+            self.registration.web_url_for('token_action'),
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -1096,7 +1096,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         assert_true(self.registration.is_pending_embargo)
 
         approval_token = self.registration.embargo.approval_state[self.user._id]['approval_token']
-        approval_url = self.registration.web_url_for('view_project', token=approval_token)
+        approval_url = self.registration.web_url_for('token_action', token=approval_token)
 
         res = self.app.get(approval_url, auth=non_contributor.auth, expect_errors=True)
         self.registration.reload()
@@ -1114,7 +1114,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         assert_true(self.registration.is_pending_embargo)
 
         rejection_token = self.registration.embargo.approval_state[self.user._id]['rejection_token']
-        approval_url = self.registration.web_url_for('view_project', token=rejection_token)
+        approval_url = self.registration.web_url_for('token_action', token=rejection_token)
 
         res = self.app.get(approval_url, auth=non_contributor.auth, expect_errors=True)
         assert_equal(http.UNAUTHORIZED, res.status_code)

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -622,7 +622,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_from_unauthorized_user_returns_HTTPError_UNAUTHORIZED(self):
         unauthorized_user = AuthUserFactory()
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.approval_token),
+            self.registration.web_url_for('token_action', token=self.approval_token),
             auth=unauthorized_user.auth,
             expect_errors=True
         )
@@ -635,7 +635,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.retraction.save()
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.approval_token),
+            self.registration.web_url_for('token_action', token=self.approval_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -643,7 +643,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
 
     def test_GET_approve_with_invalid_token_returns_HTTPError_BAD_REQUEST(self):
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.corrupt_token),
+            self.registration.web_url_for('token_action', token=self.corrupt_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -651,7 +651,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
 
     def test_GET_approve_with_non_existant_sanction_returns_HTTPError_BAD_REQUEST(self):
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.token_without_sanction),
+            self.registration.web_url_for('token_action', token=self.token_without_sanction),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -659,20 +659,20 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
 
     def test_GET_approve_with_valid_token_returns_200(self):
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.approval_token),
+            self.registration.web_url_for('token_action', token=self.approval_token),
             auth=self.user.auth
         )
         self.registration.retraction.reload()
         assert_true(self.registration.is_retracted)
         assert_false(self.registration.is_pending_retraction)
-        assert_equal(res.status_code, http.OK)
+        assert_equal(res.status_code, 302)
 
     # node_registration_retraction_disapprove_tests
     def test_GET_disapprove_from_unauthorized_user_returns_HTTPError_UNAUTHORIZED(self):
         unauthorized_user = AuthUserFactory()
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.rejection_token),
+            self.registration.web_url_for('token_action', token=self.rejection_token),
             auth=unauthorized_user.auth,
             expect_errors=True
         )
@@ -685,7 +685,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.retraction.save()
 
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.rejection_token),
+            self.registration.web_url_for('token_action', token=self.rejection_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -693,7 +693,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
 
     def test_GET_disapprove_with_invalid_token_HTTPError_BAD_REQUEST(self):
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.corrupt_token),
+            self.registration.web_url_for('token_action', token=self.corrupt_token),
             auth=self.user.auth,
             expect_errors=True
         )
@@ -701,14 +701,14 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
 
     def test_GET_disapprove_with_valid_token_returns_redirect(self):
         res = self.app.get(
-            self.registration.web_url_for('view_project', token=self.rejection_token),
+            self.registration.web_url_for('token_action', token=self.rejection_token),
             auth=self.user.auth,
         )
         self.registration.retraction.reload()
         assert_false(self.registration.is_retracted)
         assert_false(self.registration.is_pending_retraction)
         assert_true(self.registration.retraction.is_rejected)
-        assert_equal(res.status_code, http.OK)
+        assert_equal(res.status_code, 302)
 
 @pytest.mark.enable_bookmark_creation
 class ComponentRegistrationRetractionViewsTestCase(OsfTestCase):
@@ -925,7 +925,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         self.registration.retract_registration(self.user)
         approval_token = self.registration.retraction.approval_state[self.user._id]['approval_token']
 
-        approval_url = self.registration.web_url_for('view_project', token=approval_token)
+        approval_url = self.registration.web_url_for('token_action', token=approval_token)
         res = self.app.get(approval_url, auth=non_contributor.auth, expect_errors=True)
         assert_equal(res.status_code, http.UNAUTHORIZED)
         assert_true(self.registration.is_pending_retraction)
@@ -936,7 +936,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         self.registration.retract_registration(self.user)
         rejection_token = self.registration.retraction.approval_state[self.user._id]['rejection_token']
 
-        disapproval_url = self.registration.web_url_for('view_project', token=rejection_token)
+        disapproval_url = self.registration.web_url_for('token_action', token=rejection_token)
         res = self.app.get(disapproval_url, auth=non_contributor.auth, expect_errors=True)
         assert_equal(res.status_code, http.UNAUTHORIZED)
         assert_true(self.registration.is_pending_retraction)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -426,7 +426,6 @@ def configure_requests(node, **kwargs):
 # View Project
 ##############################################################################
 
-@process_token_or_pass
 @must_be_valid_project(retractions_valid=True)
 @must_be_contributor_or_public
 @ember_flag_is_active(features.EMBER_PROJECT_DETAIL)
@@ -479,6 +478,14 @@ def view_project(auth, node, **kwargs):
 
     ret.update({'addons_widget_data': addons_widget_data})
     return ret
+
+
+@process_token_or_pass
+@must_be_valid_project(retractions_valid=True)
+@must_be_contributor_or_public
+def token_action(auth, node, **kwargs):
+    return redirect(node.url)
+
 
 # Reorder components
 @must_be_valid_project

--- a/website/routes.py
+++ b/website/routes.py
@@ -1078,6 +1078,17 @@ def make_url_map(app):
             OsfWebRenderer('project/project.mako', trust=False)
         ),
 
+        # Process token action
+        Rule(
+            [
+                '/token_action/<pid>/',
+            ],
+            'get',
+            project_views.node.token_action,
+            notemplate,
+        ),
+
+
         # Create a new subproject/component
         Rule(
             '/project/<pid>/newnode/',


### PR DESCRIPTION
## Purpose

When Registries overview page moves to Ember, many registration links with token query params will no longer work because the registration will be loaded in the Ember app.  Create a new route in the flask app to process the token and then redirect to the registration.

## Changes
- Affects URLs for approving/disapproving registrations, approving/disapproving embargo, approving/rejecting embargo termination, approving/rejecting retractions.

## QA Notes
- These four registration cases should be checked.  Make sure email links work and you are directed to the appropriate location - approving registrations, embargoes, embargo terminations, and retractions. 

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/EMB-583
