### PR TITLE
[OSF Institutions] Fully rewrite the institution populating script [ENG-771]

### DIFF
--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1307,7 +1307,7 @@ class TestSearchMigration(OsfTestCase):
 
     def setUp(self):
         super(TestSearchMigration, self).setUp()
-        populate_institutions('test')
+        populate_institutions(default_args=True)
         self.es = search.search_engine.CLIENT
         search.delete_index(settings.ELASTIC_INDEX)
         search.create_index(settings.ELASTIC_INDEX)

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -84,7 +84,6 @@ def main(default_args=False):
                          'existing records: {}.'.format(diff_list))
             sys.exit(1)
 
-    init_app(routes=False)
     with transaction.atomic():
         for inst_data in institutions_to_update:
             update_or_create(inst_data)
@@ -1665,4 +1664,5 @@ INSTITUTIONS = {
 
 if __name__ == '__main__':
 
+    init_app(routes=False)
     main(default_args=False)

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Populate development database with Institution fixtures."""
 
+import argparse
 import logging
 import sys
 import urllib
@@ -18,9 +19,18 @@ from website.search.search import update_institution
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-ENVS = ['prod', 'stage', 'stage2', 'test']
+ENVS = ['prod', 'stage', 'stage2', 'stage3', 'test', ]
+
+# TODO: Store only the Entity IDs in OSF DB and move the URL building process to CAS
 SHIBBOLETH_SP_LOGIN = '{}/Shibboleth.sso/Login?entityID={{}}'.format(settings.CAS_SERVER_URL)
 SHIBBOLETH_SP_LOGOUT = '{}/Shibboleth.sso/Logout?return={{}}'.format(settings.CAS_SERVER_URL)
+
+# Using optional args instead of positional ones to explicitly set them
+parser = argparse.ArgumentParser()
+parser.add_argument('-e', '--env', help='select the server: prod, test, stage, stage2 or stage3')
+group = parser.add_mutually_exclusive_group()
+group.add_argument('-i', '--ids', nargs='+', help='select the institution(s) to add or update')
+group.add_argument('-a', '--all', action='store_true', help='add or update all institutions')
 
 
 def encode_uri_component(val):
@@ -44,11 +54,40 @@ def update_or_create(inst_data):
         return inst, True
 
 
-def main(env):
-    INSTITUTIONS = []
+def main():
 
-    if env == 'prod':
-        INSTITUTIONS = [
+    args = parser.parse_args()
+    server_env = args.env
+    update_ids = args.ids
+    update_all = args.all
+
+    if not server_env or server_env not in ENVS:
+        logger.error('A valid environment must be specified: {}'.format(ENVS))
+        sys.exit(1)
+    institutions = INSTITUTIONS[server_env]
+
+    if not update_all and not update_ids:
+        logger.error('Nothing to update or create. Please either specify a list of institutions '
+                     'using --id or run for all with --all')
+        sys.exit(1)
+    elif update_all:
+        institutions_to_update = institutions
+    else:
+        institutions_to_update = [inst for inst in institutions if inst['_id'] in update_ids]
+        if len(institutions_to_update) < len(update_ids):
+            logger.warning('One or more institutions provided via -i or --ids do not match any '
+                           'existing records, which have been skipped.')
+
+    init_app(routes=False)
+    with transaction.atomic():
+        for inst_data in institutions_to_update:
+            update_or_create(inst_data)
+        for extra_inst in Institution.objects.exclude(_id__in=[x['_id'] for x in institutions]):
+            logger.warn('Extra Institution : {} - {}'.format(extra_inst._id, extra_inst.name))
+
+
+INSTITUTIONS = {
+    'prod': [
             {
                 '_id': 'a2jlab',
                 'name': 'Access to Justice Lab',
@@ -792,9 +831,8 @@ def main(env):
                 'email_domains': [],
                 'delegation_protocol': 'saml-shib',
             },
-        ]
-    if env == 'stage':
-        INSTITUTIONS = [
+        ],
+    'stage': [
             {
                 '_id': 'cos',
                 'name': 'Center For Open Science [Stage]',
@@ -842,9 +880,8 @@ def main(env):
                 'email_domains': ['yahoo.com'],
                 'delegation_protocol': '',
             },
-        ]
-    if env == 'stage2':
-        INSTITUTIONS = [
+        ],
+    'stage2': [
             {
                 '_id': 'cos',
                 'name': 'Center For Open Science [Stage2]',
@@ -857,9 +894,22 @@ def main(env):
                 'email_domains': ['cos.io'],
                 'delegation_protocol': '',
             },
-        ]
-    elif env == 'test':
-        INSTITUTIONS = [
+        ],
+    'stage3': [
+            {
+                '_id': 'cos',
+                'name': 'Center For Open Science [Stage3]',
+                'description': 'Center for Open Science [Stage3]',
+                'banner_name': 'cos-banner.png',
+                'logo_name': 'cos-shield.png',
+                'login_url': None,
+                'logout_url': None,
+                'domains': ['staging3-osf.cos.io'],
+                'email_domains': ['cos.io'],
+                'delegation_protocol': '',
+            },
+        ],
+    'test': [
             {
                 '_id': 'a2jlab',
                 'name': 'Access to Justice Lab [Test]',
@@ -1603,19 +1653,10 @@ def main(env):
                 'email_domains': [],
                 'delegation_protocol': 'saml-shib',
             },
-        ]
-
-    init_app(routes=False)
-    with transaction.atomic():
-        for inst_data in INSTITUTIONS:
-            update_or_create(inst_data)
-        for extra_inst in Institution.objects.exclude(_id__in=[x['_id'] for x in INSTITUTIONS]):
-            logger.warn('Extra Institution : {} - {}'.format(extra_inst._id, extra_inst.name))
+        ],
+}
 
 
 if __name__ == '__main__':
-    env = str(sys.argv[1]).lower() if len(sys.argv) == 2 else None
-    if env not in ENVS:
-        print('An environment must be specified : {}', ENVS)
-        sys.exit(1)
-    main(env)
+
+    main()

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -68,15 +68,17 @@ def main():
 
     if not update_all and not update_ids:
         logger.error('Nothing to update or create. Please either specify a list of institutions '
-                     'using --id or run for all with --all')
+                     'using --ids or run for all with --all')
         sys.exit(1)
     elif update_all:
         institutions_to_update = institutions
     else:
         institutions_to_update = [inst for inst in institutions if inst['_id'] in update_ids]
-        if len(institutions_to_update) < len(update_ids):
-            logger.warning('One or more institutions provided via -i or --ids do not match any '
-                           'existing records, which have been skipped.')
+        diff_list = list(set(update_ids) - set([inst['_id'] for inst in institutions_to_update]))
+        if diff_list:
+            logger.error('One or more institution ID(s) provided via -i or --ids do not match any '
+                         'existing records: {}.'.format(diff_list))
+            sys.exit(1)
 
     init_app(routes=False)
     with transaction.atomic():

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -54,9 +54,13 @@ def update_or_create(inst_data):
         return inst, True
 
 
-def main():
+def main(default_args=False):
 
-    args = parser.parse_args()
+    if default_args:
+        args = parser.parse_args(['--env', 'test', '--all'])
+    else:
+        args = parser.parse_args()
+
     server_env = args.env
     update_ids = args.ids
     update_all = args.all
@@ -1661,4 +1665,4 @@ INSTITUTIONS = {
 
 if __name__ == '__main__':
 
-    main()
+    main(default_args=False)

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -568,7 +568,7 @@ INSTITUTIONS = {
             {
                 '_id': 'ou',
                 'name': 'The University of Oklahoma',
-                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://www.ou.edu/research-norman">Office of the Vice President for Research</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
+                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
                 'banner_name': 'ou-banner.png',
                 'logo_name': 'ou-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.ou.edu/idp/shibboleth')),
@@ -1390,7 +1390,7 @@ INSTITUTIONS = {
             {
                 '_id': 'ou',
                 'name': 'The University of Oklahoma [Test]',
-                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://www.ou.edu/research-norman">Office of the Vice President for Research</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
+                'description': '<a href="https://www.ou.edu">The University of Oklahoma</a> | <a href="https://libraries.ou.edu">University Libraries</a>',
                 'banner_name': 'ou-banner.png',
                 'logo_name': 'ou-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://shib.ou.edu/idp/shibboleth')),


### PR DESCRIPTION
## Purpose

Rewrite the institution population scripts so that we can update or create only the institution(s) we need instead of applying to all every time the script is run. In addition, this solves the sync issue between the script and the admin app mentioned in [OSF-PR#9118](https://github.com/CenterForOpenScience/osf.io/pull/9118). Finally, the script was poorly written only as a temporary script but ended up being used until now, which desperately needs a decent upgrade.

cc @mfraezz 

## Changes

* Use `argparse` ([Python 2.7.16 Version](https://docs.python.org/2/howto/argparse.html)) for handling command line arguments. Here is the `--help` on `scripts.populate_institutions.py`.

```
docker-compose run --rm web python -m scripts.populate_institutions --help

usage: populate_institutions.py [-h] [-e ENV] [-i IDS [IDS ...] | -a]

optional arguments:
  -h, --help            show this help message and exit
  -e ENV, --env ENV     select the server: prod, test, stage, stage2 or stage3
  -i IDS [IDS ...], --ids IDS [IDS ...]
                        select the institution(s) to add or update
  -a, --all             add or update all institutions
```

* Added server environment for staging 3, which is just a copy of staging 2 with minor changes.

* Fixed style and improved coding.

- [x] By-product, slip in a description update for OU (The University of Oklahoma).

- [x] Question for the reviewer, do we want to disable the `-a` / `--all` option? Let's keep `-a` / `--all` in case we want to run for all.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-771
