### PR TITLE
[WIP] [ENG-865] Add Redis to OSF docker-compose for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ volumes:
     external: false
   wb_requirements_local_bin_vol:
     external: false
+  wb_redis_data_vol:
+    external: false
   wb_tmp_vol:
     external: false
   osfstoragecache_vol:
@@ -219,6 +221,16 @@ services:
       - wb_requirements_vol:/usr/local/lib/python3.5
       - osfstoragecache_vol:/code/website/osfstoragecache
       - wb_tmp_vol:/tmp
+    stdin_open: true
+
+  wb_redis:
+    image: redis
+    command: redis-server
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    volumes:
+      - wb_redis_data_vol:/data
     stdin_open: true
 
   # wb_flower:


### PR DESCRIPTION
## Purpose

(This PR replaces https://github.com/CenterForOpenScience/osf.io/pull/9119 that accidentally got closed and can't be reopened.)

Add [Redis](https://redis.io/) to OSF `docker-compose` for local development, where WB uses the `wb_redis` server to rate-limit its API. The main feature is implemented at the WB side and the dedicated Redis servers for stagings/prod are managed by the DevOps.

- Waterbutler takes care of the rate-limiting using Redis. See [WB-PR#380](https://github.com/CenterForOpenScience/waterbutler/pull/380) for the naive solution.

- ~~Update this ticket with DevOps side change including [docker-library](https://github.com/CenterForOpenScience/docker-library) and [helm-charts](https://github.com/CenterForOpenScience/helm-charts).~~ Out of scope, DevOps task.

- ~~Update the local config for `docker` and `docker-compose` once the above DevOps task are done.~~ Out of scope, either another ticket or included in the above one. 

## Changes

Add Redis to OSF docker-compose for local development.

- [ ] Double check port conflicts as mentioned in @TomBaxter 's [previous work](https://github.com/CenterForOpenScience/osf.io/pull/7255/files#diff-c809e133f854ed5bd8fd1f78c53f643bR15)
- [ ] Investigate and decide which `redis` image we want to use and explain why.
- [x] The proper way of configuring and running redis (e.g. use a config file, secure the connection and the data, restrict access, take care of distributed scenario, etc.) is out of the scope of local development.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-865
