### PR TITLE
[ENG-99]Override `sign_up_url` for Registered Reports and Prereg landing pages.

### DIFF
--- a/osf_tests/test_prereg.py
+++ b/osf_tests/test_prereg.py
@@ -7,6 +7,7 @@ from osf.features import OSF_PREREGISTRATION
 from website.prereg import prereg_landing_page as landing_page
 from website.prereg.utils import get_prereg_schema
 from website.registries.utils import drafts_for_user
+from website.settings import DOMAIN
 
 from tests.base import OsfTestCase
 from osf_tests import factories
@@ -26,7 +27,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': False,
-                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
             }
         )
 
@@ -39,7 +40,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': False,
-                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                    'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
                 }
             )
 
@@ -52,7 +53,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
-                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
             }
         )
 
@@ -65,7 +66,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
-                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                    'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
                 }
             )
 
@@ -80,7 +81,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
-                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
             }
         )
 
@@ -93,7 +94,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
-                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                    'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
                 }
             )
 
@@ -112,7 +113,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
-                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
             }
         )
 
@@ -130,7 +131,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
-                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
+                    'sign_up_url': '{}register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F'.format(DOMAIN),
                 }
             )
 

--- a/osf_tests/test_prereg.py
+++ b/osf_tests/test_prereg.py
@@ -26,6 +26,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': False,
+                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
             }
         )
 
@@ -38,6 +39,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': False,
+                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
                 }
             )
 
@@ -50,6 +52,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
+                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
             }
         )
 
@@ -62,6 +65,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
+                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
                 }
             )
 
@@ -76,6 +80,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
+                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
             }
         )
 
@@ -88,6 +93,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
+                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
                 }
             )
 
@@ -106,6 +112,7 @@ class TestPreregLandingPage(OsfTestCase):
                 'campaign_long': 'Prereg Challenge',
                 'campaign_short': 'prereg_challenge',
                 'is_logged_in': True,
+                'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
             }
         )
 
@@ -123,6 +130,7 @@ class TestPreregLandingPage(OsfTestCase):
                     'campaign_long': 'OSF Preregistration',
                     'campaign_short': 'prereg',
                     'is_logged_in': True,
+                    'sign_up_url': 'http://localhost:5000/register/?campaign=prereg&next=http%3A%2F%2Flocalhost%2F',
                 }
             )
 

--- a/website/registries/views.py
+++ b/website/registries/views.py
@@ -3,7 +3,7 @@ from flask import request
 from framework.auth import Auth, decorators
 from framework.utils import iso8601format
 from website.registries import utils
-
+from website import util
 
 def _view_registries_landing_page(campaign=None, **kwargs):
     """Landing page for the various registrations"""
@@ -19,13 +19,14 @@ def _view_registries_landing_page(campaign=None, **kwargs):
     else:
         has_projects = False
 
+    campaign_url_param = 'osf-registered-reports' if campaign == 'registered_report' else 'prereg'
     return {
         'is_logged_in': is_logged_in,
         'has_draft_registrations': bool(utils.drafts_for_user(auth.user, campaign)),
         'has_projects': has_projects,
         'campaign_long': utils.REG_CAMPAIGNS.get(campaign),
-        'campaign_short': campaign
-
+        'campaign_short': campaign,
+        'sign_up_url': util.web_url_for('auth_register', _absolute=True, campaign=campaign_url_param, next=request.url),
     }
 
 

--- a/website/registries/views.py
+++ b/website/registries/views.py
@@ -19,7 +19,13 @@ def _view_registries_landing_page(campaign=None, **kwargs):
     else:
         has_projects = False
 
-    campaign_url_param = 'osf-registered-reports' if campaign == 'registered_report' else 'prereg'
+    if campaign == 'registered_report':
+        campaign_url_param = 'osf-registered-reports'
+    elif campaign == 'prereg_challenge' or campaign == 'prereg':
+        campaign_url_param = 'prereg'
+    else:
+        campaign_url_param = ''
+
     return {
         'is_logged_in': is_logged_in,
         'has_draft_registrations': bool(utils.drafts_for_user(auth.user, campaign)),


### PR DESCRIPTION
## Purpose

Currently, the "Sign Up" button on the navbar for Registered Reports and Prereg landing pages does not have campaign query param in it. Users registered by clicking navbar sign up on those pages will not have system tags added to them. This PR fixes the problem.

## Changes

Override `sign_up_url` for those views.

## QA Notes

Make sure `?campaign=prereg` or `?campaign=osf-registered-reports` are included in the link of the navbar sign up button for Prereg and Registered Reports landing pages.

## Ticket

https://openscience.atlassian.net/browse/ENG-99
