### PR TITLE
[ENG-61] Fix sorting on serializer fields with source attributes

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -75,25 +75,25 @@ class OSFOrderingFilter(OrderingFilter):
             return []
         sorting_params = []
         for field in query_params.getlist(self.ordering_param):
-            preserve_order = ''
+            ordering_sign = ''
             # If the field is already a source, it will be returned in the ordering list
             if field in ordering:
                 sorting_params.append(field)
                 continue
             # The field may have a '-' before the name for descending order. This needs to be preserved
             if field[0] == '-':
-                preserve_order = '-'
-                field = field[1:]
+                ordering_sign = '-'
+                field = field.lstrip('-')
             if field in serializer_class._declared_fields:
                 # Checking if the field can be sorted on
                 source_field = serializer_class._declared_fields[field]
                 source_field_name = source_field.source
                 # Checking if the original sort param could be used to sort
                 if hasattr(queryset[0], field):
-                    sorting_params.append(preserve_order + field)
+                    sorting_params.append(ordering_sign + field)
                 # Validating the source field name
                 elif hasattr(queryset[0], source_field_name):
-                    sorting_params.append(preserve_order + source_field_name)
+                    sorting_params.append(ordering_sign + source_field_name)
         return sorting_params
 
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -74,7 +74,7 @@ class OSFOrderingFilter(OrderingFilter):
             return []
         # Getting a list of fields from the model
         source_field_list = []
-        if getattr(queryset[0], '_meta', None):
+        if queryset[0] and getattr(queryset[0], '_meta', None):
             source_field_list = [f.name for f in queryset[0]._meta.get_fields()]
         sorting_params = []
         for i, field in enumerate(query_params.getlist(self.ordering_param)):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -70,7 +70,9 @@ class OSFOrderingFilter(OrderingFilter):
         """
         Returns a dictionary of serializer fields and source names. i.e. {'date_created': 'created'}
 
-        Logic borrowed from get_field_source_mapping
+        Logic borrowed from OrderingFilter.get_default_valid_fields with modifications to retrieve
+        source fields for serializer field names.
+
         :param view api view
         :
         """
@@ -81,13 +83,14 @@ class OSFOrderingFilter(OrderingFilter):
         else:
             serializer_class = getattr(view, 'serializer_class', None)
 
+        # This will not allow any serializer fields with nested related fields to be sorted on
         for field_name, field in serializer_class(context={'request': request}).fields.items():
             if not getattr(field, 'write_only', False) and not field.source == '*' and field_name != field.source:
                 field_to_source_mapping[field_name] = field.source.replace('.', '_')
 
         return field_to_source_mapping
 
