### PR TITLE
Feature/APIv2 Component VOL's

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -248,6 +248,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'registrations',
         'contributors',
         'bibliographic_contributors',
+        'implicit_contributors',
     ]
 
     id = IDField(source='_id', read_only=True)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -42,6 +42,7 @@ from api.base.utils import default_node_list_permission_queryset
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, is_truthy
 from api.base.views import JSONAPIBaseView
 from api.base.views import (
+    BaseChildrenList,
     BaseContributorDetail,
     BaseContributorList,
     BaseLinkedList,
@@ -645,16 +646,9 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         serializer.save(draft=draft)
 
 
-class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, NodeMixin, NodesFilterMixin):
+class NodeChildrenList(BaseChildrenList, bulk_views.ListBulkCreateJSONAPIView, NodeMixin, NodesFilterMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_children_list).
     """
-    permission_classes = (
-        ContributorOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
-        ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
-        ExcludeWithdrawals,
-    )
 
     required_read_scopes = [CoreScopes.NODE_CHILDREN_READ]
     required_write_scopes = [CoreScopes.NODE_CHILDREN_WRITE]
@@ -662,19 +656,7 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
     serializer_class = NodeSerializer
     view_category = 'nodes'
     view_name = 'node-children'
-
-    ordering = ('-modified',)
-
-    def get_default_queryset(self):
-        auth = get_user_auth(self.request)
-        return default_node_list_permission_queryset(auth=auth, model_cls=Node)
-
-    # overrides ListBulkCreateJSONAPIView
-    def get_queryset(self):
-        node = self.get_node()
-        node_pks = node.node_relations.filter(is_node_link=False).select_related('child')\
-                .values_list('child__pk', flat=True)
-        return self.get_queryset_from_request().filter(pk__in=node_pks).order_by('-modified')
+    model_class = Node
 
     def get_serializer_context(self):
         context = super(NodeChildrenList, self).get_serializer_context()

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -6,7 +6,15 @@ from osf.models import AbstractNode, Registration, OSFUser
 from api.base import permissions as base_permissions
 from api.base import generic_bulk_views as bulk_views
 from api.base.filters import ListFilterMixin
-from api.base.views import JSONAPIBaseView, BaseContributorDetail, BaseContributorList, BaseNodeLinksDetail, BaseNodeLinksList, WaterButlerMixin
+from api.base.views import (
+    JSONAPIBaseView,
+    BaseChildrenList,
+    BaseContributorDetail,
+    BaseContributorList,
+    BaseNodeLinksDetail,
+    BaseNodeLinksList,
+    WaterButlerMixin,
+)
 
 from api.base.serializers import HideIfWithdrawal, LinkedRegistrationsRelationshipSerializer
 from api.base.serializers import LinkedNodesRelationshipSerializer
@@ -270,34 +278,17 @@ class RegistrationImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView
         return queryset
 
 
-class RegistrationChildrenList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, RegistrationMixin):
+class RegistrationChildrenList(BaseChildrenList, generics.ListAPIView, ListFilterMixin, RegistrationMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/registrations_children_list).
     """
     view_category = 'registrations'
     view_name = 'registration-children'
     serializer_class = RegistrationSerializer
 
-    permission_classes = (
-        ContributorOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
-        ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
-        ExcludeWithdrawals,
-    )
-
     required_read_scopes = [CoreScopes.NODE_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NULL]
 
-    ordering = ('-modified',)
-
-    def get_default_queryset(self):
-        auth = get_user_auth(self.request)
-        return default_node_list_permission_queryset(auth=auth, model_cls=Registration)
-
-    def get_queryset(self):
-        registration = self.get_node()
-        registration_pks = registration.node_relations.filter(is_node_link=False).select_related('child').values_list('child__pk', flat=True)
-        return self.get_queryset_from_request().filter(pk__in=registration_pks).order_by('-modified')
+    model_class = Registration
 
 
 class RegistrationCitationDetail(NodeCitationDetail, RegistrationMixin):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -204,7 +204,7 @@ class UserSerializer(JSONAPISerializer):
     def get_node_count(self, obj):
         auth = get_user_auth(self.context['request'])
         if obj != auth.user:
