### PR TITLE
[No Ticket] Update docker-compose README on populating institutions

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -147,7 +147,7 @@
     - `docker-compose run --rm web python manage.py migrate`
 - Populate institutions:
   - After resetting your database or with a new install you will need to populate the table of institutions. **You must have run migrations first.**
-    - `docker-compose run --rm web python -m scripts.populate_institutions test`
+    - `docker-compose run --rm web python -m scripts.populate_institutions -e test -a`
 - Populate preprint, registration, and collection providers:
   - After resetting your database or with a new install, the required providers and subjects will be created automatically **when you run migrations.** To create more:
     - `docker-compose run --rm web python manage.py populate_fake_providers`


### PR DESCRIPTION
## Purpose

[OSF-PR-#9127](https://github.com/CenterForOpenScience/osf.io/pull/9127) / [ENG-771](https://openscience.atlassian.net/browse/ENG-771) rewrote the [institution populating script](https://github.com/cslzchen/osf.io/blob/master/scripts/populate_institutions.py) and changed how it is used. Thanks @corbinSanders for pointing it out that I need to update the `docker-compose` README.

cc @mfraezz I targeted this PR to `master` but feel free to change it to `develop` if you prefer.

## Changes

Updated the command to run for populating institutions during OSF setup. It uses `test` environment and run for **all** institutions.

## QA Notes

N / A

## Documentation

- [ ] Is this README the only place we need to update?

## Side Effects

N / A

## Ticket

N / A
