### PR TITLE
[ENG-643] Get Waffle Cookies working!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ language: python
 
 python:
     - "2.7"
-dist: trusty
+
+dist: precise
+
 sudo: false
 
 # TODO: uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ language: python
 
 python:
     - "2.7"
-
-dist: precise
-
+dist: trusty
 sudo: false
 
 # TODO: uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 python:
     - "2.7"
-
+dist: trusty
 sudo: false
 
 # TODO: uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+
 from django.conf.urls import include, url
 from django.views.generic.base import RedirectView
 
-from . import views
-from . import settings
-from . import versioning
+
+from api.base import views
+from api.base import settings
+from api.base import versioning
 
 default_version = versioning.decimal_version_to_url_path(settings.REST_FRAMEWORK['DEFAULT_VERSION'])
 

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from django.conf.urls import include, url
 from django.views.generic.base import RedirectView
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -411,7 +411,7 @@ def root(request, format=None, **kwargs):
     else:
         current_user = None
 
-    flags = [name for name in Flag.objects.values_list('name', flat=True) if flag_is_active(request, name)]
+    flags = [name for name in Flag.objects.values_list('name', flat=True) if flag_is_active(request._request, name)]
     samples = [name for name in Sample.objects.values_list('name', flat=True) if sample_is_active(name)]
     switches = list(Switch.objects.filter(active=True).values_list('name', flat=True))
 

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -2,7 +2,6 @@ import json
 
 import jwe
 import jwt
-import waffle
 
 from django.utils import timezone
 from rest_framework.authentication import BaseAuthentication
@@ -18,6 +17,7 @@ from osf.models import Institution
 from website.mails import send_mail, WELCOME_OSF4I
 from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
 
+from api.waffle.utils import flag_is_active
 
 class InstitutionAuthentication(BaseAuthentication):
 
@@ -112,7 +112,7 @@ class InstitutionAuthentication(BaseAuthentication):
                 user=user,
                 domain=DOMAIN,
                 osf_support_email=OSF_SUPPORT_EMAIL,
-                storage_flag_is_active=waffle.flag_is_active(request, features.STORAGE_I18N),
+                storage_flag_is_active=flag_is_active(request, features.STORAGE_I18N),
             )
 
         if not user.is_affiliated_with_institution(institution):

