### PR TITLE
[ENG-536 ]Add UNDERLYTING_DATASET_URL to payload.

### DIFF
--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -77,7 +77,7 @@ class ChronosSerializer(object):
                     'DATA_VALUE': preprint.provider.name,
                 }
             ],
-            'UNDERLYING_DATASET_URL': preprint.node.absolute_url,
+            'UNDERLYING_DATASET_URL': preprint.node.absolute_url if preprint.node else '',
         }
 
     @classmethod

--- a/osf/external/chronos.py
+++ b/osf/external/chronos.py
@@ -77,6 +77,7 @@ class ChronosSerializer(object):
                     'DATA_VALUE': preprint.provider.name,
                 }
             ],
+            'UNDERLYING_DATASET_URL': preprint.node.absolute_url,
         }
 
     @classmethod

--- a/scripts/clear_chronos_user_id_and_submissions.py
+++ b/scripts/clear_chronos_user_id_and_submissions.py
@@ -7,15 +7,24 @@ import django
 django.setup()
 
 from osf import models
+from website.app import init_app
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
-
 
 def main(dry_run=True):
-    models.OSFUser.objects.all().update(chronos_user_id=None)
-    models.ChronosSubmission.objects.all().delete()
+    if dry_run:
+        for user in models.OSFUser.objects.filter(chronos_user_id__isnull=False):
+            logger.info('Reset chronos_user_id for user with guid {}'.format(user._id))
+        for submission in models.ChronosSubmission.objects.all():
+            logger.info('Deleting chronos submission with id {}'.format(submission.publication_id))
+    else:
+        models.OSFUser.objects.all().update(chronos_user_id=None)
+        models.ChronosSubmission.objects.all().delete()
+        logger.info('Finished resetting all OSFUser chronos_user_id')
+        logger.info('Finished deleting all ChronosSubmission instances')
 
 
 if __name__ == '__main__':
-    main(dry_run='--dry' in sys.argv)
+    init_app(routes=False)
+    dry = '--dry' in sys.argv
+    main(dry_run=dry)

--- a/scripts/clear_chronos_user_id_and_submissions.py
+++ b/scripts/clear_chronos_user_id_and_submissions.py
@@ -1,0 +1,21 @@
+"""
+Clears the `chronos_user_id` field on all OSFUser instances. Needed for switching from one Chronos server to another.
+"""
+import sys
+import logging
+import django
+django.setup()
+
+from osf import models
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def main(dry_run=True):
+    models.OSFUser.objects.all().update(chronos_user_id=None)
+    models.ChronosSubmission.objects.all().delete()
+
+
+if __name__ == '__main__':
+    main(dry_run='--dry' in sys.argv)


### PR DESCRIPTION
## Purpose

Because we want to also send Chronos the link to supplemental node upon submission, we use the `UNDERLYING_DATASET_URL` field to send that information.

Also unrelated to this ticket, we add a new script to clear `chronos_user_id` field for all `OSFUser` instances, as well as delete all `ChronosSubmission` instances because we need to switch from using Chronos sandbox server to staging server.

## Changes

Serialize `UNDERLYTING_DATASET_URL` as the preprint sup node's absolute url.
Add a new `clear_chronos_user_id_and_submissions` script.

## Ticket

https://openscience.atlassian.net/browse/ENG-536
