### PR TITLE
Feature/Expose User Spam Status in Admin App [ENG-147]

### DIFF
--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -393,17 +393,7 @@
             </tr>
             <tr>
                 <td>SPAM Status</td>
-                <td>
-                    {% if node.spam_status == SPAM_STATUS.UNKNOWN %}
-                        <span class="label label-default">Unknown</span>
-                    {% elif node.spam_status == SPAM_STATUS.FLAGGED %}
-                        <span class="label label-warning">Flagged</span>
-                    {% elif node.spam_status == SPAM_STATUS.SPAM %}
-                        <span class="label label-danger">Spam</span>
-                    {% elif node.spam_status == SPAM_STATUS.HAM %}
-                        <span class="label label-success">Ham</span>
-                    {% endif %}
-                </td>
+                <td>{% include "nodes/spam_status.html" with resource=node %}</td>
             </tr>
             <tr>
                 <td>SPAM Data</td>

--- a/admin/templates/nodes/spam_status.html
+++ b/admin/templates/nodes/spam_status.html
@@ -1,0 +1,9 @@
+{% if resource.spam_status == SPAM_STATUS.UNKNOWN %}
+    <span class="label label-default">Unknown</span>
+{% elif resource.spam_status == SPAM_STATUS.FLAGGED %}
+    <span class="label label-warning">Flagged</span>
+{% elif resource.spam_status == SPAM_STATUS.SPAM %}
+    <span class="label label-danger">Spam</span>
+{% elif resource.spam_status == SPAM_STATUS.HAM %}
+    <span class="label label-success">Ham</span>
+{% endif %}

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -253,6 +253,10 @@
                     </td>
                 </tr>
                 <tr>
+                    <td>SPAM Status</td>
+                    <td>{% include "nodes/spam_status.html" with resource=user %}</td>
+                </tr>
+                <tr>
                     <td>Profile content checked for spam</td>
                     <td>{{ user.potential_spam_profile_content }}</td>
                 </tr>
@@ -283,17 +287,7 @@
                                 <td>{{ node.public }}</td>
                                 <td>{{ node.is_registration }}</td>
                                 <td>{{ node.number_contributors }}</td>
-                                <td>
-                                    {% if node.spam_status == SPAM_STATUS.UNKNOWN %}
-                                        <span class="label label-default">Unknown</span>
-                                    {% elif node.spam_status == SPAM_STATUS.FLAGGED %}
-                                        <span class="label label-warning">Flagged</span>
-                                    {% elif node.spam_status == SPAM_STATUS.SPAM %}
-                                        <span class="label label-danger">Spam</span>
-                                    {% elif node.spam_status == SPAM_STATUS.HAM %}
-                                        <span class="label label-success">Ham</span>
-                                    {% endif %}
-                                </td>
+                                <td>{% include "nodes/spam_status.html" with resource=node %}</td>
                                 {%  if perms.osf.delete_node %}
                                 <td>
                                     {% if node.number_contributors < 2 and not node.is_registration %}


### PR DESCRIPTION
## Purpose
Exposing spam status in user admin app will make it more clear exactly what the user's spam status is, rather than relying on "Is spammy", which accommodates multiple states.  This will also help verify that our schema/data migration from using user system tags to the User.spam_status field was successful.

## Changes

Display spam status in the same way we display spam status for nodes. DRY up this code to share with node spam status display.

<img width="461" alt="Screen Shot 2019-05-29 at 9 34 33 AM" src="https://user-images.githubusercontent.com/9755598/58566123-9e0af680-81f5-11e9-9e81-030c56a751ca.png">


## QA Notes

- Verify that spam user system tag pre-migration matches spam status display post-migration
- Do a quick skim over nodes' spam status on the node detail page as well as the user's nodes at the bottom of the user page.  Just make sure it's appearing/behaving as expected.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-147
