### PR TITLE
[ENG-664] Change subjects on provider change

### DIFF
--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -74,7 +74,7 @@ class PreprintView(PreprintMixin, UpdateView, GuidView):
         if not request.user.has_perm('osf.change_preprint'):
             raise PermissionsError("This user does not have permission to update this preprint's provider.")
         response = super(PreprintView, self).post(request, *args, **kwargs)
-        if str(old_provider.id) != self.get_object().provider.id:
+        if self.get_object().provider and str(old_provider.id) != self.get_object().provider.id:
             self.update_subjects_for_provider(request, old_provider, self.object.provider)
         return response
 

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -26,7 +26,6 @@ from website.preprints.tasks import update_preprint_share
 from website.project.views.register import osf_admin_change_status_identifier
 from website import search
 
-from framework.auth import Auth
 from framework.exceptions import PermissionsError
 from admin.base.views import GuidFormView, GuidView
 from admin.nodes.templatetags.node_extras import reverse_preprint
@@ -89,7 +88,7 @@ class PreprintView(PreprintMixin, UpdateView, GuidView):
         return super(PreprintView, self).get_context_data(**kwargs)
 
     def update_subjects_for_provider(self, request, old_provider, new_provider):
-        subject_problems = self.object.map_subjects_between_providers(old_provider, new_provider, Auth(request.user))
+        subject_problems = self.object.map_subjects_between_providers(old_provider, new_provider, auth=None)
         if subject_problems:
             messages.warning(request, 'Unable to find subjects in new provider for the following subject(s):')
             for problem in subject_problems:

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -90,7 +90,7 @@ class PreprintView(PreprintMixin, UpdateView, GuidView):
     def update_subjects_for_provider(self, request, old_provider, new_provider):
         subject_hierarchies = self.object.subject_hierarchy
         new_subjects = []
-        subject_problems = 0
+        subject_problems = []
         for hierarchy in subject_hierarchies:
             subject = hierarchy[-1]
             if old_provider._id == 'osf':
@@ -102,14 +102,16 @@ class PreprintView(PreprintMixin, UpdateView, GuidView):
             else:
                 new_subject = new_provider.subjects.filter(bepress_subject_id=bepress_id)
             if not new_subject.exists():
-                subject_problems = subject_problems + 1
+                subject_problems.append(subject.text)
                 new_subject = subject
             else:
                 new_subject = new_subject[0]
             new_subjects.append(new_subject.hierarchy)
         self.object.set_subjects(new_subjects, Auth(request.user))
         if subject_problems:
-            messages.warning(request, 'Unable to find subjects in new provider for {} subject(s)'.format(subject_problems))
+            messages.warning(request, 'Unable to find subjects in new provider for the following subject(s):')
+            for problem in subject_problems:
+                messages.warning(request, problem)
 
 
 class PreprintSpamList(PermissionRequiredMixin, ListView):

--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -130,6 +130,13 @@
                                 <a class="btn btn-link" role="button" data-toggle="collapse" href="#collapseChangeProvider">
                                     Change preprint provider
                                 </a>
+                                {% if messages %}
+                                    <ul class="messages">
+                                        {% for message in messages %}
+                                            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
                                 <div class="collapse" id="collapseChangeProvider">
                                     <div class="well">
                                         <form action="" method="post">

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import Permission, Group, AnonymousUser
+from django.contrib.messages.storage.fallback import FallbackStorage
 
 from tests.base import AdminTestCase
 from osf.models import Preprint, OSFUser, PreprintLog
@@ -14,6 +15,8 @@ from osf_tests.factories import (
     PreprintProviderFactory,
     PreprintRequestFactory,
     NodeFactory,
+    SubjectFactory,
+
 )
 from osf.models.admin_log_entry import AdminLogEntry
 from osf.models.spam import SpamStatus
@@ -212,6 +215,108 @@ class TestPreprintView:
         plain_view().form_valid(form)
 
         assert preprint.provider == new_provider
