### PR TITLE
[WIP][ENG-114] Checkout file nodes while new versions are being created

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -302,7 +302,7 @@ class OsfStorageFile(OsfStorageFileNode, File):
             most_recent_fileversion.region = destination_parent.target.osfstorage_region
             most_recent_fileversion.save()
 
-    def create_version(self, creator, location, metadata=None, check_permissions=True):
+    def create_version(self, creator, location, metadata=None, checkout=True):
         """
         :param creator: OSFUser
         :param location: dict A dict that represents provider details, typical structure:
@@ -319,7 +319,7 @@ class OsfStorageFile(OsfStorageFileNode, File):
         'modified': 'Mon, 16 Feb 2015 18:45:34 GMT'
         }
 
-        :param check_permissions: check if user has permission to create version (False for testing only).
+        :param checkout: checkout file when creating a new version (False for testing only).
         :return:
         """
         latest_version = self.get_version()
@@ -329,7 +329,7 @@ class OsfStorageFile(OsfStorageFileNode, File):
             return latest_version
 
         # Checkout the file to prevent concurrency issues by spamming create new version requests
-        if check_permissions and isinstance(self.target, AbstractNode):
+        if checkout and isinstance(self.target, AbstractNode):
             if not self.is_checked_out:
                 self.check_in_or_out(creator, creator, save=True)
             else:
@@ -345,7 +345,7 @@ class OsfStorageFile(OsfStorageFileNode, File):
         self.versions.add(version)
         self.save()
 
-        if check_permissions and isinstance(self.target, AbstractNode):
+        if checkout and isinstance(self.target, AbstractNode):
             self.check_in_or_out(creator, None, save=True)
 
         return version

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -803,7 +803,8 @@ class TestOsfStorageFileVersion(StorageTestCase):
                 'sha256': 'existing',
                 'vault': 'the cloud',
                 'archive': 'erchiv'
-            })
+            }
+        )
 
         assert_is(version._find_matching_archive(), True)
         assert_is_not(version.archive, None)
@@ -824,7 +825,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
                 'sha256': 'existing',
                 'vault': 'the cloud',
                 'archive': 'erchiv'
-            })
+            }, checkout=False)
 
         assert_equal(version.archive, 'erchiv')
 
@@ -836,7 +837,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
                 'object': '07d80a',
             }, {
                 'sha256': 'existing',
-            }, check_permissions=False)
+            }, checkout=False)
 
         assert_equal(version2.archive, 'erchiv')
 

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -803,8 +803,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
                 'sha256': 'existing',
                 'vault': 'the cloud',
                 'archive': 'erchiv'
-            }
-        )
+            })
 
         assert_is(version._find_matching_archive(), True)
         assert_is_not(version.archive, None)
@@ -837,7 +836,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
                 'object': '07d80a',
             }, {
                 'sha256': 'existing',
-            })
+            }, check_permissions=False)
 
         assert_equal(version2.archive, 'erchiv')
 

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -19,7 +19,7 @@ def create_test_file(target, user, filename='test_file', create_guid=True, size=
     }, {
         'size': size,
         'contentType': 'img/png'
-    }).save()
+    }, checkout=False).save()
     return test_file
 
 

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -88,7 +88,7 @@ def test_file_update_respects_region(project, user, create_test_file):
             'object': '07d80a',
         }, {
             'sha256': 'existing',
-        }, check_permissions=False
+        }, checkout=False
     )
     assert new_region != original_region
     assert new_version.region == new_region

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -88,7 +88,7 @@ def test_file_update_respects_region(project, user, create_test_file):
             'object': '07d80a',
         }, {
             'sha256': 'existing',
-        }
+        }, check_permissions=False
     )
     assert new_region != original_region
     assert new_version.region == new_region


### PR DESCRIPTION
## Purpose

So in this initial ticket we noticed bad logging behavior for `fileversionusermetadata`, this fixes that and prevents versions with identical identifiers from being created.

## Changes

- checks to see if version is checked out before it can create a new one.

## QA Notes

- no new user facing behavior
- There are no unittests for this, though I tried mightly I could not make Flask test library make concurrent requests to itself, `requests` can't access Flask test library and the  Flask test app can't make concurrent requests (that I know of). So I tested this locally. [Here's a gist with the testing resources I did use](https://gist.github.com/Johnetordoff/17fc36c7d6c1a89c0d64dea3c229efaa#file-concurently-create-and-break-wb-verisons-L42-L43)

## Documentation

Not user facing

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-114