--- a/api/waffle/utils.py
+++ b/api/waffle/utils.py
@@ -16,6 +16,7 @@ def flag_is_active(request, flag_name):
     :param flask request object:
     :return flask request object:
     """
+    # Waffle does not enjoy NoneTypes as user values.
     request.user = _get_current_user() or MockUser()
     request.COOKIES = getattr(request, 'cookies', None)
     return waffle.flag_is_active(request, flag_name)

--- a/api/waffle/utils.py
+++ b/api/waffle/utils.py
@@ -1,0 +1,29 @@
+import waffle
+
+from framework.auth.core import _get_current_user
+from osf import features
+from flask import request
+
+
+class MockUser(object):
+    is_authenticated = False
+
+
+def flag_is_active(request, flag_name):
+    """
+    This function changes the typical flask request object so it can be used by django-waffle. Other modifications for
+    django-waffle can be found in the __call__ method of OsfWebRenderer.
+    :param flask request object:
+    :return flask request object:
+    """
+    request.user = _get_current_user() or MockUser()
+    request.COOKIES = getattr(request, 'cookies', None)
+    return waffle.flag_is_active(request, flag_name)
+
+
+def storage_i18n_flag_active():
+    return flag_is_active(request, features.STORAGE_I18N)
+
+
+def storage_usage_flag_active():
+    return flag_is_active(request, features.STORAGE_USAGE)

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pytest
 
 from website.app import init_app

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -11,8 +11,11 @@ from osf_tests.factories import (
     InstitutionFactory,
     UserFactory,
 )
+from flask import Flask
+
 from tests.base import capture_signals
 
+decoratorapp = Flask('decorators')
 
 def make_user(username, fullname):
     return UserFactory(username=username, fullname=fullname)
@@ -47,6 +50,14 @@ class TestInstitutionAuth:
     @pytest.fixture()
     def institution(self):
         return InstitutionFactory()
+
+    @pytest.yield_fixture(autouse=True)
+    def flask_request_context(self):
+        """
+        required for waffle cookies
+        """
+        with decoratorapp.test_request_context():
+            yield
 
     @pytest.fixture()
     def url_auth_institution(self):

--- a/api_tests/waffle/views/test_waffle_cookies.py
+++ b/api_tests/waffle/views/test_waffle_cookies.py
@@ -1,0 +1,75 @@
+import mock
+import pytest
+from functools import wraps
+
+from osf_tests.factories import (
+    AuthUserFactory,
+    FlagFactory,
+    ProjectFactory
+)
+from website.project.views.node import _view_project
+
+from tests.json_api_test_app import JSONAPITestApp
+from tests.base import OsfTestCase
+
+from api.waffle.utils import flag_is_active
+
+
+def inject_check_is_active(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        from flask import request
+        flag_is_active(request, 'test_flag')
+        return func(self, *args, **kwargs)
+    return wrapped
+
+
+@pytest.mark.django_db
+class TestWaffleCookies(OsfTestCase):
+
+    def setUp(self):
+        super(TestWaffleCookies, self).setUp()
+        self.flag = FlagFactory(name='test_flag')
+        self.flag.percent = 50
+        self.flag.everyone = None
+        self.flag.save()
+
+    @pytest.mark.enable_bookmark_creation
+    @mock.patch('website.project.views.node._view_project', inject_check_is_active(_view_project))
+    def test_waffle_leaves_cookie(self):
+        """
+        Tests that django-waffle cookies work in the with our Flask requests. We inject an is_active test here so we
+        don't break the tests when adding/removing flags.
+
+        Flask waffle cookies are formatted:
+        `dwf_test_flag=True; Expires=True; Max-Age=2592000; Path=/`
+
+        """
+        node = ProjectFactory(is_public=True)
+        user = AuthUserFactory()
+        resp = self.app.get(node.web_url_for('view_project'), auth=user.auth, auto_follow=True)
+
+        waffle_cookie = next(value for key, value in list(resp.headers.items()) if 'dwf_test_flag=' in value)
+
+        cookie_str = 'dwf_test_flag={}; Expires=True; Max-Age=2592000; Path=/'
+
+        assert waffle_cookie == cookie_str.format('True') or waffle_cookie == cookie_str.format('False')
+
+    @pytest.mark.enable_bookmark_creation
+    def test_waffle_v2_root_leaves_cookie(self):
+        """
+        Tests that django-waffle cookies work in the with our Flask requests. Don't need to inject here because the /v2/
+        root view already checks if all flags in the DB are active and this the only route  the ember front-end uses
+        for cookies.
+
+        DRF waffle cookies are formatted:
+        `dwf_test_flag=True; expires=Fri, 09-Aug-2019 16:33:52 GMT; Max-Age=2592000; Path=/; secure`
+
+        """
+        app = JSONAPITestApp()
+        resp = app.get('/v2/')
+        waffle_cookie = next(value for key, value in list(resp.headers.items()) if key == 'Set-Cookie')
+
+        cookie_str = 'dwf_test_flag={};'
+
+        assert cookie_str.format('True') in waffle_cookie or cookie_str.format('False') in waffle_cookie

--- a/api_tests/waffle/views/test_waffle_cookies.py
+++ b/api_tests/waffle/views/test_waffle_cookies.py
@@ -1,27 +1,11 @@
-import mock
 import pytest
-from functools import wraps
 
 from osf_tests.factories import (
-    AuthUserFactory,
     FlagFactory,
-    ProjectFactory
 )
-from website.project.views.node import _view_project
 
 from tests.json_api_test_app import JSONAPITestApp
 from tests.base import OsfTestCase
-
-from api.waffle.utils import flag_is_active
-
-
-def inject_check_is_active(func):
-    @wraps(func)
-    def wrapped(self, *args, **kwargs):
-        from flask import request
-        flag_is_active(request, 'test_flag')
-        return func(self, *args, **kwargs)
-    return wrapped
 
 
 @pytest.mark.django_db
@@ -33,27 +17,6 @@ class TestWaffleCookies(OsfTestCase):
         self.flag.percent = 50
         self.flag.everyone = None
         self.flag.save()
-
-    @pytest.mark.enable_bookmark_creation
-    @mock.patch('website.project.views.node._view_project', inject_check_is_active(_view_project))
-    def test_waffle_leaves_cookie(self):
-        """
-        Tests that django-waffle cookies work in the with our Flask requests. We inject an is_active test here so we
-        don't break the tests when adding/removing flags.
-
-        Flask waffle cookies are formatted:
-        `dwf_test_flag=True; Expires=True; Max-Age=2592000; Path=/`
-
-        """
-        node = ProjectFactory(is_public=True)
-        user = AuthUserFactory()
-        resp = self.app.get(node.web_url_for('view_project'), auth=user.auth, auto_follow=True)
-
-        waffle_cookie = next(value for key, value in list(resp.headers.items()) if 'dwf_test_flag=' in value)
-
-        cookie_str = 'dwf_test_flag={}; Expires=True; Max-Age=2592000; Path=/'
-
-        assert waffle_cookie == cookie_str.format('True') or waffle_cookie == cookie_str.format('False')
 
     @pytest.mark.enable_bookmark_creation
     def test_waffle_v2_root_leaves_cookie(self):
@@ -68,7 +31,7 @@ class TestWaffleCookies(OsfTestCase):
         """
         app = JSONAPITestApp()
         resp = app.get('/v2/')
