### PR TITLE
[ENG-450] Check if the email is verified when deleting them.

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -896,7 +896,7 @@ class UserEmailsDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, U
     def perform_destroy(self, instance):
         user = self.get_user()
         email = instance.address
-        if instance.confirmed:
+        if instance.confirmed and instance.verified:
             try:
                 user.remove_email(email)
             except PermissionsError as e:


### PR DESCRIPTION
## Purpose

When clicking the `Do not add` button on the modal after logging in through the confirmation link, the email is not actually removed. This PR fixes the problem.

## Changes

After the user clicks the link, the `UserEmail` object returned by `get_object` is `confirmed` but not `verified`. So if we are removing the email, we should remove the corresponding key-value pair from `user.email_verification`, which is done by invoking the `remove_unconfirmed_email()` method.

## Ticket

https://openscience.atlassian.net/browse/ENG-450
