### PR TITLE
[No Ticket] [Level-Up-Time] Remove access token from external login unauthenticated session

### DIFF
--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -26,6 +26,13 @@ check_password = bcrypt.check_password_hash
 
 
 def authenticate(user, access_token, response):
+    """Create an authenticated OSF session for the user.
+
+    :param user: the authenticated user
+    :param access_token: the access token of type CAS issued during CAS service validation
+    :param response: the response from which the session response is created
+    :return: the session response
+    """
     data = session.data if session._get_current_object() else {}
     data.update({
         'auth_user_username': user.username,
@@ -43,7 +50,20 @@ def authenticate(user, access_token, response):
 
 def external_first_login_authenticate(user, response):
     """
-    Create a special unauthenticated session for user login through external identity provider for the first time.
+    Create a special unauthenticated OSF session for users who have just logged in via an external
+    identity provider for the first time.
+
+    The session only contains data necessary for OSF to link an existing user or create a new one.
+
+    * `auth_user_external_id_provider`, `auth_user_external_id`, `auth_user_external_first_login`
+    and `auth_user_fullname` together store the user's external identity information.
+
+    * `service_url` is used for keeping track of which page users started the login so OSF knows
+    where to redirect the user to after successful account creation or link.
+
+    * `auth_user_username` (email) is not available and will be entered by the user.
+
+    * Neither `auth_user_id` nor `auth_user_access_token` is irrelevant in this case.
 
     :param user: the user with external credential
     :param response: the response to return
@@ -55,7 +75,6 @@ def external_first_login_authenticate(user, response):
         'auth_user_external_id_provider': user['external_id_provider'],
         'auth_user_external_id': user['external_id'],
         'auth_user_fullname': user['fullname'],
-        'auth_user_access_token': user['access_token'],
         'auth_user_external_first_login': True,
         'service_url': user['service_url'],
     })

--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -289,7 +289,6 @@ def make_response_from_ticket(ticket, service_url):
                 )))
 
             # If user is authenticated by CAS, continue to create an OSF session.
-            # TODO [CAS-27]: Remove Access Token From Service Validation
             return authenticate(
                 user,
                 cas_resp.attributes.get('accessToken', ''),
@@ -303,12 +302,10 @@ def make_response_from_ticket(ticket, service_url):
             # ORCiD attributes such as the user's names can be marked private and not shared
             fullname = u'{} {}'.format(cas_resp.attributes.get('given-names', ''),
                                        cas_resp.attributes.get('family-name', '')).strip()
-            # TODO [CAS-27]: Remove Access Token From Service Validation
             user = {
                 'external_id_provider': external_credential['provider'],
                 'external_id': external_credential['id'],
                 'fullname': fullname,
-                'access_token': cas_resp.attributes.get('accessToken', ''),
                 'service_url': service_furl.url,
             }
             return external_first_login_authenticate(

--- a/tests/test_cas_authentication.py
+++ b/tests/test_cas_authentication.py
@@ -69,10 +69,10 @@ def generate_external_user_with_resp(service_url, user=True, release=True):
             'external_id_provider': validated_credentials['provider'],
             'external_id': validated_credentials['id'],
             'fullname': '',
-            'access_token': cas_resp.attributes['accessToken'],
             'service_url': service_url,
         }
         return user, validated_credentials, cas_resp
+
 
 RESPONSE_TEMPLATE = """
 <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>


### PR DESCRIPTION
## Purpose

The mystery why CAS releases a special access token to OSF who then stores it in the current authenticated session has been solved during [ENG-1013](https://openscience.atlassian.net/browse/ENG-1013) with [CAS-PR-160](https://github.com/CenterForOpenScience/cas-overlay/pull/160). We happily discovered that this access token is quite important and serves as the ONLY way for OSF to list all of a user's authorized apps (sadly, not enabled / used by current OSF). 

This short hackathon PR removes access token from the unauthenticated session of an external login. In addition, it improves the code | style | comments | docstrings where this access token is used in OSF.

## Changes

It is recommended to review the changes commit by commit.

### https://github.com/CenterForOpenScience/osf.io/pull/9156/commits/2b5a1fe9bdd011dd0e3900cf8be84e4ed398bc16

A refactor of comments, docstrings and style for `make_response_from_ticket()`, which has no functionality effect. This commit simply lets us have a better code diff for the next one which is functional.

### https://github.com/CenterForOpenScience/osf.io/pull/9156/commits/726eb15f3032c1766d837cd2371fb8d1ac9a2c05

- Keep the access token for normal OSF login authenticated session
- Removed the access token from the external login unauthenticated session
- Updated docstring and removed confusing TODO comments
- Fixed unit tests

## QA Notes

Dev QA

## Documentation

N / A

## Side Effects

N / A

## Ticket

N / A