### PR TITLE
Feature/Update User's Default Storage via APIv2 [PLAT-1321]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -125,7 +125,7 @@ class RegionRelationshipField(RelationshipField):
         try:
             region_id = Region.objects.filter(_id=data).values_list('id', flat=True).get()
         except Region.DoesNotExist:
-            raise exceptions.ValidationError(detail='Region {} is invalid.'.format(region_id))
+            raise exceptions.ValidationError(detail='Region {} is invalid.'.format(data))
         return {'region_id': region_id}
 
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -19,7 +19,7 @@ from website.settings import MAILCHIMP_GENERAL_LIST, OSF_HELP_LIST, CONFIRM_REGI
 from osf.models.provider import AbstractProviderGroupObjectPermission
 from website import mails
 from website.profile.views import update_osf_help_mails_subscription, update_mailchimp_subscription
-from api.nodes.serializers import NodeSerializer
+from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from api.base.schemas.utils import validate_user_json, from_json
 from framework.auth.views import send_confirm_email
 
@@ -131,10 +131,10 @@ class UserSerializer(JSONAPISerializer):
         related_view_kwargs={'user_id': '<_id>'},
     ))
 
-    default_region = ShowIfCurrentUser(RelationshipField(
+    default_region = ShowIfCurrentUser(RegionRelationshipField(
         related_view='regions:region-detail',
         related_view_kwargs={'region_id': 'get_default_region_id'},
-        read_only=True,
+        read_only=False,
     ))
 
     settings = ShowIfCurrentUser(RelationshipField(
@@ -211,6 +211,12 @@ class UserSerializer(JSONAPISerializer):
             elif 'accepted_terms_of_service' == attr:
                 if value and not instance.accepted_terms_of_service:
                     instance.accepted_terms_of_service = timezone.now()
+            elif 'region_id' == attr:
+                region_id = validated_data.get('region_id')
+                user_settings = instance._settings_model('osfstorage').objects.get(owner=instance)
+                user_settings.default_region_id = region_id
+                user_settings.save()
+                instance.default_region = self.context['request'].data['default_region']
             else:
                 setattr(instance, attr, value)
         try:

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -10,6 +10,8 @@ from api.base.filters import ListFilterMixin, PreprintFilterMixin
 from api.base.parsers import (
     JSONAPIRelationshipParser,
     JSONAPIRelationshipParserForRegularJSON,
+    JSONAPIMultipleRelationshipsParser,
+    JSONAPIMultipleRelationshipsParserForRegularJSON,
 )
 from api.base.serializers import get_meta_type, AddonAccountSerializer
 from api.base.utils import (
@@ -180,6 +182,7 @@ class UserDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, UserMixin):
     view_name = 'user-detail'
 
     serializer_class = UserDetailSerializer
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
 
     def get_serializer_class(self):
         if self.request.auth:

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -461,7 +461,7 @@ class TestUserUpdate:
                 'relationships': {
                     'default_region': {
                         'data': {
-                            'type': 'region',
+                            'type': 'regions',
                             'id': region._id
                         }
                     }
@@ -631,6 +631,7 @@ class TestUserUpdate:
         assert user_one.osfstorage_region == region
         assert user_one.osfstorage_region != original_user_region
         assert res.json['data']['relationships']['default_region']['data']['id'] == region._id
+        assert res.json['data']['relationships']['default_region']['data']['type'] == 'regions'
 
         # Updating with invalid region
         region_payload['data']['relationships']['default_region']['data']['id'] = 'bad_region'

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -16,6 +16,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     CollectionFactory,
     ProjectFactory,
+    RegionFactory,
 )
 from website.views import find_bookmark_collection
 
@@ -448,6 +449,27 @@ class TestUserUpdate:
         return AuthUserFactory()
 
     @pytest.fixture()
+    def region(self):
+        return RegionFactory(name='Frankfort', _id='eu-central-1')
+
+    @pytest.fixture()
+    def region_payload(self, user_one, region):
+        return {
+            'data': {
+                'type': 'users',
+                'id': user_one._id,
+                'relationships': {
+                    'default_region': {
+                        'data': {
+                            'type': 'region',
+                            'id': region._id
+                        }
+                    }
+                }
+            }
+        }
+
+    @pytest.fixture()
     def url_user_one(self, user_one):
         return '/v2/users/{}/'.format(user_one._id)
 
@@ -578,6 +600,48 @@ class TestUserUpdate:
         for_update_sql = connection.ops.for_update_sql()
         assert not any(for_update_sql in query['sql']
                        for query in ctx.captured_queries)
+
+    def test_patch_user_default_region(self, app, user_one, user_two, region, region_payload, url_user_one):
+        original_user_region = user_one.osfstorage_region
+
+        # Unauthenticated user updating region
+        res = app.patch_json_api(
+            url_user_one,
+            region_payload,
+            expect_errors=True
+        )
+        assert res.status_code == 401
+
+        # Different user updating region
+        res = app.patch_json_api(
+            url_user_one,
+            region_payload,
+            auth=user_two.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 403
+
+        # User updating own region
+        res = app.patch_json_api(
+            url_user_one,
+            region_payload,
+            auth=user_one.auth
+        )
+        assert res.status_code == 200
+        assert user_one.osfstorage_region == region
+        assert user_one.osfstorage_region != original_user_region
+        assert res.json['data']['relationships']['default_region']['data']['id'] == region._id
+
+        # Updating with invalid region
+        region_payload['data']['relationships']['default_region']['data']['id'] = 'bad_region'
+        res = app.patch_json_api(
+            url_user_one,
+            region_payload,
+            auth=user_one.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Region bad_region is invalid.'
 
     def test_update_patch_errors(
             self, app, user_one, user_two, data_new_user_one,


### PR DESCRIPTION
## Purpose

We need to be able to change a user's default storage region with the v2 api.

## Changes

If you update your user with the default_region id, you can change the region your files are stored in by default.

PATCH /v2/users/<user_id>
```json
{
  "data": {
    "type": "users",
    "id": "hcn6t",
    "attributes": {},
    "relationships": {
      "default_region": {
        "data": {
          "id": "ca-1",
          "type": "regions"
        }
      }
    }
  }
}
```
#### Truncated Response
```
{
    "data": {
        "relationships": {
            "default_region": {
                "data": {
                    "type": "regions",
                    "id": "ca-1"
                },
                "links": {
                    "related": {
                        "href": "http://localhost:8000/v2/regions/ca-1/",
                        "meta": {}
                    }
                }
            }
        },
        "links": {
            "self": "http://localhost:8000/v2/users/hcn6t/",
            "html": "http://localhost:5000/hcn6t/"
        },
        "attributes": {
            "given_name": "Dawn"
        },
        "type": "users",
        "id": "hcn6t"
    },
    "meta": {
        "version": "2.14"
    }
}
```
## QA Notes

API-only

## Documentation

Added to my TODO list

## Side Effects

A request to update a node with a bad region should now fail properly as well.

## Ticket

https://openscience.atlassian.net/browse/PLAT-1321
