### PR TITLE
Using consistent kebab-cased type names [ENG-131]

### DIFF
--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -1,10 +1,15 @@
 from rest_framework import serializers as ser
 from api.base.serializers import JSONAPISerializer, LinksField
 from api.base.utils import absolute_reverse
+from distutils.version import StrictVersion
 
 class NodeAddonFolderSerializer(JSONAPISerializer):
     class Meta:
-        type_ = 'node_addon_folders'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'node_addon_folders'
+            return 'node-addon-folders'
 
     id = ser.CharField(read_only=True)
     kind = ser.CharField(default='folder', read_only=True)

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -1,15 +1,13 @@
 from rest_framework import serializers as ser
 from api.base.serializers import JSONAPISerializer, LinksField
 from api.base.utils import absolute_reverse
-from distutils.version import StrictVersion
+from api.base.versioning import get_kebab_snake_case_field
 
 class NodeAddonFolderSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'node_addon_folders'
-            return 'node-addon-folders'
+            return get_kebab_snake_case_field(request.version, 'node-addon-folders')
 
     id = ser.CharField(read_only=True)
     kind = ser.CharField(default='folder', read_only=True)

--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -23,15 +23,11 @@ class JSONAPIRenderer(JSONRendererWithESISupport):
         # See JSON-API documentation on meta information: http://jsonapi.org/format/#document-meta
         data_type = type(data)
         if renderer_context is not None and data_type != str and data is not None:
-            meta_dict = renderer_context.get('meta')
+            meta_dict = renderer_context.get('meta', {})
             version = getattr(renderer_context['request'], 'version', None)
             warning = renderer_context['request'].META.get('warning', None)
-            if meta_dict is not None:
-                if version:
-                    meta_dict['version'] = renderer_context['request'].version
-                    data.setdefault('meta', {}).update(meta_dict)
-            elif version:
-                meta_dict = {'version': renderer_context['request'].version}
+            if version:
+                meta_dict['version'] = renderer_context['request'].version
                 data.setdefault('meta', {}).update(meta_dict)
             if warning:
                 meta_dict['warning'] = renderer_context['request'].META['warning']

--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -25,12 +25,16 @@ class JSONAPIRenderer(JSONRendererWithESISupport):
         if renderer_context is not None and data_type != str and data is not None:
             meta_dict = renderer_context.get('meta')
             version = getattr(renderer_context['request'], 'version', None)
+            warning = renderer_context['request'].META.get('warning', None)
             if meta_dict is not None:
                 if version:
                     meta_dict['version'] = renderer_context['request'].version
                     data.setdefault('meta', {}).update(meta_dict)
             elif version:
                 meta_dict = {'version': renderer_context['request'].version}
+                data.setdefault('meta', {}).update(meta_dict)
+            if warning:
+                meta_dict['warning'] = renderer_context['request'].META['warning']
                 data.setdefault('meta', {}).update(meta_dict)
         return super(JSONAPIRenderer, self).render(data, accepted_media_type, renderer_context)
 

--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -27,11 +27,10 @@ class JSONAPIRenderer(JSONRendererWithESISupport):
             version = getattr(renderer_context['request'], 'version', None)
             warning = renderer_context['request'].META.get('warning', None)
             if version:
-                meta_dict['version'] = renderer_context['request'].version
-                data.setdefault('meta', {}).update(meta_dict)
+                meta_dict['version'] = version
             if warning:
-                meta_dict['warning'] = renderer_context['request'].META['warning']
-                data.setdefault('meta', {}).update(meta_dict)
+                meta_dict['warning'] = warning
+            data.setdefault('meta', {}).update(meta_dict)
         return super(JSONAPIRenderer, self).render(data, accepted_media_type, renderer_context)
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -404,7 +404,7 @@ class TypeField(ser.CharField):
             type_ = get_meta_type(self.root.child, request)
         else:
             type_ = get_meta_type(self.root, request)
-        if StrictVersion(request.version) < StrictVersion('2.15'):
+        if StrictVersion(request.version) == StrictVersion('2.15'):
             if type_ != data:
                 raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
         else:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -408,11 +408,13 @@ class TypeField(ser.CharField):
             if type_ != data:
                 raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
         else:
