### PR TITLE
Fix ampersand displaying as "&amp;" in Public/Private dialog box [ENG-53]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -20,6 +20,7 @@ from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
 from osf.utils.functional import rapply
+from osf.utils import sanitize
 from osf import features
 
 from website import language
@@ -1019,7 +1020,7 @@ def serialize_child_tree(child_list, user, nested):
                 'node': {
                     'id': child._id,
                     'url': child.url,
-                    'title': child.title,
+                    'title': sanitize.unescape_entities(child.title),
                     'is_public': child.is_public,
                     'contributors': contributors,
                     'is_admin': child.has_admin_perm,
@@ -1077,7 +1078,7 @@ def node_child_tree(user, node):
             'node': {
                 'id': node._id,
                 'url': node.url if can_read else '',
-                'title': node.title if can_read else 'Private Project',
+                'title': sanitize.unescape_entities(node.title) if can_read else 'Private Project',
                 'is_public': node.is_public,
                 'contributors': contributors,
                 'is_admin': is_admin,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

Project titles are displaying unescaped` &amp;` for &'s in the Make Private/Public modal box. 

## Changes

Modified website/project/views/node.py to use sanitize.unescape_entities() to replace the `&amp; `with &.

<!-- Briefly describe or list your changes  -->

## QA Notes

Test the Make Private/Public modal to ensure `&amp;'s` are not displaying.

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/ENG-53