### PR TITLE
[OSF Institutions] Update SAML IdP Entity ID for FSU - Prod Server [ENG-305]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -289,7 +289,7 @@ def main(env):
                 'description': 'This service is supported by the <a href="https://www.lib.fsu.edu/">FSU Libraries</a> for our research community. Do not use this service to store or transfer personally identifiable information (PII), personal health information (PHI), or any other controlled unclassified information (CUI). FSU\'s <a href="http://regulations.fsu.edu/sites/g/files/upcbnu486/files/policies/research/FSU%20Policy%207A-26.pdf">Research Data Management Policy</a> applies. For assistance please contact the FSU Libraries <a href="mailto:lib-datamgmt@fsu.edu">Research Data Management Program</a>.',
                 'banner_name': 'fsu-banner.png',
                 'logo_name': 'fsu-shield.png',
-                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.its.fsu.edu/idp/shibboleth')),
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://idp.fsu.edu')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
                 'domains': ['osf.fsu.edu'],
                 'email_domains': [],


### PR DESCRIPTION
## Purpose

Florida State University (FSU) wants to migrate their IdP server from Shibboleth to CAS. Fortunately, institution login remains to use the SAML protocol. A small side-effect of this migration is that the main SAML metadata will be changed during this migration, including the IdP Entity ID which is used to build the login URL. This PR targets OSF prod server after the test server has been proved to be working in https://github.com/CenterForOpenScience/osf.io/pull/8974.

* Unlike the test server, the prod's metadata is included in InCommon's main metadata file. See [Metadata Aggregates](https://spaces.at.internet2.edu/display/InCFederation/Metadata+Aggregates) for more information.

* Please note that it is OK for the prod server to have the same Entity ID (`https://idp.fsu.edu`) as the test server. The metadata itself is different.

## Deployment Notes

cc @mfraezz 

### Shibboleth

- [x] As mentioned, metadata found in InCommon, no need to modify `shibboleth2.xml`.

### CAS

- [x] Modify `institutions-auth.xsl` for prod CAS server.

```xml
<!--Florida State University (FSU) -->
<xsl:when test="$idp='https://idp.fsu.edu'">
    <id>fsu</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

### OSF

- [ ] Populate institutions for OSF prod server.

## Ticket

https://openscience.atlassian.net/browse/ENG-305