-        waffle_cookie = next(value for key, value in list(resp.headers.items()) if key == 'Set-Cookie')
+        waffle_cookie = [value for key, value in list(resp.headers.items()) if 'dwf_test_flag' in value][0]
 
         cookie_str = 'dwf_test_flag={};'
 

--- a/api_tests/waffle/views/test_waffle_cookies.py
+++ b/api_tests/waffle/views/test_waffle_cookies.py
@@ -4,22 +4,19 @@ from osf_tests.factories import (
     FlagFactory,
 )
 
-from tests.json_api_test_app import JSONAPITestApp
-from tests.base import OsfTestCase
-
-
 @pytest.mark.django_db
-class TestWaffleCookies(OsfTestCase):
+class TestWaffleCookies:
 
-    def setUp(self):
-        super(TestWaffleCookies, self).setUp()
-        self.flag = FlagFactory(name='test_flag')
-        self.flag.percent = 50
-        self.flag.everyone = None
-        self.flag.save()
+    @pytest.fixture()
+    def flag(self):
+        flag = FlagFactory(name='test_flag')
+        flag.percent = 50
+        flag.everyone = None
+        flag.save()
+        return flag
 
     @pytest.mark.enable_bookmark_creation
-    def test_waffle_v2_root_leaves_cookie(self):
+    def test_waffle_v2_root_leaves_cookie(self, app, flag):
         """
         Tests that django-waffle cookies work in the with our Flask requests. Don't need to inject here because the /v2/
         root view already checks if all flags in the DB are active and this the only route  the ember front-end uses
@@ -29,7 +26,6 @@ class TestWaffleCookies(OsfTestCase):
         `dwf_test_flag=True; expires=Fri, 09-Aug-2019 16:33:52 GMT; Max-Age=2592000; Path=/; secure`
 
         """
-        app = JSONAPITestApp()
         resp = app.get('/v2/')
         waffle_cookie = [value for key, value in list(resp.headers.items()) if 'dwf_test_flag' in value][0]
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import logging
 
 import mock

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -28,7 +28,8 @@ from framework.utils import throttle_period_expired
 from osf.models import OSFUser
 from osf.utils.sanitize import strip_html
 from website import settings, mails, language
-from website.ember_osf_web.decorators import storage_i18n_flag_active, ember_flag_is_active
+from website.ember_osf_web.decorators import ember_flag_is_active
+from api.waffle.utils import storage_i18n_flag_active
 from website.util import web_url_for
 from osf.exceptions import ValidationValueError, BlacklistedEmailError
 from osf.models.provider import PreprintProvider

