### PR TITLE
[no ticket] avoid encoding error in assets containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -383,6 +383,7 @@ services:
     restart: unless-stopped
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
+      LANG: en_US.UTF-8
     volumes:
       - ./:/code:cached
       - osf_requirements_vol:/usr/lib/python2.7
@@ -396,6 +397,7 @@ services:
     restart: unless-stopped
     environment:
       DJANGO_SETTINGS_MODULE: admin.base.settings
+      LANG: en_US.UTF-8
     volumes:
       - ./:/code:cached
       - osf_requirements_vol:/usr/lib/python2.7


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
`invoke assets -w` fails with a unicode error -- Unsure of the root cause (possibly webpack speaking the non-ascii rune `…` aloud?) but @felliott found a workaround.
<!-- Describe the purpose of your changes -->

## Changes
Set `LANG=en_US.UTF-8` for `assets` and `admin_assets` containers in our docker-compose.yml. This avoids the problem in the common case, for now.
<!-- Briefly describe or list your changes  -->
