### PR TITLE
Removing collections from the django admin app user view. [ENG-63]

### DIFF
--- a/osf/admin.py
+++ b/osf/admin.py
@@ -20,6 +20,7 @@ class OSFUserAdmin(admin.ModelAdmin):
         """
         if db_field.name == 'groups':
             kwargs['queryset'] = Group.objects.exclude(name__startswith='preprint_')
+            #kwargs['queryset'] = Group.objects.exclude(name__startswith='collections_')
         return super(OSFUserAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
     def save_related(self, request, form, formsets, change):
@@ -28,9 +29,12 @@ class OSFUserAdmin(admin.ModelAdmin):
         are removed.  Manually re-adds preprint groups after adding new groups in form.
         """
         preprint_groups = list(form.instance.groups.filter(name__startswith='preprint_'))
+        collection_groups = list(form.instance.groups.filter(name__startswith='collections_'))
         super(OSFUserAdmin, self).save_related(request, form, formsets, change)
         if 'groups' in form.cleaned_data:
             for group in preprint_groups:
+                form.instance.groups.add(group)
+            for group in collection_groups:
                 form.instance.groups.add(group)
 
 class BlacklistedEmailDomainAdmin(admin.ModelAdmin):

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -32,6 +32,8 @@ class OSFUserAdmin(admin.ModelAdmin):
         """
         preprint_groups = list(form.instance.groups.filter(name__startswith='preprint_'))
         collection_groups = list(form.instance.groups.filter(name__startswith='collections_'))
+        collection_groups = []
+        print type(form)
         super(OSFUserAdmin, self).save_related(request, form, formsets, change)
         if 'groups' in form.cleaned_data:
             for group in preprint_groups:

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -16,7 +16,7 @@ class OSFUserAdmin(admin.ModelAdmin):
 
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         """
-        Restricts preprint django groups from showing up in the user's groups list in the admin app
+        Restricts preprint and collection django groups from showing up in the user's groups list in the admin app
         """
         if db_field.name == 'groups':
             kwargs['queryset'] = Group.objects.exclude(name__startswith='preprint_')
@@ -25,8 +25,9 @@ class OSFUserAdmin(admin.ModelAdmin):
 
     def save_related(self, request, form, formsets, change):
         """
-        Since m2m fields overridden with new form data in admin app, preprint groups (which are now excluded from being selections)
-        are removed.  Manually re-adds preprint groups after adding new groups in form.
+        Since m2m fields overridden with new form data in admin app, preprint groups and collection django groups
+        (which are now excluded from being selections) are removed.
+        Manually re-adds preprint groups and collection django groups after adding new groups in form.
         """
         preprint_groups = list(form.instance.groups.filter(name__startswith='preprint_'))
         collection_groups = list(form.instance.groups.filter(name__startswith='collections_'))

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -32,8 +32,6 @@ class OSFUserAdmin(admin.ModelAdmin):
         """
         preprint_groups = list(form.instance.groups.filter(name__startswith='preprint_'))
         collection_groups = list(form.instance.groups.filter(name__startswith='collections_'))
-        collection_groups = []
-        print type(form)
         super(OSFUserAdmin, self).save_related(request, form, formsets, change)
         if 'groups' in form.cleaned_data:
             for group in preprint_groups:

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django_extensions.admin import ForeignKeyAutocompleteAdmin
 from django.contrib.auth.models import Group
+from django.db.models import Q
 
 from osf.models import OSFUser, Node, BlacklistedEmailDomain
 
@@ -19,8 +20,8 @@ class OSFUserAdmin(admin.ModelAdmin):
         Restricts preprint and collection django groups from showing up in the user's groups list in the admin app
         """
         if db_field.name == 'groups':
-            kwargs['queryset'] = Group.objects.exclude(name__startswith='preprint_')
-            kwargs['queryset'] = Group.objects.exclude(name__startswith='collections_')
+            kwargs['queryset'] = Group.objects.exclude(
+                Q(name__startswith='preprint_') | Q(name__startswith='collections_'))
         return super(OSFUserAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
     def save_related(self, request, form, formsets, change):

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -20,7 +20,7 @@ class OSFUserAdmin(admin.ModelAdmin):
         """
         if db_field.name == 'groups':
             kwargs['queryset'] = Group.objects.exclude(name__startswith='preprint_')
-            #kwargs['queryset'] = Group.objects.exclude(name__startswith='collections_')
+            kwargs['queryset'] = Group.objects.exclude(name__startswith='collections_')
         return super(OSFUserAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
     def save_related(self, request, form, formsets, change):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
The django admin app user view lists every collection, including bookmarks. Each user has a bookmark collection, so for production, this list is very long. Using a method similar to preprints, the django collections are excluded from the list, while retaining permissions on save.

## Changes

<!-- Briefly describe or list your changes  -->
-osf/utils/admin.py: Excluding collections from the admin user view queryset. Retaining collection permissions on save.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/ENG-63