### PR TITLE
[ENG-580] Fix Bitbucket OAuth2 Issue on `redirect_uri`

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -56,6 +56,9 @@
         "box",
         "onedrive"
     ],
+    "addons_oauth_no_redirect": [
+        "bitbucket"
+    ],
     "addons_description": {
         "box": "Box is a file storage add-on. Connect your Box account to an OSF project to interact with files hosted on Box via the OSF.",
         "dataverse": "Dataverse is an open source software application to share, cite, and archive data. Connect your Dataverse account to share your Dataverse datasets via the OSF.",

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -14,6 +14,7 @@ from framework.auth import authenticate
 from framework.exceptions import PermissionsError, HTTPError
 from framework.sessions import session
 from osf.models.external import ExternalAccount, ExternalProvider, OAUTH1, OAUTH2
+from website.settings import ADDONS_OAUTH_NO_REDIRECT
 from website.util import api_url_for, web_url_for
 
 from tests.base import OsfTestCase
@@ -339,17 +340,21 @@ class TestExternalProviderOAuth2(OsfTestCase):
         # OAuth 2.0 is the default version
         assert_is(self.provider._oauth_version, OAUTH2)
 
-    def test_start_flow(self):
-        # Generate the appropriate URL and state token
+    def test_start_flow_oauth_standard(self):
+        # Generate the appropriate URL and state token - addons that follow standard OAuth protocol
+
+        # Make sure that the mock oauth2 provider is a standard one.  The test would fail early here
+        # if `test_start_flow_oauth_no_redirect()` was ran before this test and failed in the middle
+        # without resetting the `ADDONS_OAUTH_NO_REDIRECT` list.
+        assert self.provider.short_name not in ADDONS_OAUTH_NO_REDIRECT
 
         with self.app.app.test_request_context('/oauth/connect/mock2/'):
 
-            # make sure the user is logged in
+            # Make sure the user is logged in
             authenticate(user=self.user, access_token=None, response=None)
 
-            # auth_url is a property method - it calls out to the external
-            #   service to get a temporary key and secret before returning the
-            #   auth url
+            # `auth_url` is a property method - it calls out to the external service to get a
+            # temporary key and secret before returning the auth url
             url = self.provider.auth_url
 
             # Temporary credentials are added to the session
@@ -360,26 +365,60 @@ class TestExternalProviderOAuth2(OsfTestCase):
             parsed = urlparse.urlparse(url)
             params = urlparse.parse_qs(parsed.query)
 
-            # check parameters
-            assert_equal(
-                params,
-                {
-                    'state': [creds['state']],
-                    'response_type': ['code'],
-                    'client_id': [self.provider.client_id],
-                    'redirect_uri': [
-                        web_url_for('oauth_callback',
-                                    service_name=self.provider.short_name,
-                                    _absolute=True)
-                    ]
-                }
-            )
+            # Check parameters
+            expected_params = {
+                'state': [creds['state']],
+                'response_type': ['code'],
+                'client_id': [self.provider.client_id],
+                'redirect_uri': [
+                    web_url_for(
+                        'oauth_callback',
+                        service_name=self.provider.short_name,
+                        _absolute=True
+                    )
+                ]
+            }
+            assert_equal(params, expected_params)
 
-            # check base URL
-            assert_equal(
-                url.split('?')[0],
-                'https://mock2.com/auth',
-            )
+            # Check base URL
+            assert_equal(url.split('?')[0], 'https://mock2.com/auth')
+
+    def test_start_flow_oauth_no_redirect(self):
+        # Generate the appropriate URL and state token - addons that do not allow `redirect_uri`
+
+        # Temporarily add the mock provider to the `ADDONS_OAUTH_NO_REDIRECT` list
+        ADDONS_OAUTH_NO_REDIRECT.append(self.provider.short_name)
+
+        with self.app.app.test_request_context('/oauth/connect/mock2/'):
+
+            # Make sure the user is logged in
+            authenticate(user=self.user, access_token=None, response=None)
+
+            # `auth_url` is a property method - it calls out to the external service to get a
+            # temporary key and secret before returning the auth url
+            url = self.provider.auth_url
+
+            # Temporary credentials are added to the session
+            creds = session.data['oauth_states'][self.provider.short_name]
+            assert_in('state', creds)
+
+            # The URL to which the user would be redirected
+            parsed = urlparse.urlparse(url)
+            params = urlparse.parse_qs(parsed.query)
+
+            # Check parameters - the only difference from standard OAuth flow is no `redirect_uri`.
+            expected_params = {
+                'state': [creds['state']],
+                'response_type': ['code'],
+                'client_id': [self.provider.client_id]
+            }
+            assert_equal(params, expected_params)
+
+            # Check base URL
+            assert_equal(url.split('?')[0], 'https://mock2.com/auth')
+
+        # Reset the `ADDONS_OAUTH_NO_REDIRECT` list
+        ADDONS_OAUTH_NO_REDIRECT.remove(self.provider.short_name)
 
     @responses.activate
     def test_callback(self):

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -253,6 +253,7 @@ with open(os.path.join(ROOT, 'addons.json')) as fp:
     ADDONS_COMMENTABLE = addon_settings['addons_commentable']
     ADDONS_BASED_ON_IDS = addon_settings['addons_based_on_ids']
     ADDONS_DEFAULT = addon_settings['addons_default']
+    ADDONS_OAUTH_NO_REDIRECT = addon_settings['addons_oauth_no_redirect']
 
 SYSTEM_ADDED_ADDONS = {
     'user': [],


### PR DESCRIPTION
## Purpose

Some time between 2019/05/31 and 2019/06/04, Bitbucket's OAuth2 API no longer expects non-empty `redirect_uri` **1)** as the query param in the `GET oauth2/authorize` request and **2)** as a field in the body of the `POST oauth2/access_token` request. In addition, it now relies on the "Callback URL" of the "OAuth Consumer" instead of the query param `redirect_uri` to redirect the auth flow after successful authorization.

Bitbucket's [OAuth2 integration guide, last updated on Oct. 2018](https://developer.atlassian.com/cloud/bitbucket/oauth-2/) doesn't mention `redirect_uri` at all. My guess is that they probably changed this a while ago and finally deprecated the old usage early this week. This sudden and unannounced change breaks the `requests_oauthlib` library, which we use to handle standard OAuth flow for all external accounts / providers. I doubt this change is a bug since the new behavior is consistent according to their docs. This has nothing to do with BB V1 API deprecation or V2 GDPR update.

During `GET https://bitbucket.org/site/oauth2/authorize`, the first two work while the third fails:

1. `client_id=...&response_type=code&redirect_uri=&...`
2. `client_id=...&response_type=code&...`
3. `client_id=...&response_type=code&redirect_uri=https%3A%2F%2Fosf.io%2Foauth%2Fcallback%2Fbitbucket%2F`

Similarly during access token exchange, the first two work while the third fails:

1. Empty `redirect_uri`
![access_token_post_request_with_empty_redirect_uri](https://user-images.githubusercontent.com/3750414/58937753-529aa000-8741-11e9-95d2-2cb7d20c7d23.png)
2. Without `redirect_uri`
![access_token_post_request_without_redirect_uri](https://user-images.githubusercontent.com/3750414/58937756-53cbcd00-8741-11e9-8677-5dd7d1a72465.png)
3. Correct `redirect_uri`. Please note that `http://localhost:5001` is the one configured in the BB consumer for Postman only so that I can manually grab the code after redirection `http://local:5001?code=...`.
![access_token_post_request_400](https://user-images.githubusercontent.com/3750414/58937754-53333680-8741-11e9-90ed-d6a713183688.png)

## Changes

Set `redirect_uri=None` when initializing `OAuth2Session` if the provider is Bitbucket. One occurs during building the authorization URL and the other happens during access token exchange. No migration is needed since the `ExternalProvider` object does not store user credentials and is not stored in database.

- [x] Double check that this doesn't break other providers
  - Dropbox disconnect and re-auth checked

@mfraezz 

- [x] If not already there, please update the "Callback URL" of the BB OAuth Consumer for each server on BB's website. Take `prod` for example, use `https://osf.io/oauth/callback/bitbucket/` instead of `https://osf.io/`.

Please note that this "Callback URL" is not (and has nothing to do with) the `BitbucketProvider.callback_url` property. The `BitbucketProvider.callback_url` should have been named `BitbucketProvider.token_url` instead, which is out of the scope of this ticket.

## QA Notes

1. Disable BB addon for the project you are testing.
2. Disconnect BB addon in the account settings page.
3. Optionally, remove the app authorization from your BB account.
4. Try to connect or re-authorize BB addon in the account settings page. If you've done part 3, you will be prompted to explicitly authorize the app again. Otherwise, everything should be automatic. You should see the BB addon connected finally.
5. Optional, go back to the project, enable BB, import your profile, select the repository and take a look at the files page/widget.

In addition, test step 1 through 5 on one (or a couple of) other addon(s).

## Documentation

- [ ] If there is a place where we've documented addon OAuth connection, we probably should add this special case there.

## Side Effects

This is not a standard implementation of the OAuth 2.0 specification. Revert this commit if Bitbucket decides to follow the standard protocol in the future.

## Ticket

https://openscience.atlassian.net/browse/ENG-580