### PR TITLE
Feature/Registration VOL's [ENG-440][ENG-52]

### DIFF
--- a/api/licenses/serializers.py
+++ b/api/licenses/serializers.py
@@ -11,14 +11,7 @@ class LicenseSerializer(JSONAPISerializer):
         'name',
         'id',
     ])
-    anonymized_fields = [
-        'id',
-        'links',
-        'name',
-        'required_fields',
-        'text',
-        'url',
-    ]
+
     id = IDField(source='_id', read_only=True)
     type = TypeField()
     name = ser.CharField(required=True, help_text='License name')

--- a/api/licenses/serializers.py
+++ b/api/licenses/serializers.py
@@ -11,7 +11,14 @@ class LicenseSerializer(JSONAPISerializer):
         'name',
         'id',
     ])
-    non_anonymized_fields = ['type']
+    anonymized_fields = [
+        'id',
+        'links',
+        'name',
+        'required_fields',
+        'text',
+        'url',
+    ]
     id = IDField(source='_id', read_only=True)
     type = TypeField()
     name = ser.CharField(required=True, help_text='License name')

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -196,10 +196,15 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
 class NodeLogSerializer(JSONAPISerializer):
 
     filterable_fields = frozenset(['action', 'date'])
-    non_anonymized_fields = [
-        'id',
-        'date',
-        'action',
+    anonymized_fields = [
+        'linked_node',
+        'linked_registration',
+        'links',
+        'node',
+        'original_node',
+        'params',
+        'template_node',
+        'user',
     ]
 
     id = ser.CharField(read_only=True, source='_id')

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -171,6 +171,9 @@ class NodeLicenseRelationshipField(RelationshipField):
 
 
 class NodeCitationSerializer(JSONAPISerializer):
+    anonymized_fields = [
+        'author',
+    ]
     id = IDField(read_only=True)
     title = ser.CharField(allow_blank=True, read_only=True)
     author = ser.ListField(read_only=True)
@@ -237,7 +240,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     ])
 
     anonymized_fields = [
+        'current_user_can_comment',
         'forks',
+        'citation',
+        'custom_citation',
+        'node_license',
         'registrations',
     ]
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -236,28 +236,9 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'subjects',
     ])
 
