### PR TITLE
[ENG-344][ENG-428][ENG-483] Add fields to payload sent to Chronos

### DIFF
--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -69,6 +69,8 @@ class ChronosSerializer(object):
             'PROVIDER_MANUSCRIPT_ID': preprint._id,
             'CHRONOS_JOURNAL_ID': journal_id,
             'MANUSCRIPT_URL': preprint.url,
+            'KEYWORDS': ','.join(preprint.tags.all().values_list('name', flat=True)),
+            'EXTRAVALUES': 'Provider:{}'.format(preprint.provider.name),
         }
 
     @classmethod
@@ -76,10 +78,10 @@ class ChronosSerializer(object):
         return {
             'CHRONOS_USER_ID': user.chronos_user_id,
             'EMAIL': user.username,
-            'GIVEN_NAME': user.given_name,
+            'GIVEN_NAME': user.given_name if str(user.given_name) and str(user.family_name) else user.fullname,
             'ORCID_ID': user.social.get('orcid', None),
             'PARTNER_USER_ID': user._id,
-            'SURNAME': user.family_name,
+            'SURNAME': user.family_name if str(user.given_name) and str(user.family_name) else None,
         }
 
     @classmethod

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -70,7 +70,13 @@ class ChronosSerializer(object):
             'CHRONOS_JOURNAL_ID': journal_id,
             'MANUSCRIPT_URL': preprint.url,
             'KEYWORDS': ','.join(preprint.tags.all().values_list('name', flat=True)),
-            'EXTRAVALUES': 'Provider:{}'.format(preprint.provider.name),
+            'ADDITIONAL_DATA': [
+                {
+                    'DATA_NAME': 'Provider',
+                    'DATA_TYPE': 'string',
+                    'DATA_VALUE': preprint.provider.name,
+                }
+            ],
         }
 
     @classmethod


### PR DESCRIPTION
## Purpose

Add fields to our payload sent to Chronos.

## Changes

- Added a comma separated list of tags using the `KEYWORDS` field for the manuscript.
- Added provider information using the `EXTRAVALUES` field for the manuscript.
- Checks whether the OSFUser has both `given_name` and `family_name` defined. If not, serialize `fullname` under the `GIVEN_NAME` field and `null` under the `SURNAME` field.

## Ticket
https://openscience.atlassian.net/browse/ENG-344
https://openscience.atlassian.net/browse/ENG-428
https://openscience.atlassian.net/browse/ENG-483
