### PR TITLE
[CR] Update docker-compose to support wb-oathpit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,12 +181,12 @@ services:
       - /bin/bash
       - -c
       - invoke install --develop &&
-        (python -m compileall /usr/local/lib/python3.5 || true) &&
-        rm -Rf /python3.5/* &&
-        cp -Rf -p /usr/local/lib/python3.5 /
+        (python -m compileall /usr/local/lib/python3.6 || true) &&
+        rm -Rf /python3.6/* &&
+        cp -Rf -p /usr/local/lib/python3.6 /
     restart: 'no'
     volumes:
-      - wb_requirements_vol:/python3.5
+      - wb_requirements_vol:/python3.6
       - wb_requirements_local_bin_vol:/usr/local/bin
 
   wb:
@@ -198,7 +198,7 @@ services:
     env_file:
       - .docker-compose.wb.env
     volumes:
-      - wb_requirements_vol:/usr/local/lib/python3.5
+      - wb_requirements_vol:/usr/local/lib/python3.6
       - wb_requirements_local_bin_vol:/usr/local/bin
       - osfstoragecache_vol:/code/website/osfstoragecache
       - wb_tmp_vol:/tmp
@@ -216,7 +216,7 @@ services:
     env_file:
       - .docker-compose.wb.env
     volumes:
-      - wb_requirements_vol:/usr/local/lib/python3.5
+      - wb_requirements_vol:/usr/local/lib/python3.6
       - osfstoragecache_vol:/code/website/osfstoragecache
       - wb_tmp_vol:/tmp
     stdin_open: true


### PR DESCRIPTION
# Update docker-compose.yml to support wb-oathpit

* WB is now based off of python3.6. Update wb* services to reflect this.  To set up your new WB, run the following:
    
        $ docker-compose pull wb_requirements
        $ docker volume rm osfio_wb_requirements_vol
        $ docker volume rm osfio_wb_requirements_local_bin_vol
        $ docker-compose up wb_requirements
    
You may need to stop/remove the existing wb/wb_worker containers in order to remove the old volumes.