### PR TITLE
[ENG-1079] No logs for children

### DIFF
--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -169,9 +169,6 @@ class TestRegistrationForksList:
         expected_logs = list(
             private_registration.logs.values_list(
                 'action', flat=True))
-        expected_logs.append(
-            private_registration.nodes[0].logs.latest().action)
-        expected_logs.append('node_forked')
         expected_logs.append('node_forked')
 
         forked_logs = data['embeds']['logs']['data']

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -871,11 +871,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         return OSFGroup.objects.filter(osfgroupgroupobjectpermission__group_id__in=member_groups)
 
     def get_aggregate_logs_query(self, auth):
-        return (
-            (
-                Q(node_id__in=list(Node.objects.get_children(self).can_view(user=auth.user, private_link=auth.private_link).values_list('id', flat=True)) + [self.id])
-            ) & Q(should_hide=False)
-        )
+        return Q(node_id=self.id) & Q(should_hide=False)
 
     def get_aggregate_logs_queryset(self, auth):
         query = self.get_aggregate_logs_query(auth)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3272,15 +3272,15 @@ class TestLogMethods:
     def node(self, parent):
         return NodeFactory(parent=parent)
 
-    def test_get_aggregate_logs_queryset_recurses(self, parent, node, auth):
+    def test_get_aggregate_logs_queryset_does_not_recurse(self, parent, node, auth):
         grandchild = NodeFactory(parent=node)
         parent_log = parent.add_log(NodeLog.FILE_ADDED, auth=auth, params={'node': parent._id}, save=True)
         child_log = node.add_log(NodeLog.FILE_ADDED, auth=auth, params={'node': node._id}, save=True)
         grandchild_log = grandchild.add_log(NodeLog.FILE_ADDED, auth=auth, params={'node': grandchild._id}, save=True)
         logs = parent.get_aggregate_logs_queryset(auth)
         assert parent_log in list(logs)
-        assert child_log in list(logs)
-        assert grandchild_log in list(logs)
+        assert child_log not in list(logs)
+        assert grandchild_log not in list(logs)
 
     # copied from tests/test_models.py#TestNode
     def test_get_aggregate_logs_queryset_doesnt_return_hidden_logs(self, parent, auth):


### PR DESCRIPTION
## Purpose

Logs for children are worse than good: they're bad. Getting the first page logs for RPP takes about 16 seconds at the best of times, and if that request were made multiple times, or if it happened during a time of heavy load, it could cause a lot of problems for the system.

## Changes

1. Remove roll-up of child logs into the aggregated log query and instead just return the node being requested (minus the hidden logs).
2. Update tests

## QA Notes

### Prep
For prep, you'll want to have a complex node hierarchy, and you'll want to see how long that log list takes to load. This can be tested in the front-end via the project summary page and the api (`/v2/nodes/<node_id>/logs`).  

### How the end-user will see this
The major changes will be that the node should load faster, and that only the logs for the current node should show in the log widget. Everything else should remain the same.

### Potential other things
On the off chance of something weird, do a registration of a multi-node project hierarchy and make sure that works properly.

## Documentation

N/A

## Side Effects

Could maybe affect how registrations register, but I can't see evidence in the code to support that.

## Ticket

Research ticket: https://openscience.atlassian.net/browse/ENG-1079
