### PR TITLE
[ENG-1177] EGAP Notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ehthumbs.db
 Thumbs.db
 *.swp
 *~
+.ipynb_checkpoints
 
 # R
 #######################
@@ -202,3 +203,4 @@ ssl/
 
 # pyenv
 .python-version
+

--- a/scripts/EGAP/create_EGAP_json.py
+++ b/scripts/EGAP/create_EGAP_json.py
@@ -4,15 +4,10 @@ import datetime
 import json
 import os
 import shutil
-import re
 import jsonschema
 import argparse
 
-from django.core.management.base import BaseCommand
 from jsonschema.exceptions import ValidationError
-
-from website.project.metadata.utils import create_jsonschema_from_metaschema
-from website.project.metadata.schemas import ensure_schema_structure, from_json
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -66,6 +61,22 @@ other_mapping = {
     'q30': 'q31'
 }
 
+
+here = os.path.split(os.path.abspath(__file__))[0]
+
+
+def from_json(fname):
+    with open(os.path.join(here, fname)) as f:
+        return json.load(f)
+
+
+def ensure_schema_structure(schema):
+    schema['pages'] = schema.get('pages', [])
+    schema['title'] = schema['name']
+    schema['version'] = schema.get('version', 1)
+    return schema
+
+
 def create_file_tree_and_json(author_source, registry_source, target):
     # Things this function needs to do:
     # For each row in the registry function, create a directory.
@@ -75,14 +86,17 @@ def create_file_tree_and_json(author_source, registry_source, target):
     logger.info('Creating EGAP directory at {}'.format(top_dir))
     os.mkdir(top_dir)
     author_list = create_author_dict(author_source)
-    with open(registry_source) as csv_registry_file:
+    with open(registry_source, 'rt', encoding='utf-8-sig') as csv_registry_file:
         csv_reader = csv.reader(csv_registry_file, delimiter=',')
         header_row = next(csv_reader)
-        normalized_header_row = [col_header.decode('ascii', 'ignore') for col_header in header_row]
+        normalized_header_row = [col_header.strip() for col_header in header_row]
+        logger.info('Debug data')
+        logger.info('Header row: {}'.format(header_row))
+        logger.info('Normalized header row: {}'.format(normalized_header_row))
 
         id_index = normalized_header_row.index('ID')
         for line in csv_reader:
-            row = [cell.decode('ascii', 'ignore') for cell in line]
+            row = [cell for cell in line]
             project_id = row[id_index]
             logger.info('Adding project ID: {}'.format(project_id))
             root_directory = os.path.join(top_dir, project_id)
@@ -95,18 +109,21 @@ def create_file_tree_and_json(author_source, registry_source, target):
             registration_dict = make_registration_dict(row, normalized_header_row)
             make_json_file(root_directory, registration_dict, 'registration')
 
+
 def create_author_dict(source):
     # Reads in author CSV and returns a list of dicts with names and emails of EGAP Authors
     authors = []
-    with open(source) as csv_file:
+    with open(source, 'rt', encoding='utf-8-sig') as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=',')
         header_row = next(csv_reader)
-        normalized_header_row = [col_header.decode('ascii', 'ignore').strip() for col_header in header_row]
-
+        normalized_header_row = [col_header.strip() for col_header in header_row]
+        logger.info('Debug data')
+        logger.info('Header row: {}'.format(header_row))
+        logger.info('Normalized header row: {}'.format(normalized_header_row))
         name_index = normalized_header_row.index('Name')
         email_index = normalized_header_row.index('Email')
         for line in csv_reader:
-            row = [cell.decode('ascii', 'ignore') for cell in line]
+            row = [cell for cell in line]
             logger.info('Adding user: ' + row[name_index])
             if row[email_index] != '':
                 author_dict = {'name': row[name_index].strip(), 'email': row[email_index]}
@@ -114,6 +131,7 @@ def create_author_dict(source):
                 author_dict = {'name': row[name_index].strip()}
             authors.append(author_dict)
     return authors
+
 
 def make_project_dict(row, author_list, normalized_header_row):
     project = {}
@@ -141,12 +159,13 @@ def make_project_dict(row, author_list, normalized_header_row):
                 project['contributors'].append(author_list[author_list_index])
     return project
 
