### PR TITLE
[OSF Institutions] Add University of Kent - Prod Server [ENG-309]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -649,6 +649,18 @@ def main(env):
                 'delegation_protocol': 'saml-shib',
             },
             {
+                '_id': 'universityofkent',
+                'name': 'University of Kent',
+                'description': 'Collaboration Platform for University of Kent Research | <a href="https://www.kent.ac.uk/governance/policies-and-procedures/documents/Information-security-policy-v1-1.pdf">Information Security policy</a> | <a href="mailto:researchsupport@kent.ac.uk">Help and Support</a>',
+                'banner_name': 'universityofkent-banner.png',
+                'logo_name': 'universityofkent-shield.png',
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://sso.id.kent.ac.uk/idp')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
+                'domains': [],
+                'email_domains': [],
+                'delegation_protocol': 'saml-shib',
+            },
+            {
                 '_id': 'usc',
                 'name': 'University of Southern California',
                 'description': 'Projects must abide by <a href="http://policy.usc.edu/info-security/">USC\'s Information Security Policy</a>. Data stored for human subject research repositories must abide by <a href="http://policy.usc.edu/biorepositories/">USC\'s Biorepository Policy</a>. The OSF may not be used for storage of Personal Health Information that is subject to <a href="http://policy.usc.edu/hipaa/">HIPPA regulations</a>.',


### PR DESCRIPTION
## Purpose

Add University of Kent - second/final step: prod server.

It turns out that University of Kent used their prod server with our test server in the first step (see https://github.com/CenterForOpenScience/osf.io/pull/8977), thus the same metadata and Entity ID. The update in this PR is exactly the same as what we've done for the test server.

## Deployment Notes

cc @mfraezz 

- [x] No Domain/Cert

- [x] Update prod CAS settings - add the following to `institutions-auth.xsl`:

```xml
<!-- University of Kent (UNIVERSITYOFKENT) -->
<xsl:when test="$idp='https://sso.id.kent.ac.uk/idp'">
    <id>universityofkent</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

- [x] Update prod Shibboleth settings - add the following to `shibboleth2.xml`

Please note the `backingFilePath` may have a different name on prod settings. For example: `universityofkent-metadata.xml` or `universityofkent-prod-metadata.xml`.

```xml
<!-- University of Kent (UNIVERSITYOFKENT) -->
<MetadataProvider type="XML"
                  uri="https://sso.id.kent.ac.uk/idp/saml2/idp/metadata.php"
                  backingFilePath="universityofkent-idp-metadata.xml"
                  reloadInterval="180000" />
```

- [ ] Populate institutions for OSF prod server.

## Ticket

https://openscience.atlassian.net/browse/ENG-309
