### PR TITLE
[Needs Migration Prep] Feature/PageCounter Part I Fix [ENG-122][ENG-751][ENG-752]

### DIFF
--- a/osf/models/analytics.py
+++ b/osf/models/analytics.py
@@ -126,7 +126,12 @@ class PageCounter(BaseModel):
             # After we're sure this is stable, we can stop writing to the _id field, and query on
             # resource/file/action/version
             resource, file, action, version = cls.deconstruct_id(cleaned_page)
-            model_instance, created = cls.objects.select_for_update().get_or_create(_id=cleaned_page, resource=resource, file=file, action=action, version=version)
+            model_instance, created = PageCounter.objects.select_for_update().get_or_create(_id=cleaned_page)
+
+            model_instance.resource = resource
+            model_instance.file = file
+            model_instance.action = action
+            model_instance.version = version
 
             # if they visited something today
             if date_string == visited_by_date['date']:


### PR DESCRIPTION
## Purpose

Improvements to allow the new PageCounter columns to be populated over time.  Current PR has a line that assumes all columns have been populated, but this isn't going to be True on production immediately.  

https://github.com/CenterForOpenScience/osf.io/pull/8800 (Part 1 of Page Counter migration) adds four new columns to the PageCounter table - `file`, `record`, `version`, and `action`.  Because the `PageCounter` table is enormous, the intent of that work is to populate the table over time, no downtime required.  So for the time being, we need to write to five fields when this record is created, `file`, `record`, `version`, `action`, and the original `_id`.  After all fields have been populated, we can stop writing to `_id`.  Current page counter work is attempting to lookup PageCounter record on all five fields, but this won't work until the entire PageCounter table has been populated.

## Changes

Instead of attempting to fetch an existing PageCounter record by all five fields (`file`, `record`, `version`, `action`, and `_id`), continue to only fetch on `_id` until all the existing rows have been populated.  However, still write to `file`, `record, `version`, and `action` fields.  

This fixes the `IntegrityError duplicate key value violates unique constraint "osf_pagecounter__id_key"
DETAIL:  Key (_id)=(download:enrh5:5d4062b372aba10015bae3a1) already exists.` error

## QA Notes
1.  A management command (`migrate_pagecounter_data`) was not run on staging1 before QA started testing, which meant old data was not migrated.   Before we actually run the management command, same pre-migration prep needs to be repeated (whatever was done for spearow), in case these old view and download counts changed in the testing process.
2. It was actually a good thing that the management command wasn't run on staging, because it revealed the scenario that we would have seen on production.  It will be quick to migrate the staging data, but the production data migration will have to be spread out over time.  Until all the data was migrated, we would have seen these `IntegrityErrors`.  This fix assumes that the new columns aren't necessarily populated yet.


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-122
