### PR TITLE
[ENG-434] No throttle user email gets

### DIFF
--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -1,3 +1,4 @@
+from rest_framework import permissions
 from rest_framework.throttling import UserRateThrottle, AnonRateThrottle, SimpleRateThrottle
 import logging
 
@@ -101,6 +102,11 @@ class SendEmailThrottle(BaseThrottle, UserRateThrottle):
 
     scope = 'send-email'
 
+    def allow_request(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return super(SendEmailThrottle, self).allow_request(request, view)
 
 class SendEmailDeactivationThrottle(SendEmailThrottle):
 

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -202,6 +202,11 @@ class TestUserEmailsList:
         assert len([email for email in data if email['attributes']['confirmed']]) == confirmed_count
         assert len([email for email in data if email['attributes']['confirmed'] is False]) == unconfirmed_count
 
+    def test_get_emails_not_throttled(self, app, url, user_one):
+        for i in range(3):
+            res = app.get(url, auth=user_one.auth)
+            assert res.status_code == 200
+
     def test_get_emails_not_current_user(self, app, url, user_one, user_two):
         res = app.get(url, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403


### PR DESCRIPTION
## Purpose

The Emberized account settings page needs to be able to get the user emails list without being throttled. The `SendEmailThrottle` throttling class was applied to the `UserEmailsList` view to throttle requests that result in an email being sent. `GET` requests to this endpoint, however, do not send an email and shouldn't be throttled. This PR bypassing throttling for `GET` requests to endpoints using the `SendEmailThrottle` throttling class. These include the `UserEmailsList` view as well as `UserAccountExport`, for which `GET` is not implemented. In addition, the `SendEmailDeactivationThrottle` throttling class inherits from `SendEmailThrottle`, which only sends an email when `PATCH`ing `deactivation_requested`.

## Changes

* override `allow_request` method on `SendEmailThrottle` class to always allow `GET` requests to pass through unthrottled.
* add a test to make sure that three `GET` requests to user emails list endpoint in rapid succession do not result in throttling (the default throttling for `send-email` is `2/minute`, so the third request would be throttled without the `GET` exception)

## QA Notes

Make sure multiple requests in rapid succession to `/v2/users/me/settings/emails/` are not throttled.

## Documentation

n/a because this does not change API surface

## Side Effects

Should be none.

## Ticket

https://openscience.atlassian.net/browse/ENG-434
