### PR TITLE
Feature/APIv2 Cannot filter provider licenses [ENG-489]

### DIFF
--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -258,6 +258,8 @@ class GenericProviderLicenseList(LicenseList):
         if provider.default_license:
             licenses |= NodeLicense.objects.filter(id=provider.default_license.id)
 
+        # Since default_license could also be in acceptable_licenses, filtering
+        # this way to avoid duplicates without .distinct() usage
         return NodeLicense.objects.filter(
             Q(id__in=licenses.values_list('id', flat=True)),
         )

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -253,7 +253,7 @@ class GenericProviderLicenseList(LicenseList):
         if provider.licenses_acceptable.count():
             licenses = provider.licenses_acceptable.get_queryset()
         else:
-            licenses = NodeLicense.objects.preprint_licenses()
+            licenses = NodeLicense.objects.all()
 
         if provider.default_license:
             licenses |= NodeLicense.objects.filter(id=provider.default_license.id)

--- a/api_tests/providers/preprints/views/test_preprint_provider_licenses.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_licenses.py
@@ -51,7 +51,7 @@ class TestPreprintProviderLicenses:
 
         assert res.status_code == 200
         assert res.json['links']['meta']['total'] == len(licenses)
-        assert license_two._id == res.json['data'][0]['id']
+        assert license_two._id in [item['id'] for item in res.json['data']]
 
     def test_prerint_provider_has_acceptable_licenses_but_no_default(self, app, provider, licenses, license_one, license_two, license_three, url):
         provider.licenses_acceptable.add(license_one, license_two)
@@ -80,5 +80,3 @@ class TestPreprintProviderLicenses:
         assert license_one._id in license_ids
         assert license_three._id in license_ids
         assert license_two._id not in license_ids
-
-        assert license_three._id == license_ids[0]


### PR DESCRIPTION
## Purpose

Fix filtering on Provider Licenses - 
The provider "acceptable licenses" endpoints don't actually filter when they're supposed to. This already breaks the license picker in collections and will do the same for editable registrations.

Example: https://api.osf.io/v2/providers/registrations/osf/licenses/?filter[name]=aoeuaoeu

## Changes

- Override `get_default_queryset` instead of `get_queryset`
- Return querysets instead of lists
- Rearrange logic to make it clearer

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-489
