### PR TITLE
[ENG-123] Use testmon for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
       mkdir -p $HOME/.cache/downloads
       mkdir -p $HOME/.cache/pip
       mkdir -p $HOME/.cache/wheelhouse
+      mkdir -p $HOME/.cache/testmon
       rm -rf node_modules  ## TODO remove this later
     # postgres
     - |
@@ -121,9 +122,17 @@ install:
     - pip install uritemplate.py==0.3.0
 
 # Run Python tests (core and addon) and JS tests
+
+after_script:
+    # This ensures failed tests are removed from the cache so they can be re-tried.
+    - inv remove_failures_from_testmon --db-path=$HOME/.cache/testmon/.testmondata_$TEST_BUILD
+
 script:
     - export COVERAGE=`if [ "$TRAVIS_BRANCH" == "master-w-coverage" ]; then echo "--coverage"; else echo ""; fi`
-    - invoke test_travis_$TEST_BUILD -n 4 $COVERAGE
+    # Testmon will run for PRs, but will be disabled when merging into master or develop
+    - export TESTMON=`if [[ "$TRAVIS_PULL_REQUEST_BRANCH" == "" && "$TRAVIS_BRANCH" == "develop" || "$TRAVIS_PULL_REQUEST_BRANCH" == "" && "$TRAVIS_BRANCH" == "master" ]]; then echo ""; else  echo "--testmon"; fi`
+    - export TESTMON_DATAFILE=$HOME/.cache/testmon/.testmondata_$TEST_BUILD
+    - invoke test_travis_$TEST_BUILD -n 1 $COVERAGE $TESTMON
 
 after_success:
     - if [[ "$TRAVIS_BRANCH" == "master-w-coverage" ]]; then coveralls; fi

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,6 +9,7 @@ pytest-xdist==1.15.0
 pytest-django==3.2.1
 pytest-cov==2.5.1
 python-coveralls==2.9.1
+pytest-testmon==0.9.16
 nose
 factory-boy==2.10.0
 webtest-plus==0.3.3

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -9,6 +9,7 @@ import json
 import platform
 import subprocess
 import logging
+import sqlite3
 
 import invoke
 from invoke import Collection
@@ -22,7 +23,7 @@ logging.getLogger('invoke').setLevel(logging.CRITICAL)
 HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 WHEELHOUSE_PATH = os.environ.get('WHEELHOUSE')
 CONSTRAINTS_PATH = os.path.join(HERE, 'requirements', 'constraints.txt')
-
+NO_TESTS_COLLECTED = 5
 ns = Collection()
 
 try:
