### PR TITLE
[ENG-1134] [OSF Institutions] Institution SSO with Inactive Accounts

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -42,43 +42,65 @@ def get_session_from_cookie(cookie_val):
 
 def check_user(user):
     """
-    Verify users' status.
+    Check and verify user status.
 
-                        registered      confirmed       disabled        merged      usable password
-    ACTIVE:             x               x               o               o           x
-    NOT_CONFIRMED:      o               o               o               o           x
-    NOT_CLAIMED:        o               o               o               o           o
-    DISABLED:           x               x               x               o           x
-    USER_MERGED:        x               x               o               x           o
+                                    registered  confirmed   disabled    merged  usable-password
+    ACTIVE:                             x           x           o           o           x
+    NOT_CONFIRMED (default)     :       o           o           o           o           x
+    NOT_CONFIRMED (external)    :       o           o           o           o           o
+    NOT_CLAIMED                 :       o           o           o           o           o
+    DISABLED                    :       x           x           x           o           x
+    USER_MERGED                 :       x           x           o           x           o
 
-    :param user: the user
-    :raises UnconfirmedAccountError
-    :raises UnclaimedAccountError
-    :raises DeactivatedAccountError
-    :raises MergedAccountError
-    :raises InvalidAccountError
+    Unlike users created via username-password signup, unconfirmed accounts created by an external
+    IdP (e.g. ORCiD Login) have unusable passwords. To detect them, check the ``external_identity``
+    property of the user object. See ``created_by_external_idp_and_unconfirmed()`` for details.
+
+    :param user: the user object to check
+    :raises `UnconfirmedAccountError` if the user was created via default useraname / password
+        sign-up, or if via ORCiD login with pending status "LINK" or "CREATE" to confirm
+    :raises `UnclaimedAccountError` if the user was created as an unregistered contributor of a
+        project or group waiting to be claimed
+    :raises `DeactivatedAccountError` if the user has been disabled / deactivated
+    :raises `MergedAccountError` if the user has been merged into another account
+    :raises `InvalidAccountError` if the user is not active and not of the expected inactive status
+    :returns nothing if user is active and no exception is raised
     """
 
-    # active user must be registered, claimed, confirmed, not merged or disabled, and has a usable password
+    # An active user must be registered, claimed, confirmed, not merged, not disabled, and either
+    # has a usable password or has a verified external identity.
     if user.is_active:
         return
 
-    # user disabled
+    # The user has been disabled / deactivated
     if user.is_disabled:
         raise DeactivatedAccountError
 
-    # user merged
+    # The user has been merged into another one
     if user.is_merged:
         raise MergedAccountError
 
-    # user not confirmed or contributor not claimed
+    # The user has not been confirmed or claimed
     if not user.is_confirmed and not user.is_registered:
-        if user.has_usable_password():
+        if user.has_usable_password() or created_by_external_idp_and_unconfirmed(user):
             raise UnconfirmedAccountError
         raise UnclaimedAccountError
 
-    # OSF does not recognize other user status
+    # For all other cases, the user status is invalid. Although such status can't be reached with
+    # normal user-facing web application flow, it is still possible as a result of direct database
+    # access, coding bugs, database corruption, etc.
     raise InvalidAccountError
+
+
+def created_by_external_idp_and_unconfirmed(user):
+    """Check if the user is created by external IdP and unconfirmed.
+
+    There are only three possible values that indicates the status of a user's external identity:
+    'LINK', 'CREATE' and 'VERIFIED'. Only 'CREATE' indicates that the user is newly created by an
+    external IdP and is unconfirmed.
+    """
+
+    return 'CREATE' in set(sum([each.values() for each in user.external_identity.values()], []))
 
 
 # Three customized DRF authentication classes: basic, session/cookie and access token.

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -106,9 +106,9 @@ class InstitutionAuthentication(BaseAuthentication):
             # Relying on front-end validation until `accepted_tos` is added to the JWT payload
             user.accepted_terms_of_service = timezone.now()
 
-            # save and register user
-            user.save()
+            # Register and save user
             user.register(username)
