### PR TITLE
[WIP][ENG-152][ENG-416] Normalize user tags for Metrics

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -306,14 +306,16 @@ ELASTICSEARCH_DSL = {
 # Store yearly indices for time-series metrics
 ELASTICSEARCH_METRICS_DATE_FORMAT = '%Y'
 
+WAFFLE_CACHE_NAME = 'waffle_cache'
+STORAGE_USAGE_CACHE_NAME = 'storage_usage'
+
+
 CACHES = {
-    'default': {
+    STORAGE_USAGE_CACHE_NAME: {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'osf_cache_table',
     },
-    'waffle_cache': {
+    WAFFLE_CACHE_NAME: {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
 }
-
-WAFFLE_CACHE_NAME = 'waffle_cache'

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -311,6 +311,9 @@ STORAGE_USAGE_CACHE_NAME = 'storage_usage'
 
 
 CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
     STORAGE_USAGE_CACHE_NAME: {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'osf_cache_table',

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -4,7 +4,7 @@ import requests
 import logging
 
 from django.apps import apps
-from django.core.cache import cache
+from api.caching.utils import storage_usage_cache
 from django.db import models
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 
@@ -111,7 +111,7 @@ def update_storage_usage_cache(target_id):
     ).files.aggregate(sum=models.Sum('versions__size'))['sum'] or 0
 
     key = cache_settings.STORAGE_USAGE_KEY.format(target_id=target_id)
-    cache.set(key, storage_usage_total, cache_settings.FIVE_MIN_TIMEOUT)
+    storage_usage_cache.set(key, storage_usage_total, cache_settings.FIVE_MIN_TIMEOUT)
 
 
 def update_storage_usage(target):

--- a/api/caching/utils.py
+++ b/api/caching/utils.py
@@ -1,0 +1,5 @@
+from functools import partial
+from django.core.cache import get_cache
+from api.caching import settings
+
+storage_usage_cache = partial(get_cache, settings.STORAGE_USAGE_CACHE_NAME)

--- a/api/caching/utils.py
+++ b/api/caching/utils.py
@@ -1,5 +1,4 @@
-from functools import partial
-from django.core.cache import get_cache
+from django.core.cache import caches
 from api.caching import settings
 
-storage_usage_cache = partial(get_cache, settings.STORAGE_USAGE_CACHE_NAME)
+storage_usage_cache = caches[settings.STORAGE_USAGE_CACHE_NAME]

--- a/api/caching/utils.py
+++ b/api/caching/utils.py
@@ -1,4 +1,4 @@
 from django.core.cache import caches
-from api.caching import settings
+from django.conf import settings
 
 storage_usage_cache = caches[settings.STORAGE_USAGE_CACHE_NAME]

--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -24,14 +24,14 @@ def get_campaigns():
             # Native campaigns: PREREG and ERPC
             newest_campaigns = {
                 'prereg': {
-                    'system_tag': 'prereg_challenge_campaign',
+                    'system_tag': 'source:campaign|prereg',
                     'redirect_url': furl.furl(DOMAIN).add(path='prereg/').url,
                     'confirmation_email_template': mails.CONFIRM_EMAIL_PREREG,
                     'login_type': 'native',
                     'logo': settings.OSF_PREREG_LOGO
                 },
                 'erpc': {
-                    'system_tag': 'erp_challenge_campaign',
+                    'system_tag': 'source:campaign|erp',
                     'redirect_url': furl.furl(DOMAIN).add(path='erpc/').url,
                     'confirmation_email_template': mails.CONFIRM_EMAIL_ERPC,
                     'login_type': 'native',
@@ -61,7 +61,7 @@ def get_campaigns():
                     url_path = 'preprints/{}'.format(provider._id)
                     external_url = provider.domain
                 campaign = '{}-preprints'.format(provider._id)
-                system_tag = '{}_preprints'.format(provider._id)
+                system_tag = 'source:provider|preprint|{}'.format(provider._id)
                 newest_campaigns.update({
                     campaign: {
                         'system_tag': system_tag,
@@ -78,7 +78,7 @@ def get_campaigns():
             # TODO: refactor for futher branded registries when there is a model for registries providers
             newest_campaigns.update({
                 'osf-registries': {
-                    'system_tag': 'osf_registries',
+                    'system_tag': 'source:provider|registry|osf',
                     'redirect_url': furl.furl(DOMAIN).add(path='registries/').url,
                     'confirmation_email_template': mails.CONFIRM_EMAIL_REGISTRIES_OSF,
                     'login_type': 'proxy',
@@ -89,7 +89,7 @@ def get_campaigns():
 
             newest_campaigns.update({
                 'osf-registered-reports': {
-                    'system_tag': 'osf_registered_reports',
+                    'system_tag': 'source:campaign|osf_registered_reports',
                     'redirect_url': furl.furl(DOMAIN).add(path='rr/').url,
                     'confirmation_email_template': mails.CONFIRM_EMAIL_REGISTRIES_OSF,
                     'login_type': 'proxy',
@@ -201,3 +201,13 @@ def get_external_domains():
         if external_url:
             external_domains.append(external_url)
     return external_domains
+
+
+NODE_SOURCE_TAG_CLAIMED_TAG_RELATION = {
+    'source:campaign|erp': 'claimed:campaign|erp',
+    'source:campaign|prereg_challenge': 'claimed:campaign|prereg_challenge',
+    'source:campaign|prereg': 'claimed:campaign|prereg',
+    'source:campaign|osf_registered_reports': 'claimed:campaign|osf_registered_reports',
+    'source:campaign|osf4m': 'claimed:campaign|osf4m',
+    'source:provider|osf': 'claimed:provider|osf'
+}

--- a/osf/migrations/0156_create_cache_table.py
+++ b/osf/migrations/0156_create_cache_table.py
@@ -16,8 +16,8 @@ class Migration(migrations.Migration):
                 "value" text NOT NULL,
                 "expires" timestamp with time zone NOT NULL
             );
-            """.format(settings.CACHES['default']['LOCATION'])
+            """.format(settings.CACHES[settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])
         ], [
-            """DROP TABLE "{}"; """.format(settings.CACHES['default']['LOCATION'])
+            """DROP TABLE "{}"; """.format(settings.CACHES[settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])
         ])
     ]

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2234,6 +2234,40 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             update_storage_usage(self)  # sets cache
             return storage_usage_cache.get(key)
 
+    def add_contributor(self, *args, **kwargs):
+        contributor = super(AbstractNode, self).add_contributor(*args, **kwargs)
+        if not contributor.is_registered:
+            prereg_system_tag = self.all_tags.filter(name='source:campaign|prereg', system=True).first()
+            registered_report_system_tag = self.all_tags.filter(name='source:campaign|osf_registered_reports', system=True).first()
+            osf4m_system_tag = self.all_tags.filter(name='source:campaign|osf4m', system=True).first()
+            if prereg_system_tag:
+                contributor.add_system_tag(prereg_system_tag)
+            elif registered_report_system_tag:
+                contributor.add_system_tag(registered_report_system_tag)
+            elif osf4m_system_tag:
+                contributor.add_system_tag(osf4m_system_tag)
+            else:
+                osf_provider_tag, created = Tag.all_tags.get_or_create(name='source:provider|osf', system=True)
+                contributor.add_system_tag(osf_provider_tag)
+        return contributor
+
+    def add_unregistered_contributor(self, *args, **kwarg):
+        prereg_system_tag = self.all_tags.filter(name='source:campaign|prereg', system=True).first()
+        registered_report_system_tag = self.all_tags.filter(name='source:campaign|osf_registered_reports', system=True).first()
+        osf4m_system_tag = self.all_tags.filter(name='source:campaign|osf4m', system=True).first()
+        unreg_contrib = super(AbstractNode, self).add_unregistered_contributor(*args, **kwarg)
+        if prereg_system_tag:
+            unreg_contrib.add_system_tag(prereg_system_tag)
+        elif registered_report_system_tag:
+            unreg_contrib.add_system_tag(registered_report_system_tag)
+        elif osf4m_system_tag:
+            unreg_contrib.add_system_tag(osf4m_system_tag)
+        else:
+            osf_provider_tag, created = Tag.all_tags.get_or_create(name='source:provider|osf', system=True)
+            unreg_contrib.add_system_tag(osf_provider_tag)
+
+        return unreg_contrib
+
 
 class Node(AbstractNode):
     """

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -13,7 +13,6 @@ from django.apps import apps
 from django_bulk_update.helper import bulk_update
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericRelation
-from django.core.cache import cache
 from django.core.paginator import Paginator
 from django.core.urlresolvers import reverse
 from django.db import models, connection
@@ -66,6 +65,7 @@ from website.util import api_url_for, api_v2_url, web_url_for
 from .base import BaseModel, GuidMixin, GuidMixinQuerySet
 from api.caching.tasks import update_storage_usage
 from api.caching import settings as cache_settings
+from api.caching.utils import storage_usage_cache
 
 
 logger = logging.getLogger(__name__)
@@ -2227,12 +2227,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def storage_usage(self):
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=self._id)
 
-        storage_usage_total = cache.get(key)
+        storage_usage_total = storage_usage_cache.get(key)
         if storage_usage_total:
             return storage_usage_total
         else:
             update_storage_usage(self)  # sets cache
-            return cache.get(key)
+            return storage_usage_cache.get(key)
 
 
 class Node(AbstractNode):

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1054,6 +1054,12 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
             params=params
         )
 
+    def add_unregistered_contributor(self, *args, **kwargs):
+        system_tag_to_add, created = Tag.all_tags.get_or_create(name='source:provider|preprint|{}'.format(self.provider._id), system=True)
+        unreg_contrib = super(Preprint, self).add_unregistered_contributor(*args, **kwargs)
+        unreg_contrib.add_system_tag(system_tag_to_add)
+        return unreg_contrib
+
 
 @receiver(post_save, sender=Preprint)
 def create_file_node(sender, instance, **kwargs):

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -906,6 +906,9 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             # User needs to be saved before adding system tags (due to m2m relationship)
             user.save()
             user.add_system_tag(system_tag_for_campaign(campaign))
+        else:
+            user.save()
+            user.add_system_tag('source:provider|osf')
         return user
 
     @classmethod

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1744,7 +1744,7 @@ class TestUserMerging(OsfTestCase):
         # TODO: test security_messages
         # TODO: test mailing_lists
 
-        assert sorted(self.user.system_tags) == sorted(['shared', 'user', 'unconfirmed'])
+        assert sorted(self.user.system_tags) == sorted(['shared', 'user', 'unconfirmed', 'source:provider|osf'])
 
         # TODO: test emails
         # TODO: test external_accounts

--- a/scripts/backfill_source_tags_for_unregistered_contributors.py
+++ b/scripts/backfill_source_tags_for_unregistered_contributors.py
@@ -1,0 +1,181 @@
+from datetime import timedelta
+import logging
+from django.apps import apps
+from website.app import init_app
+from scripts import utils as script_utils
+import datetime
+import progressbar
+from django.core.paginator import Paginator
+
+import sys
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def backfill_source_tags_for_osf4m_unregistered_contributors(dry_run):
+    """ Backfill osf4m source tags to all osf4m unregistered contributors
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    OSFUser = apps.get_model('osf', 'OSFUser')
+    NodeLog = apps.get_model('osf', 'NodeLog')
+    meeting_source_tag = Tag.all_tags.get(name='source:campaign|osf4m', system=True)
+    meeting_nodes = meeting_source_tag.abstractnode_tagged.all()
+    logging.info('Number of meeting nodes found: ' + str(len(meeting_nodes)))
+    all_meeting_node_logs = NodeLog.objects.filter(action='contributor_added', node__in=meeting_nodes).only('created', 'params')
+    ThroughModel = OSFUser.tags.through
+    set_of_user_ids = set()
+    pbar = progressbar.ProgressBar(maxval=len(all_meeting_node_logs) or 1).start()
+    pbarcounter = 0
+    for entry in all_meeting_node_logs:
+        pbarcounter += 1
+        entry_created_date = entry.created
+        for contributor_id in entry.params['contributors']:
+            contributor_added = OSFUser.objects.get(guids___id=contributor_id)
+            if contributor_added.is_invited and contributor_added.date_confirmed and contributor_added.date_confirmed > entry_created_date:
+                set_of_user_ids.add(contributor_added.pk)
+                # If the user is merged to another user, add the same tag to that user as well
+                if contributor_added.merged_by is not None:
+                    set_of_user_ids.add(contributor_added.merged_by.pk)
+        pbar.update(pbarcounter)
+    logging.info('Number of meeting nodes unreg contrib found: ' + str(len(set_of_user_ids)))
+    if not dry_run:
+        list_of_user_ids_already_with_osf4m_source_tag = OSFUser.objects.filter(tags__id=meeting_source_tag.id).values_list('pk', flat=True)
+        for id in list_of_user_ids_already_with_osf4m_source_tag:
+            set_of_user_ids.discard(id)
+        ThroughModel.objects.bulk_create([ThroughModel(tag_id=meeting_source_tag.pk, osfuser_id=user_id) for user_id in set_of_user_ids])
+
+
+def backfill_source_tags_for_nodes_and_preprints_unregistered_contributors(dry_run):
+    """ Backfill preprint provider source tags to all preprint unregistered contributors
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    OSFUser = apps.get_model('osf', 'OSFUser')
+    PreprintProvider = apps.get_model('osf', 'PreprintProvider')
+    PreprintLog = apps.get_model('osf', 'PreprintLog')
+    all_providers = PreprintProvider.objects.all()
+    ThroughModel = OSFUser.tags.through
+    # Add tags to unregistered contributors
+    # Two cases: pre-NPD and post-NPD
+    for provider in all_providers:
+        provider_source_tag, created = Tag.all_tags.get_or_create(name='source:provider|preprint|{}'.format(provider._id), system=True)
+        osf_provider_source_tag = Tag.all_tags.get(name='source:provider|osf', system=True)
+        # For post-NPD preprints
+        set_of_user_ids_post_npd = set()
+        all_provider_preprints_post_npd = provider.preprints.filter(migrated__isnull=True)
+        preprint_logs = PreprintLog.objects.filter(action='contributor_added', preprint__in=all_provider_preprints_post_npd)
+        logging.info('Number of post-NPD preprints for {}: {}'.format(provider._id, str(len(all_provider_preprints_post_npd))))
+        pbar = progressbar.ProgressBar(maxval=len(preprint_logs) or 1).start()
+        pbarcounter = 0
+        for entry in preprint_logs:
+            pbarcounter += 1
+            entry_created_date = entry.created
+            for contributor_id in entry.params['contributors']:
+                contributor_added = OSFUser.load(contributor_id)
+                if contributor_added.is_invited and contributor_added.date_confirmed and contributor_added.date_confirmed > entry_created_date:
+                    set_of_user_ids_post_npd.add(contributor_added.pk)
+                    # If the user is merged to another user, add the same tag to that user as well
+                    if contributor_added.merged_by is not None:
+                        set_of_user_ids_post_npd.add(contributor_added.merged_by.pk)
+            pbar.update(pbarcounter)
+        logging.info('Number of post-NPD unreg contrib for {}: {}'.format(provider._id, str(len(set_of_user_ids_post_npd))))
+        if not dry_run:
+            list_of_user_ids_already_with_provider_source_tag = OSFUser.objects.filter(tags__id=provider_source_tag.id).values_list('pk', flat=True)
+            for id in list_of_user_ids_already_with_provider_source_tag:
+                set_of_user_ids_post_npd.discard(id)
+            ThroughModel.objects.bulk_create([ThroughModel(tag_id=provider_source_tag.pk, osfuser_id=user_id) for user_id in set_of_user_ids_post_npd])
+
+        # For pre-NPD preprints
+        set_of_user_ids_pre_npd_provider_tag= set()
+        set_of_user_ids_pre_npd_osf_tag = set()
+        all_provider_preprints_pre_npd = provider.preprints.filter(migrated__isnull=False, node__isnull=False).select_related('node').only('created', 'node')
+        logging.info('Number of pre-NPD preprints with sup nodes for {}: {}'.format(provider._id, str(len(all_provider_preprints_pre_npd))))
+        pbar = progressbar.ProgressBar(maxval=len(all_provider_preprints_pre_npd) or 1).start()
+        pbarcounter = 0
+        for preprint in all_provider_preprints_pre_npd:
+            pbarcounter += 1
+            if preprint.created < preprint.node.created:
+                # Do nothing
+                pass
+            elif preprint.created - preprint.node.created < timedelta(minutes=10):
+                node_logs = preprint.node.logs.filter(action='contributor_added').only('created', 'params')
+                for entry in node_logs:
+                    entry_created_date = entry.created
+                    for contributor_id in entry.params['contributors']:
+                        try:
+                            contributor_added = OSFUser.load(contributor_id)
+                        except:
+                            logging.info('Legacy log entry found and ignored.')
+                        if contributor_added.is_invited and contributor_added.date_confirmed and contributor_added.date_confirmed > entry_created_date:
+                            set_of_user_ids_pre_npd_provider_tag.add(contributor_added.pk)
+                            # If the user is merged to another user, add the same tag to that user as well
+                            if contributor_added.merged_by is not None:
+                                set_of_user_ids_pre_npd_provider_tag.add(contributor_added.merged_by.pk)
+            elif preprint.created - preprint.node.created > timedelta(days=1):
+                node_logs = preprint.node.logs.filter(action='contributor_added').only('created', 'params')
+                for entry in node_logs:
+                    entry_created_date = entry.created
+                    for contributor_id in entry.params['contributors']:
+                        try:
+                            contributor_added = OSFUser.load(contributor_id)
+                        except:
+                            logging.info('Legacy log entry found and ignored.')
+                        if contributor_added.is_invited and contributor_added.date_confirmed and contributor_added.date_confirmed > entry_created_date:
+                            set_of_user_ids_pre_npd_osf_tag.add(contributor_added.pk)
+                            # If the user is merged to another user, add the same tag to that user as well
+                            if contributor_added.merged_by is not None:
+                                set_of_user_ids_pre_npd_osf_tag.add(contributor_added.merged_by.pk)
+            pbar.update(pbarcounter)
+        logging.info('Number of pre-NPD unreg contrib for {}: {}'.format(provider._id, str(len(set_of_user_ids_pre_npd_provider_tag) + len(set_of_user_ids_pre_npd_osf_tag))))
+        if not dry_run:
+            list_of_user_ids_already_with_provider_source_tag = OSFUser.objects.filter(tags__id=provider_source_tag.id).values_list('pk', flat=True)
+            list_of_user_ids_already_with_osf_source_tag = OSFUser.objects.filter(tags__id=osf_provider_source_tag.id).values_list('pk', flat=True)
+            for id in list_of_user_ids_already_with_provider_source_tag:
+                set_of_user_ids_pre_npd_provider_tag.discard(id)
+            for id in list_of_user_ids_already_with_osf_source_tag:
+                set_of_user_ids_pre_npd_osf_tag.discard(id)
+            ThroughModel.objects.bulk_create([ThroughModel(tag_id=provider_source_tag.pk, osfuser_id=user_id) for user_id in set_of_user_ids_pre_npd_provider_tag])
+            ThroughModel.objects.bulk_create([ThroughModel(tag_id=osf_provider_source_tag.pk, osfuser_id=user_id) for user_id in set_of_user_ids_pre_npd_osf_tag])
+
+
+def backfill_osf_provider_tags_to_users_not_invited_but_have_no_source_tags(dry_run):
+    Tag = apps.get_model('osf', 'Tag')
+    OSFUser = apps.get_model('osf', 'OSFUser')
+    ThroughModel = OSFUser.tags.through
+    osf_provider_source_tag = Tag.all_tags.get(name='source:provider|osf', system=True)
+    source_tag_ids = Tag.all_tags.filter(name__icontains='source:', system=True).values_list('id', flat=True)
+    # Find not invited users with no source tags
+    users_with_no_source_tags = OSFUser.objects.exclude(is_invited=True).exclude(tags__id__in=source_tag_ids).only('tags').order_by('id')
+    logging.info('Number of users with no source tag {}'.format(str(len(users_with_no_source_tags))))
+
+    paginated_users = Paginator(users_with_no_source_tags, 1000)
+    pbar = progressbar.ProgressBar(maxval=paginated_users.num_pages).start()
+    pbarcounter = 0
+    for page_num in paginated_users.page_range:
+        pbarcounter += 1
+        through_models_to_create = []
+        for user in paginated_users.page(page_num).object_list:
+            through_models_to_create.append(ThroughModel(tag_id=osf_provider_source_tag.pk, osfuser_id=user.pk))
+        if not dry_run:
+            ThroughModel.objects.bulk_create(through_models_to_create)
+        pbar.update(pbarcounter)
+
+
+def main():
+    init_app(set_backends=True, routes=False)
+    dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+
+    script_start_time = datetime.datetime.now()
+    logging.info('Script started time: ' + str(script_start_time))
+    backfill_source_tags_for_osf4m_unregistered_contributors(dry_run)
+    backfill_source_tags_for_nodes_and_preprints_unregistered_contributors(dry_run)
+    backfill_osf_provider_tags_to_users_not_invited_but_have_no_source_tags(dry_run)
+    script_finish_time = datetime.datetime.now()
+    logging.info('Script finished time: ' + str(script_finish_time))
+    logging.info('Run time ' + str(script_finish_time - script_start_time))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/normalize_user_tags.py
+++ b/scripts/normalize_user_tags.py
@@ -1,0 +1,187 @@
+from datetime import datetime
+import pytz
+import logging
+from django.apps import apps
+from website.app import init_app
+from scripts import utils as script_utils
+import sys
+from django.db import transaction
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+PROVIDER_SOURCE_TAGS = [
+    ('africarxiv_preprints', 'source:provider|preprint|africarxiv'),
+    ('agrixiv_preprints', 'source:provider|preprint|agrixiv'),
+    ('arabixiv_preprints', 'source:provider|preprint|arabixiv'),
+    ('bitss_preprints', 'source:provider|preprint|metaarxiv'),
+    ('eartharxiv_preprints', 'source:provider|preprint|eartharxiv'),
+    ('ecoevorxiv_preprints', 'source:provider|preprint|ecoevorxiv'),
+    ('ecsarxiv_preprints', 'source:provider|preprint|ecsarxiv'),
+    ('engrxiv_preprints', 'source:provider|preprint|engrxiv'),
+    ('focusarchive_preprints', 'source:provider|preprint|focusarchive'),
+    ('frenxiv_preprints', 'source:provider|preprint|frenxiv'),
+    ('inarxiv_preprints', 'source:provider|preprint|inarxiv'),
+    ('lawarxiv_preprints', 'source:provider|preprint|lawarxiv'),
+    ('lissa_preprints', 'source:provider|preprint|lissa'),
+    ('marxiv_preprints', 'source:provider|preprint|marxiv'),
+    ('mediarxiv_preprints', 'source:provider|preprint|mediarxiv'),
+    ('mindrxiv_preprints', 'source:provider|preprint|mindrxiv'),
+    ('nutrixiv_preprints', 'source:provider|preprint|nutrixiv'),
+    ('osf_preprints', 'source:provider|preprint|osf'),
+    ('paleorxiv_preprints', 'source:provider|preprint|paleorxiv'),
+    ('psyarxiv_preprints', 'source:provider|preprint|psyarxiv'),
+    ('socarxiv_preprints', 'source:provider|preprint|socarxiv'),
+    ('sportrxiv_preprints', 'source:provider|preprint|sportrxiv'),
+    ('thesiscommons_preprints', 'source:provider|preprint|thesiscommons'),
+    ('bodoarxiv_preprints', 'source:provider|preprint|bodoarxiv'),
+    ('osf_registries', 'source:provider|registry|osf'),
+]
+
+CAMPAIGN_SOURCE_TAGS = [
+    ('erp_challenge_campaign', 'source:campaign|erp'),
+    ('prereg_challenge_campaign', 'source:campaign|prereg_challenge'),
+    ('osf_registered_reports', 'source:campaign|osf_registered_reports'),
+    ('osf4m', 'source:campaign|osf4m'),
+]
+
+PROVIDER_CLAIMED_TAGS = [
+    'claimed:provider|preprint|africarxiv',
+    'claimed:provider|preprint|agrixiv',
+    'claimed:provider|preprint|arabixiv',
+    'claimed:provider|preprint|metaarxiv',
+    'claimed:provider|preprint|eartharxiv',
+    'claimed:provider|preprint|ecoevorxiv',
+    'claimed:provider|preprint|ecsarxiv',
+    'claimed:provider|preprint|engrxiv',
+    'claimed:provider|preprint|focusarchive',
+    'claimed:provider|preprint|frenxiv',
+    'claimed:provider|preprint|inarxiv',
+    'claimed:provider|preprint|lawarxiv',
+    'claimed:provider|preprint|lissa',
+    'claimed:provider|preprint|marxiv',
+    'claimed:provider|preprint|mediarxiv',
+    'claimed:provider|preprint|mindrxiv',
+    'claimed:provider|preprint|nutrixiv',
+    'claimed:provider|preprint|osf',
+    'claimed:provider|preprint|paleorxiv',
+    'claimed:provider|preprint|psyarxiv',
+    'claimed:provider|preprint|socarxiv',
+    'claimed:provider|preprint|sportrxiv',
+    'claimed:provider|preprint|thesiscommons',
+    'claimed:provider|preprint|bodoarxiv',
+    'claimed:provider|registry|osf',
+]
+
+CAMPAIGN_CLAIMED_TAGS = [
+    'claimed:campaign|erp',
+    'claimed:campaign|prereg_challenge',
+    'claimed:campaign|prereg',
+    'claimed:campaign|osf_registered_reports',
+    'claimed:campaign|osf4m',
+]
+
+
+def normalize_provider_source_tags():
+    """ Normailize provider source tags
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    for tag_name in PROVIDER_SOURCE_TAGS:
+        try:
+            tag = Tag.all_tags.get(name=tag_name[0], system=True)
+            tag.name = tag_name[1]
+            tag.save()
+            logging.info(tag_name[0] + ' migrated to ' + tag_name[1])
+        except Tag.DoesNotExist:
+            pass
+
+
+def add_provider_claimed_tags():
+    """ Add provider claimed tag instances
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    for tag_name in PROVIDER_CLAIMED_TAGS:
+        tag = Tag.all_tags.create(name=tag_name, system=True)
+        tag.save()
+        logging.info('Added tag ' + tag.name)
+
+
+def normalize_campaign_source_tags():
+    """ Normalize campaign source tags
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    for tag_name in CAMPAIGN_SOURCE_TAGS:
+        try:
+            tag = Tag.all_tags.get(name=tag_name[0], system=True)
+            tag.name = tag_name[1]
+            tag.save()
+            logging.info(tag_name[0] + ' migrated to ' + tag_name[1])
+        except Tag.DoesNotExist:
+            pass
+
+
+def add_campaign_claimed_tags():
+    """ Add campaign claimed tag instances
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    for tag_name in CAMPAIGN_CLAIMED_TAGS:
+        tag = Tag.all_tags.create(name=tag_name, system=True)
+        tag.save()
+        logging.info('Added tag ' + tag.name)
+
+
+def add_osf_provider_tags():
+    """ Add 'source:provider|osf' tag instance.
+        Add 'claimed:provider|osf' tag instance.
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    Tag.all_tags.create(name='source:provider|osf', system=True)
+    Tag.all_tags.create(name='claimed:provider|osf', system=True)
+    logging.info('Added tag ' + 'source:provider|osf')
+    logging.info('Added tag ' + 'claimed:provider|osf')
+
+
+def add_prereg_campaign_tags():
+    """ Add 'source:campaign|prereg' tag instance.
+        Add 'claimed:campaign|prereg' tag instance.
+        Migrate all users created after prereg challenge end date to the new source tag.
+    """
+    Tag = apps.get_model('osf', 'Tag')
+    OSFUser = apps.get_model('osf', 'OSFuser')
+    prereg_challenge_source_tag = Tag.all_tags.get(name='source:campaign|prereg_challenge', system=True)
+    logging.info('Added tag ' + prereg_challenge_source_tag.name)
+    prereg_source_tag = Tag.all_tags.create(name='source:campaign|prereg', system=True)
+    logging.info('Added tag ' + prereg_source_tag.name)
+    prereg_challenge_cutoff_date = pytz.utc.localize(datetime(2019, 01, 01, 05, 59))
+    prereg_users_registered_after_january_first = OSFUser.objects.filter(tags__id=prereg_challenge_source_tag.id, date_registered__gt=prereg_challenge_cutoff_date)
+    logging.info('Number of OSFUsers created on/after 2019-01-01: ' + str(len(prereg_users_registered_after_january_first)))
+    for user in prereg_users_registered_after_january_first:
+        user.tags.through.objects.filter(tag=prereg_challenge_source_tag).delete()
+        user.add_system_tag(prereg_source_tag)
+        # Check  whether the user is merged to another user
+        # If so, add the same tag to that user as well
+        if user.merged_by is not None:
+            user.merged_by.add_system_tag(prereg_source_tag)
+    logging.info('Migrated users from ' + prereg_challenge_source_tag.name + ' to ' + prereg_source_tag.name)
+
+
+def main():
+    init_app(set_backends=True, routes=False)
+    dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+
+    with transaction.atomic():
+        normalize_provider_source_tags()
+        add_provider_claimed_tags()
+        normalize_campaign_source_tags()
+        add_campaign_claimed_tags()
+        add_osf_provider_tags()
+        add_prereg_campaign_tags()
+        if dry_run:
+            raise RuntimeError('Dry run, transaction rolled back')
+
+
+if __name__ == '__main__':
+    main()

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -82,7 +82,7 @@ def add_poster_by_email(conference, message):
                 user.fullname = user._id  # Users cannot use an email as their full name
 
             user.save()  # need to save in order to access m2m fields (e.g. tags)
-            user.add_system_tag('osf4m')
+            user.add_system_tag('source:campaign|osf4m')
             user.update_date_last_login()
             user.save()
 
@@ -101,7 +101,7 @@ def add_poster_by_email(conference, message):
             title=message.subject,
             creator=user
         )
-        node.add_system_tag('osf4m')
+        node.add_system_tag('source:campaign|osf4m')
         node.save()
 
         utils.provision_node(conference, message, node, user)

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -9,7 +9,7 @@ from osf.exceptions import NodeStateError
 from osf.utils.sanitize import strip_html
 
 # TODO: This should be a class method of Node
-def new_node(category, title, user, description='', parent=None):
+def new_node(category, title, user, description='', parent=None, campaign=None):
     """Create a new project or component.
 
     :param str category: Node category
@@ -37,6 +37,10 @@ def new_node(category, title, user, description='', parent=None):
     )
 
     node.save()
+
+    if campaign:
+        from framework.auth.campaigns import system_tag_for_campaign
+        node.add_system_tag(system_tag_for_campaign(campaign))
 
     return node
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -18,7 +18,7 @@ from framework.flask import redirect  # VOL-aware redirect
 from framework.sessions import session
 from framework.transactions.handlers import no_auto_transaction
 from framework.utils import get_timestamp, throttle_period_expired
-from osf.models import AbstractNode, OSFUser, Preprint, PreprintProvider, RecentlyAddedContributor
+from osf.models import AbstractNode, OSFUser, Preprint, PreprintProvider, RecentlyAddedContributor, Tag
 from osf.utils import sanitize
 from osf.utils.permissions import expand_permissions, ADMIN
 from osf.exceptions import NodeStateError
@@ -31,6 +31,7 @@ from website.project.views.node import serialize_preprints
 from website.project.model import has_anonymous_link
 from website.project.signals import unreg_contributor_added, contributor_added
 from website.util import web_url_for, is_json_request
+from framework.auth.campaigns import NODE_SOURCE_TAG_CLAIMED_TAG_RELATION
 
 
 @collect_auth
@@ -822,6 +823,18 @@ def claim_user_form(auth, **kwargs):
             if provider:
                 redirect_url = web_url_for('auth_login', next=provider.landing_url, _absolute=True)
             else:
+                node = AbstractNode.load(pid)
+                preprint = Preprint.load(pid)
+                if node:
+                    node_source_tags = node.all_tags.filter(name__icontains='source:', system=True)
+                    if node_source_tags.exists():
+                        for tag in node_source_tags:
+                            claimed_tag, created = Tag.all_tags.get_or_create(name=NODE_SOURCE_TAG_CLAIMED_TAG_RELATION[tag.name], system=True)
+                            user.add_system_tag(claimed_tag)
+                elif preprint:
+                    provider_id = preprint.provider._id
+                    preprint_source_tag, created = Tag.all_tags.get_or_create(name='claimed:provider|preprint|{}'.format(provider_id), system=True)
+                    user.add_system_tag(preprint_source_tag)
                 redirect_url = web_url_for('resolve_guid', guid=pid, _absolute=True)
 
             return redirect(cas.get_login_url(

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -111,13 +111,13 @@ def project_new(**kwargs):
 @must_be_logged_in
 def project_new_post(auth, **kwargs):
     user = auth.user
-
     data = request.get_json()
     title = strip_html(data.get('title'))
     title = title.strip()
     category = data.get('category', 'project')
     template = data.get('template')
     description = strip_html(data.get('description'))
+    campaign = data.get('campaign', None)
     new_project = {}
 
     if template:
@@ -140,7 +140,7 @@ def project_new_post(auth, **kwargs):
 
     else:
         try:
-            project = new_node(category, title, user, description)
+            project = new_node(category, title, user, description, campaign=campaign)
         except ValidationError as e:
             raise HTTPError(
                 http.BAD_REQUEST,

--- a/website/registries/utils.py
+++ b/website/registries/utils.py
@@ -1,7 +1,7 @@
 REG_CAMPAIGNS = {
     'prereg_challenge': 'Prereg Challenge',
     'prereg': 'OSF Preregistration',
-    'registered_report': 'Registered Report Protocol Preregistration',
+    'osf-registered-reports': 'Registered Report Protocol Preregistration',
 }
 
 def get_campaign_schema(campaign):

--- a/website/registries/views.py
+++ b/website/registries/views.py
@@ -30,7 +30,7 @@ def _view_registries_landing_page(campaign=None, **kwargs):
 
 
 def registered_reports_landing(**kwargs):
-    return _view_registries_landing_page('registered_report', **kwargs)
+    return _view_registries_landing_page('osf-registered-reports', **kwargs)
 
 
 @decorators.must_be_logged_in


### PR DESCRIPTION
## Purpose

To normalize user tags for metrics.

Step 1 - Normalization:
* - [X] Write a script to change names of existing provider source tags
* - [X] Write a script to add provider claimed tags for existing provider source tags 
* - [X] Write a script to change names of existing campaign source tags 
* - [X] Write a script to add campaign claimed tags for existing campaign source tags 
* - [X] Write a script to add new provider tags 
  * `source:provider|osf` 
`claimed:provider|osf` 
* - [X] Write a script to add new campaign tags 
  * `source:campaign|prereg` 
    * Migrate user created before after 2019-01-01 but with `source:campaign|prereg_challenge` tag to new tag 
  * `claimed:campaign|prereg` 

Step 2 - Backfill:
* - [X] Write a script to backfill source tags to unreg contributors added to OSF4M nodes 
* - [X] Write a script to backfill source tags to unreg contributors added to preprints/supplemental node to preprints 
  * For supplemental nodes created less than 10 minutes before the creation of the preprint, we add provider source tags to unregistered contributors added to these nodes. 
  * For supplemental nodes created more than 10 minutes but less than a day before the creation of the preprint, we do nothing to its unreg contributors. 
  * For supplemental nodes created more than a day before the creation of the preprint, we add `source|provider|osf` to unregistered contributors added to these nodes. 
* - [X] Backfill	 `source:provider|osf` to users not invited but with no source tags. 
* No need to backfill source tags to unregistered contributors for prereg challenge/prereg/registered report because we don’t know what they are. 


## Changes

Placeholder

## QA Notes

Placeholder

## Ticket

https://openscience.atlassian.net/browse/ENG-152
