### PR TITLE
[Delayed Merge] [OSF Institutions] Sync the institution script with database [No Ticket]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -529,7 +529,7 @@ def main(env):
             {
                 '_id': 'ou',
                 'name': 'The University of Oklahoma',
-                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://www.ou.edu/research-norman">Office of the Vice President for Research</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
+                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
                 'banner_name': 'ou-banner.png',
                 'logo_name': 'ou-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.ou.edu/idp/shibboleth')),
@@ -1340,7 +1340,7 @@ def main(env):
             {
                 '_id': 'ou',
                 'name': 'The University of Oklahoma [Test]',
-                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://www.ou.edu/research-norman">Office of the Vice President for Research</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
+                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
                 'banner_name': 'ou-banner.png',
                 'logo_name': 'ou-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.ou.edu/idp/shibboleth')),


### PR DESCRIPTION
## Purpose

cc @mfraezz , @pattisdr , @felliott and @mattclark 

Synchronize the institution populating script with OSF DB changes that are directly made from the OSF Admin APP.

There are two ways to add a new or modify an existing institution: either by running the institution populating script [scripts/populate_institutions.py](https://github.com/CenterForOpenScience/osf.io/blob/master/scripts/populate_institutions.py) on the server or by using the OSF Admin APP.

Every time the script is run, any changes made directly via the Admin APP since last run will be permanently lost. This PR keeps track of Admin APP changes and updates the script timely and it must be merged before running the script again (e.g. adding new institutions via PR and the script) and a new PR for the same purpose needs to be prepared. An alternative way is to cherry pick all the commits while keeping the PR open.

This is a temporary solution during the process of transferring from the script to the Admin APP. The key blocker now is that the assets (banner and shields) still needs go to via an OSF PR.

## Changes

* 2019-08-06: updated description for OU (The University of Oklahoma)

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

No Ticket
