### PR TITLE
[WIP] Add Redis to OSF docker-compose for local development [ENG-451] [ ENG-468]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ volumes:
     external: false
   wb_requirements_local_bin_vol:
     external: false
+  wb_redis_data_vol:
+    external: false
   wb_tmp_vol:
     external: false
   osfstoragecache_vol:
@@ -217,6 +219,16 @@ services:
       - wb_requirements_vol:/usr/local/lib/python3.5
       - osfstoragecache_vol:/code/website/osfstoragecache
       - wb_tmp_vol:/tmp
+    stdin_open: true
+
+  wb_redis:
+    image: redis
+    command: redis-server
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    volumes:
+      - wb_redis_data_vol:/data
     stdin_open: true
 
   # wb_flower:


### PR DESCRIPTION
## Purpose

Add [Redis](https://redis.io/) to OSF docker-compose for local development, where WB uses the `wb_redis` server to rate-limit its API. The main feature is implemented at the WB side and the dedicated Redis server is managed by the DevOps.

- Waterbutler takes care of the rate-limiting using Redis. See [WB-PR#380](https://github.com/CenterForOpenScience/waterbutler/pull/380) for details.

- [ ] Update this ticket with DevOps side change including [docker-library](https://github.com/CenterForOpenScience/docker-library) and [helm-charts](https://github.com/CenterForOpenScience/helm-charts).

- [ ] Update the local config for `docker` and `docker-compose` once the above DevOps task are done.


## Changes

TBD

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-451
https://openscience.atlassian.net/browse/ENG-468
