### PR TITLE
[ENG-363] Make registration category editable

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -38,12 +38,13 @@ class RegistrationSerializer(NodeSerializer):
         'license',
         'license_type',
         'withdrawal_justification',
+        'category',
     ]
     title = ser.CharField(read_only=True)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True)
     category_choices = NodeSerializer.category_choices
     category_choices_string = NodeSerializer.category_choices_string
-    category = ser.ChoiceField(read_only=True, choices=category_choices, help_text='Choices: ' + category_choices_string)
+    category = ser.ChoiceField(required=False, choices=category_choices, help_text='Choices: ' + category_choices_string)
     date_modified = VersionedDateTimeField(source='last_logged', read_only=True)
     fork = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_fork'))
     collection = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_collection'))

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -38,6 +38,7 @@ class Registration(AbstractNode):
         'description',
         'is_public',
         'node_license',
+        'category',
     ]
 
     article_doi = models.CharField(max_length=128,


### PR DESCRIPTION
## Purpose

Make registration category editable via the API

## Changes

- Add `category` to whitelisted admin writeable fields.
- Add tests

## QA Notes

- Please test this along with the frontend [ticket](https://openscience.atlassian.net/browse/ENG-364) that allows registration category to be editable only by the admin.

## Documentation

## Side Effects

## Ticket

[ENG-363](https://openscience.atlassian.net/browse/ENG-363)
