### PR TITLE
[ENG-691] Enables gitlab addon to access all gitlab projects with user membership

### DIFF
--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -55,7 +55,7 @@ class GitLabClient(object):
                 raise exc
 
     def repos(self):
-        return self.user().projects.list()
+        return self.gitlab.projects.list(membership=True)
 
     def branches(self, repo_id, branch=None):
         """List a repo's branches or get a single branch (in a list).


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Enable the GitLab addon to access all GitLab projects that the user is a member of. Previously, the addon was limited to GitLab projects that the user is the owner of.

## Changes

<!-- Briefly describe or list your changes  -->
Modifies the function that retrieves projects to use the general purpose project endpoint with a membership requirement as opposed to using the user/projects endpoint.

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
Testing the GitLab add on and ensuring that users are able to access GitLab projects they own as well as GitLab projects that they do not own but are members of would be beneficial. 

I tested this locally using two separate GitLab accounts. 

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
N/A

## Side Effects

<!-- Any possible side effects? -->
N/A

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/ENG-691