### PR TITLE
[ENG-176] Make institutions endpoint read-only for withdrawn registrations

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -77,6 +77,7 @@ from api.nodes.permissions import (
     WriteOrPublicForRelationshipInstitutions,
     ExcludeWithdrawals,
     NodeLinksShowIfVersion,
+    ReadOnlyIfWithdrawn,
 )
 from api.nodes.serializers import (
     NodeSerializer,
@@ -1440,7 +1441,7 @@ class NodeInstitutionsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixi
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         AdminOrPublic,
-        ExcludeWithdrawals,
+        ReadOnlyIfWithdrawn,
     )
 
     required_read_scopes = [CoreScopes.NODE_BASE_READ, CoreScopes.INSTITUTION_READ]

--- a/api_tests/registrations/views/test_withdrawn_registrations.py
+++ b/api_tests/registrations/views/test_withdrawn_registrations.py
@@ -123,13 +123,6 @@ class TestWithdrawnRegistrations(NodeCRUDTestCase):
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 403
 
-    #   test_cannot_access_withdrawn_affiliated_institutions
-        registration.save()
-        url = '/{}registrations/{}/institutions/'.format(
-            API_BASE, registration._id)
-        res = app.get(url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
-
     def test_cannot_access_withdrawn_comments(
             self, app, user, project_public, pointer_public,
             registration, withdrawn_registration):


### PR DESCRIPTION
## Purpose

 Make institutions endpoint read-only for withdrawn registrations

## Changes

## QA Notes

On a (withdrawn registration) tombstone page, check the console and make sure
no errors (related to institutions) show.

## Documentation

## Side Effects


## Ticket

[ENG-176](https://openscience.atlassian.net/browse/ENG-176)