-            if type_ != data and str(type_).replace('-', '_') != data:
-                raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
-            elif type_ != data and str(type_).replace('-', '_') == data:
-                type_ = str(type_).replace('-', '_')
-                self.context['request'].META.setdefault('warning', 'As of API Version 2.15, all types are now Kebab-case. 2.15 will accept snake_case, but this will be deprecated in future versions.')
+            kebab_case = str(type_).replace('-', '_')
+            if type_ != data:
+                if kebab_case == data:
+                    type_ = kebab_case
+                    self.context['request'].META.setdefault('warning', 'As of API Version 2.15, all types are now Kebab-case. 2.15 will accept snake_case, but this will be deprecated in future versions.')
+                else:
+                    raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
         return super(TypeField, self).to_internal_value(data)
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -409,7 +409,7 @@ class TypeField(ser.CharField):
         if type_ != data and kebab_case == data:
             type_ = kebab_case
             self.context['request'].META.setdefault('warning', 'As of API Version {0}, all types are now Kebab-case. {0} will accept snake_case, but this will be deprecated in future versions.'.format(KEBAB_CASE_VERSION))
-        else:
+        elif type_ != data:
             raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
         return super(TypeField, self).to_internal_value(data)
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -404,7 +404,7 @@ class TypeField(ser.CharField):
             type_ = get_meta_type(self.root.child, request)
         else:
             type_ = get_meta_type(self.root, request)