+
 def make_registration_dict(row, normalized_header_row):
     registration = {}
 
     for question in schema_to_spreadsheet_mapping:
-        qid = question.keys()[0]
-        column_name = question.values()[0]
+        qid = list(question.keys())[0]
+        column_name = list(question.values())[0]
         value = build_question_response(normalized_header_row, row, qid, column_name)
         validated_qid, other_response = validate_response(qid, value)
         registration[validated_qid] = value
@@ -158,6 +177,7 @@ def make_registration_dict(row, normalized_header_row):
     registration['q36'] = build_nested_response('Agree')
     return registration
 
+
 def make_json_file(filepath, data, json_type):
     if json_type == 'project':
         filepath = filepath + '/project.json'
@@ -165,6 +185,7 @@ def make_json_file(filepath, data, json_type):
         filepath = filepath + '/registration-schema.json'
     with open(filepath, 'w') as outfile:
         json.dump(data, outfile)
+
 
 def build_question_response(header_row, row, question_key, column_title):
     """Format the question's response to go in the registration_metadata
@@ -180,6 +201,7 @@ def build_question_response(header_row, row, question_key, column_title):
         value = value.split(', ')
     return build_nested_response(value)
 
+
 def clean_value(value):
     """Clean spreadsheet values of issues that will affect validation """
     if value == 'n/a':
@@ -194,6 +216,257 @@ def build_nested_response(value):
         'extra': [],
         'value': value
     }
+
+
+def base_metaschema(metaschema):
+    json_schema = {
+        'type': 'object',
+        'description': metaschema['description'],
+        'title': metaschema['title'],
+        'additionalProperties': False,
+        'properties': {
+        }
+    }
+    return json_schema
+
+
+def get_required(question):
+    """
+    Returns True if metaschema question is required.
+    """
+    required = question.get('required', False)
+    if not required:
+        properties = question.get('properties', False)
+        if properties and isinstance(properties, list):
+            for item, property in enumerate(properties):
+                if isinstance(property, dict) and property.get('required', False):
+                    required = True
+                    break
+    return required
+
+
+COMMENTS_SCHEMA = {
+    'type': 'array',
+    'items': {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'seenBy': {
+                'type': 'array',
+            },
+            'canDelete': {'type': 'boolean'},
+            'created': {'type': 'string'},
+            'lastModified': {'type': 'string'},
+            'author': {'type': 'string'},
+            'value': {'type': 'string'},
+            'isOwner': {'type': 'boolean'},
+            'getAuthor': {'type': 'string'},
+            'user': {
+                'type': 'object',
+                'additionalProperties': True,
+                'properties': {
+                    'fullname': {'type': 'string'},
+                    'id': {'type': 'integer'}
+                }
+            },
+            'saved': {'type': 'boolean'},
+            'canEdit': {'type': 'boolean'},
+            'isDeleted': {'type': 'boolean'}
+        }
+    }
+}
+
+
+def get_options_jsonschema(options, required):
+    """
+    Returns multiple choice options for schema questions
+    """
+    for item, option in enumerate(options):
+        if isinstance(option, dict) and option.get('text'):
+            options[item] = option.get('text')
+    value = {'enum': options}
+
+    if not required and '' not in value['enum']:  # Non-required fields need to accept empty strings as a value.
+        value['enum'].append('')
+
+    return value
+
+
+def get_object_jsonschema(question, required_fields, is_reviewer, is_required):
+    """
+    Returns jsonschema for nested objects within schema
+    """
+    object_jsonschema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+
+        }
+    }
+    required = []
+    properties = question.get('properties')
+    if properties:
+        for property in properties:
+            if property.get('required', False) and required_fields:
+                required.append(property['id'])
+            values = extract_question_values(property, required_fields, is_reviewer, is_required)
+            object_jsonschema['properties'][property['id']] = {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': values
+            }
+            if required_fields:
+                object_jsonschema['properties'][property['id']]['required'] = ['value']
+    if required_fields and is_required:
+        object_jsonschema['required'] = required
+
+    return object_jsonschema
+
+
+OSF_UPLOAD_EXTRA_SCHEMA = {
+    'type': 'array',
+    'items': {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'data': {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': {
+                    'kind': {'type': 'string'},
+                    'contentType': {'type': 'string'},
+                    'name': {'type': 'string'},
+                    'extra': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            'downloads': {'type': 'integer'},
+                            'version': {'type': 'integer'},
+                            'latestVersionSeen': {'type': 'string'},
+                            'guid': {'type': 'string'},
+                            'checkout': {'type': 'string'},
+                            'hashes': {
+                                'type': 'object',
+                                'additionalProperties': False,
+                                'properties': {
+                                    'sha256': {'type': 'string'},
+                                    'md5': {'type': 'string'}
+                                }
+                            }
+                        }
+                    },
+                    'materialized': {'type': 'string'},
+                    'modified': {'type': 'string'},
+                    'nodeId': {'type': 'string'},
+                    'etag': {'type': 'string'},
+                    'provider': {'type': 'string'},
+                    'path': {'type': 'string'},
+                    'nodeUrl': {'type': 'string'},
+                    'waterbutlerURL': {'type': 'string'},
+                    'resource': {'type': 'string'},
+                    'nodeApiUrl': {'type': 'string'},
+                    'type': {'type': 'string'},
+                    'accept': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            'acceptedFiles': {'type': 'boolean'},
+                            'maxSize': {'type': 'integer'},
+                        }
+                    },
+                    'links': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            'download': {'type': 'string'},
+                            'move': {'type': 'string'},
+                            'upload': {'type': 'string'},
+                            'delete': {'type': 'string'}
+                        }
+                    },
+                    'permissions': {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            'edit': {'type': 'boolean'},
+                            'view': {'type': 'boolean'}
+                        }
+                    },
+                    'created_utc': {'type': 'string'},
+                    'id': {'type': 'string'},
+                    'modified_utc': {'type': 'string'},
+                    'size': {'type': 'integer'},
+                    'sizeInt': {'type': 'integer'},
+                }
+            },
+            'fileId': {'type': ['string', 'object']},
+            'descriptionValue': {'type': 'string'},
+            'sha256': {'type': 'string'},
+            'selectedFileName': {'type': 'string'},
+            'nodeId': {'type': 'string'},
+            'viewUrl': {'type': 'string'}
+        }
+    }
+}
+
+
+def extract_question_values(question, required_fields, is_reviewer, is_required):
+    """
+    Pulls structure for 'value', 'comments', and 'extra' items
+    """
+    response = {
+        'value': {'type': 'string'},
+        'comments': COMMENTS_SCHEMA,
+        'extra': {'type': 'array'}
+    }
+    if question.get('type') == 'object':
+        response['value'] = get_object_jsonschema(question, required_fields, is_reviewer, is_required)
+    elif question.get('type') == 'choose':
+        options = question.get('options')
+        if options:
+            enum_options = get_options_jsonschema(options, is_required)
+            if question.get('format') == 'singleselect':
+                response['value'] = enum_options
+            elif question.get('format') == 'multiselect':
+                response['value'] = {'type': 'array', 'items': enum_options}
+    elif question.get('type') == 'osf-upload':
+        response['extra'] = OSF_UPLOAD_EXTRA_SCHEMA
+
+    if is_reviewer:
+        del response['extra']
+        if not question.get('type') == 'object':
+            del response['value']
+
+    return response
+
+
+def create_jsonschema_from_metaschema(metaschema, required_fields=False, is_reviewer=False):
+    """
+    Creates jsonschema from registration metaschema for validation.
+
+    Reviewer schemas only allow comment fields.
+    """
+    json_schema = base_metaschema(metaschema)
+    required = []
+
+    for page in metaschema['pages']:
+        for question in page['questions']:
+            is_required = get_required(question)
+            if is_required and required_fields:
+                required.append(question['qid'])
+            json_schema['properties'][question['qid']] = {
+                'type': 'object',
+                'additionalProperties': False,
+                'properties': extract_question_values(question, required_fields, is_reviewer, is_required)
+            }
+            if required_fields:
+                json_schema['properties'][question['qid']]['required'] = ['value']
+
+        if required and required_fields:
+            json_schema['required'] = required
+
+    return json_schema
+
 
 def validate_response(qid, value):
     """Validate question response
