### PR TITLE
[CR]bump libreoffice version in unoconv docker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     command:
       - /bin/bash
       - -c
-      - /opt/libreoffice6.0/program/python -u /usr/local/bin/unoconv --listener --server=0.0.0.0 --port=2002 -vvv &&
+      - /opt/libreoffice6.1/program/python -u /usr/local/bin/unoconv --listener --server=0.0.0.0 --port=2002 -vvv &&
         chmod -R 777 /tmp/mfrlocalcache
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Purpose

Support local MFR rendering of .docx and other files by updating `docker-compose.yml` to point to location of new LO version in the `unoconv` container.  See:

* https://github.com/CenterForOpenScience/docker-library/pull/49
* https://github.com/CenterForOpenScience/modular-file-renderer/pull/356
 
This will not be useful until the above are merged.

## Changes

* The Dockerfiles for unoconv[1] and MFR[2] have both been updated to
   pull in LibreOffice v6.1.5.  Support this by updating the path to
   LO's python binary.

 [1] https://github.com/CenterForOpenScience/docker-library/blob/master/unoconv/Dockerfile
 [2] https://github.com/CenterForOpenScience/modular-file-renderer/blob/develop/Dockerfile


## QA Notes

No QA needed, local dev only.

## Documentation

No documentation needs to be updated.

## Side Effects

None expected, this PR should only affect local dev.

## Ticket

No  ticket.