-        if StrictVersion(request.version) == StrictVersion('2.15'):
+        if StrictVersion(request.version) != StrictVersion('2.15'):
             if type_ != data:
                 raise api_exceptions.Conflict(detail=('This resource has a type of "{}", but you set the json body\'s type field to "{}". You probably need to change the type field to match the resource\'s type.'.format(type_, data)))
         else:

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -166,11 +166,9 @@ REST_FRAMEWORK = {
         '2.13',
         '2.14',
         '2.15',
-<<<<<<< HEAD
         '2.16',
         '2.17',
-=======
->>>>>>> Modified types on serializers to use kebab-case in serializers rather than snake_case for version 2.15 and above. Modified TypeField to accept both kebab and snake cases, and throw a deprecation warning when snake case is used. Modified renderer.py to display this deprecation warning in the meta section of the json response.
+        '2.18',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -166,8 +166,11 @@ REST_FRAMEWORK = {
         '2.13',
         '2.14',
         '2.15',
+<<<<<<< HEAD
         '2.16',
         '2.17',
+=======
+>>>>>>> Modified types on serializers to use kebab-case in serializers rather than snake_case for version 2.15 and above. Modified TypeField to accept both kebab and snake cases, and throw a deprecation warning when snake case is used. Modified renderer.py to display this deprecation warning in the meta section of the json response.
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/base/versioning.py
+++ b/api/base/versioning.py
@@ -3,12 +3,14 @@ from rest_framework import exceptions as drf_exceptions
 from rest_framework import versioning as drf_versioning
 from rest_framework.compat import unicode_http_header
 from rest_framework.utils.mediatypes import _MediaType
+from distutils.version import StrictVersion
 
 from api.base import exceptions
 from api.base import utils
 from api.base.renderers import BrowsableAPIRendererNoForms
 from api.base.settings import LATEST_VERSIONS
 
+KEBAB_CASE_VERSION = '2.16'
 
 def get_major_version(version):
     return int(version.split('.')[0])
@@ -27,6 +29,12 @@ def decimal_version_to_url_path(decimal_version):
 def get_latest_sub_version(major_version):
     # '2' --> '2.6'
     return LATEST_VERSIONS.get(major_version, None)
+
+def get_kebab_snake_case_field(version, field):
+    if StrictVersion(version) < StrictVersion(KEBAB_CASE_VERSION):
+        return field.replace('-', '_')
+    else:
+        return field
 
 class BaseVersioning(drf_versioning.BaseVersioning):
 

--- a/api/base/versioning.py
+++ b/api/base/versioning.py
@@ -12,7 +12,7 @@ from api.base.settings import LATEST_VERSIONS
 
 # KEBAB_CASE_VERSION determines the API version in which kebab-case will begin being accepted.
 # Note that this version will not deprecate snake_case yet.
-KEBAB_CASE_VERSION = '2.16'
+KEBAB_CASE_VERSION = '2.18'
 
 def get_major_version(version):
     return int(version.split('.')[0])

--- a/api/base/versioning.py
+++ b/api/base/versioning.py
@@ -10,6 +10,8 @@ from api.base import utils
 from api.base.renderers import BrowsableAPIRendererNoForms
 from api.base.settings import LATEST_VERSIONS
 
+# KEBAB_CASE_VERSION determines the API version in which kebab-case will begin being accepted.
+# Note that this version will not deprecate snake_case yet.
 KEBAB_CASE_VERSION = '2.16'
 
 def get_major_version(version):

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -1,5 +1,4 @@
 import bleach
-from distutils.version import StrictVersion
 
 from rest_framework import serializers as ser
 from osf.exceptions import ValidationError as ModelValidationError
@@ -18,6 +17,7 @@ from api.base.serializers import (
     AnonymizedRegexField,
     VersionedDateTimeField,
 )
+from api.base.versioning import get_kebab_snake_case_field
 
 
 class CommentReport(object):
@@ -226,9 +226,7 @@ class CommentReportSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'comment_reports'
-            return 'comment-reports'
+            return get_kebab_snake_case_field(request.version, 'comment-reports')
 
     def get_absolute_url(self, obj):
         return absolute_reverse(

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -1,4 +1,5 @@
 import bleach
+from distutils.version import StrictVersion
 
 from rest_framework import serializers as ser
 from osf.exceptions import ValidationError as ModelValidationError
@@ -223,7 +224,11 @@ class CommentReportSerializer(JSONAPISerializer):
     links = LinksField({'self': 'get_absolute_url'})
 
     class Meta:
-        type_ = 'comment_reports'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'comment_reports'
+            return 'comment-reports'
 
     def get_absolute_url(self, obj):
         return absolute_reverse(

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -5,6 +5,7 @@ from django.core.urlresolvers import resolve, reverse
 import furl
 import pytz
 import jsonschema
+from distutils.version import StrictVersion
 
 from framework.auth.core import Auth
 from osf.models import BaseFileNode, OSFUser, Comment, Preprint, AbstractNode
@@ -423,7 +424,11 @@ class FileVersionSerializer(JSONAPISerializer):
         return obj.get_basefilenode_version(file).version_name
 
     class Meta:
-        type_ = 'file_versions'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'file_versions'
+            return 'file-versions'
 
     def self_url(self, obj):
         return absolute_reverse(
@@ -514,7 +519,11 @@ class FileMetadataRecordSerializer(JSONAPISerializer):
         return obj.absolute_api_v2_url
 
     class Meta:
-        type_ = 'metadata_records'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'metadata_records'
+            return 'metadata-records'
 
 
 def get_file_download_link(obj, version=None, view_only=None):

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import resolve, reverse
 import furl
 import pytz
 import jsonschema
-from distutils.version import StrictVersion
 
 from framework.auth.core import Auth
 from osf.models import BaseFileNode, OSFUser, Comment, Preprint, AbstractNode
@@ -36,6 +35,7 @@ from api.base.serializers import (
 from api.base.utils import absolute_reverse, get_user_auth
 from api.base.exceptions import Conflict, InvalidModelValueError
 from api.base.schemas.utils import from_json
+from api.base.versioning import get_kebab_snake_case_field
 
 class CheckoutField(ser.HyperlinkedRelatedField):
 
@@ -426,9 +426,7 @@ class FileVersionSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'file_versions'
-            return 'file-versions'
+            return get_kebab_snake_case_field(request.version, 'file-versions')
 
     def self_url(self, obj):
         return absolute_reverse(
@@ -521,9 +519,7 @@ class FileMetadataRecordSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'metadata_records'
-            return 'metadata-records'
+            return get_kebab_snake_case_field(request.version, 'metadata-records')
 
 
 def get_file_download_link(obj, version=None, view_only=None):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -886,7 +886,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
 
 class NodeAddonSettingsSerializerBase(JSONAPISerializer):
     class Meta:
-        type_ = 'node_addons'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'node_addons'
+            return 'node-addons'
 
     id = ser.CharField(source='config.short_name', read_only=True)
     node_has_auth = ser.BooleanField(source='has_auth', read_only=True)
@@ -1313,7 +1317,11 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     )
     class Meta:
-        type_ = 'node_links'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'node_links'
+            return 'node-links'
 
     links = LinksField({
         'self': 'get_absolute_url',
@@ -1520,7 +1528,11 @@ class DraftRegistrationSerializer(JSONAPISerializer):
         return draft
 
     class Meta:
-        type_ = 'draft_registrations'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'draft_registrations'
+            return 'draft-registrations'
 
 
 class DraftRegistrationDetailSerializer(DraftRegistrationSerializer):
@@ -1629,7 +1641,11 @@ class NodeViewOnlyLinkSerializer(JSONAPISerializer):
         )
 
     class Meta:
-        type_ = 'view_only_links'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'view_only_links'
+            return 'view-only-links'
 
 
 class NodeViewOnlyLinkUpdateSerializer(NodeViewOnlyLinkSerializer):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -21,6 +21,7 @@ from api.base.utils import (
     absolute_reverse, get_object_or_error,
     get_user_auth, is_truthy,
 )
+from api.base.versioning import get_kebab_snake_case_field
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
 from django.apps import apps
 from django.conf import settings
@@ -888,9 +889,7 @@ class NodeAddonSettingsSerializerBase(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'node_addons'
-            return 'node-addons'
+            return get_kebab_snake_case_field(request.version, 'node-addons')
 
     id = ser.CharField(source='config.short_name', read_only=True)
     node_has_auth = ser.BooleanField(source='has_auth', read_only=True)
@@ -1319,9 +1318,7 @@ class NodeLinksSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'node_links'
-            return 'node-links'
+            return get_kebab_snake_case_field(request.version, 'node-links')
 
     links = LinksField({
         'self': 'get_absolute_url',
@@ -1530,9 +1527,7 @@ class DraftRegistrationSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'draft_registrations'
-            return 'draft-registrations'
+            return get_kebab_snake_case_field(request.version, 'draft-registrations')
 
 
 class DraftRegistrationDetailSerializer(DraftRegistrationSerializer):
@@ -1643,9 +1638,7 @@ class NodeViewOnlyLinkSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'view_only_links'
-            return 'view-only-links'
+            return get_kebab_snake_case_field(request.version, 'view-only-links')
 
 
 class NodeViewOnlyLinkUpdateSerializer(NodeViewOnlyLinkSerializer):

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers as ser
 from api.base.serializers import (JSONAPISerializer, IDField, TypeField, LinksField)
-
+from distutils.version import StrictVersion
 
 class SchemaSerializer(JSONAPISerializer):
 
@@ -28,13 +28,21 @@ class RegistrationSchemaSerializer(SchemaSerializer):
     filterable_fields = ['active']
 
     class Meta:
-        type_ = 'registration_schemas'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'registration_schemas'
+            return 'registration-schemas'
 
 
 class FileMetadataSchemaSerializer(SchemaSerializer):
 
     class Meta:
-        type_ = 'file_metadata_schemas'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'file_metadata_schemas'
+            return 'file-metadata-schemas'
 
 
 class DeprecatedMetaSchemaSerializer(SchemaSerializer):

--- a/api/schemas/serializers.py
+++ b/api/schemas/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers as ser
 from api.base.serializers import (JSONAPISerializer, IDField, TypeField, LinksField)
-from distutils.version import StrictVersion
+from api.base.versioning import get_kebab_snake_case_field
 
 class SchemaSerializer(JSONAPISerializer):
 
@@ -30,9 +30,7 @@ class RegistrationSchemaSerializer(SchemaSerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'registration_schemas'
-            return 'registration-schemas'
+            return get_kebab_snake_case_field(request.version, 'registration-schemas')
 
 
 class FileMetadataSchemaSerializer(SchemaSerializer):
@@ -40,9 +38,7 @@ class FileMetadataSchemaSerializer(SchemaSerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'file_metadata_schemas'
-            return 'file-metadata-schemas'
+            return get_kebab_snake_case_field(request.version, 'file-metadata-schemas')
 
 
 class DeprecatedMetaSchemaSerializer(SchemaSerializer):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,5 +1,6 @@
 import jsonschema
 from django.utils import timezone
+from distutils.version import StrictVersion
 
 from rest_framework import serializers as ser
 from rest_framework import exceptions
@@ -287,7 +288,11 @@ class UserAddonSettingsSerializer(JSONAPISerializer):
     })
 
     class Meta:
-        type_ = 'user_addons'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'user_addons'
+            return 'user-addons'
 
     def get_absolute_url(self, obj):
         return absolute_reverse(
@@ -482,7 +487,11 @@ class UserSettingsSerializer(JSONAPISerializer):
         )
 
     class Meta:
-        type_ = 'user_settings'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'user_settings'
+            return 'user-settings'
 
 
 class UserSettingsUpdateSerializer(UserSettingsSerializer):
@@ -604,7 +613,11 @@ class UserEmailsSerializer(JSONAPISerializer):
             return '{}?resend_confirmation=true'.format(url)
 
     class Meta:
-        type_ = 'user_emails'
+        @staticmethod
+        def get_type(request):
+            if StrictVersion(request.version) < StrictVersion('2.15'):
+                return 'user_emails'
+            return 'user-emails'
 
     def create(self, validated_data):
         user = self.context['request'].user

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,6 +1,5 @@
 import jsonschema
 from django.utils import timezone
-from distutils.version import StrictVersion
 
 from rest_framework import serializers as ser
 from rest_framework import exceptions
@@ -27,6 +26,7 @@ from website.profile.views import update_osf_help_mails_subscription, update_mai
 from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from api.base.schemas.utils import validate_user_json, from_json
 from framework.auth.views import send_confirm_email
+from api.base.versioning import get_kebab_snake_case_field
 
 
 class QuickFilesRelationshipField(RelationshipField):
@@ -290,9 +290,7 @@ class UserAddonSettingsSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'user_addons'
-            return 'user-addons'
+            return get_kebab_snake_case_field(request.version, 'user-addons')
 
     def get_absolute_url(self, obj):
         return absolute_reverse(
@@ -489,9 +487,7 @@ class UserSettingsSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'user_settings'
-            return 'user-settings'
+            return get_kebab_snake_case_field(request.version, 'user-settings')
 
 
 class UserSettingsUpdateSerializer(UserSettingsSerializer):
@@ -615,9 +611,7 @@ class UserEmailsSerializer(JSONAPISerializer):
     class Meta:
         @staticmethod
         def get_type(request):
-            if StrictVersion(request.version) < StrictVersion('2.15'):
-                return 'user_emails'
-            return 'user-emails'
+            return get_kebab_snake_case_field(request.version, 'user-emails')
 
     def create(self, validated_data):
         user = self.context['request'].user

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -115,12 +115,14 @@ class TestSerializerMetaType(ApiTestCase):
                         else:
                             json_type = serializer.Meta.type_
                         assert '_' not in json_type
+                        assert json_type == json_type.lower()
             if not re.match('^(api_test|test).*', serializer.__module__):
                 if hasattr(serializer.Meta, 'get_type'):
                     json_type = serializer.Meta.get_type(request)
                 else:
                     json_type = serializer.Meta.type_
                 assert '_' not in json_type
+                assert json_type == json_type.lower()
 
     def test_deprecation_warning_for_2_15_snake_case(self):
         user_auth = factories.AuthUserFactory()

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -24,6 +24,7 @@ from api.base import serializers as base_serializers
 from api.nodes.serializers import NodeSerializer, RelationshipField
 from api.waffle.serializers import WaffleSerializer, BaseWaffleSerializer
 from api.registrations.serializers import RegistrationSerializer
+from api.base.versioning import KEBAB_CASE_VERSION
 
 SER_MODULES = []
 for loader, name, _ in pkgutil.iter_modules(['api']):
@@ -102,7 +103,7 @@ class TestSerializerMetaType(ApiTestCase):
 
     def test_serializers_types_are_kebab_case(self):
         serializers = JSONAPISerializer.__subclasses__()
-        request = make_drf_request_with_version(version='2.15')
+        request = make_drf_request_with_version(version=KEBAB_CASE_VERSION)
         for serializer in serializers:
             if serializer == WaffleSerializer or serializer == BaseWaffleSerializer:
                 continue
@@ -126,7 +127,7 @@ class TestSerializerMetaType(ApiTestCase):
     def test_deprecation_warning_for_2_15_snake_case(self):
         user_auth = factories.AuthUserFactory()
         node = factories.NodeFactory(creator=user_auth)
-        url = '/{}nodes/{}/draft_registrations/?version=2.15'.format(API_BASE, node._id)
+        url = '/{}nodes/{}/draft_registrations/?version={}'.format(API_BASE, node._id, KEBAB_CASE_VERSION)
         schema = RegistrationSchema.objects.get(
             name='OSF-Standard Pre-Data Collection Registration',
             schema_version=2)
@@ -145,7 +146,7 @@ class TestSerializerMetaType(ApiTestCase):
         }
         res = self.app.post_json_api(url, payload, auth=user_auth.auth)
         assert res.json['data']['type'] == 'draft-registrations'
-        assert res.json['meta']['warning'] == 'As of API Version 2.15, all types are now Kebab-case. 2.15 will accept snake_case, but this will be deprecated in future versions.'
+        assert res.json['meta']['warning'] == 'As of API Version {0}, all types are now Kebab-case. {0} will accept snake_case, but this will be deprecated in future versions.'.format(KEBAB_CASE_VERSION)
 
 
 class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -19,6 +19,7 @@ from osf.models import RegistrationSchema
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
 
 from api.base.settings.defaults import API_BASE
+from api.schemas.serializers import SchemaSerializer
 from api.base.serializers import JSONAPISerializer, BaseAPISerializer
 from api.base import serializers as base_serializers
 from api.nodes.serializers import NodeSerializer, RelationshipField
@@ -106,6 +107,14 @@ class TestSerializerMetaType(ApiTestCase):
         for serializer in serializers:
             if serializer == WaffleSerializer or serializer == BaseWaffleSerializer:
                 continue
+            if serializer == SchemaSerializer:
+                for schema_serializer in serializer.__subclasses__():
+                    if 'Deprecated' not in str(schema_serializer):
+                        if hasattr(serializer.Meta, 'get_type'):
+                            json_type = serializer.Meta.get_type(request)
+                        else:
+                            json_type = serializer.Meta.type_
+                        assert '_' not in json_type
             if not re.match('^(api_test|test).*', serializer.__module__):
                 if hasattr(serializer.Meta, 'get_type'):
                     json_type = serializer.Meta.get_type(request)

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -16,7 +16,6 @@ from osf_tests import factories
 from tests.utils import make_drf_request_with_version
 
 from osf.models import RegistrationSchema
-from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
 
 from api.base.settings.defaults import API_BASE
 from api.schemas.serializers import SchemaSerializer
@@ -130,7 +129,7 @@ class TestSerializerMetaType(ApiTestCase):
         url = '/{}nodes/{}/draft_registrations/?version=2.15'.format(API_BASE, node._id)
         schema = RegistrationSchema.objects.get(
             name='OSF-Standard Pre-Data Collection Registration',
-            schema_version=LATEST_SCHEMA_VERSION)
+            schema_version=2)
         payload = {
             'data': {
                 'type': 'draft_registrations',

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -124,7 +124,7 @@ class TestSerializerMetaType(ApiTestCase):
                 assert '_' not in json_type
                 assert json_type == json_type.lower()
 
-    def test_deprecation_warning_for_2_15_snake_case(self):
+    def test_deprecation_warning_for_snake_case(self):
         user_auth = factories.AuthUserFactory()
         node = factories.NodeFactory(creator=user_auth)
         url = '/{}nodes/{}/draft_registrations/?version={}'.format(API_BASE, node._id, KEBAB_CASE_VERSION)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
The JSON API v2 had inconsistent casing for types. Some were snake_case, and others were kebab-case. This pull request creates a new API (2.18) which makes all types kebab-cased. This API will accept both kebab, and snake, but will throw a deprecation warning when a snake cased type is submitted.

## Changes

<!-- Briefly describe or list your changes  -->
### api/
- addons/serializers.py, base/serializers.py comments/serializers.py, files/serializers.py, nodes/serializers.py, and users/serializers.py: Modified Meta class to check for version, and provide kebab-cased type.
- base/renderers.py: Modified JSONAPIRenderer.render to add the deprecation warning to the response.
- base/serializers.py: Modified class TypeField to accept both kebab and snake case for version for 2.18 and after
-schemas/serializers.py: Modified Meta classes to check for version and provide kebab-cased type

### api_tests/
-base/test_serializers.py: Added tests for the new API functionality including ensuring that all JSON Serializers use kebab case, and that version 2.18 accepts both kebab and snake case, as well as returning a deprecation message when snake case is used. 

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Test that 2.18 accepts both kebab and snake, but also test that no JSON Serializers are still using snake cases. See test_serailizers.py::TestSerializerMetaType::test_serailizers_types_are_kebab_case for more details. Test deprecation warning when snake case is used for version 2.18.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
Many sections of the documentation will need to be updated:
-Draft Registration type will need to be changed from draft_registrations to draft-registrations.
-External account type will need to be changed from external-account
-File Versions type will need to be changed from file_versions to file-versions
-Node Addons type will need to be changed from node_addons to node-addons
-Draft Registrations type will need to be changed from draft_registrations to draft-registrations
-User Addons type will need to be changed from user_addons to user-addons
-Registration Schemas type will need to be changed from registration_schemas to registration-schemas
-File Metadata Schema type will need to be changed from file_metadata_schemas to file-metadata-schemas
-New API Version will need to posted to changelog

https://github.com/CenterForOpenScience/developer.osf.io/pull/46

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/ENG-131
