### PR TITLE
[HotFix] Fix Institution Auth API [ENG-765]

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -20,6 +20,12 @@ from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
 
 
 class InstitutionAuthentication(BaseAuthentication):
+    """A dedicated authentication class for view ``InstitutionAuth``.
+
+    This ``InstitutionAuth`` view and this auth class is only used and should only be used by CAS.
+    Changing it may break the institution login feature.  Please check with @longze and @matt before
+    making any changes.
+    """
 
     media_type = 'text/plain'
 

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -2,6 +2,7 @@ import json
 
 import jwe
 import jwt
+import waffle
 
 from django.utils import timezone
 from rest_framework.authentication import BaseAuthentication
@@ -17,7 +18,6 @@ from osf.models import Institution
 from website.mails import send_mail, WELCOME_OSF4I
 from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
 
-from api.waffle.utils import flag_is_active
 
 class InstitutionAuthentication(BaseAuthentication):
 
@@ -112,7 +112,7 @@ class InstitutionAuthentication(BaseAuthentication):
                 user=user,
                 domain=DOMAIN,
                 osf_support_email=OSF_SUPPORT_EMAIL,
-                storage_flag_is_active=flag_is_active(request, features.STORAGE_I18N),
+                storage_flag_is_active=waffle.flag_is_active(request, features.STORAGE_I18N),
             )
 
         if not user.is_affiliated_with_institution(institution):

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -157,6 +157,16 @@ class InstitutionUserList(JSONAPIBaseView, ListFilterMixin, generics.ListAPIView
 
 
 class InstitutionAuth(JSONAPIBaseView, generics.CreateAPIView):
+    """A dedicated view for institution auth, a.k.a "login through institutions".
+
+    This view is only used and should only be used by CAS.  Changing it may break the institution
+    login feature.  Please check with @longze and @matt before making any changes.
+
+    CAS makes POST request with JWE/JWT encrypted payload to check with OSF on the identity of users
+    authenticated by external institutions.  OSF either finds the matching user or otherwise creates
+    a new one.  Everything happens in the API authentication class and the ``post()`` simply returns
+    a 204 if the auth passes. (See ``api.institutions.authenticationInstitutionAuthentication``)
+    """
     permission_classes = (
         drf_permissions.IsAuthenticated,
         base_permissions.TokenHasScope,


### PR DESCRIPTION
## Purpose

PR https://github.com/CenterForOpenScience/osf.io/pull/9084 and one of its commit https://github.com/CenterForOpenScience/osf.io/commit/6e65c870bd67b8f4d034706f0cea3d6243643f86 break institution login. Here is the sentry error: https://sentry2.cos.io/cos/osf-back-end/issues/20047/.

Only new accounts (first time institution login users that does not have an institution account) are affected since the broken piece is the confirmation / welcome email sending.

## Changes

* Revert the change in `api/institutions/authentication.py`.
* Add comments that briefly explain what the endpoint does and a warning that encourages developers to check with code owners before making future changes.
* No test changes.

## QA Notes

QA is not needed.

## Documentation

No

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/ENG-765