--- a/osf_tests/test_waffle.py
+++ b/osf_tests/test_waffle.py
@@ -1,0 +1,55 @@
+import mock
+import pytest
+from functools import wraps
+
+from osf_tests.factories import (
+    AuthUserFactory,
+    FlagFactory,
+    ProjectFactory
+)
+from website.project.views.node import _view_project
+
+from tests.base import OsfTestCase
+
+from api.waffle.utils import flag_is_active
+
+
+def inject_check_is_active(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        from flask import request
+        flag_is_active(request, 'test_flag')
+        return func(self, *args, **kwargs)
+    return wrapped
+
+
+@pytest.mark.django_db
+class TestWaffleCookies(OsfTestCase):
+
+    def setUp(self):
+        super(TestWaffleCookies, self).setUp()
+        self.flag = FlagFactory(name='test_flag')
+        self.flag.percent = 50
+        self.flag.everyone = None
+        self.flag.save()
+
+    @pytest.mark.enable_bookmark_creation
+    @mock.patch('website.project.views.node._view_project', inject_check_is_active(_view_project))
+    def test_waffle_leaves_cookie(self):
+        """
+        Tests that django-waffle cookies work in the with our Flask requests. We inject an is_active test here so we
+        don't break the tests when adding/removing flags.
+
+        Flask waffle cookies are formatted:
+        `dwf_test_flag=True; Expires=True; Max-Age=2592000; Path=/`
+
+        """
+        node = ProjectFactory(is_public=True)
+        user = AuthUserFactory()
+        resp = self.app.get(node.web_url_for('view_project'), auth=user.auth, auto_follow=True)
+
+        waffle_cookie = next(value for key, value in list(resp.headers.items()) if 'dwf_test_flag=' in value)
+
+        cookie_str = 'dwf_test_flag={}; Expires=True; Max-Age=2592000; Path=/'
+
+        assert waffle_cookie == cookie_str.format('True') or waffle_cookie == cookie_str.format('False')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,6 @@ from osf.models import OSFUser, Session
 from osf.utils import permissions
 from website import mails
 from website import settings
-from website.ember_osf_web.decorators import storage_i18n_flag_active
 from website.project.decorators import (
     must_have_permission,
     must_be_contributor,

--- a/tests/test_ember_osf_web.py
+++ b/tests/test_ember_osf_web.py
@@ -46,7 +46,6 @@ class TestEmberFlagIsActive(OsfTestCase):
         ember_flag_is_active('active_flag')(self.mock_func)()
 
         api.waffle.utils.waffle.flag_is_active.assert_called_with(request, 'active_flag')
-        assert request.user == user
         mock_use_ember_app.assert_called_with()
 
     @mock.patch('api.waffle.utils._get_current_user', return_value=None)
@@ -62,5 +61,4 @@ class TestEmberFlagIsActive(OsfTestCase):
         self.flag.groups.add(group)
 
         api.waffle.utils.waffle.flag_is_active.assert_called_with(request, 'active_flag')
-        assert not request.user.is_authenticated
         mock_use_ember_app.assert_called_with()

--- a/tests/test_ember_osf_web.py
+++ b/tests/test_ember_osf_web.py
@@ -29,28 +29,23 @@ class TestEmberFlagIsActive(OsfTestCase):
 
         assert not mock_use_ember_app.called
 
-    @mock.patch('website.ember_osf_web.decorators._get_current_user')
-    @mock.patch('website.ember_osf_web.decorators.waffle.flag_is_active', return_value=True)
+    @mock.patch('api.waffle.utils._get_current_user')
     @mock.patch('website.ember_osf_web.decorators.use_ember_app')
-    def test_ember_flag_is_active_authenticated_user(self, mock_use_ember_app, mock_flag_is_active, mock__get_current_user):
+    def test_ember_flag_is_active_authenticated_user(self, mock_use_ember_app, mock__get_current_user):
         user = UserFactory()
         mock__get_current_user.return_value = user
 
         ember_flag_is_active('active_flag')(self.mock_func)()
 
-        mock_flag_is_active.assert_called_with(request, 'active_flag')
         assert request.user == user
         mock_use_ember_app.assert_called_with()
 
-    @mock.patch('website.ember_osf_web.decorators._get_current_user', return_value=None)
-    @mock.patch('website.ember_osf_web.decorators.waffle.flag_is_active', return_value=True)
     @mock.patch('website.ember_osf_web.decorators.use_ember_app')
-    def test_ember_flag_is_active_unauthenticated_user(self, mock_use_ember_app, mock_flag_is_active, mock__get_current_user):
+    def test_ember_flag_is_active_unauthenticated_user(self, mock_use_ember_app):
         ember_flag_is_active('active_flag')(self.mock_func)()
         group = Group.objects.create(name='foo')
 
         self.flag.groups.add(group)
 
-        mock_flag_is_active.assert_called_with(request, 'active_flag')
         assert not request.user.is_authenticated
         mock_use_ember_app.assert_called_with()

--- a/tests/test_ember_osf_web.py
+++ b/tests/test_ember_osf_web.py
@@ -25,6 +25,10 @@ class TestEmberFlagIsActive(OsfTestCase):
 
     @mock.patch('website.ember_osf_web.decorators.use_ember_app')
     def test_dont_use_ember_app(self, mock_use_ember_app):
+        # mock over external module 'waflle.flag_is_active` not ours
+        import api.waffle.utils
+        api.waffle.utils.waffle.flag_is_active = mock.Mock(return_value=False)
+
         ember_flag_is_active('inactive_flag')(self.mock_func)()
 
         assert not mock_use_ember_app.called
@@ -32,20 +36,31 @@ class TestEmberFlagIsActive(OsfTestCase):
     @mock.patch('api.waffle.utils._get_current_user')
     @mock.patch('website.ember_osf_web.decorators.use_ember_app')
     def test_ember_flag_is_active_authenticated_user(self, mock_use_ember_app, mock__get_current_user):
+        # mock over external module 'waflle.flag_is_active` not ours
+        import api.waffle.utils
+        api.waffle.utils.waffle.flag_is_active = mock.Mock(return_value=True)
+
         user = UserFactory()
         mock__get_current_user.return_value = user
 
         ember_flag_is_active('active_flag')(self.mock_func)()
 
+        api.waffle.utils.waffle.flag_is_active.assert_called_with(request, 'active_flag')
         assert request.user == user
         mock_use_ember_app.assert_called_with()
 
+    @mock.patch('api.waffle.utils._get_current_user', return_value=None)
     @mock.patch('website.ember_osf_web.decorators.use_ember_app')
-    def test_ember_flag_is_active_unauthenticated_user(self, mock_use_ember_app):
+    def test_ember_flag_is_active_unauthenticated_user(self, mock_use_ember_app, mock__get_current_user):
+        # mock over external module 'waflle.flag_is_active` not ours
+        import api.waffle.utils
+        api.waffle.utils.waffle.flag_is_active = mock.Mock(return_value=True)
+
         ember_flag_is_active('active_flag')(self.mock_func)()
         group = Group.objects.create(name='foo')
 
         self.flag.groups.add(group)
 
+        api.waffle.utils.waffle.flag_is_active.assert_called_with(request, 'active_flag')
         assert not request.user.is_authenticated
         mock_use_ember_app.assert_called_with()

--- a/website/ember_osf_web/decorators.py
+++ b/website/ember_osf_web/decorators.py
@@ -1,8 +1,8 @@
+import waffle
 import functools
 
 from flask import request
 
-from api.waffle.utils import flag_is_active
 from website.ember_osf_web.views import use_ember_app
 
 
@@ -14,7 +14,7 @@ def ember_flag_is_active(flag_name):
     def decorator(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            if flag_is_active(request, flag_name):
+            if waffle.flag_is_active(request, flag_name):
                 return use_ember_app()
             else:
                 return func(*args, **kwargs)

--- a/website/ember_osf_web/decorators.py
+++ b/website/ember_osf_web/decorators.py
@@ -1,15 +1,9 @@
 import functools
-import waffle
 
 from flask import request
 
-from framework.auth.core import _get_current_user
-from osf import features
+from api.waffle.utils import flag_is_active
 from website.ember_osf_web.views import use_ember_app
-
-
-class MockUser(object):
-    is_authenticated = False
 
 
 def ember_flag_is_active(flag_name):
@@ -21,21 +15,9 @@ def ember_flag_is_active(flag_name):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             # Waffle does not enjoy NoneTypes as user values.
-            request.user = _get_current_user() or MockUser()
-
-            if waffle.flag_is_active(request, flag_name):
+            if flag_is_active(request, flag_name):
                 return use_ember_app()
             else:
                 return func(*args, **kwargs)
         return wrapped
     return decorator
-
-
-def storage_i18n_flag_active():
-    request.user = _get_current_user() or MockUser()
-    return waffle.flag_is_active(request, features.STORAGE_I18N)
-
-
-def storage_usage_flag_active():
-    request.user = _get_current_user() or MockUser()
-    return waffle.flag_is_active(request, features.STORAGE_USAGE)

--- a/website/ember_osf_web/decorators.py
+++ b/website/ember_osf_web/decorators.py
@@ -14,7 +14,6 @@ def ember_flag_is_active(flag_name):
     def decorator(func):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            # Waffle does not enjoy NoneTypes as user values.
             if flag_is_active(request, flag_name):
                 return use_ember_app()
             else:

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -22,7 +22,6 @@ def use_ember_app(**kwargs):
         resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)
         resp = Response(stream_with_context(resp.iter_content()), resp.status_code)
     else:
-        raise Exception(os.getcwd(), __file__)
         resp = send_from_directory(ember_osf_web_dir, 'index.html')
 
     messages = pop_status_messages()

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -8,7 +8,7 @@ from flask import send_from_directory, Response, stream_with_context
 
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
-ember_osf_web_dir = os.path.abspath(os.path.join(__file__, EXTERNAL_EMBER_APPS['ember_osf_web']['path']))
+ember_osf_web_dir = os.path.abspath(os.getcwd() + '/website' + EXTERNAL_EMBER_APPS['ember_osf_web']['path'])
 
 routes = [
     '/quickfiles/',

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -8,7 +8,7 @@ from flask import send_from_directory, Response, stream_with_context
 
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
-ember_osf_web_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['ember_osf_web']['path']))
+ember_osf_web_dir = os.path.abspath(os.path.join(__file__, EXTERNAL_EMBER_APPS['ember_osf_web']['path']))
 
 routes = [
     '/quickfiles/',

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -22,6 +22,9 @@ def use_ember_app(**kwargs):
         resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)
         resp = Response(stream_with_context(resp.iter_content()), resp.status_code)
     else:
+        print __file__
+        print os.getcwd()
+        raise Exception(locals())
         resp = send_from_directory(ember_osf_web_dir, 'index.html')
 
     messages = pop_status_messages()

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -8,7 +8,7 @@ from flask import send_from_directory, Response, stream_with_context
 
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
 
-ember_osf_web_dir = os.path.abspath(os.getcwd() + '/website' + EXTERNAL_EMBER_APPS['ember_osf_web']['path'])
+ember_osf_web_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['ember_osf_web']['path']))
 
 routes = [
     '/quickfiles/',

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -22,9 +22,7 @@ def use_ember_app(**kwargs):
         resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)
         resp = Response(stream_with_context(resp.iter_content()), resp.status_code)
     else:
