### PR TITLE
Disable Add button after clicking submitting changes [ENG-130]

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -436,9 +436,6 @@ AddContributorViewModel = oop.extend(Paginator, {
                 self.contributors($.map(response.contributors, function (contrib) {
                     return contrib.id;
                 }));
-                self.hide();
-                $osf.unblock();
-                self.canSubmit(true);
                 if (self.callback) {
                     self.callback(response);
                 }
@@ -446,9 +443,6 @@ AddContributorViewModel = oop.extend(Paginator, {
                 window.location.reload();
             }
         }).fail(function (xhr, status, error) {
-            self.hide();
-            $osf.unblock();
-            self.canSubmit(true);
             var errorMessage = lodashGet(xhr, 'responseJSON.message') || ('There was a problem trying to add contributors.' + osfLanguage.REFRESH_OR_SUPPORT);
             $osf.growl('Could not add contributors', errorMessage);
             Raven.captureMessage('Error adding contributors', {
@@ -458,6 +452,10 @@ AddContributorViewModel = oop.extend(Paginator, {
                     error: error
                 }
             });
+        }).always(function () {
+            self.hide();
+            $osf.unblock();
+            self.canSubmit(true);
         });
     },
     clear: function () {

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -418,6 +418,7 @@ AddContributorViewModel = oop.extend(Paginator, {
     },
     submit: function () {
         var self = this;
+        self.canSubmit(false);
         $osf.block();
         var url = self.nodeApiUrl + 'contributors/';
         return $osf.postJSON(
@@ -437,6 +438,7 @@ AddContributorViewModel = oop.extend(Paginator, {
                 }));
                 self.hide();
                 $osf.unblock();
+                self.canSubmit(true);
                 if (self.callback) {
                     self.callback(response);
                 }
@@ -446,6 +448,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         }).fail(function (xhr, status, error) {
             self.hide();
             $osf.unblock();
+            self.canSubmit(true);
             var errorMessage = lodashGet(xhr, 'responseJSON.message') || ('There was a problem trying to add contributors.' + osfLanguage.REFRESH_OR_SUPPORT);
             $osf.growl('Could not add contributors', errorMessage);
             Raven.captureMessage('Error adding contributors', {

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -346,7 +346,7 @@
                 </span>
 
                 <span data-bind="if:selection().length && page() == 'whom'">
-                    <a class="btn btn-success" data-bind="visible:!hasChildren(), click:submit">Add</a>
+                    <a class="btn btn-success" data-bind="visible:!hasChildren(), click:submit, css: {disabled: !canSubmit()}">Add</a>
                     <a class="btn btn-primary" data-bind="visible: hasChildren(), click:selectWhich">Next</a>
                 </span>
 

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -352,7 +352,7 @@
 
                 <span data-bind="if: page() == 'which'">
                     <a class="btn btn-primary" data-bind="click:selectWhom">Back</a>
-                    <a class="btn btn-success" data-bind="click:submit">Add</a>
+                    <a class="btn btn-success" data-bind="click:submit, css: {disabled: !canSubmit()}">Add</a>
                 </span>
 
             </div><!-- end modal-footer -->


### PR DESCRIPTION
## Purpose

We've been seeing DB deadlocks happening due to the v1 contributor endpoint.  While we're not sure of the root of issue, we can probably prevent mitigate it by preventing clickmashing on the add contrib modal.

## Changes

- Disable the "Add" button after adding contributors in the add contributor modal
- Use the `canSubmit` KO variable

## QA Notes
- Start on the "Contributors" page of a node
- Click the "+Add" button
- Search for some new contributors
- Choose a contributor to add
- Click the "Add" button 
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
Frontend, none needed
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
None anticipated
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-130