### PR TITLE
Reset Password page breaks login page[ENG-49]

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -75,8 +75,7 @@ class CasClient(object):
 
         url = furl.furl(self.BASE_URL)
         url.path.segments.append('login')
-        #Login from /forgotpassword/ should redirect to the dashboard.
-        url.args['service'] = service_url.replace('forgotpassword', 'dashboard')
+        url.args['service'] = service_url
         if campaign:
             url.args['campaign'] = campaign
         elif username and verification_key:

--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -75,7 +75,8 @@ class CasClient(object):
 
         url = furl.furl(self.BASE_URL)
         url.path.segments.append('login')
-        url.args['service'] = service_url
+        #Login from /forgotpassword/ should redirect to the dashboard.
+        url.args['service'] = service_url.replace('forgotpassword', 'dashboard')
         if campaign:
             url.args['campaign'] = campaign
         elif username and verification_key:

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -2,7 +2,6 @@
 import furl
 import httplib as http
 import urllib
-import re
 
 import markupsafe
 from django.core.exceptions import ValidationError
@@ -50,10 +49,6 @@ def reset_password_get(auth, uid=None, token=None):
     :raises: HTTPError(http.BAD_REQUEST) if verification key for the user is invalid, has expired or was used
     """
 
-    #override routes.py login_url to redirect to dashboard
-    next_url = re.sub(r'resetpassword/[A-z,0-9,/]+', '', request.url)
-    next_url = next_url + 'dashboard/'
-    service_url = cas.get_login_url(next_url)
     # if users are logged in, log them out and redirect back to this page
     if auth.logged_in:
         return auth_logout(redirect_url=request.url)
@@ -70,6 +65,9 @@ def reset_password_get(auth, uid=None, token=None):
     # refresh the verification key (v2)
     user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
     user_obj.save()
+
+    #override routes.py login_url to redirect to dashboard
+    service_url = web_url_for('dashboard', _absolute=True)
 
     return {
         'uid': user_obj._id,
@@ -138,14 +136,14 @@ def forgot_password_get(auth):
     :param auth: the authentication context
     :return
     """
-    #overriding the routes.py sign in url to redirect to the dashboard after login
-    context = {}
-    next_url = request.url.replace('/forgotpassword/', '/dashboard/')
-    context['login_url'] = cas.get_login_url(next_url)
 
     # if users are logged in, log them out and redirect back to this page
     if auth.logged_in:
         return auth_logout(redirect_url=request.url)
+
+    #overriding the routes.py sign in url to redirect to the dashboard after login
+    context = {}
+    context['login_url'] = web_url_for('dashboard', _absolute=True)
 
     return context
 


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When logging in from osf.io/forgotpassword, after successfully logging in, the user is redirected back to /forgotpassword, which logs the user out.
<!-- Describe the purpose of your changes -->

## Changes

/framework/auth/cas.py has been changed to redirect back to dashboard instead of forgot password for the service url.

<!-- Briefly describe or list your changes  -->

## QA Notes

- Verify clicking on Sign In button from forgot password page navigates you to dashboard after typing in your credentials
- Verify same behavior on reset password page (this is the email link you get from the forgot password page) - osf.io/resetpassword/<user_id>/token/
## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/ENG-49