### PR TITLE
Feature/Waffle off OSFGroups APIv2 Endpoints [ENG-145]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -50,6 +50,7 @@ from api.base.views import (
     LinkedRegistrationsRelationship,
     WaterButlerMixin,
 )
+from api.base.waffle_decorators import require_flag
 from api.citations.utils import render_citation
 from api.comments.permissions import CanCommentOrPublic
 from api.comments.serializers import (
@@ -117,6 +118,7 @@ from api.users.serializers import UserSerializer
 from api.wikis.serializers import NodeWikiSerializer
 from framework.exceptions import HTTPError, PermissionsError
 from framework.auth.oauth_scopes import CoreScopes
+from osf.features import OSF_GROUPS
 from osf.models import AbstractNode
 from osf.models import (Node, PrivateLink, Institution, Comment, DraftRegistration, Registration, )
 from osf.models import OSFUser
@@ -1202,6 +1204,7 @@ class NodeGroupsList(NodeGroupsBase, generics.ListCreateAPIView, ListFilterMixin
     serializer_class = NodeGroupsSerializer
     view_name = 'node-groups'
 
+    @require_flag(OSF_GROUPS)
     def get_default_queryset(self):
         return self.get_node().osf_groups
 
@@ -1236,6 +1239,10 @@ class NodeGroupsList(NodeGroupsBase, generics.ListCreateAPIView, ListFilterMixin
         context['node'] = self.get_node(check_object_permissions=False)
         return context
 
+    @require_flag(OSF_GROUPS)
+    def perform_create(self, serializer):
+        return super(NodeGroupsList, self).perform_create(serializer)
+
 
 class NodeGroupsDetail(NodeGroupsBase, generics.RetrieveUpdateDestroyAPIView):
     """ The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_groups_read)
@@ -1252,6 +1259,7 @@ class NodeGroupsDetail(NodeGroupsBase, generics.RetrieveUpdateDestroyAPIView):
     view_name = 'node-group-detail'
 
     # Overrides RetrieveUpdateDestroyAPIView
+    @require_flag(OSF_GROUPS)
     def get_object(self):
         node = self.get_node(check_object_permissions=False)
         # Node permissions checked when group is loaded
@@ -1261,6 +1269,7 @@ class NodeGroupsDetail(NodeGroupsBase, generics.RetrieveUpdateDestroyAPIView):
         return group
 
     # Overrides RetrieveUpdateDestroyAPIView
+    @require_flag(OSF_GROUPS)
     def perform_destroy(self, instance):
         node = self.get_node(check_object_permissions=False)
         auth = get_user_auth(self.request)

--- a/api/osf_groups/views.py
+++ b/api/osf_groups/views.py
@@ -10,6 +10,7 @@ from api.base.filters import ListFilterMixin
 from api.base.utils import get_object_or_error, get_user_auth, is_bulk_request
 from api.base.views import JSONAPIBaseView
 from api.base import generic_bulk_views as bulk_views
+from api.base.waffle_decorators import require_flag
 from api.osf_groups.permissions import IsGroupManager, GroupMemberManagement
 from api.osf_groups.serializers import (
     GroupSerializer,
@@ -20,6 +21,7 @@ from api.osf_groups.serializers import (
 )
 from api.users.views import UserMixin
 from framework.auth.oauth_scopes import CoreScopes
+from osf.features import OSF_GROUPS
 from osf.models import OSFGroup, OSFUser
 from osf.utils.permissions import MANAGER, GROUP_ROLES
 
@@ -62,6 +64,7 @@ class GroupList(GroupBaseView, generics.ListCreateAPIView, ListFilterMixin):
     view_name = 'group-list'
     ordering = ('-modified', )
 
+    @require_flag(OSF_GROUPS)
     def get_default_queryset(self):
         user = self.request.user
         if user.is_anonymous:
@@ -73,6 +76,7 @@ class GroupList(GroupBaseView, generics.ListCreateAPIView, ListFilterMixin):
         return self.get_queryset_from_request()
 
     # overrides ListCreateAPIView
+    @require_flag(OSF_GROUPS)
     def perform_create(self, serializer):
         """Create an OSFGroup.
 
@@ -94,10 +98,12 @@ class GroupDetail(GroupBaseView, generics.RetrieveUpdateDestroyAPIView):
     view_name = 'group-detail'
 
     # Overrides RetrieveUpdateDestroyAPIView
+    @require_flag(OSF_GROUPS)
     def get_object(self):
         return self.get_osf_group()
 
     # Overrides RetrieveUpdateDestroyAPIView
+    @require_flag(OSF_GROUPS)
     def perform_destroy(self, instance):
         auth = get_user_auth(self.request)
         instance.remove_group(auth=auth)
@@ -136,6 +142,7 @@ class OSFGroupMemberBaseView(JSONAPIBaseView, OSFGroupMixin):
             return GroupMemberSerializer
 
     # overrides DestroyAPIView
+    @require_flag(OSF_GROUPS)
     def perform_destroy(self, instance):
         group = self.get_osf_group()
         auth = get_user_auth(self.request)
@@ -166,6 +173,7 @@ class GroupMembersList(OSFGroupMemberBaseView, bulk_views.BulkUpdateJSONAPIView,
         return queryset
 
     # Overrides ListFilterMixin
+    @require_flag(OSF_GROUPS)
     def get_default_queryset(self):
         # Returns all members and managers of the OSF Group (User objects)
         return self.get_osf_group().members
@@ -208,6 +216,10 @@ class GroupMembersList(OSFGroupMemberBaseView, bulk_views.BulkUpdateJSONAPIView,
             return Q(id__in=group.managers if role == MANAGER else group.members_only)
         return super(GroupMembersList, self).build_query_from_field(field_name, operation)
 
+    @require_flag(OSF_GROUPS)
+    def perform_create(self, serializer):
+        return super(GroupMembersList, self).perform_create(serializer)
+
 
 class GroupMemberDetail(OSFGroupMemberBaseView, generics.RetrieveUpdateDestroyAPIView, UserMixin):
     permission_classes = (
@@ -218,6 +230,7 @@ class GroupMemberDetail(OSFGroupMemberBaseView, generics.RetrieveUpdateDestroyAP
     view_name = 'group-member-detail'
 
     # Overrides RetrieveUpdateDestroyAPIView
+    @require_flag(OSF_GROUPS)
     def get_object(self):
         user = self.get_user()
         self._assert_member_belongs_to_group(user)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -5,6 +5,7 @@ from django.db.models import F, Q
 
 from api.addons.views import AddonSettingsMixin
 from api.base import permissions as base_permissions
+from api.base.waffle_decorators import require_flag
 from api.base.exceptions import Conflict, UserGone
 from api.base.filters import ListFilterMixin, PreprintFilterMixin
 from api.base.parsers import (
@@ -62,6 +63,7 @@ from framework.auth.exceptions import ChangePasswordError
 from framework.utils import throttle_period_expired
 from framework.sessions.utils import remove_sessions_for_user
 from framework.exceptions import PermissionsError, HTTPError
+from osf.features import OSF_GROUPS
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 from rest_framework import status
@@ -349,6 +351,7 @@ class UserGroups(JSONAPIBaseView, generics.ListAPIView, UserMixin, ListFilterMix
     view_name = 'user-groups'
     ordering = ('-modified', )
 
+    @require_flag(OSF_GROUPS)
     def get_default_queryset(self):
         requested_user = self.get_user()
         current_user = self.request.user

--- a/api_tests/nodes/views/test_node_groups.py
+++ b/api_tests/nodes/views/test_node_groups.py
@@ -1,5 +1,6 @@
 import pytest
 from guardian.shortcuts import get_perms
+from waffle.testutils import override_flag
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
@@ -9,6 +10,8 @@ from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
+
 
 @pytest.fixture()
 def write_contrib():
@@ -80,7 +83,6 @@ def make_node_group_payload():
 
 @pytest.mark.django_db
 class TestNodeGroupsList:
-
     @pytest.fixture()
     def make_group_id(self):
         def contrib_id(node, group):
@@ -88,92 +90,94 @@ class TestNodeGroupsList:
         return contrib_id
 
     def test_return(self, app, non_contrib, osf_group, member, manager, public_project, private_project, public_url, private_url, make_group_id):
-        public_project.add_osf_group(osf_group, permissions.WRITE)
+        with override_flag(OSF_GROUPS, active=True):
+            public_project.add_osf_group(osf_group, permissions.WRITE)
 
-        # public url logged out
-        res = app.get(public_url)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(public_project, osf_group) in ids
-        assert resp_json[0]['attributes']['permission'] == permissions.WRITE
+            # public url logged out
+            res = app.get(public_url)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(public_project, osf_group) in ids
+            assert resp_json[0]['attributes']['permission'] == permissions.WRITE
 
-        # private project logged in
-        private_project.add_osf_group(osf_group, permissions.READ)
-        res = app.get(private_url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) in ids
-        assert resp_json[0]['attributes']['permission'] == permissions.READ
+            # private project logged in
+            private_project.add_osf_group(osf_group, permissions.READ)
+            res = app.get(private_url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) in ids
+            assert resp_json[0]['attributes']['permission'] == permissions.READ
 
-        # private project logged out
-        res = app.get(private_url, expect_errors=True)
-        assert res.status_code == 401
+            # private project logged out
+            res = app.get(private_url, expect_errors=True)
+            assert res.status_code == 401
 
-        # private project non_contrib
-        res = app.get(private_url, auth=non_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # private project non_contrib
+            res = app.get(private_url, auth=non_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # private project group_member
-        res = app.get(private_url, auth=member.auth, expect_errors=True)
-        assert res.status_code == 200
+            # private project group_member
+            res = app.get(private_url, auth=member.auth, expect_errors=True)
+            assert res.status_code == 200
 
-        # private project group_manager
-        res = app.get(private_url, auth=member.auth, expect_errors=True)
-        assert res.status_code == 200
+            # private project group_manager
+            res = app.get(private_url, auth=member.auth, expect_errors=True)
+            assert res.status_code == 200
 
     def test_filter_groups(self, app, osf_group, private_project, manager, private_url, make_group_id):
-        read_group = OSFGroupFactory(creator=manager, name='house')
-        write_group = OSFGroupFactory(creator=manager, name='doghouse')
-        private_project.add_osf_group(read_group, permissions.READ)
-        private_project.add_osf_group(write_group, permissions.WRITE)
-        private_project.add_osf_group(osf_group, permissions.ADMIN)
+        with override_flag(OSF_GROUPS, active=True):
+            read_group = OSFGroupFactory(creator=manager, name='house')
+            write_group = OSFGroupFactory(creator=manager, name='doghouse')
+            private_project.add_osf_group(read_group, permissions.READ)
+            private_project.add_osf_group(write_group, permissions.WRITE)
+            private_project.add_osf_group(osf_group, permissions.ADMIN)
 
-        # test filter on permission
-        url = private_url + '?filter[permission]=admin'
-        res = app.get(url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) in ids
-        assert make_group_id(private_project, write_group) not in ids
-        assert make_group_id(private_project, read_group) not in ids
+            # test filter on permission
+            url = private_url + '?filter[permission]=admin'
+            res = app.get(url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) in ids
+            assert make_group_id(private_project, write_group) not in ids
+            assert make_group_id(private_project, read_group) not in ids
 
-        url = private_url + '?filter[permission]=write'
-        res = app.get(url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) in ids
-        assert make_group_id(private_project, write_group) in ids
-        assert make_group_id(private_project, read_group) not in ids
+            url = private_url + '?filter[permission]=write'
+            res = app.get(url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) in ids
+            assert make_group_id(private_project, write_group) in ids
+            assert make_group_id(private_project, read_group) not in ids
 
-        url = private_url + '?filter[permission]=read'
-        res = app.get(url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) in ids
-        assert make_group_id(private_project, write_group) in ids
-        assert make_group_id(private_project, read_group) in ids
+            url = private_url + '?filter[permission]=read'
+            res = app.get(url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) in ids
+            assert make_group_id(private_project, write_group) in ids
+            assert make_group_id(private_project, read_group) in ids
 
-        # test_filter_on_invalid_permission
-        url = private_url + '?filter[permission]=bad_perm'
-        res = app.get(url, auth=private_project.creator.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_perm is not a filterable permission.'
+            # test_filter_on_invalid_permission
+            url = private_url + '?filter[permission]=bad_perm'
+            res = app.get(url, auth=private_project.creator.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_perm is not a filterable permission.'
 
-        url = private_url + '?filter[name]=Plat'
-        res = app.get(url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) in ids
-        assert make_group_id(private_project, write_group) not in ids
-        assert make_group_id(private_project, read_group) not in ids
+            url = private_url + '?filter[name]=Plat'
+            res = app.get(url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) in ids
+            assert make_group_id(private_project, write_group) not in ids
+            assert make_group_id(private_project, read_group) not in ids
 
-        url = private_url + '?filter[name]=house'
-        res = app.get(url, auth=private_project.creator.auth)
-        resp_json = res.json['data']
-        ids = [each['id'] for each in resp_json]
-        assert make_group_id(private_project, osf_group) not in ids
-        assert make_group_id(private_project, write_group) in ids
-        assert make_group_id(private_project, read_group) in ids
+            url = private_url + '?filter[name]=house'
+            res = app.get(url, auth=private_project.creator.auth)
+            resp_json = res.json['data']
+            ids = [each['id'] for each in resp_json]
+            assert make_group_id(private_project, osf_group) not in ids
+            assert make_group_id(private_project, write_group) in ids
+            assert make_group_id(private_project, read_group) in ids
 
 
 @pytest.mark.django_db
@@ -181,147 +185,150 @@ class TestNodeGroupCreate:
 
     def test_create_node_groups(self, app, osf_group, public_url, non_contrib, member, manager,
                                 public_project, write_contrib, make_node_group_payload):
-        attributes = {'permission': permissions.WRITE}
-        relationships = {
-            'groups': {
-                'data': {
-                    'type': 'groups',
-                    'id': osf_group._id,
+        with override_flag(OSF_GROUPS, active=True):
+            attributes = {'permission': permissions.WRITE}
+            relationships = {
+                'groups': {
+                    'data': {
+                        'type': 'groups',
+                        'id': osf_group._id,
+                    }
                 }
             }
-        }
-        payload = make_node_group_payload(attributes=attributes, relationships=relationships)
+            payload = make_node_group_payload(attributes=attributes, relationships=relationships)
 
-        # test add group noncontrib fails
-        res = app.post_json_api(public_url, payload, auth=non_contrib, expect_errors=True)
-        assert res.status_code == 401
+            # test add group noncontrib fails
+            res = app.post_json_api(public_url, payload, auth=non_contrib, expect_errors=True)
+            assert res.status_code == 401
 
-        # add group with write permissions fails
-        res = app.post_json_api(public_url, payload, auth=write_contrib, expect_errors=True)
-        assert res.status_code == 401
+            # add group with write permissions fails
+            res = app.post_json_api(public_url, payload, auth=write_contrib, expect_errors=True)
+            assert res.status_code == 401
 
-        # add group with admin on node but not manager in group
-        res = app.post_json_api(public_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 403
+            # add group with admin on node but not manager in group
+            res = app.post_json_api(public_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # create group with admin permissions on node and manager permissions in group
-        public_project.add_contributor(manager, permissions=permissions.ADMIN, auth=Auth(public_project.creator), save=True)
+            # create group with admin permissions on node and manager permissions in group
+            public_project.add_contributor(manager, permissions=permissions.ADMIN, auth=Auth(public_project.creator), save=True)
 
-        # test_perm_not_specified - given write by default
-        relationship_only = make_node_group_payload(attributes={}, relationships=relationships)
-        res = app.post_json_api(public_url, relationship_only, auth=manager.auth)
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['permission'] == permissions.WRITE
-        assert osf_group._id in res.json['data']['relationships']['groups']['links']['related']['href']
+            # test_perm_not_specified - given write by default
+            relationship_only = make_node_group_payload(attributes={}, relationships=relationships)
+            res = app.post_json_api(public_url, relationship_only, auth=manager.auth)
+            assert res.status_code == 201
+            assert res.json['data']['attributes']['permission'] == permissions.WRITE
+            assert osf_group._id in res.json['data']['relationships']['groups']['links']['related']['href']
 
-        public_project.remove_osf_group(osf_group)
+            public_project.remove_osf_group(osf_group)
 
-        # test_relationship_not_specified
-        attributes_only = make_node_group_payload(attributes=attributes)
-        res = app.post_json_api(public_url, attributes_only, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group relationship must be specified.'
+            # test_relationship_not_specified
+            attributes_only = make_node_group_payload(attributes=attributes)
+            res = app.post_json_api(public_url, attributes_only, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group relationship must be specified.'
 
-        # test_group_is_invalid
-        relationships = {
-            'groups': {
-                'data': {
-                    'type': 'groups',
-                    'id': '12345',
+            # test_group_is_invalid
+            relationships = {
+                'groups': {
+                    'data': {
+                        'type': 'groups',
+                        'id': '12345',
+                    }
                 }
             }
-        }
-        invalid_group = make_node_group_payload(attributes=attributes, relationships=relationships)
-        res = app.post_json_api(public_url, invalid_group, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == 'Group {} is invalid.'.format('12345')
+            invalid_group = make_node_group_payload(attributes=attributes, relationships=relationships)
+            res = app.post_json_api(public_url, invalid_group, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == 'Group {} is invalid.'.format('12345')
 
-        # test_admin_perms
-        res = app.post_json_api(public_url, payload, auth=manager.auth)
-        assert public_project in osf_group.nodes
-        assert public_project.has_permission(member, permissions.WRITE)
-        assert res.json['data']['attributes']['permission'] == permissions.WRITE
-        assert osf_group._id in res.json['data']['relationships']['groups']['links']['related']['href']
+            # test_admin_perms
+            res = app.post_json_api(public_url, payload, auth=manager.auth)
+            assert public_project in osf_group.nodes
+            assert public_project.has_permission(member, permissions.WRITE)
+            assert res.json['data']['attributes']['permission'] == permissions.WRITE
+            assert osf_group._id in res.json['data']['relationships']['groups']['links']['related']['href']
 
-        # test creating group a second time fails
-        res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'The group {} has already been added to the node {}'.format(
-            osf_group._id, public_project._id
-        )
+            # test creating group a second time fails
+            res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'The group {} has already been added to the node {}'.format(
+                osf_group._id, public_project._id
+            )
 
-        # test incorrect permission string
-        public_project.remove_osf_group(osf_group)
-        payload['data']['attributes']['permission'] = 'not a real perm'
-        res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'not a real perm is not a valid permission.'
+            # test incorrect permission string
+            public_project.remove_osf_group(osf_group)
+            payload['data']['attributes']['permission'] = 'not a real perm'
+            res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'not a real perm is not a valid permission.'
 
-        # test_incorrect_type
-        payload['data']['type'] = 'incorrect_type'
-        res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test_incorrect_type
+            payload['data']['type'] = 'incorrect_type'
+            res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # test not a real group
-        payload['data']['type'] = 'node-groups'
-        payload['data']['relationships']['groups']['data']['id'] = 'not_a_real_group_id'
-        res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
+            # test not a real group
+            payload['data']['type'] = 'node-groups'
+            payload['data']['relationships']['groups']['data']['id'] = 'not_a_real_group_id'
+            res = app.post_json_api(public_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
 
 
 @pytest.mark.django_db
 class TestNodeGroupDetail:
 
     def test_node_group_detail(self, app, public_detail_url, osf_group, public_project):
-        # res for group not attached to node raised permissions error
-        res = app.get(public_detail_url, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == 'Group {} does not have permissions to node {}.'.format(osf_group._id, public_project._id)
+        with override_flag(OSF_GROUPS, active=True):
+            # res for group not attached to node raised permissions error
+            res = app.get(public_detail_url, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == 'Group {} does not have permissions to node {}.'.format(osf_group._id, public_project._id)
 
-        public_project.add_osf_group(osf_group, permissions.WRITE)
+            public_project.add_osf_group(osf_group, permissions.WRITE)
 
-        # test attributes
-        res = app.get(public_detail_url)
-        attributes = res.json['data']['attributes']
-        assert attributes['date_created'] == osf_group.created.replace(tzinfo=None).isoformat()
-        assert attributes['date_modified'] == osf_group.modified.replace(tzinfo=None).isoformat()
-        assert attributes['name'] == osf_group.name
-        assert attributes['permission'] == permissions.WRITE
+            # test attributes
+            res = app.get(public_detail_url)
+            attributes = res.json['data']['attributes']
+            assert attributes['date_created'] == osf_group.created.replace(tzinfo=None).isoformat()
+            assert attributes['date_modified'] == osf_group.modified.replace(tzinfo=None).isoformat()
+            assert attributes['name'] == osf_group.name
+            assert attributes['permission'] == permissions.WRITE
 
-        # test relationships
-        relationships = res.json['data']['relationships']
-        assert relationships.keys() == ['groups']
-        assert osf_group._id in relationships['groups']['links']['related']['href']
+            # test relationships
+            relationships = res.json['data']['relationships']
+            assert relationships.keys() == ['groups']
+            assert osf_group._id in relationships['groups']['links']['related']['href']
 
-        # get group that does not exist
-        res = app.get(public_detail_url.replace(osf_group._id, 'hellonotarealroute'), expect_errors=True)
-        assert res.status_code == 404
+            # get group that does not exist
+            res = app.get(public_detail_url.replace(osf_group._id, 'hellonotarealroute'), expect_errors=True)
+            assert res.status_code == 404
 
     def test_node_group_detail_perms(self, app, non_contrib, osf_group, member, public_project, private_project, public_detail_url, private_url):
-        public_project.add_osf_group(osf_group, permissions.READ)
-        private_project.add_osf_group(osf_group, permissions.WRITE)
-        private_detail_url = private_url + osf_group._id + '/'
+        with override_flag(OSF_GROUPS, active=True):
+            public_project.add_osf_group(osf_group, permissions.READ)
+            private_project.add_osf_group(osf_group, permissions.WRITE)
+            private_detail_url = private_url + osf_group._id + '/'
 
-        # nonauth
-        res = app.get(private_detail_url, expect_errors=True)
-        assert res.status_code == 401
+            # nonauth
+            res = app.get(private_detail_url, expect_errors=True)
+            assert res.status_code == 401
 
-        res = app.get(public_detail_url)
-        assert res.status_code == 200
+            res = app.get(public_detail_url)
+            assert res.status_code == 200
 
-        # noncontrib
-        res = app.get(private_detail_url, auth=non_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # noncontrib
+            res = app.get(private_detail_url, auth=non_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        res = app.get(public_detail_url, auth=non_contrib.auth)
-        assert res.status_code == 200
+            res = app.get(public_detail_url, auth=non_contrib.auth)
+            assert res.status_code == 200
 
-        # member
-        res = app.get(private_detail_url, auth=member.auth)
-        assert res.status_code == 200
+            # member
+            res = app.get(private_detail_url, auth=member.auth)
+            assert res.status_code == 200
 
-        res = app.get(public_detail_url, auth=member.auth)
-        assert res.status_code == 200
+            res = app.get(public_detail_url, auth=member.auth)
+            assert res.status_code == 200
 
 
 @pytest.mark.django_db
@@ -329,117 +336,119 @@ class TestNodeGroupUpdate:
 
     def test_update_permission(self, app, public_detail_url, osf_group, write_contrib, non_contrib,
                                 public_project, make_node_group_payload):
-        attributes = {'permission': permissions.WRITE}
-        payload = make_node_group_payload(attributes=attributes)
+        with override_flag(OSF_GROUPS, active=True):
+            attributes = {'permission': permissions.WRITE}
+            payload = make_node_group_payload(attributes=attributes)
 
-        # group has not been added to the node
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 404
+            # group has not been added to the node
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 404
 
-        public_project.add_osf_group(osf_group, permissions.READ)
+            public_project.add_osf_group(osf_group, permissions.READ)
 
-        # test id not present in request
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 400
+            # test id not present in request
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 400
 
-        # test passing invalid group_id to update
-        payload['data']['id'] = 'nope'
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test passing invalid group_id to update
+            payload['data']['id'] = 'nope'
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        payload['data']['id'] = public_project._id + '-' + osf_group._id
+            payload['data']['id'] = public_project._id + '-' + osf_group._id
 
-        # test update not logged in fails
-        res = app.patch_json_api(public_detail_url, payload, expect_errors=True)
-        assert res.status_code == 401
+            # test update not logged in fails
+            res = app.patch_json_api(public_detail_url, payload, expect_errors=True)
+            assert res.status_code == 401
 
-        # test update noncontrib in fails
-        res = app.patch_json_api(public_detail_url, payload, auth=non_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test update noncontrib in fails
+            res = app.patch_json_api(public_detail_url, payload, auth=non_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test update as node write contrib fails
-        res = app.patch_json_api(public_detail_url, payload, auth=write_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test update as node write contrib fails
+            res = app.patch_json_api(public_detail_url, payload, auth=write_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test update as node admin
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth)
-        res_json = res.json['data']
-        assert res.status_code == 200
-        assert not osf_group.is_member(public_project.creator.auth)
-        assert res_json['attributes']['permission'] == permissions.WRITE
-        assert permissions.WRITE_NODE in get_perms(osf_group.member_group, public_project)
+            # test update as node admin
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth)
+            res_json = res.json['data']
+            assert res.status_code == 200
+            assert not osf_group.is_member(public_project.creator.auth)
+            assert res_json['attributes']['permission'] == permissions.WRITE
+            assert permissions.WRITE_NODE in get_perms(osf_group.member_group, public_project)
 
-        # test update invalid perm
-        payload['data']['attributes']['permission'] = 'bad_perm'
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid permission.'
+            # test update invalid perm
+            payload['data']['attributes']['permission'] = 'bad_perm'
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid permission.'
 
-        # test update no perm specified, perms unchanged
-        payload['data']['attributes'] = {}
-        res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 200
-        assert res_json['attributes']['permission'] == permissions.WRITE
+            # test update no perm specified, perms unchanged
+            payload['data']['attributes'] = {}
+            res = app.patch_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 200
+            assert res_json['attributes']['permission'] == permissions.WRITE
 
 
 @pytest.mark.django_db
 class TestNodeGroupDelete:
 
     def test_delete_group(self, app, public_detail_url, public_project, osf_group, member, manager, non_contrib, write_contrib):
-        public_project.add_contributor(manager, permissions=permissions.ADMIN)
-        payload = {
-            'data': [
-                {'type': 'node-groups', 'id': '{}-{}'.format(public_project._id, osf_group._id)}
-            ]
-        }
-        # group has not been added to the node
-        res = app.delete_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
-        assert res.status_code == 404
+        with override_flag(OSF_GROUPS, active=True):
+            public_project.add_contributor(manager, permissions=permissions.ADMIN)
+            payload = {
+                'data': [
+                    {'type': 'node-groups', 'id': '{}-{}'.format(public_project._id, osf_group._id)}
+                ]
+            }
+            # group has not been added to the node
+            res = app.delete_json_api(public_detail_url, payload, auth=public_project.creator.auth, expect_errors=True)
+            assert res.status_code == 404
 
-        public_project.add_osf_group(osf_group, permissions.WRITE)
+            public_project.add_osf_group(osf_group, permissions.WRITE)
 
-        # test member with write permission cannot remove group
-        res = app.delete_json_api(public_detail_url, payload, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test member with write permission cannot remove group
+            res = app.delete_json_api(public_detail_url, payload, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # not logged in user cannot remove group
-        res = app.delete_json_api(public_detail_url, payload, expect_errors=True)
-        assert res.status_code == 401
+            # not logged in user cannot remove group
+            res = app.delete_json_api(public_detail_url, payload, expect_errors=True)
+            assert res.status_code == 401
 
-        # non contributor cannot remove group
-        res = app.delete_json_api(public_detail_url, payload, auth=non_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # non contributor cannot remove group
+            res = app.delete_json_api(public_detail_url, payload, auth=non_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # write contributor cannot remove group
-        res = app.delete_json_api(public_detail_url, payload, auth=write_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+            # write contributor cannot remove group
+            res = app.delete_json_api(public_detail_url, payload, auth=write_contrib.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test manager on group can remove group
-        res = app.delete_json_api(public_detail_url, payload, auth=manager.auth)
-        assert res.status_code == 204
-        assert osf_group not in public_project.osf_groups
+            # test manager on group can remove group
+            res = app.delete_json_api(public_detail_url, payload, auth=manager.auth)
+            assert res.status_code == 204
+            assert osf_group not in public_project.osf_groups
 
-        # test member with admin permissions can remove group
-        public_project.add_osf_group(osf_group, permissions.ADMIN)
-        res = app.delete_json_api(public_detail_url, payload, auth=member.auth)
-        assert res.status_code == 204
-        assert osf_group not in public_project.osf_groups
+            # test member with admin permissions can remove group
+            public_project.add_osf_group(osf_group, permissions.ADMIN)
+            res = app.delete_json_api(public_detail_url, payload, auth=member.auth)
+            assert res.status_code == 204
+            assert osf_group not in public_project.osf_groups
 
-        second_group = OSFGroupFactory(creator=non_contrib)
-        second_group.make_member(member)
-        public_project.add_osf_group(second_group, permissions.WRITE)
+            second_group = OSFGroupFactory(creator=non_contrib)
+            second_group.make_member(member)
+            public_project.add_osf_group(second_group, permissions.WRITE)
 
-        # test member with write cannot remove group
-        second_payload = {
-            'data': [
-                {'type': 'node-groups', 'id': '{}-{}'.format(public_project._id, second_group._id)}
-            ]
-        }
-        second_url = '/{}nodes/{}/groups/{}/'.format(API_BASE, public_project._id, second_group._id)
-        res = app.delete_json_api(second_url, second_payload, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test member with write cannot remove group
+            second_payload = {
+                'data': [
+                    {'type': 'node-groups', 'id': '{}-{}'.format(public_project._id, second_group._id)}
+                ]
+            }
+            second_url = '/{}nodes/{}/groups/{}/'.format(API_BASE, public_project._id, second_group._id)
+            res = app.delete_json_api(second_url, second_payload, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test manager can remove the group (even though they are not an admin contributor)
-        res = app.delete_json_api(second_url, second_payload, auth=non_contrib.auth, expect_errors=True)
-        assert res.status_code == 204
-        assert second_group not in public_project.osf_groups
+            # test manager can remove the group (even though they are not an admin contributor)
+            res = app.delete_json_api(second_url, second_payload, auth=non_contrib.auth, expect_errors=True)
+            assert res.status_code == 204
+            assert second_group not in public_project.osf_groups

--- a/api_tests/osf_groups/views/test_osf_group_detail.py
+++ b/api_tests/osf_groups/views/test_osf_group_detail.py
@@ -1,5 +1,6 @@
 import pytest
 
+from waffle.testutils import override_flag
 from django.contrib.auth.models import Group
 
 from api.base.settings.defaults import API_BASE
@@ -8,6 +9,8 @@ from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
+
 
 def build_member_relationship_payload(user_ids):
     return {
@@ -73,132 +76,137 @@ def name_payload(osf_group, new_name):
 class TestGroupDetail:
 
     def test_return(self, app, member, manager, user, osf_group, url):
-        # test unauthenticated
-        res = app.get(url)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == osf_group._id
-        assert data['type'] == 'groups'
-        assert data['attributes']['name'] == osf_group.name
-        assert 'members' in data['relationships']
+        with override_flag(OSF_GROUPS, active=True):
+            # test unauthenticated
+            res = app.get(url)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == osf_group._id
+            assert data['type'] == 'groups'
+            assert data['attributes']['name'] == osf_group.name
+            assert 'members' in data['relationships']
 
-        # test authenticated user
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == osf_group._id
-        assert data['type'] == 'groups'
-        assert data['attributes']['name'] == osf_group.name
-        assert 'members' in data['relationships']
+            # test authenticated user
+            res = app.get(url, auth=user.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == osf_group._id
+            assert data['type'] == 'groups'
+            assert data['attributes']['name'] == osf_group.name
+            assert 'members' in data['relationships']
 
-        # test authenticated member
-        res = app.get(url, auth=member.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == osf_group._id
-        assert data['type'] == 'groups'
-        assert data['attributes']['name'] == osf_group.name
-        assert 'members' in data['relationships']
+            # test authenticated member
+            res = app.get(url, auth=member.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == osf_group._id
+            assert data['type'] == 'groups'
+            assert data['attributes']['name'] == osf_group.name
+            assert 'members' in data['relationships']
 
-        # test authenticated manager
-        res = app.get(url, auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == osf_group._id
-        assert data['type'] == 'groups'
-        assert data['attributes']['name'] == osf_group.name
-        assert 'members' in data['relationships']
+            # test authenticated manager
+            res = app.get(url, auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == osf_group._id
+            assert data['type'] == 'groups'
+            assert data['attributes']['name'] == osf_group.name
+            assert 'members' in data['relationships']
 
-        # test invalid group
-        url = '/{}groups/{}/'.format(API_BASE, '12345_bad_id')
-        res = app.get(url, expect_errors=True)
-        assert res.status_code == 404
+            # test invalid group
+            url = '/{}groups/{}/'.format(API_BASE, '12345_bad_id')
+            res = app.get(url, expect_errors=True)
+            assert res.status_code == 404
 
 
 @pytest.mark.django_db
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupUpdate:
     def test_patch_osf_group_perms(self, app, member, manager, user, osf_group, url, name_payload, new_name):
-        # test unauthenticated
-        res = app.patch_json_api(url, expect_errors=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            # test unauthenticated
+            res = app.patch_json_api(url, expect_errors=True)
+            assert res.status_code == 401
 
-        # test authenticated_user
-        res = app.patch_json_api(url, {}, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test authenticated_user
+            res = app.patch_json_api(url, {}, auth=user.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test authenticated_member
-        res = app.patch_json_api(url, {}, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test authenticated_member
+            res = app.patch_json_api(url, {}, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test authenticated_manager
-        res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 200
-        assert res.json['data']['attributes']['name'] == new_name
+            # test authenticated_manager
+            res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 200
+            assert res.json['data']['attributes']['name'] == new_name
 
     def test_patch_osf_group_attributes(self, app, manager, osf_group, url, name_payload, old_name, new_name):
-        # test_blank_name
-        assert osf_group.name == old_name
-        name_payload['data']['attributes']['name'] = ''
-        res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'This field may not be blank.'
-        osf_group.reload
-        assert osf_group.name == old_name
+        with override_flag(OSF_GROUPS, active=True):
+            # test_blank_name
+            assert osf_group.name == old_name
+            name_payload['data']['attributes']['name'] = ''
+            res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'This field may not be blank.'
+            osf_group.reload
+            assert osf_group.name == old_name
 
-        # test_name_updated
-        name_payload['data']['attributes']['name'] = new_name
-        res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 200
-        assert res.json['data']['attributes']['name'] == new_name
-        osf_group.reload()
-        assert osf_group.name == new_name
+            # test_name_updated
+            name_payload['data']['attributes']['name'] = new_name
+            res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 200
+            assert res.json['data']['attributes']['name'] == new_name
+            osf_group.reload()
+            assert osf_group.name == new_name
 
-        # test_invalid_type
-        name_payload['data']['type'] = 'bad_type'
-        res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test_invalid_type
+            name_payload['data']['type'] = 'bad_type'
+            res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # test_id_mismatch
-        name_payload['data']['type'] = 'groups'
-        name_payload['data']['id'] = '12345_bad_id'
-        res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test_id_mismatch
+            name_payload['data']['type'] = 'groups'
+            name_payload['data']['id'] = '12345_bad_id'
+            res = app.patch_json_api(url, name_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
 
 @pytest.mark.django_db
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupDelete:
     def test_delete_perms(self, app, osf_group, manager, member, user, url):
-        res = app.delete_json_api(url, expect_errors=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.delete_json_api(url, expect_errors=True)
+            assert res.status_code == 401
 
-        res = app.delete_json_api(url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+            res = app.delete_json_api(url, auth=user.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        res = app.delete_json_api(url, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            res = app.delete_json_api(url, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        res = app.delete_json_api(url, auth=manager.auth)
-        assert res.status_code == 204
+            res = app.delete_json_api(url, auth=manager.auth)
+            assert res.status_code == 204
 
     def test_delete_specifics(self, app, osf_group, manager, member, user, url):
-        osf_group_name = osf_group.name
-        manager_group_name = osf_group.manager_group.name
-        member_group_name = osf_group.member_group.name
+        with override_flag(OSF_GROUPS, active=True):
+            osf_group_name = osf_group.name
+            manager_group_name = osf_group.manager_group.name
+            member_group_name = osf_group.member_group.name
 
-        assert manager_group_name in manager.groups.values_list('name', flat=True)
-        assert member_group_name in member.groups.values_list('name', flat=True)
+            assert manager_group_name in manager.groups.values_list('name', flat=True)
+            assert member_group_name in member.groups.values_list('name', flat=True)
 
-        res = app.delete_json_api(url, auth=manager.auth)
-        assert res.status_code == 204
+            res = app.delete_json_api(url, auth=manager.auth)
+            assert res.status_code == 204
 
-        assert not OSFGroup.objects.filter(name=osf_group_name).exists()
-        assert not Group.objects.filter(name=manager_group_name).exists()
-        assert not Group.objects.filter(name=member_group_name).exists()
+            assert not OSFGroup.objects.filter(name=osf_group_name).exists()
+            assert not Group.objects.filter(name=manager_group_name).exists()
+            assert not Group.objects.filter(name=member_group_name).exists()
 
-        assert manager_group_name not in manager.groups.values_list('name', flat=True)
-        assert member_group_name not in member.groups.values_list('name', flat=True)
+            assert manager_group_name not in manager.groups.values_list('name', flat=True)
+            assert member_group_name not in member.groups.values_list('name', flat=True)
 
-        res = app.get(url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
+            res = app.get(url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404

--- a/api_tests/osf_groups/views/test_osf_group_members_detail.py
+++ b/api_tests/osf_groups/views/test_osf_group_members_detail.py
@@ -1,4 +1,5 @@
 import pytest
+from waffle.testutils import override_flag
 
 from framework.auth.core import Auth
 from api.base.settings.defaults import API_BASE
@@ -7,6 +8,8 @@ from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
+
 
 @pytest.fixture()
 def user():
@@ -42,47 +45,49 @@ def bad_url(osf_group):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersDetail:
     def test_return_perms(self, app, member, manager, user, osf_group, url, bad_url):
-        # test unauthenticated
-        res = app.get(url)
-        assert res.status_code == 200
+        with override_flag(OSF_GROUPS, active=True):
+            # test unauthenticated
+            res = app.get(url)
+            assert res.status_code == 200
 
-        # test user
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
+            # test user
+            res = app.get(url, auth=user.auth)
+            assert res.status_code == 200
 
-        # test member
-        res = app.get(url, auth=member.auth)
-        assert res.status_code == 200
+            # test member
+            res = app.get(url, auth=member.auth)
+            assert res.status_code == 200
 
-        # test manager
-        res = app.get(url, auth=manager.auth)
-        assert res.status_code == 200
+            # test manager
+            res = app.get(url, auth=manager.auth)
+            assert res.status_code == 200
 
-        # test invalid member
-        res = app.get(bad_url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
+            # test invalid member
+            res = app.get(bad_url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
 
     def test_return_member(self, app, member, manager, osf_group, url):
-        res = app.get(url)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == '{}-{}'.format(osf_group._id, member._id)
-        assert data['type'] == 'group-members'
-        assert data['attributes']['role'] == MEMBER
-        assert data['attributes']['unregistered_member'] is None
-        assert data['attributes']['full_name'] == member.fullname
-        assert member._id in data['relationships']['users']['links']['related']['href']
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.get(url)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == '{}-{}'.format(osf_group._id, member._id)
+            assert data['type'] == 'group-members'
+            assert data['attributes']['role'] == MEMBER
+            assert data['attributes']['unregistered_member'] is None
+            assert data['attributes']['full_name'] == member.fullname
+            assert member._id in data['relationships']['users']['links']['related']['href']
 
-        user = osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
-        res = app.get('/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id))
-        assert res.status_code == 200
-        data = res.json['data']
-        assert data['id'] == '{}-{}'.format(osf_group._id, user._id)
-        assert data['type'] == 'group-members'
-        assert data['attributes']['role'] == MANAGER
-        assert data['attributes']['unregistered_member'] == 'Crazy 8s'
-        assert data['attributes']['full_name'] == 'Crazy 8s'
-        assert res.json['data']['attributes']['full_name'] == 'Crazy 8s'
+            user = osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
+            res = app.get('/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id))
+            assert res.status_code == 200
+            data = res.json['data']
+            assert data['id'] == '{}-{}'.format(osf_group._id, user._id)
+            assert data['type'] == 'group-members'
+            assert data['attributes']['role'] == MANAGER
+            assert data['attributes']['unregistered_member'] == 'Crazy 8s'
+            assert data['attributes']['full_name'] == 'Crazy 8s'
+            assert res.json['data']['attributes']['full_name'] == 'Crazy 8s'
 
 
 def build_update_payload(group_id, user_id, role):
@@ -100,153 +105,158 @@ def build_update_payload(group_id, user_id, role):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersUpdate:
     def test_update_role(self, app, member, manager, user, osf_group, url):
-        payload = build_update_payload(osf_group._id, member._id, MANAGER)
+        with override_flag(OSF_GROUPS, active=True):
+            payload = build_update_payload(osf_group._id, member._id, MANAGER)
 
-        # test unauthenticated
-        res = app.patch_json_api(url, payload, expect_errors=True)
-        assert res.status_code == 401
+            # test unauthenticated
+            res = app.patch_json_api(url, payload, expect_errors=True)
+            assert res.status_code == 401
 
-        # test user
-        res = app.patch_json_api(url, payload, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test user
+            res = app.patch_json_api(url, payload, auth=user.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test member
-        res = app.patch_json_api(url, payload, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test member
+            res = app.patch_json_api(url, payload, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test manager
-        res = app.patch_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 200
-        assert res.json['data']['attributes']['role'] == MANAGER
-        assert res.json['data']['attributes']['full_name'] == member.fullname
-        assert res.json['data']['id'] == '{}-{}'.format(osf_group._id, member._id)
+            # test manager
+            res = app.patch_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 200
+            assert res.json['data']['attributes']['role'] == MANAGER
+            assert res.json['data']['attributes']['full_name'] == member.fullname
+            assert res.json['data']['id'] == '{}-{}'.format(osf_group._id, member._id)
 
-        payload = build_update_payload(osf_group._id, member._id, MEMBER)
-        res = app.patch_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 200
-        assert res.json['data']['attributes']['role'] == MEMBER
-        assert res.json['data']['attributes']['full_name'] == member.fullname
-        assert res.json['data']['id'] == '{}-{}'.format(osf_group._id, member._id)
+            payload = build_update_payload(osf_group._id, member._id, MEMBER)
+            res = app.patch_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 200
+            assert res.json['data']['attributes']['role'] == MEMBER
+            assert res.json['data']['attributes']['full_name'] == member.fullname
+            assert res.json['data']['id'] == '{}-{}'.format(osf_group._id, member._id)
 
     def test_update_errors(self, app, member, manager, user, osf_group, url, bad_url):
-        # id not in payload
-        payload = {
-            'data': {
-                'type': 'group-members',
-                'attributes': {
-                    'role': MEMBER
+        with override_flag(OSF_GROUPS, active=True):
+            # id not in payload
+            payload = {
+                'data': {
+                    'type': 'group-members',
+                    'attributes': {
+                        'role': MEMBER
+                    }
                 }
             }
-        }
-        res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'This field may not be null.'
+            res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'This field may not be null.'
 
-        # test improperly formatted id
-        payload = build_update_payload(osf_group._id, member._id, MANAGER)
-        payload['data']['id'] = 'abcde'
-        res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test improperly formatted id
+            payload = build_update_payload(osf_group._id, member._id, MANAGER)
+            payload['data']['id'] = 'abcde'
+            res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # test improper type
-        payload = build_update_payload(osf_group._id, member._id, MANAGER)
-        payload['data']['type'] = 'bad_type'
-        res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # test improper type
+            payload = build_update_payload(osf_group._id, member._id, MANAGER)
+            payload['data']['type'] = 'bad_type'
+            res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # test invalid role
-        payload = build_update_payload(osf_group._id, member._id, 'bad_perm')
-        res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid role; choose manager or member.'
+            # test invalid role
+            payload = build_update_payload(osf_group._id, member._id, 'bad_perm')
+            res = app.patch_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid role; choose manager or member.'
 
-        # test user is not a member
-        payload = build_update_payload(osf_group._id, user._id, MEMBER)
-        bad_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
-        res = app.patch_json_api(bad_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
+            # test user is not a member
+            payload = build_update_payload(osf_group._id, user._id, MEMBER)
+            bad_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
+            res = app.patch_json_api(bad_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
 
-        # test cannot downgrade remaining manager
-        payload = build_update_payload(osf_group._id, manager._id, MEMBER)
-        manager_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, manager._id)
-        res = app.patch_json_api(manager_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test cannot downgrade remaining manager
+            payload = build_update_payload(osf_group._id, manager._id, MEMBER)
+            manager_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, manager._id)
+            res = app.patch_json_api(manager_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
-        # test cannot remove last confirmed manager
-        osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
-        assert len(osf_group.managers) == 2
-        res = app.patch_json_api(manager_url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test cannot remove last confirmed manager
+            osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
+            assert len(osf_group.managers) == 2
+            res = app.patch_json_api(manager_url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
 
 @pytest.mark.django_db
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersDelete:
     def test_delete_perms(self, app, member, manager, user, osf_group, url):
-        # test unauthenticated
-        res = app.delete_json_api(url, expect_errors=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            # test unauthenticated
+            res = app.delete_json_api(url, expect_errors=True)
+            assert res.status_code == 401
 
-        # test user
-        res = app.delete_json_api(url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test user
+            res = app.delete_json_api(url, auth=user.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test member
-        osf_group.make_member(user)
-        user_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
-        res = app.delete_json_api(user_url, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # test member
+            osf_group.make_member(user)
+            user_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
+            res = app.delete_json_api(user_url, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # test manager
-        assert osf_group.is_member(member) is True
-        assert osf_group.is_manager(member) is False
+            # test manager
+            assert osf_group.is_member(member) is True
+            assert osf_group.is_manager(member) is False
 
-        res = app.delete_json_api(url, auth=manager.auth)
-        assert res.status_code == 204
-        assert osf_group.is_member(member) is False
-        assert osf_group.is_manager(member) is False
+            res = app.delete_json_api(url, auth=manager.auth)
+            assert res.status_code == 204
+            assert osf_group.is_member(member) is False
+            assert osf_group.is_manager(member) is False
 
-        # test delete manager (not last manager)
-        osf_group.make_manager(user)
-        assert osf_group.is_member(user) is True
-        assert osf_group.is_manager(user) is True
-        user_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
-        res = app.delete_json_api(user_url, auth=user.auth)
-        assert res.status_code == 204
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # test delete manager (not last manager)
+            osf_group.make_manager(user)
+            assert osf_group.is_member(user) is True
+            assert osf_group.is_manager(user) is True
+            user_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
+            res = app.delete_json_api(user_url, auth=user.auth)
+            assert res.status_code == 204
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
     def test_delete_yourself(self, app, member, manager, user, osf_group, url):
-        assert osf_group.is_member(member) is True
-        assert osf_group.is_manager(member) is False
-        res = app.delete_json_api(url, auth=member.auth, expect_errors=True)
-        assert res.status_code == 204
-        assert osf_group.is_member(member) is False
-        assert osf_group.is_manager(member) is False
+        with override_flag(OSF_GROUPS, active=True):
+            assert osf_group.is_member(member) is True
+            assert osf_group.is_manager(member) is False
+            res = app.delete_json_api(url, auth=member.auth, expect_errors=True)
+            assert res.status_code == 204
+            assert osf_group.is_member(member) is False
+            assert osf_group.is_manager(member) is False
 
     def test_delete_errors(self, app, member, manager, user, osf_group, url, bad_url):
-        # test invalid user
-        res = app.delete_json_api(bad_url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
+        with override_flag(OSF_GROUPS, active=True):
+            # test invalid user
+            res = app.delete_json_api(bad_url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
 
-        # test user does not belong to group
-        bad_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
-        res = app.delete_json_api(bad_url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
+            # test user does not belong to group
+            bad_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, user._id)
+            res = app.delete_json_api(bad_url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
 
-        # test user is last manager
-        manager_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, manager._id)
-        res = app.delete_json_api(manager_url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test user is last manager
+            manager_url = '/{}groups/{}/members/{}/'.format(API_BASE, osf_group._id, manager._id)
+            res = app.delete_json_api(manager_url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
-        # test user is last registered manager
-        osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
-        assert len(osf_group.managers) == 2
-        res = app.delete_json_api(manager_url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test user is last registered manager
+            osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
+            assert len(osf_group.managers) == 2
+            res = app.delete_json_api(manager_url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'

--- a/api_tests/osf_groups/views/test_osf_group_members_list.py
+++ b/api_tests/osf_groups/views/test_osf_group_members_list.py
@@ -1,4 +1,5 @@
 import pytest
+from waffle.testutils import override_flag
 
 from django.utils import timezone
 
@@ -10,6 +11,8 @@ from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
+
 
 @pytest.fixture()
 def user():
@@ -46,83 +49,86 @@ def url(osf_group):
 @pytest.mark.enable_quickfiles_creation
 class TestGroupMembersList:
     def test_return_perms(self, app, member, manager, user, osf_group, url):
-        # test unauthenticated
-        res = app.get(url)
-        assert res.status_code == 200
+        with override_flag(OSF_GROUPS, active=True):
+            # test unauthenticated
+            res = app.get(url)
+            assert res.status_code == 200
 
-        # test user
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
+            # test user
+            res = app.get(url, auth=user.auth)
+            assert res.status_code == 200
 
-        # test member
-        res = app.get(url, auth=member.auth)
-        assert res.status_code == 200
+            # test member
+            res = app.get(url, auth=member.auth)
+            assert res.status_code == 200
 
-        # test manager
-        res = app.get(url, auth=manager.auth)
-        assert res.status_code == 200
+            # test manager
+            res = app.get(url, auth=manager.auth)
+            assert res.status_code == 200
 
-        # test invalid group
-        url = '/{}groups/{}/members/'.format(API_BASE, '12345_bad_id')
-        res = app.get(url, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
+            # test invalid group
+            url = '/{}groups/{}/members/'.format(API_BASE, '12345_bad_id')
+            res = app.get(url, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
 
     def test_return_members(self, app, member, manager, user, osf_group, url):
-        res = app.get(url)
-        data = res.json['data']
-        assert len(data) == 2
-        member_ids = [mem['id'] for mem in data]
-        assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
-        assert '{}-{}'.format(osf_group._id, member._id) in member_ids
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.get(url)
+            data = res.json['data']
+            assert len(data) == 2
+            member_ids = [mem['id'] for mem in data]
+            assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
+            assert '{}-{}'.format(osf_group._id, member._id) in member_ids
 
 
 @pytest.mark.django_db
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersFilter:
     def test_filtering(self, app, member, manager, user, osf_group, url):
-        # test filter members
-        url_filter = url + '?filter[role]=member'
-        res = app.get(url_filter)
-        data = res.json['data']
-        assert len(data) == 1
-        member_ids = [mem['id'] for mem in data]
-        assert '{}-{}'.format(osf_group._id, member._id) in member_ids
+        with override_flag(OSF_GROUPS, active=True):
+            # test filter members
+            url_filter = url + '?filter[role]=member'
+            res = app.get(url_filter)
+            data = res.json['data']
+            assert len(data) == 1
+            member_ids = [mem['id'] for mem in data]
+            assert '{}-{}'.format(osf_group._id, member._id) in member_ids
 
-        # test filter managers
-        url_filter = url + '?filter[role]=manager'
-        res = app.get(url_filter)
-        data = res.json['data']
-        assert len(data) == 1
-        member_ids = [mem['id'] for mem in data]
-        assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
+            # test filter managers
+            url_filter = url + '?filter[role]=manager'
+            res = app.get(url_filter)
+            data = res.json['data']
+            assert len(data) == 1
+            member_ids = [mem['id'] for mem in data]
+            assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
 
-        # test invalid role
-        url_filter = url + '?filter[role]=bad_role'
-        res = app.get(url_filter, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == "Value \'bad_role\' is not valid."
+            # test invalid role
+            url_filter = url + '?filter[role]=bad_role'
+            res = app.get(url_filter, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == "Value \'bad_role\' is not valid."
 
-        # test filter fullname
-        url_filter = url + '?filter[full_name]={}'.format(manager.fullname)
-        res = app.get(url_filter)
-        data = res.json['data']
-        assert len(data) == 1
-        member_ids = [mem['id'] for mem in data]
-        assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
+            # test filter fullname
+            url_filter = url + '?filter[full_name]={}'.format(manager.fullname)
+            res = app.get(url_filter)
+            data = res.json['data']
+            assert len(data) == 1
+            member_ids = [mem['id'] for mem in data]
+            assert '{}-{}'.format(osf_group._id, manager._id) in member_ids
 
-        # test filter fullname
-        url_filter = url + '?filter[full_name]={}'.format(member.fullname)
-        res = app.get(url_filter)
-        data = res.json['data']
-        assert len(data) == 1
-        member_ids = [mem['id'] for mem in data]
-        assert '{}-{}'.format(osf_group._id, member._id) in member_ids
+            # test filter fullname
+            url_filter = url + '?filter[full_name]={}'.format(member.fullname)
+            res = app.get(url_filter)
+            data = res.json['data']
+            assert len(data) == 1
+            member_ids = [mem['id'] for mem in data]
+            assert '{}-{}'.format(osf_group._id, member._id) in member_ids
 
-        # test invalid filter
-        url_filter = url + '?filter[created]=2018-02-01'
-        res = app.get(url_filter, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == "\'created\' is not a valid field for this endpoint."
+            # test invalid filter
+            url_filter = url + '?filter[created]=2018-02-01'
+            res = app.get(url_filter, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == "\'created\' is not a valid field for this endpoint."
 
 def make_create_payload(role, user=None, full_name=None, email=None):
     base_payload = {
@@ -154,122 +160,127 @@ def make_create_payload(role, user=None, full_name=None, email=None):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersCreate:
     def test_create_manager(self, app, manager, user3, osf_group, url):
-        payload = make_create_payload(MANAGER, user3)
-        res = app.post_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 201
-        data = res.json['data']
-        assert data['attributes']['role'] == MANAGER
-        assert data['attributes']['full_name'] == user3.fullname
-        assert data['attributes']['unregistered_member'] is None
-        assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
-        assert user3._id in data['relationships']['users']['links']['related']['href']
-        assert osf_group.has_permission(user3, MANAGE) is True
+        with override_flag(OSF_GROUPS, active=True):
+            payload = make_create_payload(MANAGER, user3)
+            res = app.post_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 201
+            data = res.json['data']
+            assert data['attributes']['role'] == MANAGER
+            assert data['attributes']['full_name'] == user3.fullname
+            assert data['attributes']['unregistered_member'] is None
+            assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
+            assert user3._id in data['relationships']['users']['links']['related']['href']
+            assert osf_group.has_permission(user3, MANAGE) is True
 
     def test_create_member(self, app, member, manager, user3, osf_group, url):
-        payload = make_create_payload(MEMBER, user3)
-        res = app.post_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 201
-        data = res.json['data']
-        assert data['attributes']['role'] == MEMBER
-        assert data['attributes']['full_name'] == user3.fullname
-        assert data['attributes']['unregistered_member'] is None
-        assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
-        assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
-        assert user3._id in data['relationships']['users']['links']['related']['href']
-        assert osf_group.has_permission(user3, MANAGE) is False
-        assert osf_group.has_permission(user3, MEMBER) is True
+        with override_flag(OSF_GROUPS, active=True):
+            payload = make_create_payload(MEMBER, user3)
+            res = app.post_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 201
+            data = res.json['data']
+            assert data['attributes']['role'] == MEMBER
+            assert data['attributes']['full_name'] == user3.fullname
+            assert data['attributes']['unregistered_member'] is None
+            assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
+            assert data['id'] == '{}-{}'.format(osf_group._id, user3._id)
+            assert user3._id in data['relationships']['users']['links']['related']['href']
+            assert osf_group.has_permission(user3, MANAGE) is False
+            assert osf_group.has_permission(user3, MEMBER) is True
 
     def test_add_unregistered_member(self, app, manager, osf_group, url):
-        full_name = 'Crazy 8s'
-        payload = make_create_payload(MEMBER, user=None, full_name=full_name, email='eight@cos.io')
-        res = app.post_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 201
-        data = res.json['data']
-        assert data['attributes']['role'] == MEMBER
-        user = OSFUser.load(data['id'].split('-')[1])
-        assert user._id in data['relationships']['users']['links']['related']['href']
-        assert osf_group.has_permission(user, MANAGE) is False
-        assert data['attributes']['full_name'] == full_name
-        assert data['attributes']['unregistered_member'] == full_name
-        assert osf_group.has_permission(user, MEMBER) is True
-        assert user in osf_group.members_only
-        assert user not in osf_group.managers
+        with override_flag(OSF_GROUPS, active=True):
+            full_name = 'Crazy 8s'
+            payload = make_create_payload(MEMBER, user=None, full_name=full_name, email='eight@cos.io')
+            res = app.post_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 201
+            data = res.json['data']
+            assert data['attributes']['role'] == MEMBER
+            user = OSFUser.load(data['id'].split('-')[1])
+            assert user._id in data['relationships']['users']['links']['related']['href']
+            assert osf_group.has_permission(user, MANAGE) is False
+            assert data['attributes']['full_name'] == full_name
+            assert data['attributes']['unregistered_member'] == full_name
+            assert osf_group.has_permission(user, MEMBER) is True
+            assert user in osf_group.members_only
+            assert user not in osf_group.managers
 
-        # test unregistered user is already a member
-        res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'User already exists.'
+            # test unregistered user is already a member
+            res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'User already exists.'
 
     def test_create_member_perms(self, app, manager, member, osf_group, user3, url):
-        payload = make_create_payload(MEMBER, user3)
-        # Unauthenticated
-        res = app.post_json_api(url, payload, expect_errors=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            payload = make_create_payload(MEMBER, user3)
+            # Unauthenticated
+            res = app.post_json_api(url, payload, expect_errors=True)
+            assert res.status_code == 401
 
-        # Logged in, nonmember
-        res = app.post_json_api(url, payload, auth=user3.auth, expect_errors=True)
-        assert res.status_code == 403
+            # Logged in, nonmember
+            res = app.post_json_api(url, payload, auth=user3.auth, expect_errors=True)
+            assert res.status_code == 403
 
-        # Logged in, nonmanager
-        res = app.post_json_api(url, payload, auth=member.auth, expect_errors=True)
-        assert res.status_code == 403
+            # Logged in, nonmanager
+            res = app.post_json_api(url, payload, auth=member.auth, expect_errors=True)
+            assert res.status_code == 403
 
     def test_create_members_errors(self, app, manager, member, user3, osf_group, url):
-        # invalid user
-        bad_user_payload = make_create_payload(MEMBER, user=user3)
-        bad_user_payload['data']['relationships']['users']['data']['id'] = 'bad_user_id'
-        res = app.post_json_api(url, bad_user_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == 'User with id bad_user_id not found.'
+        with override_flag(OSF_GROUPS, active=True):
+            # invalid user
+            bad_user_payload = make_create_payload(MEMBER, user=user3)
+            bad_user_payload['data']['relationships']['users']['data']['id'] = 'bad_user_id'
+            res = app.post_json_api(url, bad_user_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == 'User with id bad_user_id not found.'
 
-        # invalid type
-        bad_type_payload = make_create_payload(MEMBER, user=user3)
-        bad_type_payload['data']['type'] = 'bad_type'
-        res = app.post_json_api(url, bad_type_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # invalid type
+            bad_type_payload = make_create_payload(MEMBER, user=user3)
+            bad_type_payload['data']['type'] = 'bad_type'
+            res = app.post_json_api(url, bad_type_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # invalid role
-        bad_perm_payload = make_create_payload('bad_role', user=user3)
-        res = app.post_json_api(url, bad_perm_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_role is not a valid role; choose manager or member.'
+            # invalid role
+            bad_perm_payload = make_create_payload('bad_role', user=user3)
+            res = app.post_json_api(url, bad_perm_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_role is not a valid role; choose manager or member.'
 
-        # fullname not included
-        unregistered_payload = make_create_payload(MEMBER, user=None, full_name=None, email='eight@cos.io')
-        res = app.post_json_api(url, unregistered_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
+            # fullname not included
+            unregistered_payload = make_create_payload(MEMBER, user=None, full_name=None, email='eight@cos.io')
+            res = app.post_json_api(url, unregistered_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
 
-        # email not included
-        unregistered_payload = make_create_payload(MEMBER, user=None, full_name='Crazy 8s', email=None)
-        res = app.post_json_api(url, unregistered_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
+            # email not included
+            unregistered_payload = make_create_payload(MEMBER, user=None, full_name='Crazy 8s', email=None)
+            res = app.post_json_api(url, unregistered_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
 
-        # user is already a member
-        existing_member_payload = make_create_payload(MEMBER, user=member)
-        res = app.post_json_api(url, existing_member_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'User is already a member of this group.'
+            # user is already a member
+            existing_member_payload = make_create_payload(MEMBER, user=member)
+            res = app.post_json_api(url, existing_member_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'User is already a member of this group.'
 
-        # Disabled user
-        user3.date_disabled = timezone.now()
-        user3.save()
-        payload = make_create_payload(MEMBER, user=user3)
-        res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added to OSF Groups.'
+            # Disabled user
+            user3.date_disabled = timezone.now()
+            user3.save()
+            payload = make_create_payload(MEMBER, user=user3)
+            res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added to OSF Groups.'
 
-        # No role specified - given member by default
-        user3.date_disabled = None
-        user3.save()
-        payload = make_create_payload(MEMBER, user=user3)
-        payload['attributes'] = {}
-        res = app.post_json_api(url, payload, auth=manager.auth)
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['role'] == MEMBER
-        assert osf_group.has_permission(user3, 'member')
-        assert not osf_group.has_permission(user3, 'manager')
+            # No role specified - given member by default
+            user3.date_disabled = None
+            user3.save()
+            payload = make_create_payload(MEMBER, user=user3)
+            payload['attributes'] = {}
+            res = app.post_json_api(url, payload, auth=manager.auth)
+            assert res.status_code == 201
+            assert res.json['data']['attributes']['role'] == MEMBER
+            assert osf_group.has_permission(user3, 'member')
+            assert not osf_group.has_permission(user3, 'manager')
 
 def make_bulk_create_payload(role, user=None, full_name=None, email=None):
     base_payload = {
@@ -300,136 +311,139 @@ def make_bulk_create_payload(role, user=None, full_name=None, email=None):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersBulkCreate:
     def test_bulk_create_group_member_perms(self, app, url, manager, member, user, user3, osf_group):
-        payload_user_three = make_bulk_create_payload(MANAGER, user3)
-        payload_user = make_bulk_create_payload(MEMBER, user)
-        bulk_payload = [payload_user_three, payload_user]
+        with override_flag(OSF_GROUPS, active=True):
+            payload_user_three = make_bulk_create_payload(MANAGER, user3)
+            payload_user = make_bulk_create_payload(MEMBER, user)
+            bulk_payload = [payload_user_three, payload_user]
 
-        # unauthenticated
-        res = app.post_json_api(url, {'data': bulk_payload}, expect_errors=True, bulk=True)
-        assert res.status_code == 401
+            # unauthenticated
+            res = app.post_json_api(url, {'data': bulk_payload}, expect_errors=True, bulk=True)
+            assert res.status_code == 401
 
-        # non member
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # non member
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=user.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # member
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=member.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # member
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=member.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # manager
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, bulk=True)
-        assert res.status_code == 201
-        assert len(res.json['data']) == 2
+            # manager
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, bulk=True)
+            assert res.status_code == 201
+            assert len(res.json['data']) == 2
 
-        assert osf_group.is_member(user) is True
-        assert osf_group.is_member(user3) is True
-        assert osf_group.is_manager(user) is False
-        assert osf_group.is_manager(user3) is True
+            assert osf_group.is_member(user) is True
+            assert osf_group.is_member(user3) is True
+            assert osf_group.is_manager(user) is False
+            assert osf_group.is_manager(user3) is True
 
     def test_bulk_create_unregistered(self, app, manager, user, osf_group, url):
-        payload_user = make_bulk_create_payload(MEMBER, user)
-        payload_unregistered = make_bulk_create_payload(MEMBER, user=None, full_name='Crazy 8s', email='eight@cos.io')
-        res = app.post_json_api(url, {'data': [payload_user, payload_unregistered]}, auth=manager.auth, bulk=True)
-        unreg_user = OSFUser.objects.get(username='eight@cos.io')
-        assert res.status_code == 201
-        ids = [user_data['id'] for user_data in res.json['data']]
-        roles = [user_data['attributes']['role'] for user_data in res.json['data']]
-        assert '{}-{}'.format(osf_group._id, user._id) in ids
-        assert '{}-{}'.format(osf_group._id, unreg_user._id) in ids
-        assert roles[0] == MEMBER
-        assert roles[1] == MEMBER
-        unregistered_names = [user_data['attributes']['unregistered_member'] for user_data in res.json['data']]
-        assert set(['Crazy 8s', None]) == set(unregistered_names)
+        with override_flag(OSF_GROUPS, active=True):
+            payload_user = make_bulk_create_payload(MEMBER, user)
+            payload_unregistered = make_bulk_create_payload(MEMBER, user=None, full_name='Crazy 8s', email='eight@cos.io')
+            res = app.post_json_api(url, {'data': [payload_user, payload_unregistered]}, auth=manager.auth, bulk=True)
+            unreg_user = OSFUser.objects.get(username='eight@cos.io')
+            assert res.status_code == 201
+            ids = [user_data['id'] for user_data in res.json['data']]
+            roles = [user_data['attributes']['role'] for user_data in res.json['data']]
+            assert '{}-{}'.format(osf_group._id, user._id) in ids
+            assert '{}-{}'.format(osf_group._id, unreg_user._id) in ids
+            assert roles[0] == MEMBER
+            assert roles[1] == MEMBER
+            unregistered_names = [user_data['attributes']['unregistered_member'] for user_data in res.json['data']]
+            assert set(['Crazy 8s', None]) == set(unregistered_names)
 
-        assert osf_group.has_permission(user, MANAGE) is False
-        assert osf_group.has_permission(user, MEMBER) is True
-        assert osf_group.has_permission(unreg_user, MANAGE) is False
-        assert osf_group.has_permission(unreg_user, MEMBER) is True
-        assert osf_group.is_member(unreg_user) is True
-        assert osf_group.is_manager(unreg_user) is False
+            assert osf_group.has_permission(user, MANAGE) is False
+            assert osf_group.has_permission(user, MEMBER) is True
+            assert osf_group.has_permission(unreg_user, MANAGE) is False
+            assert osf_group.has_permission(unreg_user, MEMBER) is True
+            assert osf_group.is_member(unreg_user) is True
+            assert osf_group.is_manager(unreg_user) is False
 
     def test_bulk_create_group_member_errors(self, app, url, manager, member, user, user3, osf_group):
-        payload_member = make_bulk_create_payload(MANAGER, member)
-        payload_user = make_bulk_create_payload(MANAGER, user)
+        with override_flag(OSF_GROUPS, active=True):
+            payload_member = make_bulk_create_payload(MANAGER, member)
+            payload_user = make_bulk_create_payload(MANAGER, user)
 
-        # User in bulk payload is an invalid user
-        bad_user_payload = make_bulk_create_payload(MEMBER, user=user3)
-        bad_user_payload['relationships']['users']['data']['id'] = 'bad_user_id'
-        bulk_payload = [payload_user, bad_user_payload]
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == 'User with id bad_user_id not found.'
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # User in bulk payload is an invalid user
+            bad_user_payload = make_bulk_create_payload(MEMBER, user=user3)
+            bad_user_payload['relationships']['users']['data']['id'] = 'bad_user_id'
+            bulk_payload = [payload_user, bad_user_payload]
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == 'User with id bad_user_id not found.'
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
-        # User in bulk payload is invalid
-        bad_type_payload = make_bulk_create_payload(MEMBER, user=user3)
-        bad_type_payload['type'] = 'bad_type'
-        bulk_payload = [payload_user, bad_type_payload]
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 409
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # User in bulk payload is invalid
+            bad_type_payload = make_bulk_create_payload(MEMBER, user=user3)
+            bad_type_payload['type'] = 'bad_type'
+            bulk_payload = [payload_user, bad_type_payload]
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 409
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
-        # User in bulk payload has invalid role specified
-        bad_role_payload = make_bulk_create_payload('bad_role', user=user3)
-        res = app.post_json_api(url, {'data': [payload_user, bad_role_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_role is not a valid role; choose manager or member.'
-        assert osf_group.is_member(user3) is False
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user3) is False
-        assert osf_group.is_manager(user) is False
+            # User in bulk payload has invalid role specified
+            bad_role_payload = make_bulk_create_payload('bad_role', user=user3)
+            res = app.post_json_api(url, {'data': [payload_user, bad_role_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_role is not a valid role; choose manager or member.'
+            assert osf_group.is_member(user3) is False
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user3) is False
+            assert osf_group.is_manager(user) is False
 
-        # fullname not included
-        unregistered_payload = make_bulk_create_payload(MEMBER, user=None, full_name=None, email='eight@cos.io')
-        res = app.post_json_api(url, {'data': [payload_user, unregistered_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # fullname not included
+            unregistered_payload = make_bulk_create_payload(MEMBER, user=None, full_name=None, email='eight@cos.io')
+            res = app.post_json_api(url, {'data': [payload_user, unregistered_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
-        # email not included
-        unregistered_payload = make_bulk_create_payload(MEMBER, user=None, full_name='Crazy 8s', email=None)
-        res = app.post_json_api(url, {'data': [payload_user, unregistered_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # email not included
+            unregistered_payload = make_bulk_create_payload(MEMBER, user=None, full_name='Crazy 8s', email=None)
+            res = app.post_json_api(url, {'data': [payload_user, unregistered_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'You must provide a full_name/email combination to add an unconfirmed member.'
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
-        # Member of bulk payload is already a member
-        bulk_payload = [payload_member, payload_user]
-        res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'User is already a member of this group.'
-        assert osf_group.is_member(member) is True
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(member) is False
-        assert osf_group.is_manager(user) is False
+            # Member of bulk payload is already a member
+            bulk_payload = [payload_member, payload_user]
+            res = app.post_json_api(url, {'data': bulk_payload}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'User is already a member of this group.'
+            assert osf_group.is_member(member) is True
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(member) is False
+            assert osf_group.is_manager(user) is False
 
-        # Disabled user
-        user3.date_disabled = timezone.now()
-        user3.save()
-        payload = make_bulk_create_payload(MEMBER, user=user3)
-        res = app.post_json_api(url, {'data': [payload_user, payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added to OSF Groups.'
+            # Disabled user
+            user3.date_disabled = timezone.now()
+            user3.save()
+            payload = make_bulk_create_payload(MEMBER, user=user3)
+            res = app.post_json_api(url, {'data': [payload_user, payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added to OSF Groups.'
 
-        # No role specified, given member by default
-        user3.date_disabled = None
-        user3.save()
-        payload = make_bulk_create_payload(MEMBER, user=user3)
-        payload['attributes'] = {}
-        res = app.post_json_api(url, {'data': [payload_user, payload]}, auth=manager.auth, bulk=True)
-        assert res.status_code == 201
-        assert len(res.json['data']) == 2
-        ids = [user_data['id'] for user_data in res.json['data']]
-        assert '{}-{}'.format(osf_group._id, user._id) in ids
-        assert '{}-{}'.format(osf_group._id, user3._id) in ids
-        assert osf_group.is_member(user3) is True
-        assert osf_group.is_member(user) is True
-        assert osf_group.is_manager(user3) is False
-        assert osf_group.is_manager(user) is True
+            # No role specified, given member by default
+            user3.date_disabled = None
+            user3.save()
+            payload = make_bulk_create_payload(MEMBER, user=user3)
+            payload['attributes'] = {}
+            res = app.post_json_api(url, {'data': [payload_user, payload]}, auth=manager.auth, bulk=True)
+            assert res.status_code == 201
+            assert len(res.json['data']) == 2
+            ids = [user_data['id'] for user_data in res.json['data']]
+            assert '{}-{}'.format(osf_group._id, user._id) in ids
+            assert '{}-{}'.format(osf_group._id, user3._id) in ids
+            assert osf_group.is_member(user3) is True
+            assert osf_group.is_member(user) is True
+            assert osf_group.is_manager(user3) is False
+            assert osf_group.is_manager(user) is True
 
 def build_bulk_update_payload(group_id, user_id, role):
     return {
@@ -445,87 +459,89 @@ def build_bulk_update_payload(group_id, user_id, role):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersBulkUpdate:
     def test_update_role(self, app, member, manager, user, osf_group, url):
-        payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
-        bulk_payload = {'data': [payload]}
+        with override_flag(OSF_GROUPS, active=True):
+            payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
+            bulk_payload = {'data': [payload]}
 
-        # test unauthenticated
-        res = app.patch_json_api(url, bulk_payload, expect_errors=True, bulk=True)
-        assert res.status_code == 401
+            # test unauthenticated
+            res = app.patch_json_api(url, bulk_payload, expect_errors=True, bulk=True)
+            assert res.status_code == 401
 
-        # test user
-        res = app.patch_json_api(url, bulk_payload, auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # test user
+            res = app.patch_json_api(url, bulk_payload, auth=user.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # test member
-        res = app.patch_json_api(url, bulk_payload, auth=member.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # test member
+            res = app.patch_json_api(url, bulk_payload, auth=member.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # test manager
-        res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 200
-        assert res.json['data'][0]['attributes']['role'] == MANAGER
-        assert res.json['data'][0]['attributes']['full_name'] == member.fullname
-        assert res.json['data'][0]['id'] == '{}-{}'.format(osf_group._id, member._id)
+            # test manager
+            res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 200
+            assert res.json['data'][0]['attributes']['role'] == MANAGER
+            assert res.json['data'][0]['attributes']['full_name'] == member.fullname
+            assert res.json['data'][0]['id'] == '{}-{}'.format(osf_group._id, member._id)
 
-        payload = build_bulk_update_payload(osf_group._id, member._id, MEMBER)
-        bulk_payload = {'data': [payload]}
-        res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 200
-        assert res.json['data'][0]['attributes']['role'] == MEMBER
-        assert res.json['data'][0]['attributes']['full_name'] == member.fullname
-        assert res.json['data'][0]['id'] == '{}-{}'.format(osf_group._id, member._id)
+            payload = build_bulk_update_payload(osf_group._id, member._id, MEMBER)
+            bulk_payload = {'data': [payload]}
+            res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 200
+            assert res.json['data'][0]['attributes']['role'] == MEMBER
+            assert res.json['data'][0]['attributes']['full_name'] == member.fullname
+            assert res.json['data'][0]['id'] == '{}-{}'.format(osf_group._id, member._id)
 
     def test_bulk_update_errors(self, app, member, manager, user, osf_group, url):
-        # id not in payload
-        payload = {
-            'type': 'group-members',
-            'attributes': {
-                'role': MEMBER
+        with override_flag(OSF_GROUPS, active=True):
+            # id not in payload
+            payload = {
+                'type': 'group-members',
+                'attributes': {
+                    'role': MEMBER
+                }
             }
-        }
-        bulk_payload = {'data': [payload]}
+            bulk_payload = {'data': [payload]}
 
-        res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Member identifier not provided.'
+            res = app.patch_json_api(url, bulk_payload, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Member identifier not provided.'
 
-        # test improperly formatted id
-        payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
-        payload['id'] = 'abcde'
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Member identifier incorrectly formatted.'
+            # test improperly formatted id
+            payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
+            payload['id'] = 'abcde'
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Member identifier incorrectly formatted.'
 
-        # test improper type
-        payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
-        payload['type'] = 'bad_type'
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 409
+            # test improper type
+            payload = build_bulk_update_payload(osf_group._id, member._id, MANAGER)
+            payload['type'] = 'bad_type'
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 409
 
-        # test invalid role
-        payload = build_bulk_update_payload(osf_group._id, member._id, 'bad_perm')
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid role; choose manager or member.'
+            # test invalid role
+            payload = build_bulk_update_payload(osf_group._id, member._id, 'bad_perm')
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'bad_perm is not a valid role; choose manager or member.'
 
-        # test user is not a member
-        payload = build_bulk_update_payload(osf_group._id, user._id, MEMBER)
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
+            # test user is not a member
+            payload = build_bulk_update_payload(osf_group._id, user._id, MEMBER)
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
 
-        # test cannot downgrade remaining manager
-        payload = build_bulk_update_payload(osf_group._id, manager._id, MEMBER)
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test cannot downgrade remaining manager
+            payload = build_bulk_update_payload(osf_group._id, manager._id, MEMBER)
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
-        # test cannot remove last confirmed manager
-        osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
-        assert len(osf_group.managers) == 2
-        res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test cannot remove last confirmed manager
+            osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
+            assert len(osf_group.managers) == 2
+            res = app.patch_json_api(url, {'data': [payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
 def create_bulk_delete_payload(group_id, user_id):
     return {
@@ -537,72 +553,74 @@ def create_bulk_delete_payload(group_id, user_id):
 @pytest.mark.enable_quickfiles_creation
 class TestOSFGroupMembersBulkDelete:
     def test_delete_perms(self, app, member, manager, user, osf_group, url):
-        member_payload = create_bulk_delete_payload(osf_group._id, member._id)
-        bulk_payload = {'data': [member_payload]}
-        # test unauthenticated
-        res = app.delete_json_api(url, bulk_payload, expect_errors=True, bulk=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            member_payload = create_bulk_delete_payload(osf_group._id, member._id)
+            bulk_payload = {'data': [member_payload]}
+            # test unauthenticated
+            res = app.delete_json_api(url, bulk_payload, expect_errors=True, bulk=True)
+            assert res.status_code == 401
 
-        # test user
-        res = app.delete_json_api(url, bulk_payload, auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # test user
+            res = app.delete_json_api(url, bulk_payload, auth=user.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # test member
-        res = app.delete_json_api(url, bulk_payload, auth=member.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
+            # test member
+            res = app.delete_json_api(url, bulk_payload, auth=member.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 403
 
-        # test manager
-        assert osf_group.is_member(member) is True
-        assert osf_group.is_manager(member) is False
+            # test manager
+            assert osf_group.is_member(member) is True
+            assert osf_group.is_manager(member) is False
 
-        res = app.delete_json_api(url, bulk_payload, auth=manager.auth, bulk=True)
-        assert res.status_code == 204
-        assert osf_group.is_member(member) is False
-        assert osf_group.is_manager(member) is False
+            res = app.delete_json_api(url, bulk_payload, auth=manager.auth, bulk=True)
+            assert res.status_code == 204
+            assert osf_group.is_member(member) is False
+            assert osf_group.is_manager(member) is False
 
-        # test user does not belong to OSF Group
-        osf_group.make_manager(user)
-        assert osf_group.is_member(user) is True
-        assert osf_group.is_manager(user) is True
-        user_payload = create_bulk_delete_payload(osf_group._id, user._id)
-        bulk_payload = {'data': [user_payload, member_payload]}
-        res = app.delete_json_api(url, bulk_payload, auth=user.auth, bulk=True, expect_errors=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(member._id)
+            # test user does not belong to OSF Group
+            osf_group.make_manager(user)
+            assert osf_group.is_member(user) is True
+            assert osf_group.is_manager(user) is True
+            user_payload = create_bulk_delete_payload(osf_group._id, user._id)
+            bulk_payload = {'data': [user_payload, member_payload]}
+            res = app.delete_json_api(url, bulk_payload, auth=user.auth, bulk=True, expect_errors=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(member._id)
 
-        # test bulk delete manager (not last one)
-        osf_group.make_manager(user)
-        assert osf_group.is_member(user) is True
-        assert osf_group.is_manager(user) is True
-        user_payload = create_bulk_delete_payload(osf_group._id, user._id)
-        bulk_payload = {'data': [user_payload]}
-        res = app.delete_json_api(url, bulk_payload, auth=user.auth, bulk=True)
-        assert res.status_code == 204
-        assert osf_group.is_member(user) is False
-        assert osf_group.is_manager(user) is False
+            # test bulk delete manager (not last one)
+            osf_group.make_manager(user)
+            assert osf_group.is_member(user) is True
+            assert osf_group.is_manager(user) is True
+            user_payload = create_bulk_delete_payload(osf_group._id, user._id)
+            bulk_payload = {'data': [user_payload]}
+            res = app.delete_json_api(url, bulk_payload, auth=user.auth, bulk=True)
+            assert res.status_code == 204
+            assert osf_group.is_member(user) is False
+            assert osf_group.is_manager(user) is False
 
     def test_delete_errors(self, app, member, manager, user, osf_group, url):
-        # test invalid user
-        invalid_payload = create_bulk_delete_payload(osf_group._id, '12345')
-        res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
+        with override_flag(OSF_GROUPS, active=True):
+            # test invalid user
+            invalid_payload = create_bulk_delete_payload(osf_group._id, '12345')
+            res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
 
-        # test user does not belong to group
-        invalid_payload = create_bulk_delete_payload(osf_group._id, user._id)
-        res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
+            # test user does not belong to group
+            invalid_payload = create_bulk_delete_payload(osf_group._id, user._id)
+            res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 404
+            assert res.json['errors'][0]['detail'] == '{} cannot be found in this OSFGroup'.format(user._id)
 
-        # test user is last manager
-        invalid_payload = create_bulk_delete_payload(osf_group._id, manager._id)
-        res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test user is last manager
+            invalid_payload = create_bulk_delete_payload(osf_group._id, manager._id)
+            res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
 
-        # test user is last registered manager
-        osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
-        assert len(osf_group.managers) == 2
-        res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'
+            # test user is last registered manager
+            osf_group.add_unregistered_member('Crazy 8s', 'eight@cos.io', Auth(manager), MANAGER)
+            assert len(osf_group.managers) == 2
+            res = app.delete_json_api(url, {'data': [invalid_payload]}, auth=manager.auth, expect_errors=True, bulk=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Group must have at least one manager.'

--- a/api_tests/osf_groups/views/test_osf_groups_list.py
+++ b/api_tests/osf_groups/views/test_osf_groups_list.py
@@ -1,4 +1,5 @@
 import pytest
+from waffle.testutils import override_flag
 
 from api.base.settings.defaults import API_BASE
 from osf.models import OSFGroup
@@ -6,6 +7,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
 
 @pytest.fixture()
 def user():
@@ -33,62 +35,64 @@ class TestGroupList:
         return '/{}groups/'.format(API_BASE)
 
     def test_return(self, app, member, manager, user, osf_group, url):
-        # test nonauthenticated
-        res = app.get(url)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+        with override_flag(OSF_GROUPS, active=True):
+            # test nonauthenticated
+            res = app.get(url)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        # test authenticated user
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+            # test authenticated user
+            res = app.get(url, auth=user.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        # test authenticated member
-        res = app.get(url, auth=member.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
-        assert data[0]['type'] == 'groups'
-        assert data[0]['attributes']['name'] == osf_group.name
+            # test authenticated member
+            res = app.get(url, auth=member.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
+            assert data[0]['type'] == 'groups'
+            assert data[0]['attributes']['name'] == osf_group.name
 
-        # test authenticated manager
-        res = app.get(url, auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
-        assert data[0]['type'] == 'groups'
-        assert data[0]['attributes']['name'] == osf_group.name
+            # test authenticated manager
+            res = app.get(url, auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
+            assert data[0]['type'] == 'groups'
+            assert data[0]['attributes']['name'] == osf_group.name
 
     def test_groups_filter(self, app, member, manager, user, osf_group, url):
-        second_group = OSFGroupFactory(name='Apples', creator=manager)
-        res = app.get(url + '?filter[name]=Platform', auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
+        with override_flag(OSF_GROUPS, active=True):
+            second_group = OSFGroupFactory(name='Apples', creator=manager)
+            res = app.get(url + '?filter[name]=Platform', auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
 
-        res = app.get(url + '?filter[name]=Apple', auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == second_group._id
+            res = app.get(url + '?filter[name]=Apple', auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == second_group._id
 
-        res = app.get(url + '?filter[bad_field]=Apple', auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
+            res = app.get(url + '?filter[bad_field]=Apple', auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
 
-        res = app.get(url + '?filter[name]=Platform')
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+            res = app.get(url + '?filter[name]=Platform')
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        res = app.get(url + '?filter[name]=Apple')
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+            res = app.get(url + '?filter[name]=Apple')
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
 
 @pytest.mark.django_db
@@ -110,36 +114,38 @@ class TestOSFGroupCreate:
 
     def test_create_osf_group(self, app, url, manager, simple_payload):
         # Nonauthenticated
-        res = app.post_json_api(url, simple_payload, expect_errors=True)
-        assert res.status_code == 401
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.post_json_api(url, simple_payload, expect_errors=True)
+            assert res.status_code == 401
 
-        # Authenticated
-        res = app.post_json_api(url, simple_payload, auth=manager.auth)
-        assert res.status_code == 201
-        assert res.json['data']['type'] == 'groups'
-        assert res.json['data']['attributes']['name'] == 'My New Lab'
-        group = OSFGroup.objects.get(_id=res.json['data']['id'])
-        assert group.creator_id == manager.id
-        assert group.has_permission(manager, 'manage') is True
-        assert group.has_permission(manager, 'member') is True
+            # Authenticated
+            res = app.post_json_api(url, simple_payload, auth=manager.auth)
+            assert res.status_code == 201
+            assert res.json['data']['type'] == 'groups'
+            assert res.json['data']['attributes']['name'] == 'My New Lab'
+            group = OSFGroup.objects.get(_id=res.json['data']['id'])
+            assert group.creator_id == manager.id
+            assert group.has_permission(manager, 'manage') is True
+            assert group.has_permission(manager, 'member') is True
 
     def test_create_osf_group_validation_errors(self, app, url, manager, simple_payload):
         # Need data key
-        res = app.post_json_api(url, simple_payload['data'], auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data.'
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.post_json_api(url, simple_payload['data'], auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'Request must include /data.'
 
-        # Incorrect type
-        simple_payload['data']['type'] = 'incorrect_type'
-        res = app.post_json_api(url, simple_payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 409
+            # Incorrect type
+            simple_payload['data']['type'] = 'incorrect_type'
+            res = app.post_json_api(url, simple_payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 409
 
-        # Required name field
-        payload = {
-            'data': {
-                'type': 'groups'
+            # Required name field
+            payload = {
+                'data': {
+                    'type': 'groups'
+                }
             }
-        }
-        res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'This field is required.'
+            res = app.post_json_api(url, payload, auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
+            assert res.json['errors'][0]['detail'] == 'This field is required.'

--- a/api_tests/users/views/test_user_osf_groups_list.py
+++ b/api_tests/users/views/test_user_osf_groups_list.py
@@ -1,10 +1,13 @@
 import pytest
+from waffle.testutils import override_flag
 
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import (
     AuthUserFactory,
     OSFGroupFactory,
 )
+from osf.features import OSF_GROUPS
+
 
 @pytest.fixture()
 def user():
@@ -42,72 +45,75 @@ class TestUserGroupList:
         return '/{}users/{}/groups/'.format(API_BASE, member._id)
 
     def test_return_manager_groups(self, app, member, manager, user, osf_group, second_osf_group, manager_url):
-        # test nonauthenticated
-        res = app.get(manager_url)
-        assert res.status_code == 200
-        ids = [group['id'] for group in res.json['data']]
-        assert len(ids) == 0
+        with override_flag(OSF_GROUPS, active=True):
+            # test nonauthenticated
+            res = app.get(manager_url)
+            assert res.status_code == 200
+            ids = [group['id'] for group in res.json['data']]
+            assert len(ids) == 0
 
-        # test authenticated user
-        res = app.get(manager_url, auth=user.auth)
-        assert res.status_code == 200
-        ids = [group['id'] for group in res.json['data']]
-        assert len(ids) == 0
+            # test authenticated user
+            res = app.get(manager_url, auth=user.auth)
+            assert res.status_code == 200
+            ids = [group['id'] for group in res.json['data']]
+            assert len(ids) == 0
 
-        # test authenticated member
-        res = app.get(manager_url, auth=member.auth)
-        assert res.status_code == 200
-        ids = [group['id'] for group in res.json['data']]
-        assert len(ids) == 1
+            # test authenticated member
+            res = app.get(manager_url, auth=member.auth)
+            assert res.status_code == 200
+            ids = [group['id'] for group in res.json['data']]
+            assert len(ids) == 1
 
-        # test authenticated manager
-        res = app.get(manager_url, auth=manager.auth)
-        assert res.status_code == 200
-        ids = [group['id'] for group in res.json['data']]
-        assert len(ids) == 2
-        assert osf_group._id in ids
-        assert second_osf_group._id in ids
+            # test authenticated manager
+            res = app.get(manager_url, auth=manager.auth)
+            assert res.status_code == 200
+            ids = [group['id'] for group in res.json['data']]
+            assert len(ids) == 2
+            assert osf_group._id in ids
+            assert second_osf_group._id in ids
 
     def test_groups_filter(self, app, member, manager, user, osf_group, second_osf_group, manager_url):
-        res = app.get(manager_url + '?filter[name]=Platform', auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
+        with override_flag(OSF_GROUPS, active=True):
+            res = app.get(manager_url + '?filter[name]=Platform', auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
 
-        res = app.get(manager_url + '?filter[name]=Apple', auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+            res = app.get(manager_url + '?filter[name]=Apple', auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        res = app.get(manager_url + '?filter[bad_field]=Apple', auth=manager.auth, expect_errors=True)
-        assert res.status_code == 400
+            res = app.get(manager_url + '?filter[bad_field]=Apple', auth=manager.auth, expect_errors=True)
+            assert res.status_code == 400
 
     def test_return_member_groups(self, app, member, manager, user, osf_group, second_osf_group, member_url):
-        # test nonauthenticated
-        res = app.get(member_url)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+        with override_flag(OSF_GROUPS, active=True):
+            # test nonauthenticated
+            res = app.get(member_url)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        # test authenticated user
-        res = app.get(member_url, auth=user.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 0
+            # test authenticated user
+            res = app.get(member_url, auth=user.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 0
 
-        # test authenticated member
-        res = app.get(member_url, auth=member.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
+            # test authenticated member
+            res = app.get(member_url, auth=member.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
 
-        # test authenticated manager
-        res = app.get(member_url, auth=manager.auth)
-        assert res.status_code == 200
-        data = res.json['data']
-        assert len(data) == 1
-        assert data[0]['id'] == osf_group._id
-        assert data[0]['type'] == 'groups'
-        assert data[0]['attributes']['name'] == osf_group.name
+            # test authenticated manager
+            res = app.get(member_url, auth=manager.auth)
+            assert res.status_code == 200
+            data = res.json['data']
+            assert len(data) == 1
+            assert data[0]['id'] == osf_group._id
+            assert data[0]['type'] == 'groups'
+            assert data[0]['attributes']['name'] == osf_group.name

--- a/osf/features.py
+++ b/osf/features.py
@@ -6,6 +6,7 @@ ENFORCE_CSRF = 'enforce_csrf'
 INSTITUTIONAL_LANDING_FLAG = 'institutions_nav_bar'
 STORAGE_I18N = 'storage_i18n'
 OSF_PREREGISTRATION = 'osf_preregistration'
+OSF_GROUPS = 'osf_groups'
 
 EMBER_AUTH_REGISTER = 'ember_auth_register'
 EMBER_CREATE_DRAFT_REGISTRATION = 'ember_create_draft_registration_page'

--- a/osf/migrations/0167_auto_20190506_1556.py
+++ b/osf/migrations/0167_auto_20190506_1556.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import migrations
+
+from osf import features
+from osf.utils.migrations import AddWaffleFlags
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('osf', '0166_merge_20190429_1632'),
+    ]
+
+    operations = [
+        AddWaffleFlags([features.OSF_GROUPS], on_for_everyone=False),
+    ]


### PR DESCRIPTION
## Purpose
It will probably be awhile before Groups Front End is out -  in the meantime, it is possible, though unlikely, that people start using Groups endpoints.  Because of a few side effects, like emails being sent, and a few places on emberized front end pages that need special handlings (admin group members shouldn't be able to create  draft registrations for example), waffle off the current groups API endpoints for now.

## Changes
![Screen Shot 2019-05-06 at 3 36 45 PM](https://user-images.githubusercontent.com/9755598/57253621-c8153280-7014-11e9-95dc-851fc406572e.png)

- Use custom `require_flag` decorator on all relevant methods on the OSFGroup API views to make sure all CRUD operations are blocked
- If hitting an endpoint that is waffled off, you get a 404 `This endpoint is disabled`.
- Add migration to add waffle flag turning off endpoints
- Override waffle flag in tests so API tests are preserved

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

- I've left the relationship links on other serializers - NodeSerializer and UserSerializer - thought it was a big overkill to go in and remove all of those.  If those relationship links are followed, you will also get a 404 unless they are waffled on.
## Ticket

https://openscience.atlassian.net/browse/ENG-145