+
+    @pytest.fixture
+    def provider_one(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture
+    def provider_two(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture
+    def provider_osf(self):
+        return PreprintProviderFactory(_id='osf')
+
+    @pytest.fixture
+    def preprint_user(self, user):
+        change_permission = Permission.objects.get(codename='change_preprint')
+        view_permission = Permission.objects.get(codename='view_preprint')
+        user.user_permissions.add(change_permission)
+        user.user_permissions.add(view_permission)
+        return user
+
+    @pytest.fixture
+    def subject_osf(self, provider_osf):
+        return SubjectFactory(provider=provider_osf)
+
+    @pytest.fixture
+    def subject_one(self, provider_one):
+        return SubjectFactory(provider=provider_one)
+
+    def test_change_preprint_provider_subjects_custom_taxonomies(self, plain_view, preprint_user, provider_one, provider_two, subject_one):
+        """ Testing that subjects are changed when providers are changed between two custom taxonomies.
+        """
+
+        subject_two = SubjectFactory(provider=provider_two,
+            bepress_subject=subject_one.bepress_subject)
+
+        preprint = PreprintFactory(subjects=[[subject_one._id]], provider=provider_one, creator=preprint_user)
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}), data={'provider': provider_two.id})
+        request.user = preprint_user
+        response = plain_view.as_view()(request, guid=preprint._id)
+
+        assert response.status_code == 302
+        preprint.refresh_from_db()
+        assert preprint.provider == provider_two
+        assert subject_two in preprint.subjects.all()
+
+    def test_change_preprint_provider_subjects_from_osf(self, plain_view, preprint_user, provider_one, provider_osf, subject_osf):
+        """ Testing that subjects are changed when a provider is changed from osf using the bepress subject id of the new subject.
+        """
+
+        subject_two = SubjectFactory(provider=provider_one,
+            bepress_subject=subject_osf)
+
+        preprint = PreprintFactory(subjects=[[subject_osf._id]], provider=provider_osf, creator=preprint_user)
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}), data={'provider': provider_one.id})
+        request.user = preprint_user
+        response = plain_view.as_view()(request, guid=preprint._id)
+
+        assert response.status_code == 302
+        preprint.refresh_from_db()
+        assert preprint.provider == provider_one
+        assert subject_two in preprint.subjects.all()
+
+    def test_change_preprint_provider_subjects_to_osf(self, plain_view, preprint_user, provider_one, provider_osf, subject_osf):
+        """ Testing that subjects are changed when providers are changed to osf using the bepress subject id of the old subject
+        """
+
+        subject_one = SubjectFactory(provider=provider_one,
+            bepress_subject=subject_osf)
+
+        preprint = PreprintFactory(subjects=[[subject_one._id]], provider=provider_one, creator=preprint_user)
+
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}), data={'provider': provider_osf.id})
+        request.user = preprint_user
+        response = plain_view.as_view()(request, guid=preprint._id)
+
+        assert response.status_code == 302
+        preprint.refresh_from_db()
+        assert preprint.provider == provider_osf
+        assert subject_osf in preprint.subjects.all()
+
+    def test_change_preprint_provider_subjects_problem_subject(self, plain_view, preprint_user, provider_one, provider_osf, subject_osf):
+        """ Testing that subjects are changed when providers are changed and theres no related mapping between subjects, the old subject stays in place.
+        """
+
+        preprint = PreprintFactory(subjects=[[subject_osf._id]], provider=provider_osf, creator=preprint_user)
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': preprint._id}), data={'provider': provider_one.id})
+        request.user = preprint_user
+
+        # django.contrib.messages has a bug which effects unittests
+        # more info here -> https://code.djangoproject.com/ticket/17971
+        setattr(request, 'session', 'session')
+        messages = FallbackStorage(request)
+        setattr(request, '_messages', messages)
+
+        response = plain_view.as_view()(request, guid=preprint._id)
+
+        assert response.status_code == 302
+        preprint.refresh_from_db()
+        assert preprint.provider == provider_one
+        assert subject_osf in preprint.subjects.all()
+
 
 @pytest.mark.urls('admin.base.urls')
 class TestPreprintFormView:

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -805,7 +805,7 @@ class TaxonomizableMixin(models.Model):
 
         :return: None
         """
-        if auth and not self.has_permission(auth.user, ADMIN):
+        if auth and not (hasattr(self, 'has_permission') and self.has_permission(auth.user, ADMIN)):
             self.check_subject_perms(auth)
         self.assert_subject_format(new_subjects, expect_list=True, error_msg='Expecting list of lists.')
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -805,7 +805,8 @@ class TaxonomizableMixin(models.Model):
 
         :return: None
         """
