### PR TITLE
[Preprint Withdrawals][OSF][EMB-551] Fix requests state counts after NPD

### DIFF
--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -407,7 +407,10 @@ class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView,
         return get_object_or_error(PreprintProvider, self.kwargs['provider_id'], self.request, display_name='PreprintProvider')
 
     def get_default_queryset(self):
-        return PreprintRequest.objects.filter(request_type=RequestTypes.WITHDRAWAL.value, target__provider_id=self.get_provider().id)
+        return PreprintRequest.objects.filter(request_type=RequestTypes.WITHDRAWAL.value,
+                                              target__provider_id=self.get_provider().id,
+                                              target__is_public=True,
+                                              target__deleted__isnull=True)
 
     def get_renderer_context(self):
         context = super(PreprintProviderWithdrawRequestList, self).get_renderer_context()

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -407,10 +407,12 @@ class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView,
         return get_object_or_error(PreprintProvider, self.kwargs['provider_id'], self.request, display_name='PreprintProvider')
 
     def get_default_queryset(self):
-        return PreprintRequest.objects.filter(request_type=RequestTypes.WITHDRAWAL.value,
-                                              target__provider_id=self.get_provider().id,
-                                              target__is_public=True,
-                                              target__deleted__isnull=True)
+        return PreprintRequest.objects.filter(
+            request_type=RequestTypes.WITHDRAWAL.value,
+            target__provider_id=self.get_provider().id,
+            target__is_public=True,
+            target__deleted__isnull=True,
+        )
 
     def get_renderer_context(self):
         context = super(PreprintProviderWithdrawRequestList, self).get_renderer_context()

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -691,9 +691,11 @@ class ReviewProviderMixin(GuardianMixin):
     def get_request_state_counts(self):
         # import stuff here to get around circular imports
         from osf.models import PreprintRequest
-        qs = PreprintRequest.objects.filter(target__provider__id=self.id,
-                                            target__is_public=True,
-                                            target__deleted__isnull=True)
+        qs = PreprintRequest.objects.filter(
+            target__provider__id=self.id,
+            target__is_public=True,
+            target__deleted__isnull=True,
+        )
         qs = qs.values('machine_state').annotate(count=models.Count('*'))
         counts = {state.value: 0 for state in DefaultStates}
         counts.update({row['machine_state']: row['count'] for row in qs if row['machine_state'] in counts})

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -691,7 +691,9 @@ class ReviewProviderMixin(GuardianMixin):
     def get_request_state_counts(self):
         # import stuff here to get around circular imports
         from osf.models import PreprintRequest
-        qs = PreprintRequest.objects.filter(target__provider__id=self.id)
+        qs = PreprintRequest.objects.filter(target__provider__id=self.id,
+                                            target__is_public=True,
+                                            target__deleted__isnull=True)
         qs = qs.values('machine_state').annotate(count=models.Count('*'))
         counts = {state.value: 0 for state in DefaultStates}
         counts.update({row['machine_state']: row['count'] for row in qs if row['machine_state'] in counts})

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -691,10 +691,7 @@ class ReviewProviderMixin(GuardianMixin):
     def get_request_state_counts(self):
         # import stuff here to get around circular imports
         from osf.models import PreprintRequest
-        qs = PreprintRequest.objects.filter(target__provider__id=self.id,
-                                            target__node__isnull=False,
-                                            target__node__is_deleted=False,
-                                            target__node__is_public=True)
+        qs = PreprintRequest.objects.filter(target__provider__id=self.id)
         qs = qs.values('machine_state').annotate(count=models.Count('*'))
         counts = {state.value: 0 for state in DefaultStates}
         counts.update({row['machine_state']: row['count'] for row in qs if row['machine_state'] in counts})


### PR DESCRIPTION
## Purpose

Fix request state counts after node-preprint divorce.

## Changes

Because preprints are no longer tied to a node, `target__node__isnull`, `target__node__is_deleted` and `target__node__is_public` no longer makes sense.