### PR TITLE
[ENG-650] Use sync_manuscript for ChronosSubmissionDetailSerializer

### DIFF
--- a/api/chronos/serializers.py
+++ b/api/chronos/serializers.py
@@ -86,7 +86,7 @@ class ChronosSubmissionDetailSerializer(ChronosSubmissionSerializer):
     id = ser.CharField(source='publication_id', required=True)
 
     def update(self, instance, validated_data):
-        return ChronosClient().update_manuscript(instance)
+        return ChronosClient().sync_manuscript(instance)
 
 
 class ChronosSubmissionCreateSerializer(ChronosSubmissionSerializer):

--- a/api_tests/chronos/views/test_chronos_submission_detail.py
+++ b/api_tests/chronos/views/test_chronos_submission_detail.py
@@ -51,14 +51,14 @@ class TestChronosSubmissionDetail:
             }
         }
 
-    @mock.patch('api.chronos.serializers.ChronosClient.update_manuscript')
-    def test_update_success(self, mock_update, app, url, submission, submitter):
-        mock_update.return_value = submission
+    @mock.patch('api.chronos.serializers.ChronosClient.sync_manuscript')
+    def test_update_success(self, mock_sync, app, url, submission, submitter):
+        mock_sync.return_value = submission
         payload = self.update_payload(submission)
         res = app.patch_json_api(url, payload, auth=submitter.auth)
         assert res.status_code == 200
-        assert mock_update.called
-        mock_update.assert_called_once_with(submission)
+        assert mock_sync.called
+        mock_sync.assert_called_once_with(submission)
 
     @mock.patch('api.chronos.serializers.ChronosClient.update_manuscript')
     def test_update_failure(self, mock_update, app, url, submission, preprint_contributor, moderator, user):


### PR DESCRIPTION
## Purpose

`ChronosSubmissionDetailSerializer` was meant to be used by `ChronosSubmissionDetail` view to provide an endpoint for getting the current Chronos submission status from Chronos API, instead of updating submission info, because an OSFUser does not (and should not) have any ways to update submission information through our API.

## Changes

Therefore, instead of invoking `update_manuscript()` in `update()` hook of the serializer, we call `sync_manuscript()` instead.

## QA Notes

No QA for the backend ticket. See front-end ticket for QA notes.


## Ticket

https://openscience.atlassian.net/browse/ENG-650
