### PR TITLE
[ENG-471] Add route redirect

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -300,6 +300,11 @@ def conference_results(meeting):
         'settings': settings,
     }
 
+
+def redirect_to_conference_results(meeting):
+    return redirect('/meetings/{}'.format(meeting))
+
+
 def conference_submissions(**kwargs):
     """Return data for all OSF4M submissions.
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -415,10 +415,17 @@ def make_url_map(app):
         ),
 
         Rule(
-            '/view/<meeting>/',
+            '/meetings/<meeting>/',
             'get',
             conference_views.conference_results,
             OsfWebRenderer('public/pages/meeting.mako', trust=False),
+        ),
+
+        Rule(
+            '/view/<meeting>/',
+            'get',
+            conference_views.redirect_to_conference_results,
+            notemplate
         ),
 
         Rule(


### PR DESCRIPTION
## Purpose

Use `/meetings/<meeting_id>` instead of `/view/<meeting_id>` for meeting detail views.
For backwards compatibility, redirect to new one if users goes to the old route.

## Ticket

https://openscience.atlassian.net/browse/ENG-471
