### PR TITLE
[EMB-519] Change the way we get confirmation url for claim user emails.

### DIFF
--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -399,7 +399,7 @@ def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 360
         uid=unclaimed_user._primary_key,
         pid=node._primary_key,
         token=unclaimed_record['token'],
-        _external=True,
+        _absolute=True,
     )
 
     # Send mail to referrer, telling them to forward verification link to claimer


### PR DESCRIPTION
## Purpose

Generate a correct absolute url for confirmation email sent for claiming unregistered users.

## Changes

Currently, we pass `_external=True` to `web_url_for`, which will in turn pass that parameter to `flask.url_for` to generate an absolute url. However, according to Flask's [docs for `url_for`](http://flask.pocoo.org/docs/1.0/api/?highlight=url_for#flask.url_for)

> _external – if set to True, an absolute URL is generated. Server address can be changed via SERVER_NAME configuration variable which defaults to localhost.

It seems that `SERVER_NAME` is not defined in our app. It might be defined as an env var on other stagings but certainly not on staging-3 (where current tests are conducted). This explains why `localhost` is used as the domain name in the confirmation email.

Changing `_external=True` to `_absolute=True` will make `web_url_for` construct the url using `website.settings.DOMAIN`, which should be defined on prod and all stagings.

## Ticket

https://openscience.atlassian.net/browse/EMB-519
