### PR TITLE
Feature/Fix Request Access requests with CSRF [ENG-516]

### DIFF
--- a/website/static/js/accessRequestManager.js
+++ b/website/static/js/accessRequestManager.js
@@ -66,7 +66,7 @@ var AccessRequestModel = function(accessRequest, pageOwner, isRegistration, isPa
             'POST',
             requestUrl,
             {
-                'is_cors': true,
+                'isCors': true,
                 'data': payload,
                 'fields': {
                     xhrFields: {withCredentials: true}

--- a/website/static/js/requestAccess.js
+++ b/website/static/js/requestAccess.js
@@ -48,7 +48,7 @@ var RequestAccessViewModel = function(currentUserRequestState, nodeId, user) {
             'POST',
             self.updateUrl,
             {
-                'is_cors': true,
+                'isCors': true,
                 'data': payload,
                 'fields': {
                     xhrFields: {withCredentials: true}


### PR DESCRIPTION
## Purpose

If `enforce_csrf` waffle switch is turned on, request access to projects doesn't work, and approving a user's request for access doesn't work.  

## Changes
Fix casing issue.  `osf.ajaxJSON` helper does not add CSRF token info by default, you need to override isCors=true.  We were passing in `is_cors` instead.

## QA Notes

- Test that both requesting access and approving a request access works with `enforce_csrf` waffle switch on.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-516