### PR TITLE
[OSF Institutions] Update SAML IdP Entity ID for FSU - Test Server [SVCS-961]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1040,7 +1040,7 @@ def main(env):
                 'description': 'This service is supported by the <a href="https://www.lib.fsu.edu/">FSU Libraries</a> for our research community. Do not use this service to store or transfer personally identifiable information (PII), personal health information (PHI), or any other controlled unclassified information (CUI). FSU\'s <a href="http://regulations.fsu.edu/sites/g/files/upcbnu486/files/policies/research/FSU%20Policy%207A-26.pdf">Research Data Management Policy</a> applies. For assistance please contact the FSU Libraries <a href="mailto:lib-datamgmt@fsu.edu">Research Data Management Program</a>.',
                 'banner_name': 'fsu-banner.png',
                 'logo_name': 'fsu-shield.png',
-                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.its.fsu.edu/idp/shibboleth')),
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://idp.fsu.edu')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
                 'domains': ['test-osf-fsu.cos.io'],
                 'email_domains': [],


### PR DESCRIPTION
## Purpose

Florida State University (FSU) wants to migrate their IdP server from Shibboleth to CAS. Fortunately, institution login remains to use the SAML protocol. A small side-effect of this migration is that the main SAML metadata will be changed during this migration, including the IdP Entity ID which is used to build the login URL. This PR targets OSF test server only to test and verify the new changes while keeping our production server working with the old one.

## Deployment Notes

@binoculars 

### Shibboleth

- [ ] Add or modify `shibboleth2.xml` for test Shib server.

```xml
<!-- Florida State University (FSU) -->
<MetadataProvider type="XML"
                  uri="https://casqna.fsu.edu/cas/idp/metadata"
                  backingFilePath="fsu-idp-metadata.xml"
                  reloadInterval="180000" />
```

### CAS

- [ ] Add or modify `institutions-auth.xsl` for test CAS server.

```xml
<!--Florida State University (FSU) -->
<xsl:when test="$idp='https://idp.fsu.edu'">
    <id>fsu</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

@mfraezz 

### OSF

- [ ] Populate institutions for the test server only.

## Ticket

https://openscience.atlassian.net/browse/SVCS-961
