### PR TITLE
Feature/flagged nodes confirm ham [ENG-488]

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -349,9 +349,9 @@ class NodeFlaggedSpamList(NodeSpamList, DeleteView):
     template_name = 'nodes/flagged_spam_list.html'
 
     def delete(self, request, *args, **kwargs):
-        if not request.user.has_perm('auth.mark_spam'):
+        if (('spam_confirm' in request.POST.keys() and not request.user.has_perm('auth.mark_spam')) or
+                ('ham_confirm' in request.POST.keys() and not request.user.has_perm('auth.mark_ham'))):
             raise PermissionDenied('You do not have permission to update a node flagged as spam.')
-        print (request.POST)
         node_ids = [
             nid for nid in request.POST.keys()
             if nid not in ('csrfmiddlewaretoken', 'spam_confirm', 'ham_confirm')

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -368,7 +368,7 @@ class NodeFlaggedSpamList(NodeSpamList, DeleteView):
                     message='Confirmed SPAM: {}'.format(nid),
                     action_flag=CONFIRM_SPAM
                 )
-            else:
+            elif ('ham_confirm' in request.POST.keys()):
                 node.confirm_ham(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -349,17 +349,17 @@ class NodeFlaggedSpamList(NodeSpamList, DeleteView):
     template_name = 'nodes/flagged_spam_list.html'
 
     def delete(self, request, *args, **kwargs):
-        if (('spam_confirm' in request.POST.keys() and not request.user.has_perm('auth.mark_spam')) or
-                ('ham_confirm' in request.POST.keys() and not request.user.has_perm('auth.mark_ham'))):
+        if (('spam_confirm' in list(request.POST.keys()) and not request.user.has_perm('auth.mark_spam')) or
+                ('ham_confirm' in list(request.POST.keys()) and not request.user.has_perm('auth.mark_ham'))):
             raise PermissionDenied('You do not have permission to update a node flagged as spam.')
         node_ids = [
-            nid for nid in request.POST.keys()
+            nid for nid in list(request.POST.keys())
             if nid not in ('csrfmiddlewaretoken', 'spam_confirm', 'ham_confirm')
         ]
         for nid in node_ids:
             node = Node.load(nid)
             osf_admin_change_status_identifier(node)
-            if ('spam_confirm' in request.POST.keys()):
+            if ('spam_confirm' in list(request.POST.keys())):
                 node.confirm_spam(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,
@@ -368,7 +368,7 @@ class NodeFlaggedSpamList(NodeSpamList, DeleteView):
                     message='Confirmed SPAM: {}'.format(nid),
                     action_flag=CONFIRM_SPAM
                 )
-            elif ('ham_confirm' in request.POST.keys()):
+            elif ('ham_confirm' in list(request.POST.keys())):
                 node.confirm_ham(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,

--- a/admin/templates/nodes/ham_spam_modal.html
+++ b/admin/templates/nodes/ham_spam_modal.html
@@ -1,0 +1,19 @@
+<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirm{{ target_type|capfirst }}ListModal">
+    Confirm {{ target_type|capfirst }}
+</button>
+<div id="confirm{{ target_type|capfirst }}ListModal" class="modal fade well" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">x</button>
+                <h3>Are you sure the selected node(s) are {{ target_type }}?</h3>
+            </div>
+            <div class="modal-footer">
+                <input class="btn btn-danger" type="submit" value="Confirm" name={{ target_type|add:"_confirm" }} />
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/admin/templates/nodes/node_list.html
+++ b/admin/templates/nodes/node_list.html
@@ -93,25 +93,10 @@
     </tbody>
 </table>
 {% if form_action and perms.osf.mark_spam %}
-<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
-    Confirm Spam
-</button>
-<div id="confirmSpamListModal" class="modal fade well" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal">x</button>
-                <h3>Are you sure the selected node(s) are spam?</h3>
-            </div>
-            <div class="modal-footer">
-                <input class="btn btn-danger" type="submit" value="Confirm" />
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    Cancel
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
+    {% include 'nodes/ham_spam_modal.html' with target_type="spam" %}
+{% endif %}
+{% if form_action and perms.osf.mark_ham %}
+    {% include 'nodes/ham_spam_modal.html' with target_type="ham" %}
+{% endif %}
 {% csrf_token %}
 </form>
-{% endif %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Break out the "Confirm Ham"/"Confirm Spam" buttons and modal dialogs into a template. Add in capability for bulk Confirm Ham operations. 

## Changes

<!-- Briefly describe or list your changes  -->

- Modified admin/nodes.py NodeFlaggedSpamList to add functionality for bulk HAM operations.
- Created admin/templates/nodes/ham_spam_modal.html template for Ham/Spam button and modal.
- Modified admin/templates/nodes/node_list.html to utilize the ham_spam_modal.html template.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Test /nodes/flagged_spam to ensure Confirm Ham and Confirm Spam is working properly.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/ENG-488