@@ -227,6 +500,7 @@ def validate_response(qid, value):
             raise Exception(exc)
     return qid, None
 
+
 def main(default_args=False):
     if default_args:
         args = parser.parse_args(['--source', 'default', '--target', 'default'])
@@ -252,6 +526,7 @@ def main(default_args=False):
     if dry_run:
         shutil.rmtree(target_directory)
         raise RuntimeError('Dry run, file tree being deleted.')
+
 
 if __name__ == '__main__':
 

--- a/scripts/EGAP/egap-registration.json
+++ b/scripts/EGAP/egap-registration.json
@@ -1,0 +1,382 @@
+{
+	"name": "EGAP Registration",
+	"version": 2,
+	"description": "The EGAP registry focuses on designs for experiments and observational studies in governance and politics.",
+	"pages": [{
+			"id": "page1",
+			"title": "General Information About the Project",
+			"questions": [{
+					"qid": "q1",
+					"nav": "Title",
+					"type": "string",
+					"format": "text",
+					"title": "B1 Title of Study",
+					"description": "Provide the working title of your study.",
+					"required": true
+				},
+				{
+					"qid": "q2",
+					"nav": "Authors",
+					"title": "B2 Authors",
+					"help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo",
+					"format": "textarea",
+					"required": true
+				},
+				{
+					"qid": "q3",
+					"nav": "EGAP Registration ID",
+					"title": "EGAP Registration ID",
+					"format": "textarea",
+					"required": true
+				},
+				{
+					"qid": "q4",
+					"nav": "Timestamp",
+					"title": "Timestamp of original registration",
+					"format": "textarea",
+					"required": true
+				},
+				{
+					"qid": "q5",
+					"nav": "Acknowledgements",
+					"title": "B3 Acknowledgements",
+					"type": "string",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q6",
+					"title": "B4 Is one of the study authors a university faculty member?",
+					"nav": "University Faculty Member?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"Yes",
+						"No",
+						"Other (describe in text box below)"
+					],
+					"description": "Please choose one"
+				},
+				{
+					"qid": "q7",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q8",
+					"title": "B5 Is this Registration Prospective or Retrospective?",
+					"nav": "Prospective or Retrospective?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"Registration prior to any research activities",
+						"Registration prior to assignment of treatment",
+						"Registration prior to realization of outcomes",
+						"Registration prior to researcher access to outcome data",
+						"Registration prior to researcher analysis of outcome data",
+						"Registration after researcher analysis of outcome data",
+						"Other (describe in text box below)"
+					],
+					"description": "Please choose one"
+				},
+				{
+					"qid": "q9",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q10",
+					"title": "B6 Is this an experimental study?",
+					"nav": "Experimental study?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"Yes",
+						"No"
+					],
+					"description": "(with random assignment of units to different conditions)"
+				},
+				{
+					"qid": "q11",
+					"title": "B7 Date of start of study",
+					"nav": "Date of start of study",
+					"type": "string",
+					"format": "text",
+					"description": "Understood as first date of treatment assignment or equivalent for observational study",
+					"help": "E.g., 06/02/2018"
+				},
+				{
+					"qid": "q12",
+					"title": "B8 Gate Date",
+					"nav": "Gate Date?",
+					"type": "string",
+					"format": "text",
+					"description": "Gating is discouraged, but if necessary, EGAP policy limits the gate range to 18 months maximum.",
+					"help": "E.g., 06/02/2018"
+				},
+				{
+					"qid": "q13",
+					"title": "B9 Was this design presented at an EGAP meeting?",
+					"nav": "Presented at an EGAP meeting?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"No",
+						"Yes"
+					],
+					"description": "Indicate if the design received feedback from a EGAP design workshop or other special EGAP session prior to registration"
+				},
+				{
+					"qid": "q14",
+					"title": "B10 Is there a pre-analysis plan associated with this registration?",
+					"nav": "Pre-analysis plan associated with this registration?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"No",
+						"Yes"
+					],
+					"description": "If so, please attach it in the Additional Documentation section on the final screen."
+				}
+			]
+		},
+		{
+			"id": "page2",
+			"title": "Registration Data",
+			"questions": [{
+					"qid": "q15",
+					"nav": "Background and explanation of rationale.",
+					"title": "C1 Background and explanation of rationale.",
+					"format": "textarea",
+					"required": true,
+					"description": "Brief description of goals of project. If you are also attaching a pre-analysis plan, please refrain from simply copying and pasting a section from your plan here. If possible, please also avoid saying \"see attached pre-analysis plan,\" as it renders the search functionality less useful. Rather, please provide a short (1-2 paragraph) summary of the project background."
+				},
+				{
+					"qid": "q16",
+					"nav": "Background and explanation of rationale.",
+					"title": "C2 What are the hypotheses to be tested/quantities of interest to be estimated?",
+					"format": "textarea",
+					"required": true,
+					"description": "Please list the hypotheses including hypotheses on heterogeneous effects. If you are also attaching a pre-analysis plan, please refrain from simply copying and pasting a section from your plan here. If possible, please also avoid saying \"see attached pre-analysis plan,\" as it renders the search functionality less useful. Rather, please provide a short (1-2 paragraph) summary of project hypotheses."
+				},
+				{
+					"qid": "q17",
+					"nav": "How will these hypotheses be tested?",
+					"title": "C3 How will these hypotheses be tested?",
+					"format": "textarea",
+					"required": true,
+					"description": "Brief description of your methodology. If you are also attaching a pre-analysis plan, please refrain from simply copying and pasting a section from your plan here. If possible, please also avoid saying \"see attached pre-analysis plan,\" as it renders the search functionality less useful. Rather, please provide a short (1-2 paragraph) summary of project methodology."
+				},
+				{
+					"qid": "q18",
+					"title": "C4 Country",
+					"nav": "Country",
+					"type": "string",
+					"format": "text",
+					"help": "comma separated names of countries (e.g. Canada, United States of America, Mexico)"
+				},
+				{
+					"qid": "q19",
+					"title": "C5 Sample Size (# of Units)",
+					"nav": "Sample Size",
+					"type": "string",
+					"format": "text"
+				},
+				{
+					"qid": "q20",
+					"title": "C6 Was a power analysis conducted prior to data collection?",
+					"nav": "Power analysis conducted prior to data collection?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"No",
+						"Yes",
+						"Other (describe in text box below)"
+					]
+				},
+				{
+					"qid": "q21",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q22",
+					"title": "C7 Has this research received Institutional Review Board (IRB) or ethics committee approval?",
+					"nav": "Review Board (IRB) or ethics committee approval?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"No",
+						"Yes",
+						"Other (describe in text box below)"
+					]
+				},
+				{
+					"qid": "q23",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q24",
+					"title": "C8 IRB Number",
+					"nav": "IRB Number",
+					"type": "string",
+					"format": "text"
+				},
+				{
+					"qid": "q25",
+					"title": "C9 Date of IRB Approval",
+					"nav": "IRB Number",
+					"type": "string",
+					"format": "text"
+				},
+				{
+					"qid": "q26",
+					"title": "C10 Will the intervention be implemented by the researcher or a third party? If a third party, please provide the name.",
+					"nav": "Review Board (IRB) or ethics committee approval?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"Researchers",
+						"Other (describe in text box below)"
+					]
+				},
+				{
+					"qid": "q27",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q28",
+					"title": "C11 Did any of the research team receive remuneration from the implementing agency for taking part in this research?",
+					"nav": "Remuneration?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"Yes",
+						"No",
+						"Other (describe in text box below)"
+					]
+				},
+				{
+					"qid": "q29",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q30",
+					"title": "C12 If relevant, is there an advance agreement with the implementation group that all results can be published?",
+					"nav": "is there an advance agreement with the implementation group that all results can be published?",
+					"type": "choose",
+					"format": "singleselect",
+					"options": [
+						"N/A",
+						"Yes",
+						"No",
+						"Other (describe in text box below)"
+					]
+				},
+				{
+					"qid": "q31",
+					"title": "Other",
+					"format": "textarea",
+					"required": false
+				},
+				{
+					"qid": "q32",
+					"title": "C13 JEL classification(s)",
+					"nav": "JEL classification(s)",
+					"type": "string",
+					"format": "text",
+					"description": "Please provide alphanumeric code(s). If multiple classifications, separate by commas (e.g. D31, C19, F22)"
+				}
+			]
+		},
+		{
+			"id": "page3",
+			"title": "Keywords and Data",
+			"questions": [{
+				"qid": "q33",
+				"nav": "Keywords",
+				"type": "choose",
+				"format": "multiselect",
+				"title": "Keywords for Methodology",
+				"description": "Choose one or more categories that describe your study methodology.",
+				"options": [
+					"Experimental Design",
+					"Field Experiments",
+					"Lab Experiments",
+					"Mixed Method",
+					"Statistics",
+					"Survey Methodology"
+				]
+			}, {
+				"qid": "q34",
+				"nav": "Keywords",
+				"type": "choose",
+				"format": "multiselect",
+				"title": "Keywords for Policy",
+				"description": "Choose one or more policy categories.",
+				"options": [
+					"Conflict and Violence",
+					"Corruption",
+					"Development",
+					"Elections",
+					"Ethnic Politics",
+					"Gender",
+					"Governance"
+				]
+			}, {
+				"qid": "q35",
+				"title": "Certification",
+				"nav": "Certification",
+				"type": "choose",
+				"format": "singleselect",
+				"description": "By submitting this form and accompanying documents with EGAP, I confirm that I have rights to put this information in the public domain and I understand that this information will remain on the EGAP registry in perpetuity, regardless of whether the research is subsequently implemented or not.",
+				"options": [
+					"Agree"
+				],
+				"required": true
+			}, {
+				"qid": "q36",
+				"title": "Confirmation",
+				"nav": "Confirmation",
+				"type": "choose",
+				"format": "singleselect",
+				"description": "You should receive a confirmation of your registration within three business days. Your registration is considered complete only when confirmation is received. If you do not receive confirmation within three business days please contact paps@egap.org.",
+				"options": [
+					"Agree"
+				],
+				"required": true
+			}, {
+				"qid": "q37",
+				"nav": "Additional Documentation",
+				"title": "Additional Documentation",
+				"type": "osf-upload",
+				"format": "osf-upload-open",
+				"description": "Please upload your pre-analysis plan, along with any other supporting documents, such as survey instrument, research protocol, any data, etc."
+			}, {
+				"qid": "q38",
+				"nav": "Anonymous Documentation",
+				"title": "Anonymous Documentation",
+				"type": "osf-upload",
+				"format": "osf-upload-open",
+				"description": "Please upload your anonymized pre-analysis plan, along with any other supporting documents, such as survey instrument, research protocol, any data, etc."
+			}]
+		}
+	]
+}

