### PR TITLE
Feature/My Projects Page project permissions  [PLAT-1344]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1957,6 +1957,7 @@ var Information = {
 
         var template = '';
         var category;
+        var permission;
         var showRemoveFromCollection;
         var collectionFilter = args.currentView().collection;
         if (args.selected().length === 0) {
@@ -1965,7 +1966,14 @@ var Information = {
         if (args.selected().length === 1) {
             var item = args.selected()[0].data;
             var resourceType = item.type;
-            var permission = item.attributes.current_user_permissions.slice(-1)[0];
+            var allPerms = item.attributes.current_user_permissions;
+            if (allPerms.includes('admin')) {
+                permission = 'admin';
+            } else if (allPerms.includes('write')) {
+                permission = 'write';
+            } else {
+                permission = 'read';
+            }
             showRemoveFromCollection = collectionFilter.data.nodeType === 'collection' && args.selected()[0].depth === 1 && args.fetchers[collectionFilter.id]._flat.indexOf(item) !== -1; // Be able to remove top level items but not their children
             if (resourceType === 'preprints') {
                 category = 'Preprint';


### PR DESCRIPTION
## Purpose

My Projects page is listing the lowest permission a user has for each node - read, instead of the highest.

`NodeSerializer.current_user_permissions` lists node permissions from highest perms to lowest perms, and `PreprintSerializer.current_user_permissions` lists perms from lowest to highest:
```
  "current_user_permissions": [
                    "admin",
                    "write",
                    "read"
                ],
```

```
 "current_user_permissions": [
                    "read",
                    "write",
                    "admin"
                ],
```


## Changes

Modify the My Projects page so instead of pulling the first permission off of a list of permissions, it checks to see if a certain permission exists.  Avoids requiring the permissions list sent from the API to be in a specific order.

## Notes
- Groups/guardian work will unify nodes/preprints serializer to have consistency in what order the permissions are in, so I'm deferring that here.

## QA Notes

Verify selected permissions for a few projects and a few preprints on the My Projects page.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/PLAT-1344