### PR TITLE
Remove duplicate httpscheme part from zip/repo url

### DIFF
--- a/addons/gitlab/apps.py
+++ b/addons/gitlab/apps.py
@@ -52,8 +52,8 @@ def gitlab_hgrid_data(node_settings, auth, **kwargs):
         'upload': node_settings.owner.api_url + 'gitlab/file/' + ref,
         'fetch': node_settings.owner.api_url + 'gitlab/hgrid/' + ref,
         'branch': node_settings.owner.api_url + 'gitlab/hgrid/root/' + ref,
-        'zip': 'https://{0}/{1}/repository/archive.zip?branch={2}'.format(node_settings.external_account.oauth_secret, repo.path_with_namespace, ref),
-        'repo': 'https://{0}/{1}/tree/{2}'.format(node_settings.external_account.oauth_secret, repo.path_with_namespace, ref)
+        'zip': '{0}/{1}/repository/archive.zip?branch={2}'.format(node_settings.external_account.oauth_secret, repo.path_with_namespace, ref),
+        'repo': '{0}/{1}/tree/{2}'.format(node_settings.external_account.oauth_secret, repo.path_with_namespace, ref)
     }
 
     branch_names = [each.name for each in branches]


### PR DESCRIPTION
Currently, in the gitlab file viewer pane, the external-link "Open" contains a broken link.

I believe ccdbcdf8d0bed050b219d4b7cd03759b1f9bc118 forcefully added an http scheme to gitlab_account.oauth_secret without removing these bits.


## Purpose

Fix broken URL in gitlab file viewer

## Changes

Remove duplicate https:// scheme string
