### PR TITLE
[WIP][Hotfix] Upgrade ES version for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     - WHEELHOUSE="$HOME/.cache/wheelhouse"
     - LIBXML2_DEB="libxml2-dbg_2.9.1+dfsg1-3ubuntu4.9_amd64.deb"
     - POSTGRES_DEB="postgresql-9.6_9.6.3-1.pgdg12.4+1_amd64.deb"
-    - ELASTICSEARCH_ARCHIVE="elasticsearch-2.4.5.tar.gz"
+    - ELASTICSEARCH_ARCHIVE="elasticsearch-6.3.0.tar.gz"
     - LIBJEMALLOC_DEB="libjemalloc1_3.5.1-2_amd64.deb"
     - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.3_amd64.deb"
     # - VARNISH_DEB="varnish_4.1.0-1~trusty_amd64.deb"
@@ -72,11 +72,11 @@ before_install:
       cd $HOME/.cache/downloads
 
       if [ ! -f "$ELASTICSEARCH_ARCHIVE" ]; then
-        curl -SLO https://download.elasticsearch.org/elasticsearch/elasticsearch/$ELASTICSEARCH_ARCHIVE
+        curl -SLO https://artifacts.elastic.co/downloads/elasticsearch/$ELASTICSEARCH_ARCHIVE
       fi
 
       if [ ! -f "$ELASTICSEARCH_ARCHIVE.sha1.txt" ]; then
-        curl -SLO https://download.elasticsearch.org/elasticsearch/elasticsearch/$ELASTICSEARCH_ARCHIVE.sha1.txt
+        curl -SLO https://artifacts.elastic.co/downloads/elasticsearch/$ELASTICSEARCH_ARCHIVE.sha1.txt
       fi
 
       sha1sum --check $ELASTICSEARCH_ARCHIVE.sha1.txt


### PR DESCRIPTION
## Purpose

Opps! We forgot the ancient ES version 2.4.5 was slated for extinction today. This caused travis fails, so lets bump that verision!

## Changes

- just bump the version
- change urls (the old ones don't carry more re)

## QA Notes

I picked ES 6.4.0 because it's most stable, but it would be fine to upgrade beyond that.

## Documentation

🐞 fix, no docs

## Side Effects

none that I know of.

## Ticket

None