### PR TITLE
[ENG-234][ENG-233][ENG-237] Add withdrawal request denied email

### DIFF
--- a/osf/models/request.py
+++ b/osf/models/request.py
@@ -25,8 +25,12 @@ class AbstractRequest(BaseModel, ObjectIDMixin):
 
 
 class NodeRequest(AbstractRequest, NodeRequestableMixin):
+    """ Request for Node Access
+    """
     target = models.ForeignKey('AbstractNode', related_name='requests')
 
 
 class PreprintRequest(AbstractRequest, PreprintRequestableMixin):
+    """ Request for Preprint Withdrawal
+    """
     target = models.ForeignKey('Preprint', related_name='requests')

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -287,7 +287,16 @@ class PreprintRequestMachine(BaseMachine):
             reviews_signals.reviews_email_withdrawal_requests.send(timestamp=timezone.now(), context=context)
 
     def notify_accept_reject(self, ev):
-        pass
+        if ev.event.name == DefaultTriggers.REJECT.value:
+            context = self.get_context()
+            mails.send_mail(
+                self.machineable.creator.username,
+                mails.PREPRINT_WITHDRAWAL_REQUEST_DECLINED,
+                mimetype='html',
+                **context
+            )
+        else:
+            pass
 
     def notify_edit_comment(self, ev):
         """ Not presently required to notify for this event

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -439,3 +439,8 @@ PREPRINT_WITHDRAWAL_REQUEST_GRANTED = Mail(
     'preprint_withdrawal_request_granted',
     subject='Your ${reviewable.provider.preprint_word} has been withdrawn',
 )
+
+PREPRINT_WITHDRAWAL_REQUEST_DECLINED = Mail(
+    'preprint_withdrawal_request_declined',
+    subject='Your withdrawal request has been declined',
+)

--- a/website/templates/emails/preprint_withdrawal_request_declined.html.mako
+++ b/website/templates/emails/preprint_withdrawal_request_declined.html.mako
@@ -1,0 +1,18 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <%!
+        from website import settings
+    %>
+        Dear ${requester.fullname},<br>
+        <br>
+        Your request to withdraw your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name} has been declined by the service moderators. The ${reviewable.provider.preprint_word} is still publicly available on ${reviewable.provider.name}.
+        <br>
+        Sincerely,<br>
+        The ${reviewable.provider.name} and OSF Teams
+        <br>
+
+</tr>
+</%def>


### PR DESCRIPTION
## Purpose

Per product's request, adding new email notification sent to requesters when withdrawal requests are denied.

## Ticket

https://openscience.atlassian.net/browse/ENG-234