-            return default_node_list_permission_queryset(user=auth.user, model_cls=Node).filter(contributor__user__id=obj.id).count()
+            return default_node_list_permission_queryset(auth=auth, model_cls=Node).filter(contributor__user__id=obj.id).count()
 
         return default_node_list_queryset(model_cls=Node).filter(contributor__user__id=obj.id).count()
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -15,7 +15,6 @@ from api.base.parsers import (
 )
 from api.base.serializers import get_meta_type, AddonAccountSerializer
 from api.base.utils import (
-    default_node_list_queryset,
     default_node_list_permission_queryset,
     get_object_or_error,
     get_user_auth,
@@ -316,9 +315,8 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, UserNodesFilte
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         user = self.get_user()
-        if user != self.request.user:
-            return default_node_list_permission_queryset(user=self.request.user, model_cls=Node).filter(contributor__user__id=user.id)
-        return self.optimize_node_queryset(default_node_list_queryset(model_cls=Node).filter(contributor__user__id=user.id))
+        auth = get_user_auth(self.request)
+        return default_node_list_permission_queryset(auth=auth, model_cls=Node).filter(contributor__user__id=user.id)
 
     # overrides ListAPIView
     def get_queryset(self):
@@ -442,8 +440,8 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesF
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         user = self.get_user()
-        current_user = self.request.user
-        qs = default_node_list_permission_queryset(user=current_user, model_cls=Registration)
+        auth = get_user_auth(self.request)
+        qs = default_node_list_permission_queryset(auth=auth, model_cls=Registration)
         return qs.filter(contributor__user__id=user.id)
 
     # overrides ListAPIView

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -230,6 +230,8 @@ class TestNodeChildrenList:
         assert res.status_code == 200
         assert component._id in ids
         assert 'contributors' in res.json['data'][0]['relationships']
+        assert 'implicit_contributors' in res.json['data'][0]['relationships']
+        assert 'bibliographic_contributors' in res.json['data'][0]['relationships']
 
         # get node related_counts with vol once vol is attached to components
         res = app.get(node_url)
@@ -240,6 +242,8 @@ class TestNodeChildrenList:
         view_only_link.save()
         res = app.get(view_only_link_url)
         assert 'contributors' not in res.json['data'][0]['relationships']
+        assert 'implicit_contributors' not in res.json['data'][0]['relationships']
+        assert 'bibliographic_contributors' not in res.json['data'][0]['relationships']
 
         # delete vol
         view_only_link.is_deleted = True

--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -9,6 +9,7 @@ from osf_tests.factories import (
     ProjectFactory,
     RegistrationFactory,
     AuthUserFactory,
+    PrivateLinkFactory,
 )
 from tests.base import fake
 from osf.utils import permissions
@@ -58,6 +59,13 @@ class TestNodeChildrenList:
     @pytest.fixture()
     def public_project_url(self, user, public_project):
         return '/{}nodes/{}/children/'.format(API_BASE, public_project._id)
+
+    @pytest.fixture()
+    def view_only_link(self, private_project):
+        view_only_link = PrivateLinkFactory(name='node_view_only_link')
+        view_only_link.nodes.add(private_project)
+        view_only_link.save()
+        return view_only_link
 
     def test_return_public_node_children_list(
             self, app, public_component,
@@ -197,6 +205,47 @@ class TestNodeChildrenList:
         assert res.status_code == 200
         # Nodes with implicit admin perms are also included in the count
         assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 1
+
+    def test_private_node_children_with_view_only_link(self, user, app, private_project,
+            component, view_only_link, private_project_url):
+
+        # get node related_counts with vol before vol is attached to components
+        node_url = '/{}nodes/{}/?related_counts=children&view_only={}'.format(API_BASE,
+            private_project._id, view_only_link.key)
+        res = app.get(node_url)
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 0
+
+        # view only link is not attached to components
+        view_only_link_url = '{}?view_only={}'.format(private_project_url, view_only_link.key)
+        res = app.get(view_only_link_url)
+        ids = [node['id'] for node in res.json['data']]
+        assert res.status_code == 200
+        assert len(ids) == 0
+        assert component._id not in ids
+
+        # view only link is attached to components
+        view_only_link.nodes.add(component)
+        res = app.get(view_only_link_url)
+        ids = [node['id'] for node in res.json['data']]
+        assert res.status_code == 200
+        assert component._id in ids
+        assert 'contributors' in res.json['data'][0]['relationships']
+
+        # get node related_counts with vol once vol is attached to components
+        res = app.get(node_url)
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 1
+
+        # make private vol anonymous
+        view_only_link.anonymous = True
+        view_only_link.save()
+        res = app.get(view_only_link_url)
+        assert 'contributors' not in res.json['data'][0]['relationships']
+
+        # delete vol
+        view_only_link.is_deleted = True
+        view_only_link.save()
+        res = app.get(view_only_link_url, expect_errors=True)
+        assert res.status_code == 401
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Purpose

Now that we're using APIv2 VOL functionality, some gaps in VOL's are being uncovered.  Components do not take into account whether or not there is a view-only link (applies to both nodes and registrations).
 
## Changes
- Modify how default node list permission querysets are formed (used in both nodes and registration querysets) to use AbstractNode manager `.can_view()` which takes VOL's into consideration 
- Makes `implicit_contributors` anonymous

## QA Notes

- Test that registration components with and without vols behave as expected.
- If a registration has a VOL, but it's components are not included in the VOL, you should *not* see components.  Additionally, the component count should be 0.
- If a registration's components are included in the VOL, their components should be visible, and the component count should be accurate.
- This applies to nodes too, but this is only testable via the API.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

- Note, this conflicts quite a bit with groups/guardian.  Would prefer VOL's to go out first, then get guardian up-to-date with this, and then do a regression on VOL's on feature/guardian to be safe. 

## Ticket

https://openscience.atlassian.net/browse/ENG-546
