### PR TITLE
Optimizing query for tasks.update_storage_usage_cache [ENG-1046]

### DIFF
--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -120,13 +120,13 @@ def update_storage_usage_cache(target_id, target_guid, per_page=5000):
     count = per_page
     offset = 0
     storage_usage_total = 0
-    while count:
-        with connection.cursor() as cursor:
-            cursor.execute(sql, [target_id, per_page, offset])
-            result = cursor.fetchall()
-            storage_usage_total += int(result[0][1]) if result[0][1] else 0
-            count = int(result[0][0]) if result[0][0] else 0
-            offset += count
+    with connection.cursor() as cursor:
+        while count:
+                cursor.execute(sql, [target_id, per_page, offset])
+                result = cursor.fetchall()
+                storage_usage_total += int(result[0][1]) if result[0][1] else 0
+                count = int(result[0][0]) if result[0][0] else 0
+                offset += count
 
     key = cache_settings.STORAGE_USAGE_KEY.format(target_id=target_guid)
     storage_usage_cache.set(key, storage_usage_total, cache_settings.FIVE_MIN_TIMEOUT)

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -117,7 +117,7 @@ def update_storage_usage_cache(target_id):
         cursor.execute(sql, [target_id])
         result = cursor.fetchall()
 
-    storage_usage_total = int(result[0][0])
+    storage_usage_total = int(result[0][0]) if result[0][0] else 0
 
     key = cache_settings.STORAGE_USAGE_KEY.format(target_id=target_id)
     storage_usage_cache.set(key, storage_usage_total, cache_settings.FIVE_MIN_TIMEOUT)

--- a/api_tests/wb/views/test_wb_hooks.py
+++ b/api_tests/wb/views/test_wb_hooks.py
@@ -880,7 +880,7 @@ class TestCopy():
         assert node.storage_usage is None
 
         # But there's really 1337 bytes in the node
-        update_storage_usage_cache(node._id)
+        update_storage_usage_cache(node.id)
         assert node.storage_usage == 1337
 
         # And we have exactly 1337 bytes copied in node_two

--- a/api_tests/wb/views/test_wb_hooks.py
+++ b/api_tests/wb/views/test_wb_hooks.py
@@ -880,7 +880,7 @@ class TestCopy():
         assert node.storage_usage is None
 
         # But there's really 1337 bytes in the node
-        update_storage_usage_cache(node.id)
+        update_storage_usage_cache(node.id, node._id)
         assert node.storage_usage == 1337
 
         # And we have exactly 1337 bytes copied in node_two


### PR DESCRIPTION

## Purpose

Replacing the naive query with a SQL query to optimize tasks.update_storage_usage_cache, as this is run frequently and is inefficient.

## Changes

- api/caching/tasks.py - Modifying update_storage_usage_cache to use a more efficient query.

- I tested this by calling update_storage_usage_cache directly in the shell then making sure the set amount was correct.

## QA Notes

-Ensure this is calculating file size correctly, specifically after moving/copying files.


## Documentation

N/A

## Side Effects

Should not be any

## Ticket

https://openscience.atlassian.net/browse/ENG-1046