-    # Overrides Ordering Filter
+    # Overrides OrderingFilter
     def remove_invalid_fields(self, queryset, fields, view, request):
         """
         Returns an array of valid fields to be used for ordering.

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -54,7 +54,7 @@ class OSFOrderingFilter(OrderingFilter):
         field_order = self.check_serializer_fields(queryset, request.query_params, view, ordering)
         if field_order:
             ordering = tuple(field_order)
-        if isinstance(queryset, DjangoQuerySet) and not field_order:
+       elif isinstance(queryset, DjangoQuerySet):
             if queryset.ordered:
                 return queryset
             elif ordering and getattr(queryset.query, 'distinct_fields', None):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -73,7 +73,9 @@ class OSFOrderingFilter(OrderingFilter):
         if not queryset:
             return []
         # Getting a list of fields from the model
-        source_field_list = [f.name for f in queryset[0]._meta.get_fields()]
+        source_field_list = []
+        if getattr(queryset[0], '_meta', None):
+            source_field_list = [f.name for f in queryset[0]._meta.get_fields()]
         sorting_params = []
         for i, field in enumerate(query_params.getlist(self.ordering_param)):
             if field in ordering:

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -73,13 +73,14 @@ class OSFOrderingFilter(OrderingFilter):
         serializer_class = view.serializer_class
         if not queryset:
             return []
-        # Getting a list of fields from the model
-        # import ipdb; ipdb.set_trace()
         sorting_params = []
         for i, field in enumerate(query_params.getlist(self.ordering_param)):
+            preserve_order = ''
+            # If the field is already a source, it will be returned in the ordering list
             if field in ordering:
                 sorting_params.append(field)
-            preserve_order = ''
+                continue
+            # The field may have a '-' before the name for descending order. This needs to be preserved
             if field[0] == '-':
                 preserve_order = '-'
                 field = field[1:]
@@ -87,8 +88,10 @@ class OSFOrderingFilter(OrderingFilter):
                 # Checking if the field can be sorted on
                 source_field = serializer_class._declared_fields[field]
                 source_field_name = source_field.source
+                # Checking if the original sort param could be used to sort
                 if getattr(queryset[0], field, 'None') != 'None':
                     sorting_params.append(preserve_order + field)
+                # Validating the source field name
                 elif getattr(queryset[0], source_field_name, 'None') != 'None':
                     sorting_params.append(preserve_order + source_field_name)
         return sorting_params

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -54,7 +54,7 @@ class OSFOrderingFilter(OrderingFilter):
         field_order = self.check_serializer_fields(queryset, request.query_params, view, ordering)
         if field_order:
             ordering = tuple(field_order)
-       elif isinstance(queryset, DjangoQuerySet):
+        elif isinstance(queryset, DjangoQuerySet):
             if queryset.ordered:
                 return queryset
             elif ordering and getattr(queryset.query, 'distinct_fields', None):
@@ -74,7 +74,7 @@ class OSFOrderingFilter(OrderingFilter):
         if not queryset:
             return []
         sorting_params = []
-        for i, field in enumerate(query_params.getlist(self.ordering_param)):
+        for field in query_params.getlist(self.ordering_param):
             preserve_order = ''
             # If the field is already a source, it will be returned in the ordering list
             if field in ordering:
@@ -89,10 +89,10 @@ class OSFOrderingFilter(OrderingFilter):
                 source_field = serializer_class._declared_fields[field]
                 source_field_name = source_field.source
                 # Checking if the original sort param could be used to sort
-                if getattr(queryset[0], field, 'None') != 'None':
+                if hasattr(queryset[0], field):
                     sorting_params.append(preserve_order + field)
                 # Validating the source field name
-                elif getattr(queryset[0], source_field_name, 'None') != 'None':
+                elif hasattr(queryset[0], source_field_name):
                     sorting_params.append(preserve_order + source_field_name)
         return sorting_params
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -51,6 +51,7 @@ class OSFOrderingFilter(OrderingFilter):
     # override
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view)
+        # self.check_serializer_field(queryset, request.query_params, view.serializer_class)
         if isinstance(queryset, DjangoQuerySet):
             if queryset.ordered:
                 return queryset
@@ -65,6 +66,18 @@ class OSFOrderingFilter(OrderingFilter):
                 return sorted_list
             return queryset.sort(*ordering)
         return queryset
+
+    def check_serializer_field(self, queryset, field, serializer_class):
+        fields = field.query_params.getlist('sort')
+        # Getting a list of fields from the model
+        source_field_list = [f.name for f in queryset[0]._meta.get_fields()]
+        for field in fields:
+            if field in source_field_list:
+                return field
+
+    def get_source(self, field):
+        #recursive search for field in source
+        pass
 
 
 class FilterMixin(object):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -66,27 +66,46 @@ class OSFOrderingFilter(OrderingFilter):
             return queryset.sort(*ordering)
         return queryset
 
+    def get_serializer_source_field(self, view, request):
+        """
+        Returns a dictionary of serializer fields and source names. i.e. {'date_created': 'created'}
+
+        Logic borrowed from get_field_source_mapping
+        :param view api view
+        :
+        """
+        field_to_source_mapping = {}
+
+        if hasattr(view, 'get_serializer_class'):
+            serializer_class = view.get_serializer_class()
+        else:
+            serializer_class = getattr(view, 'serializer_class', None)
+
+        for field_name, field in serializer_class(context={'request': request}).fields.items():
+            if not getattr(field, 'write_only', False) and not field.source == '*' and field_name != field.source:
+                field_to_source_mapping[field_name] = field.source.replace('.', '_')
+
+        return field_to_source_mapping
+
+    # Overrides Ordering Filter
     def remove_invalid_fields(self, queryset, fields, view, request):
+        """
+        Returns an array of valid fields to be used for ordering.
+        Any valid source fields which are input remain in the valid fields list using the super method.
+        Serializer fields are mapped to their source fields and returned.
+        :param fields, array, input sort fields
+        :returns array of source fields for sorting.
+        """
         valid_fields = super(OSFOrderingFilter, self).remove_invalid_fields(queryset, fields, view, request)
-        if valid_fields == []:
-            if hasattr(view, 'get_serializer_class'):
-                serializer_class = view.get_serializer_class()
-            else:
-                serializer_class = getattr(view, 'serializer_class', None)
-            serializer_fields = [
-                (field_name, field.source)
-                for field_name, field in serializer_class(context={'request': request}).fields.items()
-                if not getattr(field, 'write_only', False) and not field.source == '*' and field_name != field.source
-            ]
+        if not valid_fields:
             for invalid_field in fields:
-                ordering_sign = ''
-                if invalid_field[0] == '-':
-                    ordering_sign = '-'
-                    invalid_field = invalid_field.lstrip('-')
-                if invalid_field in [a[0] for a in serializer_fields]:
-                    valid_fields.append(ordering_sign + [b[1] for b in serializer_fields if b[0] == invalid_field][0])
-        for n, i in enumerate(valid_fields):
-            valid_fields[n] = i.replace('.', '')
+                ordering_sign = '-' if invalid_field[0] == '-' else ''
+                invalid_field = invalid_field.lstrip('-')
+
+                field_source_mapping = self.get_serializer_source_field(view, request)
+                source_field = field_source_mapping.get(invalid_field, None)
+                if source_field:
+                    valid_fields.append(ordering_sign + source_field)
         return valid_fields
 
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -476,8 +476,8 @@ class TestOSFOrderingFilter(ApiTestCase):
 
     def test_sort_by_serializer_field(self):
         user = AuthUserFactory()
-        node_one = NodeFactory(creator=user)
-        node_two = NodeFactory(creator=user)
+        NodeFactory(creator=user)
+        NodeFactory(creator=user)
 
         # Ensuring that sorting by the serializer field returns the same result
         # as using the source field
@@ -485,20 +485,16 @@ class TestOSFOrderingFilter(ApiTestCase):
         res_date_created = self.app.get('/{}nodes/?sort=date_created'.format(API_BASE), auth=user.auth)
         assert res_created.status_code == 200
         assert res_created.json['data'] == res_date_created.json['data']
-        assert res_created.json['data'][0]['id'] == str(node_one._id)
-        assert res_date_created.json['data'][0]['id'] == node_one._id
-        assert res_created.json['data'][1]['id'] == node_two._id
-        assert res_date_created.json['data'][1]['id'] == node_two._id
+        assert res_created.json['data'][0]['id'] == res_date_created.json['data'][0]['id']
+        assert res_created.json['data'][1]['id'] == res_date_created.json['data'][1]['id']
 
         # Testing both are capable of using the inverse sort sign '-'
         res_created = self.app.get('/{}nodes/?sort=-created'.format(API_BASE), auth=user.auth)
         res_date_created = self.app.get('/{}nodes/?sort=-date_created'.format(API_BASE), auth=user.auth)
         assert res_created.status_code == 200
         assert res_created.json['data'] == res_date_created.json['data']
-        assert res_created.json['data'][1]['id'] == node_one._id
-        assert res_date_created.json['data'][1]['id'] == node_one._id
-        assert res_created.json['data'][0]['id'] == node_two._id
-        assert res_date_created.json['data'][0]['id'] == node_two._id
+        assert res_created.json['data'][1]['id'] == res_date_created.json['data'][1]['id']
+        assert res_created.json['data'][0]['id'] == res_date_created.json['data'][0]['id']
 
     def test_sort_by_serializer_multi_level_field(self):
         user = AuthUserFactory()

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from nose.tools import *  # noqa:
 
 from rest_framework import serializers as ser
-from framework.auth.core import Auth
 
 from unittest import TestCase
 
@@ -27,7 +26,6 @@ from api.base.exceptions import (
 from osf_tests.factories import (
     NodeFactory,
     AuthUserFactory,
-    ExternalAccountFactory,
 )
 from api.base.settings.defaults import API_BASE
 from api.base.serializers import RelationshipField
@@ -505,30 +503,6 @@ class TestOSFOrderingFilter(ApiTestCase):
         assert res_created.json['data'] == res_date_created.json['data']
         assert res_created.json['data'][1]['id'] == res_date_created.json['data'][1]['id']
         assert res_created.json['data'][0]['id'] == res_date_created.json['data'][0]['id']
-
-    def test_sort_by_serializer_multi_level_field(self):
-        user = AuthUserFactory()
-        node = NodeFactory(creator=user)
-
-        # external_account_id is a source field on a foreign key.
-        # This test ensures you can sort on a foreign key field both ascending and descending
-
-        # Ascending
-        s3_addon = node.get_or_add_addon('s3', Auth(user))
-        node.get_or_add_addon('github', Auth(user))
-        s3_addon.external_account_id = ExternalAccountFactory()
-        node.save()
-        s3_addon.save()
-        res_addon = self.app.get(self.get_multi_field_sort_url('external_account_id', node._id), auth=user.auth)
-        assert res_addon.status_code == 200
-        assert res_addon.json['data'][1]['id'] == 's3'
-        assert res_addon.json['data'][0]['id'] == 'github'
-
-        # Descending
-        res_addon = self.app.get(self.get_multi_field_sort_url('external_account_id', node._id, False), auth=user.auth)
-        assert res_addon.status_code == 200
-        assert res_addon.json['data'][0]['id'] == 's3'
-        assert res_addon.json['data'][1]['id'] == 'github'
 
 
 class TestQueryPatternRegex(TestCase):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Currently, all sorting must be done on the model name. This is not intuitive to a user as some fields such as date_created have a source of created.
<!-- Describe the purpose of your changes -->

## Changes
api/base/filters.py - Modifying OSFOrderingFilter to support sorting on serializer fields.
api_tests/base/test_filters.py - Adding tests to ensure ordering is working correctly
<!-- Briefly describe or list your changes  -->

## QA Notes
Test ordering on models with ?sort=date_created. The order should match ?sort=created
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation
There is currently no documentation on parameterized sorting in the documentation. Perhaps there should be?
<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
Sorting by source name was not deprecated, so side effects should be minimal
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-61
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
