### PR TITLE
Fix/NodeSerializer Component Count [EMB-593]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -560,8 +560,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
                   FROM parents JOIN osf_noderelation ON parents.PARENT_ID = osf_noderelation.child_id
                   WHERE osf_noderelation.is_node_link IS FALSE
                 ), has_admin AS (SELECT * FROM osf_contributor WHERE (node_id IN (SELECT parent_id FROM parents) OR node_id = %s) AND user_id = %s AND admin IS TRUE LIMIT 1)
-                SELECT DISTINCT
-                  COUNT(child_id)
+                SELECT COUNT(DISTINCT child_id)
                 FROM
                   osf_noderelation
                 JOIN osf_abstractnode ON osf_noderelation.child_id = osf_abstractnode.id

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -150,6 +150,54 @@ class TestNodeChildrenList:
 
         assert pointed_to._id not in ids
 
+    # Regression test for https://openscience.atlassian.net/browse/EMB-593
+    # Duplicates returned in child count
+    def test_node_children_related_counts_duplicate_query_results(self, app, user, public_project,
+            private_project, public_project_url):
+        user_2 = AuthUserFactory()
+
+        # Adding a child component
+        child = NodeFactory(parent=public_project, creator=user, is_public=True, category='software')
+        child.add_contributor(user_2, ['read', 'write'], save=True)
+        # Adding a grandchild
+        NodeFactory(parent=child, creator=user, is_public=True)
+        # Adding a node link
+        public_project.add_pointer(
+            private_project,
+            auth=Auth(public_project.creator)
+        )
+        # Assert NodeChildrenList returns one result
+        res = app.get(public_project_url, auth=user.auth)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == child._id
+
+        project_url = '/{}nodes/{}/?related_counts=children'.format(API_BASE, public_project._id)
+        res = app.get(project_url, auth=user.auth)
+        assert res.status_code == 200
+        # Verifying related_counts match direct children count (grandchildren not included, pointers not included)
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 1
+
+    def test_node_children_related_counts(self, app, user, public_project):
+        parent = ProjectFactory(creator=user, is_public=False)
+        user_2 = AuthUserFactory()
+        parent.add_contributor(user_2, ['read', 'write', 'admin'])
+
+        child = NodeFactory(parent=parent, creator=user_2, is_public=False, category='software')
+        NodeFactory(parent=child, creator=user_2, is_public=False)
+
+        # child has one component. `user` can view due to implict admin perms
+        component_url = '/{}nodes/{}/children/'.format(API_BASE, child._id, auth=user.auth)
+        res = app.get(component_url, auth=user.auth)
+
+        assert len(res.json['data']) == 1
+
+        project_url = '/{}nodes/{}/?related_counts=children'.format(API_BASE, child._id)
+
+        res = app.get(project_url, auth=user.auth)
+        assert res.status_code == 200
+        # Nodes with implicit admin perms are also included in the count
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 1
+
 
 @pytest.mark.django_db
 class TestNodeChildrenListFiltering:


### PR DESCRIPTION
## Purpose

Child count can be inaccurate.  If you navigate to `nodes/node_id/children`, the total number of children returned should match the value if you fetch `nodes/node_id/?related_counts=children`.  While the child count is correctly factoring in implicit admin permissions, only counting immediate descendants, and excluding node links, it is possible that the query returns duplicate results.

## Changes

Since this query is complex, spanning multiple tables, it is possible that duplicate results are returned. Use the proper syntax for counting the number of distinct rows.
```sql
SELECT COUNT(DISTINCT column) FROM table;
```


## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/EMB-593