-        print __file__
-        print os.getcwd()
-        raise Exception(locals())
+        raise Exception(os.getcwd(), __file__)
         resp = send_from_directory(ember_osf_web_dir, 'index.html')
 
     messages = pop_status_messages()

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -7,7 +7,7 @@ from addons.osfstorage.models import Region
 from website.filters import profile_image_url
 from osf.utils.permissions import READ
 from osf.utils import workflows
-from website.ember_osf_web.decorators import storage_i18n_flag_active
+from api.waffle.utils import storage_i18n_flag_active
 
 
 def get_profile_image_url(user, size=settings.PROFILE_IMAGE_MEDIUM):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -32,12 +32,14 @@ from website import mails
 from website import mailchimp_utils
 from website import settings
 from website import language
-from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_flag_active
+from website.ember_osf_web.decorators import ember_flag_is_active
 from website.oauth.utils import get_available_scopes
 from website.profile import utils as profile_utils
 from website.util import api_v2_url, web_url_for, paths
 from website.util.sanitize import escape_html
 from addons.base import utils as addon_utils
+
+from api.waffle.utils import storage_i18n_flag_active
 
 logger = logging.getLogger(__name__)
 

--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -27,9 +27,16 @@ def serialize_meta_schemas(meta_schemas):
 
 def serialize_draft_registration(draft, auth=None):
     from website.project.utils import serialize_node  # noqa