+            user.save()
 
             # send confirmation email
             send_mail(

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -144,6 +144,9 @@ class InstitutionAuthentication(BaseAuthentication):
                 user.middle_names = middle_names
             if suffix:
                 user.suffix = suffix
+            # Users claimed or confirmed via institution SSO should have their full name updated
+            if activation_required:
+                user.fullname = fullname
             user.update_date_last_login()
 
             # Relying on front-end validation until `accepted_tos` is added to the JWT payload

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -3,27 +3,24 @@ import json
 import jwe
 import jwt
 import pytest
-from flask import Flask
 
 from api.base import settings
 from api.base.settings.defaults import API_BASE
+
 from framework.auth import signals, Auth
+
 from osf.models import OSFUser
 from osf_tests.factories import InstitutionFactory, ProjectFactory, UserFactory
 
 from tests.base import capture_signals
-
-decoratorapp = Flask('decorators')
 
 
 def make_user(username, fullname):
     return UserFactory(username=username, fullname=fullname)
 
 
-def make_payload(
-        institution, username, fullname='Fake User',
-        given_name='', family_name=''
-):
+def make_payload(institution, username, fullname='Fake User', given_name='', family_name=''):
+
     data = {
         'provider': {
             'id': institution._id,
@@ -37,10 +34,18 @@ def make_payload(
             }
         }
     }
-    return jwe.encrypt(jwt.encode({
-        'sub': username,
-        'data': json.dumps(data)
-    }, settings.JWT_SECRET, algorithm='HS256'), settings.JWE_SECRET)
+
+    return jwe.encrypt(
+        jwt.encode(
+            {
+                'sub': username,
+                'data': json.dumps(data)
+            },
+            settings.JWT_SECRET,
+            algorithm='HS256'
+        ),
+        settings.JWE_SECRET
+    )
 
 
 @pytest.mark.django_db
@@ -50,149 +55,126 @@ class TestInstitutionAuth:
     def institution(self):
         return InstitutionFactory()
 
-    @pytest.yield_fixture(autouse=True)
-    def flask_request_context(self):
-        """
-        required for waffle cookies
-        """
-        with decoratorapp.test_request_context():
-            yield
-
     @pytest.fixture()
     def url_auth_institution(self):
         return '/{0}institutions/auth/'.format(API_BASE)
 
-    def test_creates_user(self, app, url_auth_institution, institution):
-        username = 'hmoco@circle.edu'
+    def test_invalid_payload(self, app, url_auth_institution):
+        res = app.post(url_auth_institution, 'INVALID_PAYLOAD', expect_errors=True)
+        assert res.status_code == 403
+
+    def test_new_user_created(self, app, url_auth_institution, institution):
+
+        username = 'user_created@osf.edu'
         assert OSFUser.objects.filter(username=username).count() == 0
 
         with capture_signals() as mock_signals:
-            res = app.post(
-                url_auth_institution,
-                make_payload(institution, username)
-            )
-
+            res = app.post(url_auth_institution, make_payload(institution, username))
         assert res.status_code == 204
         assert mock_signals.signals_sent() == set([signals.user_confirmed])
 
         user = OSFUser.objects.filter(username=username).first()
-
         assert user
+        assert user.fullname == 'Fake User'
+        assert user.accepted_terms_of_service is not None
         assert institution in user.affiliated_institutions.all()
 
-    def test_adds_institution(self, app, institution, url_auth_institution):
-        username = 'hmoco@circle.edu'
+    def test_existing_user_found_but_not_affiliated(self, app, institution, url_auth_institution):
 
-        user = make_user(username, 'Mr Moco')
+        username = 'user_not_affiliated@osf.edu'
+        user = make_user(username, 'Foo Bar')
+        user.save()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution, make_payload(institution, username))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert institution in user.affiliated_institutions.all()
+
+    def test_user_found_and_affiliated(self, app, institution, url_auth_institution):
+
+        username = 'user_affiliated@osf.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution)
+        user.save()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution, make_payload(institution, username))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == 1
+
+    def test_new_user_names_guessed_if_not_provided(self, app, institution, url_auth_institution):
+
+        username = 'user_created_with_fullname_only@osf.edu'
+        res = app.post(url_auth_institution, make_payload(institution, username))
+        assert res.status_code == 204
+
+        user = OSFUser.objects.filter(username=username).first()
+        assert user
+        assert user.fullname == 'Fake User'
+        # Given name and family name are guessed from full name
+        assert user.given_name == 'Fake'
+        assert user.family_name == 'User'
+
+    def test_new_user_names_used_when_provided(self, app, institution, url_auth_institution):
+
+        username = 'user_created_with_names@osf.edu'
+        res = app.post(
+            url_auth_institution,
+            make_payload(institution, username, given_name='Foo', family_name='Bar')
+        )
+        assert res.status_code == 204
+
+        user = OSFUser.objects.filter(username=username).first()
+        assert user
+        assert user.fullname == 'Fake User'
+        # Given name and family name are set instead of guessed
+        assert user.given_name == 'Foo'
+        assert user.family_name == 'Bar'
+
+    def test_user_active(self, app, institution, url_auth_institution):
+
+        username, fullname, password = 'user_active@user.edu', 'Foo Bar', 'FuAsKeEr'
+        user = make_user(username, fullname)
+        user.set_password(password)
         user.save()
 
         with capture_signals() as mock_signals:
             res = app.post(
                 url_auth_institution,
-                make_payload(institution, username)
+                make_payload(
+                    institution,
+                    username,
+                    family_name='User',
+                    given_name='Fake',
+                    fullname='Fake User'
+                )
             )