--- a/scripts/EGAP/egap_workflow.ipynb
+++ b/scripts/EGAP/egap_workflow.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from create_EGAP_json import create_file_tree_and_json\n",
+    "\n",
+    "author_source = '/Users/bgeiger/Desktop/EGAP/20190821_author_emails.csv'\n",
+    "registry_source = '/Users/bgeiger/Desktop/EGAP/20191014_OSF_database.csv'\n",
+    "target_directory= '/Users/bgeiger/Desktop/EGAP/output/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_file_tree_and_json(author_source, registry_source, target_directory)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Purpose

Create an EGAP Jupyter Notebook capable of running the scripts for the EGAP migration

## Changes

1. Un-DRY the first script to remove the need to have the entire OSF running just to run this migration.
2. Make the script work with Python 3 (which current versions of Jupyter require)
3. Add notebook
4. Copy EGAP Schema to EGAP scripts directory
5. Ignore iPython checkpoint files in git

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
_No, this is mostly an aid for testing_

  - What is the level of risk?
_Low_

    - Any permissions code touched?
_No_

    - Is this an additive or subtractive change, other?
_Additive_

  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
_By running the notebook_

    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
_N/A_

  - What features or workflows might this change impact?
_EGAP Migration_

  - How will this impact performance?
_It will not_


## Side Effects

No side effects. The reduction of DRYness was to prevent the possibility of side effects.

## Ticket

https://openscience.atlassian.net/browse/ENG-1177