### PR TITLE
[OSF Institutions] Update SAML IdP Entity ID for Ferris - Prod Server [ENG-308]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -277,7 +277,7 @@ def main(env):
                 'description': 'In partnership with the <a href="https://www.ferris.edu/research/">Office of Research and Sponsored Programs</a>, the <a href="https://www.ferris.edu/HTMLS/administration/academicaffairs/index.htm">Provost and Vice President for Academic Affairs</a>, and the <a href="https://www.ferris.edu/library/">FLITE Library</a>. Do not use this service to store or transfer personally identifiable information (PII), personal health information (PHI), intellectual property (IP) or any other controlled unclassified information (CUI). All projects must abide by the <a href="https://www.ferris.edu/HTMLS/administration/academicaffairs/Forms_Policies/Documents/Policy_Letters/AA-Intellectual-Property-Rights.pdf">FSU Intellectual Property Rights and Electronic Distance Learning Materials</a> letter of agreement.',
                 'banner_name': 'ferris-banner.png',
                 'logo_name': 'ferris-shield.png',
-                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://login.ferris.edu/samlsso')),
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('login.ferris.edu')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
                 'domains': [],
                 'email_domains': [],


### PR DESCRIPTION
## Purpose

Finally, after verifying that both [TestIdP-TestSP](https://github.com/CenterForOpenScience/osf.io/pull/8827) and [TestIdP-ProdSP](https://github.com/CenterForOpenScience/osf.io/pull/8982) work, we are moving to to ProdIdP-ProdSP release in this PR.

## Deployment Notes

### Prod Server

- [x] No domain/cert

- CAS

  - [x] Update the first non-comment line below in `institutions-auth.xsl` for Ferris State University.

```xml
<!-- Ferris State University (FERRIS) -->
<xsl:when test="$idp='login.ferris.edu'">
    <id>ferris</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenName']/@value"/></givenName>
        <fullname/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

- Shibboleth

  - [x] Add the following attribute mapping to `attribute-map.xml`

```xml

<!-- Ferris State University -->
<Attribute name="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" id="uid" />
<Attribute nameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" name="http://wso2.org/claims/emailaddress" id="mail" />
<Attribute nameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" name="http://wso2.org/claims/lastname" id="sn" />
<Attribute nameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" name="http://wso2.org/claims/givenname" id="givenName" />
```

  - [x] Add `ferris-prod-metadata.xml` [JIRA LINK](https://openscience.atlassian.net/secure/attachment/38682/ferris-prod-metadata.xml) under `conf/`. The name and path for `ferris-prod-metadata.xml` may be different on prod settings.

  - [x] Add or modify the Ferris provider in `shibboleth2.xml`. The `path` may have a different name in prod settings.

```xml
<!-- Ferris State University (FERRIS) -->
<MetadataProvider type="XML" path="ferris-prod-metadata.xml" />
```

- [ ] OSF: populate institutions Prod OSF

### Test Servers

> Q: Should I revert our test server to point back to your test IdP server again?
> A: Your test server can still point to our prod server - I don't think it really matters

- [x] So we keep test server as it is?

## QA Notes

No

## Documentation

No

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/ENG-308
