### PR TITLE
Hotfix/Fix footBanners class [PLAT-1352]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -71,8 +71,7 @@ a {
     align-items: center;
 }
 
-footBanners {
-    position:fixed;
+.footBanners {
     width: 100%;
     z-index: 10;
     bottom:0;

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -139,7 +139,7 @@
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
 
-<footBanners>
+<div class="footBanners">
     <div id="IEDepreciationBanner"  class="alert warningBanner">
         <div class="warningBannerText">
             OSF does not support the use of Internet Explorer. For optimal performance, please switch to another browser.
@@ -179,7 +179,7 @@
             </div>
         </div>
     </div>
-</footBanners>
+</div>
 % endif
 
 


### PR DESCRIPTION
## Purpose

COS copyright banner was covering portions of the project.  Fix for https://github.com/CenterForOpenScience/osf.io/pull/8893.

## Changes

- Make footBanners a class instead of its own tag
- Remove position:fixed.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