@@ -272,7 +273,7 @@ def requirements(ctx, base=False, addons=False, release=False, dev=False, all=Fa
 
 
 @task
-def test_module(ctx, module=None, numprocesses=None, nocapture=False, params=None, coverage=False):
+def test_module(ctx, module=None, numprocesses=None, nocapture=False, params=None, coverage=False, testmon=False):
     """Helper for running tests.
     """
     os.environ['DJANGO_SETTINGS_MODULE'] = 'osf_tests.settings'
@@ -300,11 +301,16 @@ def test_module(ctx, module=None, numprocesses=None, nocapture=False, params=Non
         args += ['-n {}'.format(numprocesses), '--max-slave-restart=0']
     modules = [module] if isinstance(module, basestring) else module
     args.extend(modules)
+    if testmon:
+        args.extend(['--testmon'])
+
     if params:
         params = [params] if isinstance(params, basestring) else params
         args.extend(params)
     retcode = pytest.main(args)
-    sys.exit(retcode)
+
+    # exit code 5 is all tests skipped which is the same as passing with testmon
+    sys.exit(0 if retcode == NO_TESTS_COLLECTED else retcode)
 
 
 OSF_TESTS = [
@@ -367,52 +373,52 @@ ADMIN_TESTS = [
 
 
 @task
-def test_osf(ctx, numprocesses=None, coverage=False):
+def test_osf(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the OSF test suite."""
     print('Testing modules "{}"'.format(OSF_TESTS))
-    test_module(ctx, module=OSF_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=OSF_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 @task
-def test_website(ctx, numprocesses=None, coverage=False):
+def test_website(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the old test suite."""
     print('Testing modules "{}"'.format(WEBSITE_TESTS))
-    test_module(ctx, module=WEBSITE_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=WEBSITE_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 @task
-def test_api1(ctx, numprocesses=None, coverage=False):
+def test_api1(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the API test suite."""
     print('Testing modules "{}"'.format(API_TESTS1 + ADMIN_TESTS))
-    test_module(ctx, module=API_TESTS1 + ADMIN_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=API_TESTS1 + ADMIN_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_api2(ctx, numprocesses=None, coverage=False):
+def test_api2(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the API test suite."""
     print('Testing modules "{}"'.format(API_TESTS2))
-    test_module(ctx, module=API_TESTS2, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=API_TESTS2, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_api3(ctx, numprocesses=None, coverage=False):
+def test_api3(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the API test suite."""
     print('Testing modules "{}"'.format(API_TESTS3 + OSF_TESTS))
     # NOTE: There may be some concurrency issues with ES
-    test_module(ctx, module=API_TESTS3 + OSF_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=API_TESTS3 + OSF_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_admin(ctx, numprocesses=None, coverage=False):
+def test_admin(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run the Admin test suite."""
     print('Testing module "admin_tests"')
-    test_module(ctx, module=ADMIN_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=ADMIN_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_addons(ctx, numprocesses=None, coverage=False):
+def test_addons(ctx, numprocesses=None, coverage=False, testmon=False):
     """Run all the tests in the addons directory.
     """
     print('Testing modules "{}"'.format(ADDON_TESTS))
-    test_module(ctx, module=ADDON_TESTS, numprocesses=numprocesses, coverage=coverage)
+    test_module(ctx, module=ADDON_TESTS, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
@@ -435,6 +441,13 @@ def test(ctx, all=False, lint=False):
         karma(ctx)
 
 @task
+def remove_failures_from_testmon(ctx, db_path=None):
+
+    conn = sqlite3.connect(db_path)
+    tests_decached = conn.execute("delete from node where result <> '{}'").rowcount
+    ctx.run('echo {} failures purged from travis cache'.format(tests_decached))
+
+@task
 def travis_setup(ctx):
     ctx.run('npm install -g bower', echo=True)
 
@@ -447,41 +460,41 @@ def travis_setup(ctx):
         ctx.run('bower install {}'.format(bower_json['dependencies']['styles']), echo=True)
 
 @task
-def test_travis_addons(ctx, numprocesses=None, coverage=False):
+def test_travis_addons(ctx, numprocesses=None, coverage=False, testmon=False):
     """
     Run half of the tests to help travis go faster.
     """
     travis_setup(ctx)
     syntax(ctx)
-    test_addons(ctx, numprocesses=numprocesses, coverage=coverage)
+    test_addons(ctx, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 @task
-def test_travis_website(ctx, numprocesses=None, coverage=False):
+def test_travis_website(ctx, numprocesses=None, coverage=False, testmon=False):
     """
     Run other half of the tests to help travis go faster.
     """
     travis_setup(ctx)
-    test_website(ctx, numprocesses=numprocesses, coverage=coverage)
+    test_website(ctx, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_travis_api1_and_js(ctx, numprocesses=None, coverage=False):
+def test_travis_api1_and_js(ctx, numprocesses=None, coverage=False, testmon=False):
     # TODO: Uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved
     # karma(ctx)
     travis_setup(ctx)
-    test_api1(ctx, numprocesses=numprocesses, coverage=coverage)
+    test_api1(ctx, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_travis_api2(ctx, numprocesses=None, coverage=False):
+def test_travis_api2(ctx, numprocesses=None, coverage=False, testmon=False):
     travis_setup(ctx)
-    test_api2(ctx, numprocesses=numprocesses, coverage=coverage)
+    test_api2(ctx, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 
 @task
-def test_travis_api3_and_osf(ctx, numprocesses=None, coverage=False):
+def test_travis_api3_and_osf(ctx, numprocesses=None, coverage=False, testmon=False):
     travis_setup(ctx)
-    test_api3(ctx, numprocesses=numprocesses, coverage=coverage)
+    test_api3(ctx, numprocesses=numprocesses, coverage=coverage, testmon=testmon)
 
 @task
 def karma(ctx, travis=False):


### PR DESCRIPTION
# Purpose 
Tests take time, this speeds them up! 

# Dev Notes
Testmon speeds up tests by saving checksums of test code and skipping them via pytest if they are unchanged. Because any given PR is going to effect a very small proportion of total tests we can skip a large number (like ~90%) of them most of the time.

If you’re curious/skeptical if/how this is possible, it works with the coverage.py pytest plugin, which is stable and commonly used. It however has some limitations which are detailed [here](https://coverage.readthedocs.io/en/latest/trouble.html).

Our implementation of testmon runs during a travis build meaning each branch will get a seperate sqllite db that is cached by Travis between builds. This means you will have all the test info from the default branch from the first time you test and test info from the newly modified code each subsequent time. 

# Bugs and Annoyances to watch out for when writing new tests.

- Testmon is still under development. If you encounter inexplicable problems, check the repo and confer with me, it’s probably not your fault.

- Testmon doesn't rerun tests if only the test has changed, so tests that have failed are removed from the Travis cache at the beggining of a build.

- Testmon should be run with one DB per collection of files, don't use locally to do multiple groups of tests, if they don't share the same dependencies they won't be saved properly. 

# QA Notes
Unlikely to produce any user facing changes.

# Documentation
I’m going to put up docs on Notion and in code

## Ticket

https://openscience.atlassian.net/browse/ENG-123