### PR TITLE
[Hotfix][ENG-100] Fix merge_user for PND

### DIFF
--- a/scripts/remove_after_use/fix_unmerged_preprints.py
+++ b/scripts/remove_after_use/fix_unmerged_preprints.py
@@ -1,0 +1,23 @@
+import logging
+
+from website.app import setup_django
+setup_django()
+
+from osf.models import OSFUser
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+
+    # retrieving users that are merged into oblivion
+    merged_users = OSFUser.objects.filter(merged_by__isnull=False)
+
+    for user in merged_users:
+        merged_by = user.merged_by
+        merged_by._merge_users_preprints(user)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_fix_unmerged_preprints.py
+++ b/scripts/tests/test_fix_unmerged_preprints.py
@@ -1,0 +1,76 @@
+import pytest
+
+from osf.models import PreprintContributor
+from osf_tests.factories import AuthUserFactory, PreprintFactory
+from scripts.remove_after_use.fix_unmerged_preprints import main as fix_unmerged_preprints
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestFixUnmergedPreprints:
+
+    @pytest.fixture()
+    def merger(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def mergee(self, merger):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def preprint_mergee_creator(self, mergee):
+        return PreprintFactory(creator=mergee)
+
+    @pytest.fixture()
+    def preprint_with_contributor(self, mergee):
+        preprint = PreprintFactory()
+        preprint.add_contributor(mergee, permissions='write', visible=False, save=True)
+        preprint.save()
+        return preprint
+
+    @pytest.fixture()
+    def preprint_with_merger_and_mergee(self, mergee, merger):
+        preprint = PreprintFactory()
+        preprint.add_contributor(mergee)
+        preprint.add_contributor(merger)
+        preprint.save()
+        return preprint
+
+    def test_main(self, merger, mergee, preprint_mergee_creator, preprint_with_contributor):
+        mergee.merged_by = merger
+        mergee.save()
+
+        fix_unmerged_preprints()
+
+        preprint_mergee_creator.reload()
+        preprint_with_contributor.reload()
+        assert merger == preprint_mergee_creator.creator
+        assert merger in preprint_with_contributor.contributors.all()
+        assert preprint_with_contributor.creator != merger
+        assert preprint_with_contributor.creator in preprint_with_contributor.contributors.all()
+
+        contrib_obj = PreprintContributor.objects.get(user=merger, preprint=preprint_mergee_creator)
+        assert contrib_obj.visible
+        assert contrib_obj.permission == 'admin'
+
+        contrib_obj = PreprintContributor.objects.get(user=merger, preprint=preprint_with_contributor)
+        assert not contrib_obj.visible
+        assert contrib_obj.permission == 'write'
+
+    def test_integrity_error(self, merger, mergee, preprint_mergee_creator, preprint_with_contributor, preprint_with_merger_and_mergee):
+        """
+        If both merger and mergee are contribs on the same project trying to add them to a preprint violates a unique
+        constraint and throws an error
+        """
+        mergee.merged_by = merger
+        mergee.save()
+
+        fix_unmerged_preprints()
+
+        preprint_mergee_creator.reload()
+        preprint_with_contributor.reload()
+        assert merger == preprint_mergee_creator.creator
+        assert merger in preprint_with_contributor.contributors.all()
+        assert preprint_with_contributor.creator != merger
+        assert preprint_with_contributor.creator in preprint_with_contributor.contributors.all()


### PR DESCRIPTION
## Purpose

Since the PND users who require merges aren't getting their preprints migrated to their primary account, this fix migrates those preprint to the primary account and ensures future merges include preprints.

## Changes

- adds `_merge_users_preprints` method to user
- adds script for migration `fix_unmerged_preprints`
- adds tests for model and script

## QA Notes

We are in touch with effected users and should check with them after this has delpoyed.

## Documentation

🐞 fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-100