### PR TITLE
[ENG-379] support buster-based unoconv image (dev-only change)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,10 +157,12 @@ services:
 
   unoconv:
     image: centerforopenscience/unoconv
+    environment:
+      UNO_PATH: /usr/lib/libreoffice
     command:
       - /bin/bash
       - -c
-      - /opt/libreoffice6.1/program/python -u /usr/local/bin/unoconv --listener --server=0.0.0.0 --port=2002 -vvv &&
+      - /usr/bin/python3.7 /usr/local/bin/unoconv --listener --server=0.0.0.0 --port=2002 -vvv &&
         chmod -R 777 /tmp/mfrlocalcache
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Purpose

Allow running the `unoconv` container in local development once https://github.com/CenterForOpenScience/docker-library/pull/51 is merged.

The unoconv image MFR needs to convert Word docs to pdf has been updated to be based off of Debian buster and to install libreoffice via apt-get.  As a result, the invocation to start unoconv has changed.

## Changes

* Update the path to the python binary.  Debian's libreoffice does not come with its own python.

* Set the `UNO_PATH` envvar so `unoconv` can find the libreoffice installation.

## QA Notes

QA not needed.  This change only affects devs running unoconv locally.

## Documentation

No docs to update.

## Side Effects

None expected!

## Ticket

https://openscience.atlassian.net/browse/ENG-379