### PR TITLE
Feature/Bump Version to Serialize Subjects as Relationships [ENG-161]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -166,6 +166,7 @@ REST_FRAMEWORK = {
         '2.13',
         '2.14',
         '2.15',
+        '2.16',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -6,6 +6,8 @@ from api.base.serializers import JSONAPISerializer, LinksField, ShowIfVersion, R
 from api.subjects.serializers import UpdateSubjectsMixin
 from osf.models import Subject
 
+subjects_as_relationships_version = '2.16'
+
 class TaxonomyField(ser.Field):
     def to_representation(self, subject):
         if not isinstance(subject, Subject):
@@ -112,12 +114,13 @@ class TaxonomizableSerializerMixin(ser.Serializer, UpdateSubjectsMixin):
 
     def expect_subjects_as_relationships(self, request):
         """Determines whether subjects should be serialized as a relationship.
-        Earlier versions serialize subjects as an attribute.
+        Earlier versions serialize subjects as an attribute(before 2.16).
+        Version 2.16 and later serializer subjects as relationships.
 
         :param object request: Request object
         :return bool: Subjects should be serialized as relationships
         """
-        return StrictVersion(getattr(request, 'version', '2.0')) > StrictVersion('2.14')
+        return StrictVersion(getattr(request, 'version', '2.0')) >= StrictVersion(subjects_as_relationships_version)
 
 
 class TaxonomySerializer(JSONAPISerializer):

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -4,6 +4,7 @@ from urlparse import urlparse
 from django.utils.timezone import now
 
 from api.base.settings.defaults import API_BASE
+from api.taxonomies.serializers import subjects_as_relationships_version
 from api_tests.subjects.mixins import UpdateSubjectsMixin, SubjectsFilterMixin, SubjectsListMixin, SubjectsRelationshipMixin
 from framework.auth.core import Auth
 from osf_tests.factories import (
@@ -4436,13 +4437,13 @@ class TestCollectedMetaSubjectFiltering(SubjectsFilterMixin):
         actual = set([obj['id'] for obj in res.json['data']])
         assert expected == actual
 
-    def test_subject_filter_using_id_v_2_15(
+    def test_subject_filter_using_id_v_2_16(
             self, app, user, subject_one, subject_two, resource, resource_two,
             has_subject, project_one, project_two):
 
         expected = set([project_one._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_one._id),
+            '{}{}&version={}'.format(has_subject, subject_one._id, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
@@ -4450,19 +4451,19 @@ class TestCollectedMetaSubjectFiltering(SubjectsFilterMixin):
 
         expected = set([project_two._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_two._id),
+            '{}{}&version={}'.format(has_subject, subject_two._id, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
         assert expected == actual
 
-    def test_subject_filter_using_text_v_2_15(
+    def test_subject_filter_using_text_v_2_16(
             self, app, user, subject_two, resource, resource_two,
             has_subject, project_one, project_two):
         resource_two.subjects.add(subject_two)
         expected = set([project_two._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_two.text),
+            '{}{}&version={}'.format(has_subject, subject_two.text, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
@@ -4644,7 +4645,7 @@ class TestCollectedMetaDetail:
         assert res.json['data']['id'] == cgm.guid._id
 
     #   test_cgm_has_subjects_links_for_later_versions
-        res = app.get(url + '?version=2.15')
+        res = app.get(url + '?version={}'.format(subjects_as_relationships_version))
         related_url = res.json['data']['relationships']['subjects']['links']['related']['href']
         expected_url = '{}subjects/'.format(url)
         assert urlparse(related_url).path == expected_url

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -6,6 +6,7 @@ from urlparse import urlparse
 
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 from api.base.settings.defaults import API_BASE
+from api.taxonomies.serializers import subjects_as_relationships_version
 from api_tests.subjects.mixins import UpdateSubjectsMixin
 from framework.auth.core import Auth
 from osf.models import NodeLog
@@ -222,7 +223,7 @@ class TestNodeDetail:
         assert urlparse(self_url).path == expected_url
 
     #   test_node_has_subjects_links_for_later_versions
-        res = app.get(url_public + '?version=2.15')
+        res = app.get(url_public + '?version={}'.format(subjects_as_relationships_version))
         related_url = res.json['data']['relationships']['subjects']['links']['related']['href']
         expected_url = '{}subjects/'.format(url_public)
         assert urlparse(related_url).path == expected_url

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -6,6 +6,7 @@ from urlparse import urlparse
 from rest_framework import exceptions
 from django.utils import timezone
 from api.base.settings.defaults import API_BASE
+from api.taxonomies.serializers import subjects_as_relationships_version
 from api_tests.subjects.mixins import UpdateSubjectsMixin
 from osf.utils import permissions
 from osf.models import Registration, NodeLog, NodeLicense
@@ -223,7 +224,7 @@ class TestRegistrationDetail:
         assert 'registrations' not in res.json['data']['relationships']
 
     #   test_registration_has_subjects_links_for_later_versions
-        res = app.get(public_url + '?version=2.15')
+        res = app.get(public_url + '?version={}'.format(subjects_as_relationships_version))
         related_url = res.json['data']['relationships']['subjects']['links']['related']['href']
         expected_url = '{}subjects/'.format(public_url)
         assert urlparse(related_url).path == expected_url

--- a/api_tests/subjects/mixins.py
+++ b/api_tests/subjects/mixins.py
@@ -2,6 +2,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
+from api.taxonomies.serializers import subjects_as_relationships_version
 from osf.models import Preprint, NodeLog
 from osf_tests.factories import (
     AuthUserFactory,
@@ -79,7 +80,7 @@ class SubjectsFilterMixin(object):
         actual = set([obj['id'] for obj in res.json['data']])
         assert expected == actual
 
-    def test_subject_filter_using_id_v_2_15(
+    def test_subject_filter_using_id_v_2_16(
             self, app, user, subject_one, subject_two, resource, resource_two,
             has_subject):
 
@@ -88,7 +89,7 @@ class SubjectsFilterMixin(object):
 
         expected = set([resource._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_one._id),
+            '{}{}&version={}'.format(has_subject, subject_one._id, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
@@ -96,19 +97,19 @@ class SubjectsFilterMixin(object):
 
         expected = set([resource_two._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_two._id),
+            '{}{}&version={}'.format(has_subject, subject_two._id, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
         assert expected == actual
 
-    def test_subject_filter_using_text_v_2_15(
+    def test_subject_filter_using_text_v_2_16(
             self, app, user, subject_two, resource, resource_two,
             has_subject):
         resource_two.subjects.add(subject_two)
         expected = set([resource_two._id])
         res = app.get(
-            '{}{}&version=2.15'.format(has_subject, subject_two.text),
+            '{}{}&version={}'.format(has_subject, subject_two.text, subjects_as_relationships_version),
             auth=user.auth
         )
         actual = set([obj['id'] for obj in res.json['data']])
@@ -295,7 +296,7 @@ class UpdateSubjectsMixin(object):
     def test_set_subjects_as_relationships_perms(self, app, user_admin_contrib, resource, subject, resource_type_plural,
             url, make_resource_payload, user_write_contrib, user_read_contrib, user_non_contrib, write_can_edit):
 
-        url = '{}?version=2.15'.format(url)
+        url = '{}?version={}'.format(url, subjects_as_relationships_version)
         update_subjects_payload = make_resource_payload(resource, resource_type_plural, relationships={
             'subjects': {
                 'data': [
@@ -395,7 +396,7 @@ class UpdateSubjectsMixin(object):
         subject.parent = parent
         subject.save()
 
-        url = '{}?version=2.15'.format(url)
+        url = '{}?version={}'.format(url, subjects_as_relationships_version)
         update_subjects_payload = make_resource_payload(resource, resource_type_plural, relationships={
             'subjects': {
                 'data': [
@@ -424,7 +425,7 @@ class UpdateSubjectsMixin(object):
         subject.save()
 
         # Sent in level three only
-        url = '{}?version=2.15'.format(url)
+        url = '{}?version={}'.format(url, subjects_as_relationships_version)
         update_subjects_payload = make_resource_payload(resource, resource_type_plural, relationships={
             'subjects': {
                 'data': [

--- a/api_tests/subjects/views/test_subject_detail.py
+++ b/api_tests/subjects/views/test_subject_detail.py
@@ -1,6 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
+from api.taxonomies.serializers import subjects_as_relationships_version
 from osf_tests.factories import SubjectFactory
 
 
@@ -36,7 +37,7 @@ class TestSubject:
         return '/{}subjects/{}/'.format(API_BASE, subject._id)
 
     def test_get_subject_detail(self, app, url_subject_detail, subject, subject_child_one, subject_child_two):
-        res = app.get(url_subject_detail + '?version=2.15&related_counts=children')
+        res = app.get(url_subject_detail + '?version={}&related_counts=children'.format(subjects_as_relationships_version))
         data = res.json['data']
         assert data['attributes']['text'] == subject.text
         assert 'children' in data['relationships']


### PR DESCRIPTION
## Purpose

Followup for https://github.com/CenterForOpenScience/osf.io/pull/8948 

New API versions have been added since this PR was written. Bump API version to 2.16 that will start serializing subjects as relationships.  Earlier versions pre-2.16 should still serialize subjects as attributes.

- Reduce hardcoding 

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

Adding PR for dev docs for versions 2.15 and 2.16 -

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-161