+    from website.util import api_v2_url
     from api.base.utils import absolute_reverse
+    from django.core.urlresolvers import NoReverseMatch
 
     node = draft.branched_from
+
+    try:
+        register_url = absolute_reverse('nodes:node-registrations', kwargs={'node_id': node._id, 'version': 'v2'}),
+    except (NoReverseMatch, SyntaxError):  # TODO: fix bug on certain Travis environments
+        register_url = api_v2_url('v2/nodes/{}/registrations/'.format(node._id), params=None, base_prefix='')
 
     return {
         'pk': draft._id,
@@ -44,7 +51,7 @@ def serialize_draft_registration(draft, auth=None):
             'edit': node.web_url_for('edit_draft_registration_page', draft_id=draft._id, _guid=True),
             'submit': node.api_url_for('submit_draft_for_review', draft_id=draft._id),
             'before_register': node.api_url_for('project_before_register'),
-            'register': absolute_reverse('nodes:node-registrations', kwargs={'node_id': node._id, 'version': 'v2'}),
+            'register': register_url,
             'register_page': node.web_url_for('draft_before_register_page', draft_id=draft._id, _guid=True),
             'registrations': node.web_url_for('node_registrations', _guid=True)
         },

--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -27,16 +27,9 @@ def serialize_meta_schemas(meta_schemas):
 
 def serialize_draft_registration(draft, auth=None):
     from website.project.utils import serialize_node  # noqa
-    from website.util import api_v2_url
     from api.base.utils import absolute_reverse
-    from django.core.urlresolvers import NoReverseMatch
 
     node = draft.branched_from
-
-    try:
-        register_url = absolute_reverse('nodes:node-registrations', kwargs={'node_id': node._id, 'version': 'v2'}),
-    except (NoReverseMatch, SyntaxError):  # TODO: fix bug on certain Travis environments
-        register_url = api_v2_url('v2/nodes/{}/registrations/'.format(node._id), params=None, base_prefix='')
 
     return {
         'pk': draft._id,
@@ -51,7 +44,7 @@ def serialize_draft_registration(draft, auth=None):
             'edit': node.web_url_for('edit_draft_registration_page', draft_id=draft._id, _guid=True),
             'submit': node.api_url_for('submit_draft_for_review', draft_id=draft._id),
             'before_register': node.api_url_for('project_before_register'),
-            'register': register_url,
+            'register': absolute_reverse('nodes:node-registrations', kwargs={'node_id': node._id, 'version': 'v2'}),
             'register_page': node.web_url_for('draft_before_register_page', draft_id=draft._id, _guid=True),
             'registrations': node.web_url_for('node_registrations', _guid=True)
         },

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -3,7 +3,6 @@ import os
 import logging
 import httplib as http
 import math
-import waffle
 from collections import defaultdict
 from itertools import islice
 
@@ -16,7 +15,8 @@ from framework import status
 from framework.utils import iso8601format
 from framework.flask import redirect  # VOL-aware redirect
 from framework.auth.decorators import must_be_logged_in, collect_auth
-from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_flag_active, storage_usage_flag_active
+from website.ember_osf_web.decorators import ember_flag_is_active
+from api.waffle.utils import flag_is_active, storage_i18n_flag_active, storage_usage_flag_active
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
 from osf.utils.functional import rapply
