### PR TITLE
[hotfix][no ticket] strip comments from registered meta (APIv1)

### DIFF
--- a/osf/utils/registrations.py
+++ b/osf/utils/registrations.py
@@ -1,0 +1,37 @@
+import copy
+
+def strip_registered_meta_comments(messy_dict_or_list, in_place=False):
+    """Removes Prereg Challenge comments from a given `registered_meta` dict.
+
+    Nothing publicly exposed needs these comments:
+    ```
+    {
+        "registered_meta": {
+            "q20": {
+                "comments": [ ... ], <~~~ THIS
+                "value": "foo",
+                "extra": []
+            },
+        }
+    }
+    ```
+
+    If `in_place` is truthy, modifies `messy_dict_or_list` and returns it.
+    Else, returns a deep copy without modifying the given `messy_dict_or_list`
+    """
+    obj = messy_dict_or_list if in_place else copy.deepcopy(messy_dict_or_list)
+
+    if isinstance(obj, list):
+        for nested_obj in obj:
+            strip_registered_meta_comments(nested_obj, in_place=True)
+    elif isinstance(obj, dict):
+        comments = obj.get('comments', None)
+
+        # some schemas have a question named "comments" -- those will have a dict value
+        if isinstance(comments, list):
+            del obj['comments']
+
+        # dig into the deeply nested structure
+        for nested_obj in obj.values():
+            strip_registered_meta_comments(nested_obj, in_place=True)
+    return obj

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -20,6 +20,7 @@ from api.waffle.utils import flag_is_active, storage_i18n_flag_active, storage_u
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
 from osf.utils.functional import rapply
+from osf.utils.registrations import strip_registered_meta_comments
 from osf.utils import sanitize
 from osf import features
 
@@ -762,7 +763,7 @@ def _view_project(node, auth, primary=False,
             'registered_from_url': node.registered_from.url if is_registration else '',
             'registered_date': iso8601format(node.registered_date) if is_registration else '',
             'root_id': node.root._id if node.root else None,
-            'registered_meta': node.registered_meta,
+            'registered_meta': strip_registered_meta_comments(node.registered_meta),
             'registered_schemas': serialize_meta_schemas(list(node.registered_schema.all())) if is_registration else False,
             'is_fork': node.is_fork,
             'is_collected': node.is_collected,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Follow-up to #9170 -- apply the same to APIv1
<!-- Describe the purpose of your changes -->

## Changes
Strip out prereg challenge comments from registrations' `registered_meta`
<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