-        self.check_subject_perms(auth)
+        if auth and not self.has_permission(auth.user, ADMIN):
+            self.check_subject_perms(auth)
         self.assert_subject_format(new_subjects, expect_list=True, error_msg='Expecting list of lists.')
 
         old_subjects = list(self.subjects.values_list('id', flat=True))
@@ -850,7 +851,7 @@ class TaxonomizableMixin(models.Model):
 
         self.save(old_subjects=old_subjects)
 
-    def map_subjects_between_providers(self, old_provider, new_provider, auth):
+    def map_subjects_between_providers(self, old_provider, new_provider, auth=None):
         """
         Maps subjects between preprint providers using bepress_subject_id.
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -805,7 +805,7 @@ class TaxonomizableMixin(models.Model):
 
         :return: None
         """
-        if auth and not (hasattr(self, 'has_permission') and self.has_permission(auth.user, ADMIN)):
+        if auth:
             self.check_subject_perms(auth)
         self.assert_subject_format(new_subjects, expect_list=True, error_msg='Expecting list of lists.')
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1736,8 +1736,15 @@ class TestPreprintPermissions(OsfTestCase):
 class TestPreprintProvider(OsfTestCase):
     def setUp(self):
         super(TestPreprintProvider, self).setUp()
+        self.user = AuthUserFactory()
+        self.auth = Auth(user=self.user)
+        self.provider_osf = PreprintProviderFactory(_id='osf')
         self.preprint = PreprintFactory(provider=None, is_published=False)
         self.provider = PreprintProviderFactory(name='WWEArxiv')
+        self.provider_two = PreprintProviderFactory(name='IceCreamArxiv')
+        self.subject_one = SubjectFactory(provider=self.provider)
+        self.subject_osf = SubjectFactory(provider=self.provider_osf)
+
 
     def test_add_provider(self):
         assert_not_equal(self.preprint.provider, self.provider)
@@ -1806,6 +1813,41 @@ class TestPreprintProvider(OsfTestCase):
         assert self.provider.has_highlighted_subjects is True
         assert set(self.provider.highlighted_subjects) == set([subj_aaa])
 
+    def test_change_preprint_provider_custom_taxonomies(self):
+        subject_two = SubjectFactory(provider=self.provider_two,
+            bepress_subject=self.subject_one.bepress_subject)
+        preprint = PreprintFactory(subjects=[[self.subject_one._id]], provider=self.provider, creator=self.user)
+        preprint.map_subjects_between_providers(self.provider, self.provider_two, self.auth)
+        preprint.refresh_from_db()
+        assert subject_problems == []
+        assert subject_two in preprint.subjects.all()
+
+    def test_change_preprint_provider_from_osf(self):
+        subject_two = SubjectFactory(provider=self.provider,
+            bepress_subject=self.subject_osf)
+        preprint = PreprintFactory(subjects=[[self.subject_osf._id]], provider=self.provider_osf, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider_osf, self.provider, self.auth)
+        preprint.refresh_from_db()
+        assert subject_problems == []
+        assert subject_two in preprint.subjects.all()
+
+    def test_change_preprint_provider_to_osf(self):
+        subject_two = SubjectFactory(provider=self.provider,
+            bepress_subject=self.subject_osf)
+        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider, self.provider_osf, self.auth)
+        preprint.refresh_from_db()
+        assert subject_problems == []
+        assert self.subject_osf in preprint.subjects.all()
+
+    def test_change_preprint_provider_problem_subject(self):
+        subject_two = SubjectFactory(provider=self.provider,
+            bepress_subject=self.subject_osf)
+        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider, self.provider_two, self.auth)
+        preprint.refresh_from_db()
+        assert subject_problems == [subject_two.text]
+        assert subject_two in preprint.subjects.all()
 
 class TestPreprintIdentifiers(OsfTestCase):
     def setUp(self):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1741,8 +1741,9 @@ class TestPreprintProvider(OsfTestCase):
         self.provider_osf = PreprintProviderFactory(_id='osf')
         self.preprint = PreprintFactory(provider=None, is_published=False)
         self.provider = PreprintProviderFactory(name='WWEArxiv')
