### PR TITLE
[ENG-460] Fix Broken Repos and Team Repos Endpoints Due to Bitbucket GDPR Update

### DIFF
--- a/addons/bitbucket/models.py
+++ b/addons/bitbucket/models.py
@@ -225,7 +225,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
                 mine = connection.repos()
                 ours = connection.team_repos()
                 repo_names = [
-                    '{0} / {1}'.format(repo['owner']['username'], repo['slug'])
+                    repo['full_name']
                     for repo in mine + ours
                 ]
             except Exception:

--- a/addons/bitbucket/models.py
+++ b/addons/bitbucket/models.py
@@ -225,7 +225,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
                 mine = connection.repos()
                 ours = connection.team_repos()
                 repo_names = [
-                    repo['full_name']
+                    repo['full_name'].replace('/', ' / ')
                     for repo in mine + ours
                 ]
             except Exception:

--- a/addons/bitbucket/tests/utils.py
+++ b/addons/bitbucket/tests/utils.py
@@ -36,15 +36,14 @@ def create_mock_bitbucket(user='octo-cat', private=False):
         'owner': {'username': user},
     }
     bitbucket_mock.repos.return_value = [
-        {'name': 'cow-problems-app',   'owner': {'username': user}, 'is_private': private},
-        {'name': 'duck-problems-app',  'owner': {'username': user}, 'is_private': True},
-        {'name': 'horse-problems-app', 'owner': {'username': user}, 'is_private': False},
+        {'full_name': '{}/cow-problems-app'.format(user)},
+        {'full_name': '{}/duck-problems-app'.format(user)},
+        {'full_name': '{}/horse-problems-app'.format(user)},
     ]
     bitbucket_mock.team_repos.return_value = [
-        {'name': 'pig-problems-app',   'owner': {'username': 'team-barn-devs'}, 'is_private': private},
-        {'name': 'goat-problems-app',  'owner': {'username': 'team-barn-devs'}, 'is_private': True},
-        {'name': 'goose-problems-app', 'owner': {'username': 'team-barn-devs'}, 'is_private': False},
-
+        {'full_name': 'team-barn-devs/pig-problems-app'},
+        {'full_name': 'team-barn-devs/goat-problems-app'},
+        {'full_name': 'team-barn-devs/goose-problems-app'},
     ]
 
     bitbucket_mock.repo_default_branch.return_value = 'master'


### PR DESCRIPTION
## Purpose

https://github.com/CenterForOpenScience/osf.io/pull/9024 has expected [the GDPR update removing `username` issue](https://github.com/CenterForOpenScience/osf.io/pull/9024/commits/0332eea245ec7158cb277046a36670be0adaf365) where [repos](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D) and [team repos](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams/%7Busername%7D/repositories) endpoints may be broken. In short, these two endpoints no longer return the `values.owner.username` field, which is required to build the "username/repo" list when importing addon accounts. This PR fix the problem by using the `values.full_name` field directly instead.

## Changes

* For both [repos](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D) and [team repos](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams/%7Busername%7D/repositories) endpoints, the BB addon only uses the `values.owner.username` and `values.slug` (repo name) to build the "username/repo" list when importing addon accounts. With `values.owner.username` gone, we now use the `values.full_name` field which is already in the form of "username/repo". Thus there is no need to do string concatenation any more.

![Screen Shot 2019-05-31 at 2 15 16 PM](https://user-images.githubusercontent.com/3750414/58726001-90e53780-83ae-11e9-910b-ab685551ab61.png)


* Another change is that the [team repos](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams/%7Busername%7D/repositories) endpoint must now be accessed with the `values.uuid`. For example, `https://api.bitbucket.org/2.0/repositories/%7B8eabf058-fbf1-4bf5-a395-8a107b9e429c%7D` instead of `https://api.bitbucket.org/2.0/repositories/fitz_cos_team`. To obtain this URL, simply use the `links.repositories.href` field returned by the [teams](https://developer.atlassian.com/bitbucket/api/2/reference/resource/teams) endpoint.

* Although I updated the mock return value for `repos()` and `team_repos()`, they are not used in the tests at all.

## QA Notes

See https://github.com/CenterForOpenScience/osf.io/pull/9024.

## Documentation

No

## Side Effects

## Ticket

https://openscience.atlassian.net/browse/ENG-460
