### PR TITLE
[EMB-572] Pluralize user_password

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -364,7 +364,7 @@ class UserChangePasswordSerializer(BaseAPISerializer):
     new_password = ser.CharField(write_only=True, required=True)
 
     class Meta:
-        type_ = 'user_password'
+        type_ = 'user_passwords'
 
 
 class UserSettingsSerializer(JSONAPISerializer):

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -105,7 +105,7 @@ class TestUserChangePassword:
     def payload(self, user_one):
         return {
             'data': {
-                'type': 'user_password',
+                'type': 'user_passwords',
                 'id': user_one._id,
                 'attributes': {
                     'existing_password': 'password1',


### PR DESCRIPTION
## Purpose

Ember naturally pluralizes models when sending requests to the API.  The backend should also be pluralized for consistency.

## Changes

- Pluralize `user_password` to `user_passwords`
- Update test

## QA Notes

`N/A`

## Documentation

`N/A`

## Side Effects

Will only affect the user settings page when updating password

## Ticket

https://openscience.atlassian.net/browse/EMB-572