-    non_anonymized_fields = [
-        'id',
-        'title',
-        'description',
-        'category',
-        'date_created',
-        'date_modified',
-        'registration',
-        'tags',
-        'public',
-        'license',
-        'links',
-        'children',
-        'comments',
-        'contributors',
-        'files',
-        'node_links',
-        'parent',
-        'root',
-        'logs',
-        'wikis',
-        'subjects',
+    anonymized_fields = [
+        'forks',
+        'registrations',
     ]
 
     id = IDField(source='_id', read_only=True)
@@ -1006,7 +987,15 @@ class ContributorIDField(IDField):
 class NodeContributorsSerializer(JSONAPISerializer):
     """ Separate from UserSerializer due to necessity to override almost every field as read only
     """
-    non_anonymized_fields = ['bibliographic', 'permission']
+    anonymized_fields = [
+        'id',
+        'index',
+        'links',
+        'node',
+        'type',
+        'unregistered_contributor',
+        'users',
+    ]
     filterable_fields = frozenset([
         'id',
         'bibliographic',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1505,13 +1505,10 @@ class NodeViewOnlyLinkUpdateSerializer(NodeViewOnlyLinkSerializer):
     def update(self, link, validated_data):
         assert isinstance(link, PrivateLink), 'link must be a PrivateLink'
 
-        name = validated_data.get('name')
-        anonymous = validated_data.get('anonymous')
-
-        if name:
-            link.name = name
-        if anonymous:
-            link.anonymous = anonymous
+        if 'name' in validated_data:
+            link.name = validated_data.get('name')
+        if 'anonymous' in validated_data:
+            link.anonymous = validated_data.get('anonymous')
 
         link.save()
         return link

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -246,6 +246,8 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'custom_citation',
         'node_license',
         'registrations',
+        'contributors',
+        'bibliographic_contributors',
     ]
 
     id = IDField(source='_id', read_only=True)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1881,7 +1881,7 @@ class NodeViewOnlyLinkDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIV
 
     def get_object(self):
         try:
-            return self.get_node().private_links.get(_id=self.kwargs['link_id'])
+            return self.get_node().private_links.get(_id=self.kwargs['link_id'], is_deleted=False)
         except PrivateLink.DoesNotExist:
             raise NotFound
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from rest_framework import serializers as ser
 from rest_framework import exceptions
 from api.base.exceptions import Conflict, InvalidModelValueError
-
+from api.base.serializers import is_anonymized
 from api.base.utils import absolute_reverse, get_user_auth, is_truthy
 from website.project.metadata.utils import is_prereg_admin_not_project_admin
 from website.project.model import NodeUpdateError
@@ -22,9 +22,9 @@ from api.base.serializers import (
 )
 from framework.auth.core import Auth
 from osf.exceptions import ValidationValueError, NodeStateError
-from osf.models import Node
+from osf.models import Node, RegistrationSchema
 from osf.utils import permissions
-
+from website.settings import ANONYMIZED_TITLES
 from framework.sentry import log_exception
 
 class RegistrationSerializer(NodeSerializer):
@@ -299,22 +299,14 @@ class RegistrationSerializer(NodeSerializer):
         read_only=True,
     )
 
-    links = LinksField({'self': 'get_registration_url', 'html': 'get_absolute_html_url'})
-
-    def get_registration_url(self, obj):
-        return absolute_reverse(
-            'registrations:registration-detail', kwargs={
-                'node_id': obj._id,
-                'version': self.context['request'].parser_context['kwargs']['version'],
-            },
-        )
+    links = LinksField({'html': 'get_absolute_html_url'})
 
     def get_absolute_url(self, obj):
-        return self.get_registration_url(obj)
+        return obj.get_absolute_url()
 
     def get_registered_meta(self, obj):
         if obj.registered_meta:
-            meta_values = obj.registered_meta.values()[0]
+            meta_values = self.anonymize_registered_meta(obj)
             try:
                 return json.loads(meta_values)
             except TypeError:
@@ -344,6 +336,21 @@ class RegistrationSerializer(NodeSerializer):
 
     def get_total_comments_count(self, obj):
         return obj.comment_set.filter(page='node', is_deleted=False).count()
+
+    def anonymize_registered_meta(self, obj):
+        """
+        Looks at every question on every page of the schema, for any titles
+        matching ANONYMIZED_TITLES.  If present, deletes that question's response
+        from meta_values.
+        """
+        meta_values = obj.registered_meta.values()[0]
+        if is_anonymized(self.context['request']):
+            registration_schema = RegistrationSchema.objects.get(_id=obj.registered_schema_id)
+            for page in registration_schema.schema['pages']:
+                for question in page['questions']:
+                    if question['title'] in ANONYMIZED_TITLES and meta_values.get(question.get('qid')):
+                        del meta_values[question['qid']]
+        return meta_values
 
     def check_admin_perms(self, registration, user, validated_data):
         """

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -77,7 +77,32 @@ class UserSerializer(JSONAPISerializer):
     writeable_method_fields = frozenset([
         'accepted_terms_of_service',
     ])
-    non_anonymized_fields = ['type']
+    anonymized_fields = [
+        'accepted_terms_of_service',
+        'active',
+        'can_view_reviews',
+        'date_registered',
+        'default_region',
+        'education',
+        'emails',
+        'employment',
+        'family_name',
+        'full_name',
+        'given_name',
+        'id',
+        'institutions',
+        'links',
+        'locale',
+        'middle_names',
+        'nodes',
+        'preprints',
+        'quickfiles',
+        'registrations',
+        'settings',
+        'social',
+        'suffix',
+        'timezone',
+    ]
     id = IDField(source='_id', read_only=True)
     type = TypeField()
     full_name = ser.CharField(source='fullname', required=True, label='Full name', help_text='Display name used in the general user interface', max_length=186)

--- a/api_tests/nodes/views/test_node_sparse_fieldsets.py
+++ b/api_tests/nodes/views/test_node_sparse_fieldsets.py
@@ -273,10 +273,9 @@ class TestSparseViewOnlyLinks:
             'fields[nodes]': 'title,current_user_can_comment,contributors',
             'fields[contributors]': 'id',
             'embed': 'contributors'
-        })  # current_user_can_comment is an anonymized field, should be removed
+        })  # current_user_can_comment and contributors are anonymized fields, should be removed
         assert res.status_code == 200
         assert res.json['data']['attributes'].keys() == ['title']
 
-        for contrib in res.json['data']['embeds']['contributors']['data']:
-            assert contrib['id'] == ''
-            assert contrib['attributes'] == {}
+        embeds = res.json['data'].get('embeds', None)
+        assert embeds is None or 'contributors' not in embeds

--- a/api_tests/nodes/views/test_node_view_only_links_list.py
+++ b/api_tests/nodes/views/test_node_view_only_links_list.py
@@ -30,6 +30,12 @@ def non_contrib():
 
 
 @pytest.fixture()
+def base_url(public_project):
+    return '/{}nodes/{}/view_only_links/'.format(
+        API_BASE, public_project._id)
+
+
+@pytest.fixture()
 def public_project(user, read_contrib, write_contrib):
     public_project = ProjectFactory(is_public=True, creator=user)
     public_project.add_contributor(
@@ -53,12 +59,11 @@ def view_only_link(public_project):
 class TestViewOnlyLinksList:
 
     @pytest.fixture()
-    def url(self, public_project, view_only_link):
-        return '/{}nodes/{}/view_only_links/'.format(
-            API_BASE, public_project._id)
+    def url(self, base_url):
+        return base_url
 
     def test_non_mutating_view_only_links_list_tests(
-            self, app, user, write_contrib, read_contrib, non_contrib, url):
+            self, app, user, write_contrib, read_contrib, non_contrib, url, public_project, view_only_link):
 
         #   test_admin_can_view_vols_list
         res = app.get(url, auth=user.auth)
@@ -83,7 +88,7 @@ class TestViewOnlyLinksList:
         res = app.get(url, expect_errors=True)
         assert res.status_code == 401
 
-    def test_deleted_vols_not_returned(self, app, user, url, public_project):
+    def test_deleted_vols_not_returned(self, app, user, url, public_project, view_only_link):
         view_only_link = PrivateLinkFactory(name='testlink2')
         view_only_link.nodes.add(public_project)
         view_only_link.save()
@@ -93,7 +98,7 @@ class TestViewOnlyLinksList:
         assert res.status_code == 200
         assert len(data) == 2
 
-        view_only_link.nodes.remove(public_project)
+        view_only_link.is_deleted = True
         view_only_link.save()
 
         res = app.get(url, auth=user.auth)
@@ -107,9 +112,8 @@ class TestViewOnlyLinksList:
 class TestViewOnlyLinksCreate:
 
     @pytest.fixture()
-    def url(self, public_project):
-        return '/{}nodes/{}/view_only_links/'.format(
-            API_BASE, public_project._id)
+    def url(self, base_url):
+        return base_url
 
     def test_invalid_vol_name(self, app, user, url):
         payload = {
@@ -126,9 +130,8 @@ class TestViewOnlyLinksCreate:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Invalid link name.'
 
-    def test_default_anonymous_not_in_payload(self, app, user, public_project):
-        url = '/{}nodes/{}/view_only_links/?embed=creator'.format(
-            API_BASE, public_project._id)
+    def test_default_anonymous_not_in_payload(self, app, user, public_project, base_url):
+        url = '{}?embed=creator'.format(base_url)
         payload = {
             'attributes': {
                 'name': 'testlink',
@@ -141,9 +144,8 @@ class TestViewOnlyLinksCreate:
         assert not data['attributes']['anonymous']
         assert data['embeds']['creator']['data']['id'] == user._id
 
-    def test_default_name_not_in_payload(self, app, user, public_project):
-        url = '/{}nodes/{}/view_only_links/?embed=creator'.format(
-            API_BASE, public_project._id)
+    def test_default_name_not_in_payload(self, app, user, public_project, base_url):
+        url = '{}?embed=creator'.format(base_url)
         payload = {
             'attributes': {
                 'anonymous': False,
@@ -157,9 +159,8 @@ class TestViewOnlyLinksCreate:
         assert data['embeds']['creator']['data']['id'] == user._id
 
     def test_admin_can_create_vol(
-            self, app, user, public_project, view_only_link):
-        url = '/{}nodes/{}/view_only_links/?embed=creator'.format(
-            API_BASE, public_project._id)
+            self, app, user, url, public_project, view_only_link):
+        url = '{}?embed=creator'.format(url)
         payload = {
             'attributes': {
                 'name': 'testlink',

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -214,9 +214,8 @@ class TestNodeDetailViewOnlyLinks:
             'embed': 'contributors',
         })
         assert res.status_code == 200
-        contributors = res.json['data']['embeds']['contributors']['data']
-        for contributor in contributors:
-            assert contributor['id'] == ''
+        embeds = res.json['data'].get('embeds', None)
+        assert embeds is None or 'contributors' not in embeds
 
     #   test_private_node_with_link_non_anonymous_does_expose_contributor_id
         res = app.get(private_node_one_url, {
@@ -244,9 +243,8 @@ class TestNodeDetailViewOnlyLinks:
             'embed': 'contributors',
         })
         assert res.status_code == 200
-        contributors = res.json['data']['embeds']['contributors']['data']
-        for contributor in contributors:
-            assert contributor['id'] == ''
+        embeds = res.json['data'].get('embeds', None)
+        assert embeds is None or 'contributors' not in embeds
 
     #   test_public_node_with_link_non_anonymous_does_expose_contributor_id
         res = app.get(public_node_one_url, {
@@ -428,13 +426,9 @@ class TestNodeListViewOnlyLinks:
         nodes = res.json['data']
         assertions = 0
         for node in nodes:
-            contributors = node['embeds']['contributors']['data']
-            for contributor in contributors:
-                assertions += 1
-                assert contributor['id'] == ''
-                assert contributor['type'] == 'contributors'
-                assert contributor['links'] == {}
-                assert 'relationships' not in contributor
+            embeds = node.get('embeds', None)
+            assert embeds is None or 'contributors' not in embeds
+            assertions += 1
         assert assertions != 0
 
     #   test_non_anonymous_link_does_show_contributor_id_in_node_list

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -409,6 +409,9 @@ class TestNodeListViewOnlyLinks:
             for contributor in contributors:
                 assertions += 1
                 assert contributor['id'] == ''
+                assert contributor['type'] == 'contributors'
+                assert contributor['links'] == {}
+                assert 'relationships' not in contributor
         assert assertions != 0
 
     #   test_non_anonymous_link_does_show_contributor_id_in_node_list

--- a/api_tests/registrations/views/test_registration_view_only_links_detail.py
+++ b/api_tests/registrations/views/test_registration_view_only_links_detail.py
@@ -1,0 +1,71 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.nodes.views.test_node_view_only_links_detail import (
+    TestViewOnlyLinksDetail,
+    TestViewOnlyLinksUpdate,
+    TestViewOnlyLinksDelete,
+)
+from osf_tests.factories import (
+    RegistrationFactory,
+    AuthUserFactory,
+    PrivateLinkFactory
+)
+from osf.utils import permissions
+
+
+@pytest.fixture()
+def url(public_project, view_only_link):
+    return '/{}registrations/{}/view_only_links/{}/'.format(
+        API_BASE, public_project._id, view_only_link._id)
+
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def read_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def write_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def non_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def public_project(user, read_contrib, write_contrib):
+    public_project = RegistrationFactory(is_public=True, creator=user)
+    public_project.add_contributor(
+        read_contrib, permissions=[permissions.READ])
+    public_project.add_contributor(
+        write_contrib, permissions=[permissions.READ, permissions.WRITE])
+    public_project.save()
+    return public_project
+
+
+@pytest.fixture()
+def view_only_link(public_project):
+    view_only_link = PrivateLinkFactory(name='testlink')
+    view_only_link.nodes.add(public_project)
+    view_only_link.save()
+    return view_only_link
+
+
+@pytest.mark.django_db
+class TestRegistrationViewOnlyLinksDetail(TestViewOnlyLinksDetail):
+    pass
+
+@pytest.mark.django_db
+class TestRegistrationViewOnlyLinksUpdate(TestViewOnlyLinksUpdate):
+    pass
+
+@pytest.mark.django_db
+class TestRegistrationViewOnlyLinksDelete(TestViewOnlyLinksDelete):
+    pass

--- a/api_tests/registrations/views/test_registration_view_only_links_list.py
+++ b/api_tests/registrations/views/test_registration_view_only_links_list.py
@@ -1,0 +1,66 @@
+import pytest
+
+from osf.utils import permissions
+from api.base.settings.defaults import API_BASE
+from api_tests.nodes.views.test_node_view_only_links_list import (
+    TestViewOnlyLinksList,
+    TestViewOnlyLinksCreate,
+)
+from osf_tests.factories import (
+    RegistrationFactory,
+    AuthUserFactory,
+    PrivateLinkFactory
+)
+
+
+@pytest.fixture()
+def base_url(public_project):
+    return '/{}registrations/{}/view_only_links/'.format(
+        API_BASE, public_project._id)
+
+
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def read_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def write_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def non_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def public_project(user, read_contrib, write_contrib):
+    public_project = RegistrationFactory(is_public=True, creator=user)
+    public_project.add_contributor(
+        read_contrib, permissions=[permissions.READ])
+    public_project.add_contributor(
+        write_contrib, permissions=[permissions.READ, permissions.WRITE])
+    public_project.save()
+    return public_project
+
+
+@pytest.fixture()
+def view_only_link(public_project):
+    view_only_link = PrivateLinkFactory(name='testlink')
+    view_only_link.nodes.add(public_project)
+    view_only_link.save()
+    return view_only_link
+
+
+class TestRegistrationViewOnlyLinksList(TestViewOnlyLinksList):
+    pass
+
+
+class TestRegistrationViewOnlyLinksCreate(TestViewOnlyLinksCreate):
+    pass

--- a/api_tests/registrations/views/test_view_only_query_parameter.py
+++ b/api_tests/registrations/views/test_view_only_query_parameter.py
@@ -1,0 +1,215 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.nodes.views.test_view_only_query_parameter import (
+    TestNodeDetailViewOnlyLinks,
+    TestNodeListViewOnlyLinks,
+)
+from osf_tests.factories import (
+    RegistrationFactory,
+    AuthUserFactory,
+    PrivateLinkFactory,
+)
+from osf.models import RegistrationSchema
+from osf.utils import permissions
+
+
+@pytest.fixture()
+def admin():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def base_url():
+    return '/{}registrations/'.format(API_BASE)
+
+
+@pytest.fixture()
+def read_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def write_contrib():
+    return AuthUserFactory()
+
+
+@pytest.fixture()
+def valid_contributors(admin, read_contrib, write_contrib):
+    return [
+        admin._id,
+        read_contrib._id,
+        write_contrib._id,
+    ]
+
+
+@pytest.fixture()
+def private_node_one(admin, read_contrib, write_contrib):
+    private_node_one = RegistrationFactory(
+        is_public=False,
+        creator=admin,
+        title='Private One')
+    private_node_one.add_contributor(
+        read_contrib, permissions=[
+            permissions.READ], save=True)
+    private_node_one.add_contributor(
+        write_contrib,
+        permissions=[
+            permissions.READ,
+            permissions.WRITE],
+        save=True)
+    return private_node_one
+
+
+@pytest.fixture()
+def private_node_one_anonymous_link(private_node_one):
+    private_node_one_anonymous_link = PrivateLinkFactory(anonymous=True)
+    private_node_one_anonymous_link.nodes.add(private_node_one)
+    private_node_one_anonymous_link.save()
+    return private_node_one_anonymous_link
+
+
+@pytest.fixture()
+def private_node_one_private_link(private_node_one):
+    private_node_one_private_link = PrivateLinkFactory(anonymous=False)
+    private_node_one_private_link.nodes.add(private_node_one)
+    private_node_one_private_link.save()
+    return private_node_one_private_link
+
+
+@pytest.fixture()
+def private_node_one_url(private_node_one):
+    return '/{}registrations/{}/'.format(API_BASE, private_node_one._id)
+
+
+@pytest.fixture()
+def private_node_two(admin, read_contrib, write_contrib):
+    private_node_two = RegistrationFactory(
+        is_public=False,
+        creator=admin,
+        title='Private Two')
+    private_node_two.add_contributor(
+        read_contrib, permissions=[permissions.READ], save=True)
+    private_node_two.add_contributor(
+        write_contrib,
+        permissions=[
+            permissions.READ,
+            permissions.WRITE],
+        save=True)
+    return private_node_two
+
+
+@pytest.fixture()
+def private_node_two_url(private_node_two):
+    return '/{}registrations/{}/'.format(API_BASE, private_node_two._id)
+
+
+@pytest.fixture()
+def public_node_one(admin, read_contrib, write_contrib):
+    public_node_one = RegistrationFactory(
+        is_public=True, creator=admin, title='Public One')
+    public_node_one.add_contributor(
+        read_contrib, permissions=[permissions.READ], save=True)
+    public_node_one.add_contributor(
+        write_contrib,
+        permissions=[
+            permissions.READ,
+            permissions.WRITE],
+        save=True)
+    return public_node_one
+
+
+@pytest.fixture()
+def public_node_one_anonymous_link(public_node_one):
+    public_node_one_anonymous_link = PrivateLinkFactory(anonymous=True)
+    public_node_one_anonymous_link.nodes.add(public_node_one)
+    public_node_one_anonymous_link.save()
+    return public_node_one_anonymous_link
+
+
+@pytest.fixture()
+def public_node_one_private_link(public_node_one):
+    public_node_one_private_link = PrivateLinkFactory(anonymous=False)
+    public_node_one_private_link.nodes.add(public_node_one)
+    public_node_one_private_link.save()
+    return public_node_one_private_link
+
+
+@pytest.fixture()
+def public_node_one_url(public_node_one):
+    return '/{}registrations/{}/'.format(API_BASE, public_node_one._id)
+
+
+@pytest.fixture()
+def public_node_two(admin, read_contrib, write_contrib):
+    public_node_two = RegistrationFactory(
+        is_public=True, creator=admin, title='Public Two')
+    public_node_two.add_contributor(
+        read_contrib, permissions=[permissions.READ], save=True)
+    public_node_two.add_contributor(
+        write_contrib,
+        permissions=[
+            permissions.READ,
+            permissions.WRITE],
+        save=True)
+    return public_node_two
+
+
+@pytest.fixture()
+def public_node_two_url(public_node_two):
+    return '/{}registrations/{}/'.format(API_BASE, public_node_two._id)
+
+
+class TestRegistrationDetailViewOnlyLinks(TestNodeDetailViewOnlyLinks):
+    @pytest.fixture()
+    def registration_schema(self):
+        name = 'Registered Report Protocol Preregistration'
+        return RegistrationSchema.objects.get(name=name, schema_version=2)
+
+    @pytest.fixture()
+    def reg_report(self, registration_schema, admin):
+        registration = RegistrationFactory(schema=registration_schema, creator=admin, is_public=False)
+        registration.registered_meta[registration_schema._id] = {
+            'q1': {
+                'comments': [],
+                'extra': [],
+                'value': 'This is the answer to a question'
+            },
+            'q2': {
+                'comments': [],
+                'extra': [],
+                'value': 'Grapes McGee'
+            }
+
+        }
+        registration.save()
+        return registration
+
+    @pytest.fixture()
+    def reg_report_anonymous_link(self, reg_report):
+        anon_link = PrivateLinkFactory(anonymous=True)
+        anon_link.nodes.add(reg_report)
+        anon_link.save()
+        return anon_link
+
+    def test_author_questions_are_anonymous(self, app, base_url, reg_report, admin, reg_report_anonymous_link):
+        # Admin contributor sees q2 (author question)
+        url = '/{}registrations/{}/'.format(API_BASE, reg_report._id)
+        res = app.get(url, auth=admin.auth)
+        assert res.status_code == 200
+        meta = res.json['data']['attributes']['registered_meta']
+        assert 'q1' in meta
+        assert 'q2' in meta
+
+        # Anonymous view only link has q2 (author response) removed
+        res = app.get(url, {
+            'view_only': reg_report_anonymous_link.key
+        })
+        assert res.status_code == 200
+        meta = res.json['data']['attributes']['registered_meta']
+        assert 'q1' in meta
+        assert 'q2' not in meta
+
+
+class TestRegistrationListViewOnlyLinks(TestNodeListViewOnlyLinks):
+    pass

--- a/osf/utils/permissions.py
+++ b/osf/utils/permissions.py
@@ -57,7 +57,7 @@ def reduce_permissions(permissions):
 def check_private_key_for_anonymized_link(private_key):
     from osf.models import PrivateLink
     try:
-        link = PrivateLink.objects.get(key=private_key)
+        link = PrivateLink.objects.get(key=private_key, is_deleted=False)
     except PrivateLink.DoesNotExist:
         return False
     return link.anonymous

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -272,7 +272,7 @@ def node_forks(auth, node, **kwargs):
 @must_have_permission(READ)
 @ember_flag_is_active(features.EMBER_PROJECT_SETTINGS)
 def node_setting(auth, node, **kwargs):
-    if node.is_registration and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
+    if node.is_registration and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
         # Registration settings page obviated during redesign
         return redirect(node.url)
     auth.user.update_affiliated_institutions_by_email_domain()

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -124,7 +124,7 @@ def node_registration_retraction_post(auth, node, **kwargs):
 @must_be_contributor_or_public
 @ember_flag_is_active(features.EMBER_REGISTRATION_FORM_DETAIL)
 def node_register_template_page(auth, node, metaschema_id, **kwargs):
-    if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
+    if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
         # Registration meta page obviated during redesign
         return redirect(node.url)
     if node.is_registration and bool(node.registered_schema):

--- a/website/views.py
+++ b/website/views.py
@@ -301,9 +301,7 @@ def resolve_guid(guid, suffix=None):
         if isinstance(referent, Registration) and (
                 not suffix or suffix.rstrip('/').lower() in ('comments', 'links', 'components')
         ):
-            # Ideally, auth wouldn't be checked here. Necessary for routing
-            auth = Auth.from_kwargs(request.args.to_dict(), {})
-            if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE) and not auth.private_link:
+            if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
                 # Route only the base detail view to ember
                 if PROXY_EMBER_APPS:
                     resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)


### PR DESCRIPTION
### NOTE: Depends on FE changes -- merge/release those first (or at the same time): https://github.com/CenterForOpenScience/ember-osf-web/pull/660

## Purpose

Registrations in the API viewed with and without view-only links should contain most of the same information except user-identifying information.  We're currently filtering too much relevant information when a registration is viewed through a VOL.  Registered_meta needs to strip identifying information from the schema responses.  We lack good registration VOL tests - as a part of adding registration VOL tests, fix any bugs found.

## Changes

- To specify which fields should be anonymized, hardcode the anonymized_fields on the serializer, instead of all the fields that shouldn't be anonymized. (anonymized_fields will usu be the exception, not the rule). This change exposes `registered_meta` which wasn't being displayed before
- Delete question responses that have been specified as having identifying information
- Add Registration VOL crud tests
- Fix bugs in ENG-52 -  APIv2 Returning deleted VOL's and unable to make VOL's anonymous

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-52
https://openscience.atlassian.net/browse/ENG-440
