### PR TITLE
[ENG-142] Fix Fangorn rate throttling 202s

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -656,16 +656,8 @@ function doItemOp(operation, to, from, rename, conflict) {
             tb.pendingFileOps.pop();
         }
         if (xhr.status === 202) {
-            var mithrilContent = m('div', [
-                m('h3.break-word', operation.action + ' "' + (from.data.materialized || '/') + '" to "' + (to.data.materialized || '/') + '" is taking a bit longer than expected.'),
-                m('p', 'We\'ll send you an email when it has finished.'),
-                m('p', 'In the mean time you can leave this page; your ' + operation.status + ' will still be completed.')
-            ]);
-            var mithrilButtons = m('div', [
-                m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { tb.modal.dismiss(); }}, 'Close')
-            ]);
-            var header =  m('h3.modal-title.break-word', 'Operation Information');
-            tb.modal.update(mithrilContent, mithrilButtons, header);
+            var message =  'We\'ll send you an email when it has finished. <br> You can leave this page; your ' + operation.status + ' will still be completed.';
+            $osf.growl(operation.action + ' "' + (from.data.materialized || '/') + '" to "' + (to.data.materialized || '/') + '" is pending', message);
             return;
         }
         from.data = tb.options.lazyLoadPreprocess.call(this, resp).data;


### PR DESCRIPTION
## Purpose

Currently fangorn on staging can't handle creating dialogs for 202 it skips modals 

## Changes

This:
![screenshot-1](https://user-images.githubusercontent.com/9688518/60277909-7e3a2180-98cc-11e9-87d3-ebaf98e824b1.png)

Becomes this:
![Screen Shot 2019-06-27 at 10 36 52 AM](https://user-images.githubusercontent.com/9688518/60277953-8db96a80-98cc-11e9-857a-d2f921c78681.png)
(dialog boxes aren't timed)
## QA Notes

Testing this now should be the same, just expect modals as opposed to dialog boxes.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-142