### PR TITLE
[ENG-736] expose preprint request actions to Preprint admins

### DIFF
--- a/api/requests/views.py
+++ b/api/requests/views.py
@@ -11,7 +11,6 @@ from api.base.filters import ListFilterMixin
 from api.base.utils import get_object_or_error
 from api.requests.permissions import NodeRequestPermission, PreprintRequestPermission
 from api.requests.serializers import NodeRequestSerializer, PreprintRequestSerializer
-from api.providers.permissions import MustBeModerator
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Node, NodeRequest, PreprintRequest, Preprint
 
@@ -145,7 +144,7 @@ class PreprintRequestActionList(JSONAPIBaseView, generics.ListAPIView, PreprintR
     permission_classes = (
         permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        MustBeModerator,
+        PreprintRequestPermission,
     )
 
     required_read_scopes = [CoreScopes.ACTIONS_READ]

--- a/api_tests/requests/mixins.py
+++ b/api_tests/requests/mixins.py
@@ -83,6 +83,10 @@ class PreprintRequestTestMixin(object):
         return AuthUserFactory()
 
     @pytest.fixture()
+    def requester(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
     def pre_mod_provider(self, moderator):
         ppp = PreprintProviderFactory(reviews_workflow='pre-moderation')
         ppp.get_group('moderator').user_set.add(moderator)
@@ -203,4 +207,48 @@ class PreprintRequestTestMixin(object):
             machine_state=DefaultStates.INITIAL.value
         )
         request.run_submit(admin)
+        return request
+
+    @pytest.fixture()
+    def nonadmin_pre_request(self, pre_mod_preprint, requester):
+        request = PreprintRequestFactory(
+            creator=requester,
+            target=pre_mod_preprint,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value
+        )
+        request.run_submit(requester)
+        return request
+
+    @pytest.fixture()
+    def nonadmin_post_request(self, post_mod_preprint, requester):
+        request = PreprintRequestFactory(
+            creator=requester,
+            target=post_mod_preprint,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value
+        )
+        request.run_submit(requester)
+        return request
+
+    @pytest.fixture()
+    def nonadmin_none_request(self, none_mod_preprint, requester):
+        request = PreprintRequestFactory(
+            creator=requester,
+            target=none_mod_preprint,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value
+        )
+        request.run_submit(requester)
+        return request
+
+    @pytest.fixture()
+    def nonadmin_auto_approved_pre_request(self, auto_withdrawable_pre_mod_preprint, requester):
+        request = PreprintRequestFactory(
+            creator=requester,
+            target=auto_withdrawable_pre_mod_preprint,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value
+        )
+        request.run_submit(requester)
         return request

--- a/api_tests/requests/views/test_request_action_list.py
+++ b/api_tests/requests/views/test_request_action_list.py
@@ -9,9 +9,9 @@ class TestPreprintRequestActionList(PreprintRequestTestMixin):
     def url(self, request):
         return '/{}requests/{}/actions/'.format(API_BASE, request._id)
 
-    def test_nonmod_cannot_view(self, app, noncontrib, write_contrib, admin, pre_request, post_request, none_request):
+    def test_nonmod_nonadmin_nonrequester_cannot_view(self, app, noncontrib, write_contrib, pre_request, post_request, none_request):
         for request in [pre_request, post_request, none_request]:
-            for user in [noncontrib, write_contrib, admin]:
+            for user in [noncontrib, write_contrib]:
                 res = app.get(self.url(request), auth=user.auth, expect_errors=True)
                 assert res.status_code == 403
 
@@ -22,6 +22,28 @@ class TestPreprintRequestActionList(PreprintRequestTestMixin):
             assert len(res.json['data']) == 1
             assert res.json['data'][0]['attributes']['auto'] is False
         res = app.get(self.url(auto_approved_pre_request), auth=moderator.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['attributes']['auto'] is True
+
+    def test_admin_can_view(self, app, admin, pre_request, post_request, none_request, auto_approved_pre_request):
+        for request in [pre_request, post_request, none_request]:
+            res = app.get(self.url(request), auth=admin.auth)
+            assert res.status_code == 200
+            assert len(res.json['data']) == 1
+            assert res.json['data'][0]['attributes']['auto'] is False
+        res = app.get(self.url(auto_approved_pre_request), auth=admin.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['attributes']['auto'] is True
+
+    def test_nonadmin_requester_can_view(self, app, requester, nonadmin_pre_request, nonadmin_post_request, nonadmin_none_request, nonadmin_auto_approved_pre_request):
+        for request in [nonadmin_pre_request, nonadmin_post_request, nonadmin_none_request]:
+            res = app.get(self.url(request), auth=requester.auth)
+            assert res.status_code == 200
+            assert len(res.json['data']) == 1
+            assert res.json['data'][0]['attributes']['auto'] is False
+        res = app.get(self.url(nonadmin_auto_approved_pre_request), auth=requester.auth)
         assert res.status_code == 200
         assert len(res.json['data']) == 2
         assert res.json['data'][0]['attributes']['auto'] is True


### PR DESCRIPTION
## Purpose

Preprint admins need to be able to view preprint request actions to be able to see that a withdrawal request was rejected and view the rejection reason.

#8585 originally added this endpoint and restricted it to moderators (which satisfied the only use-case at the time).

## Changes

Change required permission on `PreprintRequestActionList` view to `PreprintRequestPermission`, which includes moderators and preprint admins.

## QA Notes

This should be tested as part of re-testing [ENG-559](https://openscience.atlassian.net/browse/ENG-559).

## Documentation

N/A (request actions are not documented)

## Side Effects

None expected.

## Ticket

https://openscience.atlassian.net/browse/ENG-736