-
         assert res.status_code == 204
-        assert mock_signals.signals_sent() == set()
-
-        user.reload()
-        assert institution in user.affiliated_institutions.all()
-
-    def test_finds_user(self, app, institution, url_auth_institution):
-        username = 'hmoco@circle.edu'
-
-        user = make_user(username, 'Mr Moco')
-        user.affiliated_institutions.add(institution)
-        user.save()
-
-        res = app.post(
-            url_auth_institution,
-            make_payload(institution, username)
-        )
-        assert res.status_code == 204
-
-        user.reload()
-        assert user.affiliated_institutions.count() == 1
-
-    def test_bad_token(self, app, url_auth_institution):
-        res = app.post(
-            url_auth_institution,
-            'al;kjasdfljadf',
-            expect_errors=True
-        )
-        assert res.status_code == 403
-
-    def test_user_names_guessed_if_not_provided(
-            self, app, institution, url_auth_institution):
-        # Regression for https://openscience.atlassian.net/browse/OSF-7212
-        username = 'fake@user.edu'
-        res = app.post(
-            url_auth_institution,
-            make_payload(institution, username)
-        )
-
-        assert res.status_code == 204
-        user = OSFUser.objects.filter(username=username).first()
-
-        assert user
-        assert user.fullname == 'Fake User'
-        assert user.given_name == 'Fake'
-        assert user.family_name == 'User'
-
-    def test_user_names_used_when_provided(
-            self, app, institution, url_auth_institution):
-        # Regression for https://openscience.atlassian.net/browse/OSF-7212
-        username = 'fake@user.edu'
-        res = app.post(
-            url_auth_institution,
-            make_payload(
-                institution,
-                username,
-                family_name='West',
-                given_name='Kanye'
-            )
-        )
-
-        assert res.status_code == 204
-        user = OSFUser.objects.filter(username=username).first()
-
-        assert user
-        assert user.fullname == 'Fake User'
-        assert user.given_name == 'Kanye'
-        assert user.family_name == 'West'
-
-    def test_user_active(self, app, institution, url_auth_institution):
-
-        username, fullname, password = 'fake_active@user.edu', 'Active User', 'FuAsKeEr'
-        user = make_user(username, fullname)
-        user.set_password(password)
-        user.save()
-
-        res = app.post(
-            url_auth_institution,
-            make_payload(
-                institution,
-                username,
-                family_name='Family',
-                given_name='Given',
-                fullname='Full'
-            )
-        )
-        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
 
         user = OSFUser.objects.filter(username=username).first()
         assert user
         # User names remains untouched
         assert user.fullname == fullname
-        assert user.family_name == 'User'
-        assert user.given_name == 'Active'
+        assert user.family_name == 'Bar'
+        assert user.given_name == 'Foo'
         # Existing active user keeps their password
         assert user.has_usable_password()
         assert user.check_password(password)
+        # Confirm affiliation
+        assert institution in user.affiliated_institutions.all()
 
     def test_user_unclaimed(self, app, institution, url_auth_institution):
 
