### PR TITLE
BitBucket V1 Deprecation and V2 GDPR update check [ENG-490]

### DIFF
--- a/addons/bitbucket/api.py
+++ b/addons/bitbucket/api.py
@@ -1,9 +1,11 @@
 import urllib
 
+from addons.bitbucket import settings
+
+from framework import sentry
 from framework.exceptions import HTTPError
 
 from website.util.client import BaseClient
-from addons.bitbucket import settings
 
 
 class BitbucketClient(BaseClient):
@@ -27,6 +29,14 @@ class BitbucketClient(BaseClient):
         API docs::
 
         * https://developer.atlassian.com/bitbucket/api/2/reference/resource/user
+
+        Bitbucket API GDPR Update::
+
+        * https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
+
+        As mentioned in the GDPR update on "removal of username", the ``/2.0/user`` endpoint will
+        continue to provide the ``username`` field in its response since this endpoint only ever
+        returns the authenticated user's own user object, not that of other users.
 
         :rtype: dict
         :return: a metadata object representing the user
@@ -75,7 +85,30 @@ class BitbucketClient(BaseClient):
             throws=HTTPError(401),
             params={'pagelen': 100}
         )
-        return res.json()['values']
+        repo_list = res.json()['values']
+
+        # GDPR docs: https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
+        #
+        # The GDPR guide is quite ambiguous on "removal of username".  It mentions that this change
+        # should only affect the ``/2.0/users/`` endpoint but also says that the ``username`` field
+        # will be removed from the ``User`` object.  Without an explicit exception statement, we are
+        # not quite certain that each repository object in the response will continue to provide the
+        # ``owner.username``.  This attribute is used to 1) Set the ``user`` field for the addon's
+        # ``node_settings`` and 2) to build the repo URL during addon configuration.  The config
+        # would break if ``username`` is gone.  If it happened, we can apply a few fixes including
+        # 1) replacing ``owner.username`` with ``owner.account_id``, 2) using the ``display_name``
+        # of the ``ExternalAccount`` model, and 3) using one of the repo URL links in the response.
+        #
+        # Added the following check and sentry log to make sure that we would be informed of the
+        # failure if it happened after the GDPR update.  Checking the first itme should be good.
+        for repo in repo_list:
+            username = repo['owner'].get('username', None)
+            if not username:
+                sentry.log_message('WARNING: Bitbucket V2 "repositories/user" no '
+                                   'longer returns required field "owner.username".')
+            break
+
+        return repo_list
 
     def team_repos(self):
         """Return a list of repositories owned by teams the user is a member of.

--- a/addons/bitbucket/api.py
+++ b/addons/bitbucket/api.py
@@ -113,11 +113,10 @@ class BitbucketClient(BaseClient):
 
     def repo_default_branch(self, user, repo):
         """Return the default branch for a BB repository (what they call the
-        "main branch").  They do not provide this via their v2 API,
-        but there is a v1 endpoint that will return it.
+        "main branch").
 
         API doc:
-        https://confluence.atlassian.com/bitbucket/repository-resource-1-0-296095202.html#repositoryResource1.0-GETtherepository%27smainbranch
+        https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D
 
         :param str user: Bitbucket user name
         :param str repo: Bitbucket repo name
@@ -127,11 +126,11 @@ class BitbucketClient(BaseClient):
         """
         res = self._make_request(
             'GET',
-            self._build_url(settings.BITBUCKET_V1_API_URL, 'repositories', user, repo, 'main-branch'),
+            self._build_url(settings.BITBUCKET_V2_API_URL, 'repositories', user, repo),
             expects=(200, ),
             throws=HTTPError(401)
         )
-        return res.json()['name']
+        return res.json()['mainbranch']['name']
 
     def branches(self, user, repo):
         """List a repo's branches.  This endpoint is paginated and may require

--- a/addons/bitbucket/settings/defaults.py
+++ b/addons/bitbucket/settings/defaults.py
@@ -19,7 +19,6 @@ MAX_RENDER_SIZE = None
 
 CACHE = False
 
-BITBUCKET_V1_API_URL = 'https://api.bitbucket.org/1.0'
 BITBUCKET_V2_API_URL = 'https://api.bitbucket.org/2.0'
 
 REFRESH_TIME = 5 * 60


### PR DESCRIPTION
### Purpose

- BitBucket V1 Deprecation:
  - https://developer.atlassian.com/cloud/bitbucket/deprecation-notice-v1-apis/
- BitBucket V2 GDPR Update:
  - https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
  - https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-workspaces/

### Changes

- The only V1 usage in OSF is fetching the main/default branch. This dedicated endpoint is no longer available in V2 and does not have a V2 counterpart. Fortunately, we can still obtain it from the repo's own metadata.

- The GDPR update shouldn't affect the OSF side but we are not 100% sure due to BB's ambiguous GDPR docs and migration guide. Added a check and sentry log to the `repos` endpoint to make sure that we would be informed of the failure if it happened after the GDPR update.

### Side Effects

No

### Documentation

TBD; probably at least the following three

- [x] Bitbucket V1 deprecation
- [x] Bitbucket V2 GDPR update
- [x] Git-based provider

### QA Notes

Please verify that: 
- Setting up a new Bitbucket addon for a project works as expected. Please use a new project disconnect the addon from you OSF main settings first.
- The project page loads Bitbucket storage successfully with the correct default branch name

### DevOps Notes

This PR is independent of the WB PR: https://github.com/CenterForOpenScience/waterbutler/pull/375

### Ticket

https://openscience.atlassian.net/browse/ENG-303