### PR TITLE
Feature/Update export_user_account.py for Quickfiles and NPD [ENG-95]

### DIFF
--- a/osf/management/commands/export_user_account.py
+++ b/osf/management/commands/export_user_account.py
@@ -10,6 +10,7 @@ import requests
 import shutil
 import tempfile
 
+from django.db.models import Q
 from django.core import serializers
 from django.core.management.base import BaseCommand
 from django.contrib.contenttypes.models import ContentType
@@ -23,7 +24,9 @@ from osf.models import (
     OSFUser,
     Preprint,
     Registration,
+    QuickFilesNode
 )
+from osf.utils.workflows import DefaultStates
 from scripts.utils import Progress
 from api.base.utils import waterbutler_api_url_for
 
@@ -32,6 +35,8 @@ GBs = 1024 ** 3.0
 TMP_PATH = tempfile.mkdtemp()
 
 PREPRINT_EXPORT_FIELDS = [
+    'title',
+    'description',
     'is_published',
     'created',
     'modified',
@@ -114,7 +119,7 @@ def export_wikis(node, current_dir):
             with io.open(os.path.join(wikis_dir, '{}.md'.format(wiki.wiki_page.page_name)), 'w', encoding='utf-8') as f:
                 f.write(wiki.content)
 
-def export_node(node, user, current_dir):
+def export_resource(node, user, current_dir):
     """
     Exports metadata, files, and wikis for given node (project, registration, or preprint).
     If the given node has children,
@@ -125,56 +130,59 @@ def export_node(node, user, current_dir):
 
     """
     export_metadata(node, current_dir)
-    if WikiPage.objects.get_wiki_pages_latest(node):
+    if hasattr(node, 'wikis') and WikiPage.objects.get_wiki_pages_latest(node):
         export_wikis(node, current_dir)
     ctype = ContentType.objects.get_for_model(node.__class__)
     if OsfStorageFileNode.objects.filter(target_object_id=node.id, target_content_type=ctype):
         export_files(node, user, current_dir)
 
-    descendants = list(node.find_readable_descendants(Auth(user)))
-    if len(descendants):
-        components_dir = os.path.join(current_dir, 'components')
-        os.mkdir(components_dir)
-        for child in descendants:
-            current_dir = os.path.join(components_dir, child._id)
-            os.mkdir(current_dir)
-            export_node(child, user, current_dir)
+    if hasattr(node, 'find_readable_descendants'):
+        descendants = list(node.find_readable_descendants(Auth(user)))
+        if len(descendants):
+            components_dir = os.path.join(current_dir, 'components')
+            os.mkdir(components_dir)
+            for child in descendants:
+                current_dir = os.path.join(components_dir, child._id)
+                os.mkdir(current_dir)
+                export_resource(child, user, current_dir)
 
-def export_nodes(nodes_to_export, user, dir, nodes_type):
+def export_resources(nodes_to_export, user, dir, nodes_type):
     """
-    Creates appropriate directory structure and exports a given set of nodes
-    (projects, registrations, or preprints) by calling export helper functions.
+    Creates appropriate directory structure and exports a given set of resources
+    (projects, registrations, quickfiles or preprints) by calling export helper functions.
 
     """
     progress = Progress()
-    if nodes_type == 'preprints':
-        progress.start(nodes_to_export.count(), nodes_type.upper())
-        for node in nodes_to_export:
-            # export the preprint (just metadata)
-            current_dir = os.path.join(dir, node._id)
-            os.mkdir(current_dir)
-            export_metadata(node, current_dir)
-            # export the associated project (metadata, files, wiki, etc)
-            current_dir = os.path.join(dir, node.node._id)
-            os.mkdir(current_dir)
-            export_node(node.node, user, current_dir)
-            progress.increment()
-        progress.stop()
-    else:
-        progress.start(nodes_to_export.count(), nodes_type.upper())
-        for node in nodes_to_export:
-            current_dir = os.path.join(dir, node._id)
-            os.mkdir(current_dir)
-            export_node(node, user, current_dir)
-            progress.increment()
-        progress.stop()
+    progress.start(nodes_to_export.count(), nodes_type.upper())
+    for node in nodes_to_export:
+        current_dir = os.path.join(dir, node._id)
+        os.mkdir(current_dir)
+        export_resource(node, user, current_dir)
+        progress.increment()
+    progress.stop()
 
 def get_usage(user):
+    # includes nodes, registrations, quickfiles
     nodes = user.nodes.filter(is_deleted=False).exclude(type='osf.collection').values_list('id', flat=True)
     node_ctype = ContentType.objects.get_for_model(AbstractNode)
-    files = OsfStorageFile.objects.filter(target_object_id__in=nodes, target_content_type=node_ctype).values_list('id', flat=True)
-    versions = FileVersion.objects.filter(basefilenode__in=files)
+    node_files = get_resource_files(nodes, node_ctype)
+
+    preprint_ctype = ContentType.objects.get_for_model(Preprint)
+    preprint_files = get_resource_files(get_preprints_to_export(user), preprint_ctype)
+
+    versions = FileVersion.objects.filter(Q(basefilenode__in=node_files) | Q(basefilenode__in=preprint_files))
     return sum([v.size or 0 for v in versions]) / GBs
+
+def get_resource_files(resource_list, resource_ctype):
+    return OsfStorageFile.objects.filter(target_object_id__in=resource_list, target_content_type=resource_ctype).values_list('id', flat=True)
+
+def get_preprints_to_export(user):
+    return Preprint.objects.filter(
+        Q(preprintcontributor__user_id=user.id) &
+        Q(deleted__isnull=True) &
+        ~Q(machine_state=DefaultStates.INITIAL.value)
+    )
+
 
 def export_account(user_id, path, only_private=False, only_admin=False, export_files=True, export_wikis=True):
     """
@@ -186,13 +194,8 @@ def export_account(user_id, path, only_private=False, only_admin=False, export_f
         preprints/
             <preprint_guid>/
                 metadata.json
-                <project_guid>/
-                    metadata.json
-                    files/
-                        osfstorage-archive.zip
-                    wikis/
-                        <wiki_page_name>.md
-
+                files/
+                    osfstorage-archive.zip
         projects/
             <project_guid>/
                 metadata.json
@@ -214,6 +217,12 @@ def export_account(user_id, path, only_private=False, only_admin=False, export_f
         registrations/
             *same as projects*
 
+        quickfiles/
+            <quickfiles_id>/
+                metadata.json
+                files/
+                    osfstorage-archive.zip
+
     """
     user = OSFUser.objects.get(guids___id=user_id, guids___id__isnull=False)
     proceed = raw_input('\nUser has {:.2f} GB of data in OSFStorage that will be exported.\nWould you like to continue? [y/n] '.format(get_usage(user)))
@@ -225,21 +234,18 @@ def export_account(user_id, path, only_private=False, only_admin=False, export_f
     preprints_dir = os.path.join(base_dir, 'preprints')
     projects_dir = os.path.join(base_dir, 'projects')
     registrations_dir = os.path.join(base_dir, 'registrations')
+    quickfiles_dir = os.path.join(base_dir, 'quickfiles')
 
     os.mkdir(base_dir)
     os.mkdir(preprints_dir)
     os.mkdir(projects_dir)
     os.mkdir(registrations_dir)
+    os.mkdir(quickfiles_dir)
 
-    preprints_to_export = (Preprint.objects
-        .filter(node___contributors__guids___id=user_id, guids___id__isnull=False)
-        .select_related('node')
-    )
+    preprints_to_export = get_preprints_to_export(user)
 
-    preprint_projects_exported = preprints_to_export.values_list('node__guids___id', flat=True)
     projects_to_export = (user.nodes
         .filter(is_deleted=False, type='osf.node')
-        .exclude(guids___id__in=preprint_projects_exported)
         .get_roots()
     )
 
@@ -248,9 +254,14 @@ def export_account(user_id, path, only_private=False, only_admin=False, export_f
         .get_roots()
     )
 
-    export_nodes(projects_to_export, user, projects_dir, 'projects')
-    export_nodes(preprints_to_export, user, preprints_dir, 'preprints')
-    export_nodes(registrations_to_export, user, registrations_dir, 'registrations')
+    quickfiles_to_export = (
+        QuickFilesNode.objects.filter(creator=user)
+    )
+
+    export_resources(projects_to_export, user, projects_dir, 'projects')
+    export_resources(preprints_to_export, user, preprints_dir, 'preprints')
+    export_resources(registrations_to_export, user, registrations_dir, 'registrations')
+    export_resources(quickfiles_to_export, user, quickfiles_dir, 'quickfiles')
 
     timestamp = dt.datetime.fromtimestamp(time.time()).strftime('%Y%m%d%H%M%S')
     output = os.path.join(path, '{user_id}-export-{timestamp}'.format(**locals()))


### PR DESCRIPTION
## Purpose

Current `export_user_account` script still assumes that preprints and nodes are tightly linked (as they were before the node-preprint divorce), and doesn't export quickfiles.

## Changes

- Makes minimal changes to pull preprint metadata and files off of the preprint instead of an attached node, and pulls all the quickfiles off of the user.

## Notes

Continuing to only export a very limited set of metadata about these resources. 

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-95