### PR TITLE
Feature/APIv2: Update Parser that handles multiple relationships [ENG-429]

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -222,6 +222,10 @@ class JSONAPIOnetoOneRelationshipParserForRegularJSON(JSONAPIOnetoOneRelationshi
 
 
 class JSONAPIMultipleRelationshipsParser(JSONAPIParser):
+    """
+    If edits are made to this class, be sure to check JSONAPIMultipleRelationshipsParserForRegularJSON to see if corresponding
+    edits should be made there.
+    """
     def flatten_relationships(self, relationships):
         rel = {}
         for resource in relationships:
@@ -238,12 +242,22 @@ class JSONAPIMultipleRelationshipsParser(JSONAPIParser):
 
 
 class JSONAPIMultipleRelationshipsParserForRegularJSON(JSONAPIParserForRegularJSON):
+    """
+    Allows same processing as JSONAPIMultipleRelationshipsParser to occur for requests with application/json media type.
+    """
     def flatten_relationships(self, relationships):
-        ret = super(JSONAPIMultipleRelationshipsParserForRegularJSON, self).flatten_relationships(relationships)
-        related_resource = relationships.keys()[0]
-        if ret.get('target_type') and ret.get('id'):
-            return {related_resource: ret['id']}
-        return ret
+        rel = {}
+        for resource in relationships:
+            ret = super(JSONAPIMultipleRelationshipsParserForRegularJSON, self).flatten_relationships({resource: relationships[resource]})
+            if isinstance(ret, list):
+                rel[resource] = []
+                for item in ret:
+                    if item.get('target_type') and item.get('id'):
+                        rel[resource].append(item['id'])
+            else:
+                if ret.get('target_type') and ret.get('id'):
+                    rel[resource] = ret['id']
+        return rel
 
 
 class HMACSignedParser(JSONParser):

--- a/api_tests/base/test_parsers.py
+++ b/api_tests/base/test_parsers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from api.base.parsers import JSONAPIMultipleRelationshipsParser
+from api.base.parsers import JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON
 
 
 SINGLE_RELATIONSHIP = {
@@ -100,3 +100,18 @@ class TestMultipleRelationshipsParser:
     def test_flatten_relationships(self, relationship, expected):
         parser = JSONAPIMultipleRelationshipsParser()
         assert JSONAPIMultipleRelationshipsParser.flatten_relationships(parser, relationship) == expected
+
+
+class TestMultipleRelationshipsParserForRegularJSON:
+
+    @pytest.mark.parametrize('relationship,expected',
+    [
+        (SINGLE_RELATIONSHIP, {'region': 'us-1'}),
+        (MULTIPLE_RELATIONSHIP, {'affiliated_institutions': ['cos', 'ljaf']}),
+        (MIXED_RELATIONSHIP, {'region': 'us-1', 'affiliated_institutions': ['cos', 'ljaf']}),
+        (MULTIPLE_SINGLE_RELATIONSHIPS, {'node': 'abcde', 'provider': 'agrixiv'}),
+        (MULTIPLE_MULTIPLE_RELATIONSHIPS, {'affiliated_institutions': ['cos', 'ljaf'], 'providers': ['agrixiv', 'osfpreprints']}),
+    ])
+    def test_flatten_relationships(self, relationship, expected):
+        parser = JSONAPIMultipleRelationshipsParserForRegularJSON()
+        assert JSONAPIMultipleRelationshipsParserForRegularJSON.flatten_relationships(parser, relationship) == expected

--- a/api_tests/base/test_parsers.py
+++ b/api_tests/base/test_parsers.py
@@ -101,17 +101,5 @@ class TestMultipleRelationshipsParser:
         parser = JSONAPIMultipleRelationshipsParser()
         assert JSONAPIMultipleRelationshipsParser.flatten_relationships(parser, relationship) == expected
 
-
-class TestMultipleRelationshipsParserForRegularJSON:
-
-    @pytest.mark.parametrize('relationship,expected',
-    [
-        (SINGLE_RELATIONSHIP, {'region': 'us-1'}),
-        (MULTIPLE_RELATIONSHIP, {'affiliated_institutions': ['cos', 'ljaf']}),
-        (MIXED_RELATIONSHIP, {'region': 'us-1', 'affiliated_institutions': ['cos', 'ljaf']}),
-        (MULTIPLE_SINGLE_RELATIONSHIPS, {'node': 'abcde', 'provider': 'agrixiv'}),
-        (MULTIPLE_MULTIPLE_RELATIONSHIPS, {'affiliated_institutions': ['cos', 'ljaf'], 'providers': ['agrixiv', 'osfpreprints']}),
-    ])
-    def test_flatten_relationships(self, relationship, expected):
         parser = JSONAPIMultipleRelationshipsParserForRegularJSON()
         assert JSONAPIMultipleRelationshipsParserForRegularJSON.flatten_relationships(parser, relationship) == expected


### PR DESCRIPTION
## Purpose

Modify `JSONAPIMultipleRelationshipsParserForRegularJSON` to have the same handling of list data as the `JSONAPIMultipleRelationshipsParser`.  It currently cannot handle multiple relationships (affiliated_institutions, for example).

- Both parsers should have the same behavior, they just handle different content types - application/json versus application/vnd.api+json.

## Changes

JSONAPIMultipleRelationshipsParserForRegularJSON given same handling as JSONAPIMultipleRelationshipsParser.

## QA Notes
For example, a request that looks like this wasn't working if the Content-Type is `application/json`.  We are trying to support both this and the json-api content-type, `application/vnd.api+json`.
```json
 
PATCH v2/registrations/xyb6e/
{
  "data": {
    "id": "xyb6e",
    "type": "registrations",
    "relationships": {
      "affiliated_institutions": {
                "data": [
                    {"type": "institutions", "id": "cos"}
                ]
            }
      }
  }
}
```

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-429