+        self.provider_one = PreprintProviderFactory(name='DoughnutArxiv')
         self.provider_two = PreprintProviderFactory(name='IceCreamArxiv')
-        self.subject_one = SubjectFactory(provider=self.provider)
+        self.subject_one = SubjectFactory(provider=self.provider_one)
         self.subject_osf = SubjectFactory(provider=self.provider_osf)
 
 
@@ -1816,35 +1817,35 @@ class TestPreprintProvider(OsfTestCase):
     def test_change_preprint_provider_custom_taxonomies(self):
         subject_two = SubjectFactory(provider=self.provider_two,
             bepress_subject=self.subject_one.bepress_subject)
-        preprint = PreprintFactory(subjects=[[self.subject_one._id]], provider=self.provider, creator=self.user)
-        preprint.map_subjects_between_providers(self.provider, self.provider_two, self.auth)
+        preprint = PreprintFactory(subjects=[[self.subject_one._id]], provider=self.provider_one, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider_one, self.provider_two, self.auth)
         preprint.refresh_from_db()
         assert subject_problems == []
         assert subject_two in preprint.subjects.all()
 
     def test_change_preprint_provider_from_osf(self):
-        subject_two = SubjectFactory(provider=self.provider,
+        subject_two = SubjectFactory(provider=self.provider_one,
             bepress_subject=self.subject_osf)
         preprint = PreprintFactory(subjects=[[self.subject_osf._id]], provider=self.provider_osf, creator=self.user)
-        subject_problems = preprint.map_subjects_between_providers(self.provider_osf, self.provider, self.auth)
+        subject_problems = preprint.map_subjects_between_providers(self.provider_osf, self.provider_one, self.auth)
         preprint.refresh_from_db()
         assert subject_problems == []
         assert subject_two in preprint.subjects.all()
 
     def test_change_preprint_provider_to_osf(self):
-        subject_two = SubjectFactory(provider=self.provider,
+        subject_two = SubjectFactory(provider=self.provider_one,
             bepress_subject=self.subject_osf)
-        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider, creator=self.user)
-        subject_problems = preprint.map_subjects_between_providers(self.provider, self.provider_osf, self.auth)
+        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider_one, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider_one, self.provider_osf, self.auth)
         preprint.refresh_from_db()
         assert subject_problems == []
         assert self.subject_osf in preprint.subjects.all()
 
     def test_change_preprint_provider_problem_subject(self):
-        subject_two = SubjectFactory(provider=self.provider,
+        subject_two = SubjectFactory(provider=self.provider_one,
             bepress_subject=self.subject_osf)
-        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider, creator=self.user)
-        subject_problems = preprint.map_subjects_between_providers(self.provider, self.provider_two, self.auth)
+        preprint = PreprintFactory(subjects=[[subject_two._id]], provider=self.provider_one, creator=self.user)
+        subject_problems = preprint.map_subjects_between_providers(self.provider_one, self.provider_two, self.auth)
         preprint.refresh_from_db()
         assert subject_problems == [subject_two.text]
         assert subject_two in preprint.subjects.all()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Currently, when preprint providers are changed in the admin app, subjects stay the same, even though they might be a part of the custom taxonomy for the old provider. 

## Changes

<!-- Briefly describe or list your changes  -->
- admin/preprints/views.py modified to include a function to find and update the subjects for a preprint upon provider change. If a subject cannot be found in the new provider taxonomy, the old subject is retained, and a warning message is displayed.
- admin_tests/preprints.test_views.py modified to test the above feature.
- admin/templates/preprints/preprint.html modified to enable the displaying of warning messages when subjects cannot be mapped.

## QA Notes
Test changing providers within the admin app for a preprint.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects
There should not be any side effects. Worse case if a subject with a mapping isn't found, then it simply retains the old subject.
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-664
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
