### PR TITLE
[EMB-548][ENG-233][ENG-237][Preprint Withdrawals] Fix email template.

### DIFF
--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -143,6 +143,7 @@ class ReviewsMachine(BaseMachine):
         reviews_signals.reviews_email.send(creator=ev.kwargs.get('user'), context=context,
                                            template='reviews_submission_status',
                                            action=self.action)
+
     def notify_edit_comment(self, ev):
         context = self.get_context()
         context['comment'] = self.action.comment
@@ -153,8 +154,9 @@ class ReviewsMachine(BaseMachine):
 
     def notify_withdraw(self, ev):
         context = self.get_context()
+        context['ever_public'] = self.machineable.ever_public
         try:
-            preprint_request_action = PreprintRequestAction.objects.get(target__id=self.machineable.id,
+            preprint_request_action = PreprintRequestAction.objects.get(target__target__id=self.machineable.id,
                                                                    from_state='pending',
                                                                    to_state='accepted',
                                                                    trigger='accept')

--- a/website/templates/emails/preprint_withdrawal_request_granted.html.mako
+++ b/website/templates/emails/preprint_withdrawal_request_granted.html.mako
@@ -8,21 +8,35 @@
     %>
         Dear ${contributor.fullname},<br>
         <br>
-    % if is_requester:
-        Your request to withdraw your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name} has been approved by the service moderators.
-        <br>
-        The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
-        <br>
-    % elif withdrawal_submitter_is_moderator_or_admin:
-        A moderator has withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
-        <br>
-        The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
-        <br>
+    % if not ever_public:
+        % if is_requester:
+            You have withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
+            <br>
+            The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}.
+            <br>
+        % else:
+            ${requester.fullname} has withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
+            <br>
+            The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}.
+            <br>
+        % endif
     % else:
-        ${requester.fullname} has withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
-        <br>
-        The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
-        <br>
+        % if is_requester:
+            Your request to withdraw your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name} has been approved by the service moderators.
+            <br>
+            The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
+            <br>
+        % elif withdrawal_submitter_is_moderator_or_admin:
+            A moderator has withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
+            <br>
+            The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
+            <br>
+        % else:
+            ${requester.fullname} has withdrawn your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
+            <br>
+            The ${reviewable.provider.preprint_word} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${reviewable.provider.preprint_word}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
+            <br>
+        % endif
     % endif
         <br>
         Sincerely,<br>


### PR DESCRIPTION
## Purpose

Fix email sent to preprint contributors when their withdrawal requests are approved. Currently, if an author submit a withdrawal request before the preprint is published, they will receive an email saying their preprint is removed but a tombstone page exists, which is not the case.
Therefore, we add a new email template for when `ever_public` on a preprint is `False`.
This PR also fixes a bug where in `notify_withdraw()` hook, we are actually not using correct parameters for lookup of `PreprintRequestAction` instances, resulting in incorrect emails to be sent.

## Changes

Add new email templates.
Change lookup parameters.

## Ticket

 https://openscience.atlassian.net/browse/EMB-548
