### PR TITLE
Feature/Fix Old Approval Links for Registrations[ENG-419]

### DIFF
--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -516,6 +516,286 @@ class RegistrationWithChildNodesEmbargoModelTestCase(OsfTestCase):
 
 
 @pytest.mark.enable_bookmark_creation
+class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
+    """
+    TODO: Remove this set of tests when process_token_or_pass decorator taken
+    off the view_project view
+    """
+    def setUp(self):
+        super(LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user)
+        self.registration = RegistrationFactory(creator=self.user, project=self.project)
+
+    def test_GET_approve_registration_without_embargo_raises_HTTPBad_Request(self):
+        assert_false(self.registration.is_pending_embargo)
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    def test_GET_approve_with_invalid_token_returns_HTTPBad_Request(self):
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    def test_GET_approve_with_wrong_token_returns_HTTPBad_Request(self):
+        admin2 = UserFactory()
+        Contributor.objects.create(user=admin2, node=self.registration)
+        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        wrong_approval_token = self.registration.embargo.approval_state[admin2._id]['approval_token']
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=wrong_approval_token),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    def test_GET_approve_with_wrong_admins_token_returns_HTTPBad_Request(self):
+        admin2 = UserFactory()
+        Contributor.objects.create(user=admin2, node=self.registration)
+        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        wrong_approval_token = self.registration.embargo.approval_state[admin2._id]['approval_token']
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=wrong_approval_token),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_true(self.registration.is_pending_embargo)
+        assert_equal(res.status_code, 400)
+
+    @mock.patch('flask.redirect')
+    def test_GET_approve_with_valid_token_redirects(self, mock_redirect):
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        approval_token = self.registration.embargo.approval_state[self.user._id]['approval_token']
+        self.app.get(
+            self.registration.web_url_for('view_project', token=approval_token),
+            auth=self.user.auth,
+        )
+        self.registration.embargo.reload()
+        assert_true(self.registration.embargo_end_date)
+        assert_false(self.registration.is_pending_embargo)
+        assert_true(mock_redirect.called_with(self.registration.web_url_for('view_project')))
+
+    def test_GET_disapprove_registration_without_embargo_HTTPBad_Request(self):
+        assert_false(self.registration.is_pending_embargo)
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    def test_GET_disapprove_with_invalid_token_returns_HTTPBad_Request(self):
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=DUMMY_TOKEN),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        self.registration.embargo.reload()
+        assert_true(self.registration.is_pending_embargo)
+        assert_equal(res.status_code, 400)
+
+    def test_GET_disapprove_with_wrong_admins_token_returns_HTTPBad_Request(self):
+        admin2 = UserFactory()
+        Contributor.objects.create(user=admin2, node=self.registration)
+        self.registration.add_permission(admin2, 'admin', save=True)
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        wrong_rejection_token = self.registration.embargo.approval_state[admin2._id]['rejection_token']
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=wrong_rejection_token),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_true(self.registration.is_pending_embargo)
+        assert_equal(res.status_code, 400)
+
+    def test_GET_disapprove_with_valid(self):
+        project = ProjectFactory(creator=self.user)
+        registration = RegistrationFactory(project=project)
+        registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10)
+        )
+        registration.save()
+        assert_true(registration.is_pending_embargo)
+
+        rejection_token = registration.embargo.approval_state[self.user._id]['rejection_token']
+
+        res = self.app.get(
+            registration.registered_from.web_url_for('view_project', token=rejection_token),
+            auth=self.user.auth,
+        )
+        registration.embargo.reload()
+        assert_equal(registration.embargo.state, Embargo.REJECTED)
+        assert_false(registration.is_pending_embargo)
+        assert_equal(res.status_code, 200)
+        assert_equal(project.web_url_for('view_project'), res.request.path)
+
+    def test_GET_disapprove_for_existing_registration_returns_200(self):
+        self.registration.embargo_registration(
+            self.user,
+            timezone.now() + datetime.timedelta(days=10),
+            for_existing_registration=True
+        )
+        self.registration.save()
+        assert_true(self.registration.is_pending_embargo)
+
+        rejection_token = self.registration.embargo.approval_state[self.user._id]['rejection_token']
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=rejection_token),
+            auth=self.user.auth,
+        )
+        self.registration.embargo.reload()
+        assert_equal(self.registration.embargo.state, Embargo.REJECTED)
+        assert_false(self.registration.is_pending_embargo)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.request.path, self.registration.web_url_for('view_project'))
+
+    def test_GET_from_unauthorized_user_with_registration_token(self):
+        unauthorized_user = AuthUserFactory()
+
+        self.registration.require_approval(self.user)
+        self.registration.save()
+
+        app_token = self.registration.registration_approval.approval_state[self.user._id]['approval_token']
+        rej_token = self.registration.registration_approval.approval_state[self.user._id]['rejection_token']
+
+        # Test unauth user cannot approve
+        res = self.app.get(
+            # approval token goes through registration
+            self.registration.web_url_for('view_project', token=app_token),
+            auth=unauthorized_user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 401)
+
+        # Test unauth user cannot reject
+        res = self.app.get(
+            # rejection token goes through registration parent
+            self.project.web_url_for('view_project', token=rej_token),
+            auth=unauthorized_user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 401)
+
+        # Delete Node and try again
+        self.project.is_deleted = True
+        self.project.save()
+
+        # Test unauth user cannot approve deleted node
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=app_token),
+            auth=unauthorized_user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 401)
+
+        # Test unauth user cannot reject
+        res = self.app.get(
+            self.project.web_url_for('view_project', token=rej_token),
+            auth=unauthorized_user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 401)
+
+        # Test auth user can approve registration with deleted parent
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=app_token),
+            auth=self.user.auth,
+        )
+        assert_equal(res.status_code, 200)
+
+    def test_GET_from_authorized_user_with_registration_app_token(self):
+        self.registration.require_approval(self.user)
+        self.registration.save()
+        app_token = self.registration.registration_approval.approval_state[self.user._id]['approval_token']
+
+        res = self.app.get(
+            self.registration.web_url_for('view_project', token=app_token),
+            auth=self.user.auth,
+        )
+        assert_equal(res.status_code, 200)
+
+    def test_GET_from_authorized_user_with_registration_rej_token(self):
+        self.registration.require_approval(self.user)
+        self.registration.save()
+        rej_token = self.registration.registration_approval.approval_state[self.user._id]['rejection_token']
+
+        res = self.app.get(
+            self.project.web_url_for('view_project', token=rej_token),
+            auth=self.user.auth,
+        )
+        assert_equal(res.status_code, 200)
+
+    def test_GET_from_authorized_user_with_registration_rej_token_deleted_node(self):
+        self.registration.require_approval(self.user)
+        self.registration.save()
+        rej_token = self.registration.registration_approval.approval_state[self.user._id]['rejection_token']
+
+        self.project.is_deleted = True
+        self.project.save()
+
+        res = self.app.get(
+            self.project.web_url_for('view_project', token=rej_token),
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 410)
+        res = self.app.get(
+            self.registration.web_url_for('view_project'),
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 410)
+
+
+@pytest.mark.enable_bookmark_creation
 class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def setUp(self):
         super(RegistrationEmbargoApprovalDisapprovalViewsTestCase, self).setUp()

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -427,6 +427,7 @@ def configure_requests(node, **kwargs):
 # View Project
 ##############################################################################
 
+@process_token_or_pass
 @must_be_valid_project(retractions_valid=True)
 @must_be_contributor_or_public
 @ember_flag_is_active(features.EMBER_PROJECT_DETAIL)


### PR DESCRIPTION
## Purpose

Fix for https://github.com/CenterForOpenScience/osf.io/pull/8947

Registries overview is changing the registration approval (and embargo, withdrawal, etc. links).  The reason is the old-style links won't work with emberized pages.   But when we release registries overview, these old links still need to work. Old links expire after 48 hours. 

old style:
`/project/{guid}/?token=<acceptance_token>`

new style:
`/token_action/{guid}/?token=<acceptance_token>`

## Changes
Restore process_token_or_pass decorator for old link handling.


## QA Notes

- We should make registrations and save the approval links right before this goes on test.osf.io (so we have the old links).   On test.osf.io (with front end registries-over waffled off, verify that these old-style links work.  Also make new registrations, and verify that the new-style links work (still with legacy frontend).



## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-419