### PR TITLE
Feature/APIv2 Components with VOL's [ENG-546]

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -148,6 +148,10 @@ def default_node_list_queryset(model_cls):
     return model_cls.objects.filter(is_deleted=False).annotate(region=F('addons_osfstorage_node_settings__region___id'))
 
 def default_node_permission_queryset(user, model_cls):
+    """
+    Return nodes that are either public or you have perms because you're a contributor.
+    Implicit admin permissions not included here (NodeList, UserNodes, for example, don't factor this in.)
+    """
     assert model_cls in {Node, Registration}
     if user is None or user.is_anonymous:
         return model_cls.objects.filter(is_public=True)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -30,6 +30,7 @@ from api.base.serializers import (
 )
 from api.base.throttling import RootAnonThrottle, UserRateThrottle
 from api.base.utils import is_bulk_request, get_user_auth, default_node_list_queryset
+from api.nodes.filters import NodesFilterMixin
 from api.nodes.utils import get_file_object
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ContributorOrPublicForRelationshipPointers
@@ -456,7 +457,10 @@ def error_404(request, format=None, *args, **kwargs):
     )
 
 
-class BaseChildrenList(JSONAPIBaseView):
+class BaseChildrenList(JSONAPIBaseView, NodesFilterMixin):
+    """
+    For use with NodeChildrenList and RegistrationChildrenList views.
+    """
     permission_classes = (
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
@@ -466,6 +470,7 @@ class BaseChildrenList(JSONAPIBaseView):
     )
     ordering = ('-modified',)
 
+    # overrides NodesFilterMixin
     def get_default_queryset(self):
         return default_node_list_queryset(model_cls=self.model_class)
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -469,7 +469,7 @@ class BaseChildrenList(JSONAPIBaseView):
     def get_default_queryset(self):
         return default_node_list_queryset(model_cls=self.model_class)
 
-    # overrides ListAPIView
+    # overrides GenericAPIView
     def get_queryset(self):
         """
         Returns non-deleted children of the current resource that the user has permission to view -

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -29,11 +29,12 @@ from api.base.serializers import (
     LinkedRegistrationsRelationshipSerializer,
 )
 from api.base.throttling import RootAnonThrottle, UserRateThrottle
-from api.base.utils import is_bulk_request, get_user_auth
+from api.base.utils import is_bulk_request, get_user_auth, default_node_list_queryset
 from api.nodes.utils import get_file_object
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ContributorOrPublicForRelationshipPointers
 from api.nodes.permissions import ReadOnlyIfRegistration
+from api.nodes.permissions import ExcludeWithdrawals
 from api.users.serializers import UserSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Contributor, MaintenanceState, BaseFileNode
@@ -453,6 +454,33 @@ def error_404(request, format=None, *args, **kwargs):
         status=404,
         content_type='application/vnd.api+json; application/json',
     )
+
+
+class BaseChildrenList(JSONAPIBaseView):
+    permission_classes = (
+        ContributorOrPublic,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        ReadOnlyIfRegistration,
+        base_permissions.TokenHasScope,
+        ExcludeWithdrawals,
+    )
+    ordering = ('-modified',)
+
+    def get_default_queryset(self):
+        return default_node_list_queryset(model_cls=self.model_class)
+
+    # overrides ListAPIView
+    def get_queryset(self):
+        """
+        Returns non-deleted children of the current resource that the user has permission to view -
+        Children could be public, viewable through a view-only link (if provided), or the user
+        is a contributor, or has implicit admin perms.
+        """
+        node = self.get_node()
+        auth = get_user_auth(self.request)
+        node_pks = node.node_relations.filter(is_node_link=False).select_related('child')\
+            .values_list('child__pk', flat=True)
+        return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user, auth.private_link).order_by('-modified')
 
 
 class BaseContributorDetail(JSONAPIBaseView, generics.RetrieveAPIView):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -248,6 +248,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'registrations',
         'contributors',
         'bibliographic_contributors',
+        'implicit_contributors',
     ]
 
     id = IDField(source='_id', read_only=True)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -645,7 +645,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         serializer.save(draft=draft)
 
 
-class NodeChildrenList(BaseChildrenList, bulk_views.ListBulkCreateJSONAPIView, NodeMixin, NodesFilterMixin):
+class NodeChildrenList(BaseChildrenList, bulk_views.ListBulkCreateJSONAPIView, NodeMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_children_list).
     """
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -38,10 +38,11 @@ from api.base.throttling import (
     NonCookieAuthThrottle,
     AddContributorThrottle,
 )
-from api.base.utils import default_node_list_queryset, default_node_list_permission_queryset
+from api.base.utils import default_node_list_permission_queryset
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, is_truthy
 from api.base.views import JSONAPIBaseView
 from api.base.views import (
+    BaseChildrenList,
     BaseContributorDetail,
     BaseContributorList,
     BaseLinkedList,
@@ -644,16 +645,9 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
         serializer.save(draft=draft)
 
 
-class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, NodeMixin, NodesFilterMixin):
+class NodeChildrenList(BaseChildrenList, bulk_views.ListBulkCreateJSONAPIView, NodeMixin, NodesFilterMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_children_list).
     """
-    permission_classes = (
-        ContributorOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
-        ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
-        ExcludeWithdrawals,
-    )
 
     required_read_scopes = [CoreScopes.NODE_CHILDREN_READ]
     required_write_scopes = [CoreScopes.NODE_CHILDREN_WRITE]
@@ -661,19 +655,7 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
     serializer_class = NodeSerializer
     view_category = 'nodes'
     view_name = 'node-children'
-
-    ordering = ('-modified',)
-
-    def get_default_queryset(self):
-        return default_node_list_queryset(model_cls=Node)
-
-    # overrides ListBulkCreateJSONAPIView
-    def get_queryset(self):
-        node = self.get_node()
-        auth = get_user_auth(self.request)
-        node_pks = node.node_relations.filter(is_node_link=False).select_related('child')\
-                .values_list('child__pk', flat=True)
-        return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user).order_by('-modified')
+    model_class = Node
 
     def get_serializer_context(self):
         context = super(NodeChildrenList, self).get_serializer_context()

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -275,7 +275,7 @@ class RegistrationImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView
         return queryset
 
 
-class RegistrationChildrenList(BaseChildrenList, generics.ListAPIView, ListFilterMixin, RegistrationMixin):
+class RegistrationChildrenList(BaseChildrenList, generics.ListAPIView, RegistrationMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/registrations_children_list).
     """
     view_category = 'registrations'


### PR DESCRIPTION
## Purpose

Now that we're using APIv2 VOL functionality, some gaps in VOL's are being uncovered.  Components do not take into account whether or not there is a view-only link (applies to both nodes and registrations).
 
## Changes
- Refactor a BaseChildrenList class to be used in both NodeChildrenList and NodeRegistrationList 
- Modify so that view_only_links are considered when determining if a user can view a component
- (extra) Makes `implicit_contributors` anonymous if viewing a node with an anonymous VOL

## QA Notes

- Test that registration components with and without vols behave as expected.
- If a registration has a VOL, but it's components are not included in the VOL, you should *not* see components.  Additionally, the component count should be 0.
- If a registration's components are included in the VOL, their components should be visible, and the component count should be accurate.
- This applies to nodes too, but this is only testable via the API.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects


## Ticket

https://openscience.atlassian.net/browse/ENG-546