### PR TITLE
Feature/Change Datacite Test Prefix [ENG-371]

### DIFF
--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -511,7 +511,7 @@ class TestNodeIdentifierCreate:
             responses.Response(
                 responses.POST,
                 client.base_url + '/metadata',
-                body='OK (10.5072/FK2osf.io/dp438)',
+                body='OK (10.70102/FK2osf.io/dp438)',
                 status=201,
             )
         )
@@ -519,7 +519,7 @@ class TestNodeIdentifierCreate:
             responses.Response(
                 responses.POST,
                 client.base_url + '/doi',
-                body='OK (10.5072/FK2osf.io/dp438)',
+                body='OK (10.70102/FK2osf.io/dp438)',
                 status=201,
             )
         )

--- a/tests/identifiers/fixtures/datacite_node_metadata.xml
+++ b/tests/identifiers/fixtures/datacite_node_metadata.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd">
-  <identifier identifierType="DOI">10.5072/FK2osf.io/r7nm4</identifier>
+  <identifier identifierType="DOI">10.70102/FK2osf.io/r7nm4</identifier>
   <creators>
     <creator>
       <creatorName>Freddie Mercury1</creatorName>

--- a/tests/identifiers/fixtures/datacite_post_metadata_response.xml
+++ b/tests/identifiers/fixtures/datacite_post_metadata_response.xml
@@ -1,5 +1,5 @@
 <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.dat/metadata.xsd">
-  <identifier identifierType="DOI">10.5072/FK2osf.io/yvzp4</identifier>
+  <identifier identifierType="DOI">10.70102/FK2osf.io/yvzp4</identifier>
   <creators>
     <creator>
       <creatorName>John Tordoff</creatorName>

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -37,8 +37,8 @@ def datacite_client(registration):
 
         url = 'https://mds.fakedatacite.org'
         metadata_get = mock.Mock(return_value=datacite_metadata_response())
-        metadata_post = mock.Mock(return_value='OK (10.5072/FK2osf.io/{})'.format(registration._id))
-        doi_post = mock.Mock(return_value='OK (10.5072/FK2osf.io/{})'.format(registration._id))
+        metadata_post = mock.Mock(return_value='OK (10.70102/FK2osf.io/{})'.format(registration._id))
+        doi_post = mock.Mock(return_value='OK (10.70102/FK2osf.io/{})'.format(registration._id))
         metadata_delete = mock.Mock(return_value='OK heeeeeeey')
 
     return DataCiteClient(
@@ -151,7 +151,7 @@ class TestDataCiteViews(OsfTestCase):
             responses.Response(
                 responses.POST,
                 self.client.base_url + '/metadata',
-                body='OK (10.5072/FK2osf.io/cq695)',
+                body='OK (10.70102/FK2osf.io/cq695)',
                 status=201,
             )
         )
@@ -159,7 +159,7 @@ class TestDataCiteViews(OsfTestCase):
             responses.Response(
                 responses.POST,
                 self.client.base_url + '/doi',
-                body='OK (10.5072/FK2osf.io/cq695)',
+                body='OK (10.70102/FK2osf.io/cq695)',
                 status=201,
             )
         )
@@ -210,5 +210,3 @@ class TestDataCiteViews(OsfTestCase):
     def test_qatest_doesnt_make_dois(self):
         self.node.add_tag('qatest', auth=Auth(self.user))
         assert not request_identifiers(self.node)
-
-

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -77,7 +77,7 @@ class DataCiteClient(AbstractIdentifierClient):
         if category == 'doi':
             metadata = self.build_metadata(node)
             resp = self._client.metadata_post(metadata)
-            # Typical response: 'OK (10.5072/FK2osf.io/cq695)' to doi 10.5072/FK2osf.io/cq695
+            # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695
             doi = re.match(r'OK \((?P<doi>[a-zA-Z0-9 .\/]{0,})\)', resp).groupdict()['doi']
             if settings.DATACITE_MINT_DOIS:
                 self._client.doi_post(doi, node.absolute_url)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -319,7 +319,7 @@ EZID_ARK_NAMESPACE = 'ark:99999'
 DATACITE_USERNAME = None
 DATACITE_PASSWORD = None
 DATACITE_URL = None
-DATACITE_PREFIX = '10.5072'  # Datacite's test DOI prefix -- update in production
+DATACITE_PREFIX = '10.70102'  # Datacite's test DOI prefix -- update in production
 # Minting DOIs only works on Datacite's production server, so
 # disable minting on staging and development environments by default
 DATACITE_MINT_DOIS = not DEV_MODE


### PR DESCRIPTION
## Purpose

Update Datacite test prefix from 10.5072 to 10.70102.  
## Changes

Datacite has changed the prefix used on Test and Staging Environments for Projects and Registrations to 10.70102. 

## QA Notes

Assert that datacite works on staging and test environments again for minting doi's on projects and registrations.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

This will probably need a config change from devops. 

## Ticket

https://openscience.atlassian.net/browse/ENG-371