@@ -281,7 +281,7 @@ def node_forks(auth, node, **kwargs):
 @must_have_permission(READ)
 @ember_flag_is_active(features.EMBER_PROJECT_SETTINGS)
 def node_setting(auth, node, **kwargs):
-    if node.is_registration and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+    if node.is_registration and flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
         # Registration settings page obviated during redesign
         return redirect(node.url)
     auth.user.update_affiliated_institutions_by_email_domain()

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -3,7 +3,6 @@ import httplib as http
 import itertools
 
 from flask import request
-import waffle
 
 from framework import status
 from framework.exceptions import HTTPError
@@ -36,6 +35,7 @@ from website.project.model import has_anonymous_link
 from website.archiver.decorators import fail_archive_on_error
 
 from .node import _view_project
+from api.waffle.utils import flag_is_active
 
 @must_be_valid_project
 @must_not_be_retracted_registration
@@ -127,7 +127,7 @@ def node_registration_retraction_post(auth, node, **kwargs):
 @must_be_contributor_or_public
 @ember_flag_is_active(features.EMBER_REGISTRATION_FORM_DETAIL)
 def node_register_template_page(auth, node, metaschema_id, **kwargs):
-    if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+    if flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
         # Registration meta page obviated during redesign
         return redirect(node.url)
     if node.is_registration and bool(node.registered_schema):

--- a/website/routes.py
+++ b/website/routes.py
@@ -4,8 +4,10 @@ import os
 import httplib as http
 import requests
 import urlparse
-import waffle
 import json
+
+import waffle
+from waffle.utils import get_setting
 
 from flask import request
 from flask import send_from_directory
@@ -14,6 +16,9 @@ from flask import stream_with_context
 from flask import g
 from django.core.urlresolvers import reverse
 from django.conf import settings as api_settings
+from django.utils.encoding import smart_str
+from werkzeug.http import dump_cookie
+
 
 from geolite2 import geolite2
 
@@ -62,6 +67,8 @@ from website.ember_osf_web import views as ember_osf_web_views
 from website.closed_challenges import views as closed_challenges_views
 from website.identifiers import views as identifier_views
 from website.settings import EXTERNAL_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT
+
+from api.waffle.utils import flag_is_active
 
 def set_status_message(user):
     if user and not user.accepted_terms_of_service:
@@ -150,7 +157,7 @@ def get_globals():
                 'write_key': settings.KEEN['private']['write_key'],
             },
         },
-        'institutional_landing_flag': waffle.flag_is_active(request, features.INSTITUTIONAL_LANDING_FLAG),
+        'institutional_landing_flag': flag_is_active(request, features.INSTITUTIONAL_LANDING_FLAG),
         'maintenance': maintenance.get_maintenance(),
         'recaptcha_site_key': settings.RECAPTCHA_SITE_KEY,
         'custom_citations': settings.CUSTOM_CITATIONS,
@@ -183,6 +190,27 @@ class OsfWebRenderer(WebRenderer):
         kwargs['data'] = get_globals
         super(OsfWebRenderer, self).__init__(*args, **kwargs)
 
+    def __call__(self, data, *args, **kwargs):
+        """
+        This function has been added to keep our Flask requests compatible with django-waffle, it's been adapted from
+        waffle's own middleware code at https://github.com/django-waffle/django-waffle/blob/master/waffle/middleware.py
+        """
+
+        resp = super(OsfWebRenderer, self).__call__(data, *args, **kwargs)
+        secure = get_setting('SECURE')
+        max_age = get_setting('MAX_AGE')
+
+        if hasattr(request, 'waffles'):
+            for k in request.waffles:
+                name = smart_str(get_setting('COOKIE') % k)
+                active, rollout = request.waffles[k]
+                if rollout and not active:
+                    # "Inactive" is a session cookie during rollout mode.
+                    age = None
+                else:
+                    age = max_age
+                resp.headers.add('Set-Cookie', dump_cookie(name.encode(), bytes(active), age, bytes(secure)))
+        return resp
 
 #: Use if a view only redirects or raises error
 notemplate = OsfWebRenderer('', renderer=render_mako_string, trust=False)

--- a/website/routes.py
+++ b/website/routes.py
@@ -14,7 +14,6 @@ from flask import send_from_directory
 from flask import Response
 from flask import stream_with_context
 from flask import g
-from django.core.urlresolvers import reverse
 from django.conf import settings as api_settings
 from django.utils.encoding import smart_str
 from werkzeug.http import dump_cookie
@@ -101,11 +100,6 @@ def get_globals():
     else:
         request_login_url = request.url
 
