### PR TITLE
Feature/Fix VersionedDateTimeField for Newer Versions [PLAT-1350]

### DIFF
--- a/api/banners/views.py
+++ b/api/banners/views.py
@@ -21,7 +21,6 @@ class CurrentBanner(JSONAPIBaseView, generics.RetrieveAPIView):
 
     serializer_class = BannerSerializer
     # This view goes under the _/ namespace
-    versioning_class = None
     view_category = 'banners'
     view_name = 'current'
 

--- a/api/banners/views.py
+++ b/api/banners/views.py
@@ -5,6 +5,7 @@ from api.base.views import JSONAPIBaseView
 from api.base.utils import get_object_or_error
 from api.banners.serializers import BannerSerializer
 from api.base import permissions as base_permissions
+from api.base.versioning import PrivateVersioning
 
 from rest_framework import generics
 from rest_framework import permissions
@@ -21,6 +22,7 @@ class CurrentBanner(JSONAPIBaseView, generics.RetrieveAPIView):
 
     serializer_class = BannerSerializer
     # This view goes under the _/ namespace
+    versioning_class = PrivateVersioning
     view_category = 'banners'
     view_name = 'current'
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -354,7 +354,7 @@ class VersionedDateTimeField(ser.DateTimeField):
     def to_representation(self, value):
         request = self.context.get('request')
         if request:
-            if request.version >= '2.2':
+            if StrictVersion(request.version) >= '2.2':
                 self.format = '%Y-%m-%dT%H:%M:%S.%fZ'
             else:
                 self.format = '%Y-%m-%dT%H:%M:%S.%f' if value.microsecond else '%Y-%m-%dT%H:%M:%S'

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -648,3 +648,15 @@ class VersionedDateTimeField(DbTestCase):
             ),
             data['attributes']['date_modified']
         )
+
+    # regression test for https://openscience.atlassian.net/browse/PLAT-1350
+    # VersionedDateTimeField was treating version 2.10 and higher as decimals,
+    # less than 2.2
+    def test_old_date_formats_to_new_format_with_2_10(self):
+        req = make_drf_request_with_version(version='2.10')
+        setattr(self.node, 'last_logged', self.old_date)
+        data = NodeSerializer(self.node, context={'request': req}).data['data']
+        assert_equal(
+            datetime.strftime(self.old_date, self.new_format),
+            data['attributes']['date_modified']
+        )


### PR DESCRIPTION
## Purpose

Dashboard was displaying times incorrectly. The cause was that the `VersionedDateTimeField` was not properly treating versions 2.10 and higher as greater than 2.9, it was treating them as decimals, making them less than 2.2.

The VersionedDateTimeField is configured to display time info with timezone information for versions greater or equal than 2.2, meaning the most recent versions of the API were falling back to old time formatting behavior.

## Changes

Use StrictVersion on the VersionedDateTimeField to handle more recent versions correctly.
h/t @jamescdavis for helping me troubleshoot and verifying that restoring the timezone designator in v2 will fix dashboard issues.

## QA Notes

Verify that the `modified` dates on the dashboard match the `modified` date on the corresponding project page.  Additionally, navigating directly to node endpoints with latest version, dates should have timezone information in them: (YYYY-MM-DDTHH:MM:SS.mmmmmmZ) formatting

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

- Lots of times expected to be broken on embosfed pages because of this bug. This should fix! 
- Serializing current banners now properly displays the date in a (YYYY-MM-DDTHH:MM:SS.mmmmmmZ) format for newer versions.
## Ticket
https://openscience.atlassian.net/browse/PLAT-1350