-        username, fullname = 'fake_unclaimed@user.edu', 'Unclaimed User'
+        username, fullname = 'user_nclaimed@user.edu', 'Foo Bar'
         project = ProjectFactory()
         user = project.add_unregistered_contributor(
             fullname=fullname,
@@ -203,68 +185,76 @@ class TestInstitutionAuth:
         # Unclaimed user is given an unusable password when being added as a contributor
         assert not user.has_usable_password()
 
-        res = app.post(
-            url_auth_institution,
-            make_payload(
-                institution,
-                username,
-                family_name='Family',
-                given_name='Given',
-                fullname='Full'
+        with capture_signals() as mock_signals:
+            res = app.post(
+                url_auth_institution,
+                make_payload(
+                    institution,
+                    username,
+                    family_name='User',
+                    given_name='Fake',
+                    fullname='Fake User'
+                )
             )
-        )
         assert res.status_code == 204
+        assert mock_signals.signals_sent() == set([signals.user_confirmed])
 
         user = OSFUser.objects.filter(username=username).first()
         assert user
-        # User becomes active and names (except the full name) are updated
+        # User becomes active and all names are updated
         assert user.is_active
-        assert user.fullname == 'Full'
-        assert user.family_name == 'Family'
-        assert user.given_name == 'Given'
+        assert user.fullname == 'Fake User'
+        assert user.family_name == 'User'
+        assert user.given_name == 'Fake'
         # Unclaimed records must have been cleared
         assert not user.unclaimed_records
         # Previously unclaimed user must be assigned a usable password during institution auth
         assert user.has_usable_password()
         # User remains to be a contributor of the project
         assert project.is_contributor(user)
+        # Confirm affiliation
+        assert institution in user.affiliated_institutions.all()
 
     def test_user_unconfirmed(self, app, institution, url_auth_institution):
 
-        username, fullname, password = 'fake_unconfirmed@user.edu', 'Unconfirmed User', 'FuAsKeEr'
+        username, fullname, password = 'user_unconfirmed@osf.edu', 'Foo Bar', 'FuAsKeEr'
         user = OSFUser.create_unconfirmed(username, password, fullname)
         user.save()
         # Unconfirmed user has a usable password created during sign-up
         assert user.has_usable_password()
 
-        res = app.post(
-            url_auth_institution,
-            make_payload(
-                institution,
-                username,
-                family_name='Family',
-                given_name='Given',
-                fullname='Full'
+        with capture_signals() as mock_signals:
+            res = app.post(
+                url_auth_institution,
+                make_payload(
+                    institution,
+                    username,
+                    family_name='User',
+                    given_name='Fake',
+                    fullname='Fake User'
+                )
             )
-        )
         assert res.status_code == 204
+        assert mock_signals.signals_sent() == set([signals.user_confirmed])
 
         user = OSFUser.objects.filter(username=username).first()
         assert user
-        # User becomes active and names (except the full name) are updated
+        # User becomes active and all names are updated
         assert user.is_active
-        assert user.fullname == 'Full'
-        assert user.family_name == 'Family'
-        assert user.given_name == 'Given'
+        assert user.fullname == 'Fake User'
+        assert user.family_name == 'User'
+        assert user.given_name == 'Fake'
         # Pending email verifications must be cleared
         assert not user.email_verifications
         # Previously unconfirmed user must be given a new password during institution auth
         assert user.has_usable_password()
         assert not user.check_password(password)
+        # Confirm affiliation
+        assert institution in user.affiliated_institutions.all()
 
     def test_user_inactive(self, app, institution, url_auth_institution):
 
-        username, fullname, password = 'fake_inactive@user.edu', 'Inactive User', 'FuAsKeEr'
+        username, fullname, password = 'user_inactive@osf.edu', 'Foo Bar', 'FuAsKeEr'
         user = make_user(username, fullname)
         user.set_password(password)
         # User must be saved before deactivation
@@ -275,23 +265,26 @@ class TestInstitutionAuth:
         assert user.has_usable_password()
         assert user.check_password(password)
 
-        res = app.post(
-            url_auth_institution,
-            make_payload(
-                institution,
-                username,
-                family_name='Family',
-                given_name='Given',
-                fullname='Full'
-            ),
-            expect_errors=True
-        )
+        with capture_signals() as mock_signals:
+            res = app.post(
+                url_auth_institution,
+                make_payload(
+                    institution,
+                    username,
+                    family_name='User',
+                    given_name='Fake',
+                    fullname='Fake User'
+                ),
+                expect_errors=True
+            )
         assert res.status_code == 403
+        assert not mock_signals.signals_sent()
 
         user = OSFUser.objects.filter(username=username).first()
         assert user
-        # Inactive user remains untouched
+        # Inactive user remains untouched, including affiliation
         assert user.is_disabled
         assert user.fullname == fullname
-        assert user.family_name == 'User'
-        assert user.given_name == 'Inactive'
+        assert user.given_name == 'Foo'
+        assert user.family_name == 'Bar'
+        assert institution not in user.affiliated_institutions.all()

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -219,7 +219,7 @@ class TestInstitutionAuth:
         assert user
         # User becomes active and names (except the full name) are updated
         assert user.is_active
-        assert user.fullname == fullname
+        assert user.fullname == 'Full'
         assert user.family_name == 'Family'
         assert user.given_name == 'Given'
         # Unclaimed records must have been cleared
@@ -253,7 +253,7 @@ class TestInstitutionAuth:
         assert user
         # User becomes active and names (except the full name) are updated
         assert user.is_active
-        assert user.fullname == fullname
+        assert user.fullname == 'Full'
         assert user.family_name == 'Family'
         assert user.given_name == 'Given'
         # Pending email verifications must be cleared

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -110,6 +110,19 @@ class TestInstitutionAuth:
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == 1
 
+    def test_new_user_names_not_provided(self, app, institution, url_auth_institution):
+
+        username = 'user_created_without_names@osf.edu'
+        res = app.post(
+            url_auth_institution,
+            make_payload(institution, username, fullname=''),
+            expect_errors=True
+        )
+        assert res.status_code == 403
+
+        user = OSFUser.objects.filter(username=username).first()
+        assert not user
+
     def test_new_user_names_guessed_if_not_provided(self, app, institution, url_auth_institution):
 
         username = 'user_created_with_fullname_only@osf.edu'


### PR DESCRIPTION
## Purpose

Improve institution SSO with inactive user accounts.

### DevOps Notes

* ~~This PR only touches the institution auth api,~~ This PR's primary change touches the institution auth API, which only affects  and can only be tested on `test` and `prod`. Thus, this PR targets `master` as a `hotfix`.

* The secondary change that updated [`drf.check_user()`](https://github.com/CenterForOpenScience/osf.io/blob/develop/api/base/authentication/drf.py#L43) to check unconfirmed status for users created by ORCiD login. This is such a trivial change that shouldn't affects the PR's eligibility for being a `hotfix`.

- [x] ~~Currently blocked by~~ **Product Demo** passed.

## Changes

* Fixed an issue where there is a chance that users are not saved after register
* Take care of inactive users during institution auth
  * Unclaimed: clear records, set full name, set usable password and register
  * Unconfirmed:
    * If created by default username-password signup: clear email verifications, set full name, reset / refresh usable password and register
    * If created by external IdP login (i.e ORCiD only for now): fail api institution auth. This improvement will be taken care of in another ticket [ENG-1189](https://openscience.atlassian.net/browse/ENG-1189).
  * Merged / Disabled / Other: fail api institution auth
* Add tests for active / unconfirmed / unclaimed / disabled accounts
* Add a test for payload missing names

### By-product
* Refactored all tests for institution auth
* Updated DocStr and Comments for institution auth
* Added both info and error level logs for different cases of institution login. Sentry is informed for errors as well.
* Fixed the inconsistency between `OSFUser.update_is_active()` and `drf.check_user()` (OSF-side only). CAS-side will be taken care of in another ticket [ENG-1187](https://openscience.atlassian.net/browse/ENG-1187).

### Out-of-scope

As mentioned during CR, the different "status" (success / error message) is not sent back to CAS in the API response. For now CAS only and can only care about the status code due to a limitation. This limitation will be analyzed in [ENG-1185](https://openscience.atlassian.net/browse/ENG-1185) and then be fixed in [ENG-880](https://openscience.atlassian.net/browse/ENG-880).

## QA Notes

Dev QA

## Documentation

No

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/ENG-1134
