### PR TITLE
[EMB-476] Allow retrieving identifiers on withdrawn registrations

### DIFF
--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import NotFound
 
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -15,6 +15,7 @@ from api.nodes.permissions import (
     IsPublic,
     AdminOrPublic,
     EditIfPublic,
+    ReadOnlyIfWithdrawn,
 )
 
 from osf.models import Node, Registration, Preprint, Identifier
@@ -27,6 +28,7 @@ class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixi
         AdminOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        ReadOnlyIfWithdrawn,
     )
 
     required_read_scopes = [CoreScopes.IDENTIFIERS_READ]
@@ -47,12 +49,6 @@ class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixi
     # overrides ListCreateAPIView
     def get_queryset(self):
         return self.get_queryset_from_request()
-
-    def create(self, *args, **kwargs):
-        obj = self.get_object()
-        if hasattr(obj, 'is_retracted') and obj.is_retracted:
-            raise PermissionDenied(detail='Not allowed to create identifiers for withdrawn preprints or registrations')
-        return super(IdentifierList, self).create(*args, **kwargs)
 
 class IdentifierDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     """List of identifiers for a specified node. *Read-only*.

--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -13,7 +13,6 @@ from api.identifiers.serializers import NodeIdentifierSerializer, RegistrationId
 
 from api.nodes.permissions import (
     IsPublic,
-    ExcludeWithdrawals,
     AdminOrPublic,
     EditIfPublic,
 )
@@ -28,7 +27,6 @@ class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixi
         AdminOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ExcludeWithdrawals,
     )
 
     required_read_scopes = [CoreScopes.IDENTIFIERS_READ]

--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -1,5 +1,5 @@
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied
 
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -48,6 +48,11 @@ class IdentifierList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixi
     def get_queryset(self):
         return self.get_queryset_from_request()
 
+    def create(self, *args, **kwargs):
+        obj = self.get_object()
+        if hasattr(obj, 'is_retracted') and obj.is_retracted:
+            raise PermissionDenied(detail='Not allowed to create identifiers for withdrawn preprints or registrations')
+        return super(IdentifierList, self).create(*args, **kwargs)
 
 class IdentifierDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     """List of identifiers for a specified node. *Read-only*.

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -140,6 +140,16 @@ class ExcludeWithdrawals(permissions.BasePermission):
             return False
         return True
 
+class ReadOnlyIfWithdrawn(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, Node):
+            node = obj
+        else:
+            context = request.parser_context['kwargs']
+            node = AbstractNode.load(context[view.node_lookup_url_kwarg])
+        if node.is_retracted:
+            return request.method in permissions.SAFE_METHODS
+        return True
 
 class ContributorDetailPermissions(permissions.BasePermission):
     """Permissions for contributor detail page."""

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -578,8 +578,6 @@ class TestRegistrationIdentifierCreate(TestNodeIdentifierCreate):
     def retraction(self, resource, user):
         return WithdrawnRegistrationFactory(registration=resource)
 
-    def test_create_doi_for_withdrawn_registration(self, app, user, retraction, identifier_url, identifier_payload, client):
-        with mock.patch('osf.models.AbstractNode.get_doi_client') as mock_get_doi:
-            mock_get_doi.return_value = client
-            res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+    def test_create_doi_for_withdrawn_registration(self, app, user, retraction, identifier_url, identifier_payload):
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 403

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -578,6 +578,8 @@ class TestRegistrationIdentifierCreate(TestNodeIdentifierCreate):
     def retraction(self, resource, user):
         return WithdrawnRegistrationFactory(registration=resource)
 
-    def test_create_doi_for_withdrawn_registration(self, app, user, retraction, identifier_url, identifier_payload):
-        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+    def test_create_doi_for_withdrawn_registration(self, app, user, retraction, identifier_url, identifier_payload, client):
+        with mock.patch('osf.models.AbstractNode.get_doi_client') as mock_get_doi:
+            mock_get_doi.return_value = client
+            res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 403


### PR DESCRIPTION
## Purpose

Registries tombstone page (overview page for withdrawn registration) needs to show the registration
doi. Currently, `registrations/<guid>/identifiers/` returns unauthorized access error. 

Fix: Allow retrieving identifiers on withdrawn registrations

## Changes

- Fix `RegistrationIdentifierListView`

## QA Notes

If a registration has a DOI, please verify it shows on the tombstone page.

## Documentation

## Side Effects

## Ticket
No ticket. minor fix.
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
