### PR TITLE
[OSF Institutions] A Temporary Update for Ferris to Test New Server [SVCS-466]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1028,7 +1028,7 @@ def main(env):
                 'description': 'In partnership with the <a href="https://www.ferris.edu/research/">Office of Research and Sponsored Programs</a>, the <a href="https://www.ferris.edu/HTMLS/administration/academicaffairs/index.htm">Provost and Vice President for Academic Affairs</a>, and the <a href="https://www.ferris.edu/library/">FLITE Library</a>. Do not use this service to store or transfer personally identifiable information (PII), personal health information (PHI), intellectual property (IP) or any other controlled unclassified information (CUI). All projects must abide by the <a href="https://www.ferris.edu/HTMLS/administration/academicaffairs/Forms_Policies/Documents/Policy_Letters/AA-Intellectual-Property-Rights.pdf">FSU Intellectual Property Rights and Electronic Distance Learning Materials</a> letter of agreement.',
                 'banner_name': 'ferris-banner.png',
                 'logo_name': 'ferris-shield.png',
-                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('fsueeit.ferris.edu')),
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('login.ferris.edu')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
                 'domains': [],
                 'email_domains': [],


### PR DESCRIPTION
## Purpose

Ferris State Univ. requested to use our test Shibboleth server to test their
newly configured production IdP server. This PR updates OSF, CAS and Shibboleth due to metadata and Entity ID change.

cc @mfraezz 

## Changes

**TEST SERVER ONLY**

- [x] CAS: update the first non-comment line below in `institutions-auth.xsl` for Ferris State University.

```xml
<!-- Ferris State University (FERRIS) -->
<xsl:when test="$idp='login.ferris.edu'">
    <id>ferris</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
        <fullname/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

- [x] Shib

Add `ferris-prod-metadata.xml` [JIRA LINK](https://openscience.atlassian.net/secure/attachment/38682/ferris-prod-metadata.xml) under `conf/` and update `shibboleth2.xml`. **DO NOT** remove existing `ferris-metadata.xml` which will still be used when we switch back later.

```xml
<!-- Ferris State University (FERRIS) -->
<!-- <MetadataProvider type="XML" path="ferris-metadata.xml" /> -->
<MetadataProvider type="XML" path="ferris-prod-metadata.xml" />
```

- [x] OSF: populate the test institutions

## QA Notes

No

## Documentation

No

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/SVCS-466