-    try:
-        waffle_url = reverse('wafflejs')  # TODO: fix bug only effects Travis
-    except (KeyError, SyntaxError):
-        waffle_url = '/_/wafflejs'
-
     return {
         'private_link_anonymous': is_private_link_anonymous_view(),
         'user_name': user.username if user else '',
@@ -168,7 +162,6 @@ def get_globals():
         'custom_citations': settings.CUSTOM_CITATIONS,
         'osf_support_email': settings.OSF_SUPPORT_EMAIL,
         'osf_contact_email': settings.OSF_CONTACT_EMAIL,
-        'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=waffle_url),
         'footer_links': settings.FOOTER_LINKS,
         'features': features,
         'waffle': waffle,

--- a/website/routes.py
+++ b/website/routes.py
@@ -101,6 +101,11 @@ def get_globals():
     else:
         request_login_url = request.url
 
+    try:
+        waffle_url = reverse('wafflejs')  # TODO: fix bug only effects Travis
+    except (KeyError, SyntaxError):
+        waffle_url = '/_/wafflejs'
+
     return {
         'private_link_anonymous': is_private_link_anonymous_view(),
         'user_name': user.username if user else '',
@@ -163,7 +168,7 @@ def get_globals():
         'custom_citations': settings.CUSTOM_CITATIONS,
         'osf_support_email': settings.OSF_SUPPORT_EMAIL,
         'osf_contact_email': settings.OSF_CONTACT_EMAIL,
-        'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=reverse('wafflejs')),
+        'wafflejs_url': '{api_domain}{waffle_url}'.format(api_domain=settings.API_DOMAIN.rstrip('/'), waffle_url=waffle_url),
         'footer_links': settings.FOOTER_LINKS,
         'features': features,
         'waffle': waffle,

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -30,7 +30,7 @@ USE_EXTERNAL_EMBER = True
 EXTERNAL_EMBER_APPS = {
     'ember_osf_web': {
         'server': 'http://localhost:4200',
-        'path': os.environ.get('HOME') + '/ember_osf_web/'
+        'path': os.environ.get('HOME') + 'website/ember_osf_web/'
     },
     'preprints': {
         'server': 'http://localhost:4201',

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -369,8 +369,6 @@
 
 <%def name="javascript_bottom()">
     ### Javascript loaded at the bottom of the page ###
-    <!-- Uncomment to include a waffle object to access flags, samples, and switches. -->
-    <!-- <script src="${wafflejs_url}"></script> -->
 </%def>
 
 <%def name="footer()">

--- a/website/views.py
+++ b/website/views.py
@@ -7,7 +7,6 @@ import math
 import os
 import requests
 import urllib
-import waffle
 
 from django.apps import apps
 from flask import request, send_from_directory, Response, stream_with_context
@@ -28,10 +27,12 @@ from osf.models import BaseFileNode, Guid, Institution, Preprint, AbstractNode, 
 from addons.osfstorage.models import Region
 
 from website.settings import EXTERNAL_EMBER_APPS, PROXY_EMBER_APPS, EXTERNAL_EMBER_SERVER_TIMEOUT, DOMAIN
-from website.ember_osf_web.decorators import ember_flag_is_active, storage_i18n_flag_active
+from website.ember_osf_web.decorators import ember_flag_is_active
 from website.ember_osf_web.views import use_ember_app
 from website.project.model import has_anonymous_link
 from osf.utils import permissions
+
+from api.waffle.utils import flag_is_active, storage_i18n_flag_active
 
 logger = logging.getLogger(__name__)
 preprints_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['preprints']['path']))
@@ -319,7 +320,7 @@ def resolve_guid(guid, suffix=None):
         if isinstance(referent, Registration) and (
                 not suffix or suffix.rstrip('/').lower() in ('comments', 'links', 'components')
         ):
-            if waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+            if flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
                 # Route only the base detail view to ember
                 if PROXY_EMBER_APPS:
                     resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True, timeout=EXTERNAL_EMBER_SERVER_TIMEOUT)


### PR DESCRIPTION
## Purpose

Currently our waffle flags don't really work as expected, because we are using some Flask elements django-waffle doesn't properly append a `set-cookie` head to the request object. This means we can't distinguish users on an individual level.

## Changes

- Hack-y fix of `OsfWebRender` which imitates waffle middleware
- tests

## QA Notes

When testing this issue you must be aware of 4 things!

- Check for superuser-hood!
- The flags are cached when check `is_active`! always check you have the correct flag with ` python manage.py waffle_flag <flag_name>`,  r
- Be very carefully with your flags because their attributes are inconsistent, for example `everyone` will override all other options whether it is False or True, or attributes like `authenticated` don't work this way.
- You can't set a cookie until you visually see a page being checked, going to `localhost:8000/v2/` will respect a cookie if it's there, but can't set it.

## Documentation

Not user facing, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-643