### PR TITLE
[ENG-422] APIv2 Browsable API-only 500 Error 

### DIFF
--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -50,6 +50,9 @@ class BrowsableAPIRendererNoForms(BrowsableAPIRenderer):
             del context[form]
         return context
 
+    def show_form_for_method(self, view, method, request, obj):
+        return False
+
 
 class PlainTextRenderer(StaticHTMLRenderer):
     """

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -386,10 +386,7 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
     ordering = ('_order',)  # default ordering
 
     def get_resource(self):
-        try:
-            return self.get_node()
-        except PermissionDenied:
-            return None
+        return self.get_node()
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView, BulkDeleteJSONAPIView
     def get_serializer_class(self):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -386,7 +386,10 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
     ordering = ('_order',)  # default ordering
 
     def get_resource(self):
-        return self.get_node()
+        try:
+            return self.get_node()
+        except PermissionDenied:
+            return None
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView, BulkDeleteJSONAPIView
     def get_serializer_class(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
-The browsable API is receiving 500 errors when accessing a contributor list as a 'write' contributor: v2/nodes/<guid>/contributors/.
-Accessing a deleted node on the Browsable API returns a 500 rather than a 410 (Gone)

## Changes
-api/base/renderers.py: Modified BrowsableAPIRendererNoForms to include 

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
