### PR TITLE
[Hotfix] Route Registration A/VOLs to v1 UI

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -272,7 +272,7 @@ def node_forks(auth, node, **kwargs):
 @must_have_permission(READ)
 @ember_flag_is_active(features.EMBER_PROJECT_SETTINGS)
 def node_setting(auth, node, **kwargs):
-    if node.is_registration and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+    if node.is_registration and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
         # Registration settings page obviated during redesign
         return redirect(node.url)
     auth.user.update_affiliated_institutions_by_email_domain()

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -124,7 +124,7 @@ def node_registration_retraction_post(auth, node, **kwargs):
 @must_be_contributor_or_public
 @ember_flag_is_active(features.EMBER_REGISTRATION_FORM_DETAIL)
 def node_register_template_page(auth, node, metaschema_id, **kwargs):
-    if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+    if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
         # Registration meta page obviated during redesign
         return redirect(node.url)
     if node.is_registration and bool(node.registered_schema):

--- a/website/views.py
+++ b/website/views.py
@@ -301,7 +301,9 @@ def resolve_guid(guid, suffix=None):
         if isinstance(referent, Registration) and (
                 not suffix or suffix.rstrip('/').lower() in ('comments', 'links', 'components')
         ):
-            if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+            # Ideally, auth wouldn't be checked here. Necessary for routing
+            auth = Auth.from_kwargs(request.args.to_dict(), {})
+            if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
                 # Route only the base detail view to ember
                 if PROXY_EMBER_APPS:
                     resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)


### PR DESCRIPTION
## Purpose
Avoids critical bug while a Front-end fix is implemented

## Changes


## QA Notes
Ensure
1) Registrations reached via means that don't include a VOL route to ember views
2) Registrations reached with a `view_only` param route to old UI

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
