### PR TITLE
[ENG-586] Add ShowIfChronosSubmitter conditional field

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -301,20 +301,6 @@ class HideIfProviderCommentsPrivate(ConditionalField):
         return True
 
 
-class ShowIfChronosSubmitter(ConditionalField):
-    """
-    If the ChronosSubmission instance's submitter is not the current user, hide this field.
-    """
-
-    def should_show(self, instance):
-        request = self.context.get('request')
-        auth = utils.get_user_auth(request)
-        if auth.logged_in:
-            if instance.submitter == auth.user:
-                return True
-        return False
-
-
 class AllowMissing(ser.Field):
     def __init__(self, field, **kwargs):
         super(AllowMissing, self).__init__(**kwargs)

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -301,6 +301,20 @@ class HideIfProviderCommentsPrivate(ConditionalField):
         return True
 
 
+class ShowIfChronosSubmitter(ConditionalField):
+    """
+    If the ChronosSubmission instance's submitter is not the current user, hide this field.
+    """
+
+    def should_show(self, instance):
+        request = self.context.get('request')
+        auth = utils.get_user_auth(request)
+        if auth.logged_in:
+            if instance.submitter == auth.user:
+                return True
+        return False
+
+
 class AllowMissing(ser.Field):
     def __init__(self, field, **kwargs):
         super(AllowMissing, self).__init__(**kwargs)

--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -2,11 +2,26 @@ from rest_framework import serializers as ser
 from rest_framework.exceptions import NotFound
 
 from api.base.exceptions import Conflict
-from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField, ShowIfChronosSubmitter
-from api.base.utils import absolute_reverse
+from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField, ConditionalField
+from api.base.utils import absolute_reverse, get_user_auth
 from osf.external.chronos import ChronosClient
 from osf.models import ChronosJournal
 from osf.utils.workflows import ChronosSubmissionStatus
+
+
+class ShowIfChronosSubmitter(ConditionalField):
+    """
+    If the ChronosSubmission instance's submitter is not the current user, hide this field.
+    """
+
+    def should_show(self, instance):
+        request = self.context.get('request')
+        auth = get_user_auth(request)
+        if auth.logged_in:
+            if instance.submitter == auth.user:
+                return True
+        return False
+
 
 class ChronosJournalRelationshipField(RelationshipField):
     def to_internal_value(self, journal_id):
@@ -15,6 +30,7 @@ class ChronosJournalRelationshipField(RelationshipField):
         except ChronosJournal.DoesNotExist:
             raise NotFound('Unable to find specified journal.')
         return {'journal': journal}
+
 
 class ChronosJournalSerializer(JSONAPISerializer):
     class Meta:

--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers as ser
 from rest_framework.exceptions import NotFound
 
 from api.base.exceptions import Conflict
-from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField
+from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField, ShowIfChronosSubmitter
 from api.base.utils import absolute_reverse
 from osf.external.chronos import ChronosClient
 from osf.models import ChronosJournal
@@ -37,7 +37,7 @@ class ChronosSubmissionSerializer(JSONAPISerializer):
         type_ = 'chronos-submissions'
 
     id = ser.CharField(source='publication_id', read_only=True)
-    submission_url = ser.CharField(read_only=True)
+    submission_url = ShowIfChronosSubmitter(ser.CharField(read_only=True))
     status = ser.SerializerMethodField()
     modified = ser.DateTimeField(read_only=True)
 

--- a/api_tests/chronos/views/test_chronos_submission_list.py
+++ b/api_tests/chronos/views/test_chronos_submission_list.py
@@ -123,6 +123,9 @@ class TestChronosSubmissionList:
         assert res.json['data'][0]['id'] in submission_ids
         assert res.json['data'][1]['id'] in submission_ids
         assert res.json['data'][2]['id'] in submission_ids
+        assert res.json['data'][0]['attributes']['submission_url'] is not None
+        assert res.json['data'][1]['attributes']['submission_url'] is not None
+        assert res.json['data'][2]['attributes']['submission_url'] is not None
 
     # Preprint contributors can view all submissions, regardless of states
     def test_list_contributor(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, preprint_contributor):
@@ -134,6 +137,9 @@ class TestChronosSubmissionList:
         assert res.json['data'][0]['id'] in submission_ids
         assert res.json['data'][1]['id'] in submission_ids
         assert res.json['data'][2]['id'] in submission_ids
+        assert res.json['data'][0]['attributes'].get('submission_url') is None
+        assert res.json['data'][1]['attributes'].get('submission_url') is None
+        assert res.json['data'][2]['attributes'].get('submission_url') is None
 
     # Moderators can only see accepted and published submissions
     def test_list_moderator(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, moderator):
@@ -143,6 +149,8 @@ class TestChronosSubmissionList:
         submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
         assert res.json['data'][0]['id'] in submission_ids
         assert res.json['data'][1]['id'] in submission_ids
+        assert res.json['data'][0]['attributes'].get('submission_url') is None
+        assert res.json['data'][1]['attributes'].get('submission_url') is None
 
     # Logged in users can only see accepted and published submissions
     def test_list_user(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission, user):
@@ -152,6 +160,8 @@ class TestChronosSubmissionList:
         submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
         assert res.json['data'][0]['id'] in submission_ids
         assert res.json['data'][1]['id'] in submission_ids
+        assert res.json['data'][0]['attributes'].get('submission_url') is None
+        assert res.json['data'][1]['attributes'].get('submission_url') is None
 
     # Users with no auth can only see accepted and published submissions
     def test_list_no_auth(self, app, url, submission_submitted, submission_accepted, submission_published, other_submission):
@@ -161,6 +171,8 @@ class TestChronosSubmissionList:
         submission_ids = [submission_accepted.publication_id, submission_published.publication_id]
         assert res.json['data'][0]['id'] in submission_ids
         assert res.json['data'][1]['id'] in submission_ids
+        assert res.json['data'][0]['attributes'].get('submission_url') is None
+        assert res.json['data'][1]['attributes'].get('submission_url') is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Purpose

Only show `submission_url` if the user is the submitter.

## Changes

Add `ShowIfChronosSubmitter` conditional field and make use of that field.
Add tests.

## QA Notes

Nothing for this backend PR. See frontend counterpart for testing info.

## Ticket

https://openscience.atlassian.net/browse/ENG-586
