### PR TITLE
[No Ticket] [OSF Institutions] California Lutheran University w/ SAML SSO

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1015,7 +1015,7 @@ INSTITUTIONS = {
             },
             {
                 '_id': 'callutheran',
-                'name': 'California Lutheran University [Test]',
+                'name': 'California Lutheran University CAS-SSO [Test]',
                 'description': '',
                 'banner_name': 'callutheran-banner.png',
                 'logo_name': 'callutheran-shield.png',
@@ -1024,6 +1024,18 @@ INSTITUTIONS = {
                 'domains': ['test-osf-callutheran.cos.io'],
                 'email_domains': [],
                 'delegation_protocol': 'cas-pac4j',
+            },
+            {
+                '_id': 'callutheran2',
+                'name': 'California Lutheran University SAML-SSO [Test]',
+                'description': '',
+                'banner_name': 'callutheran-banner.png',
+                'logo_name': 'callutheran-shield.png',
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('login.callutheran.edu')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
+                'domains': ['test-osf-callutheran2.cos.io'],
+                'email_domains': [],
+                'delegation_protocol': 'saml-shib',
             },
             {
                 '_id': 'capolicylab',


### PR DESCRIPTION
## Purpose

California Lutheran University decides to switch from CAS-based SSO to SAML-based SSO. The PR takes care of the `test` server.

As far as institution login is concerned, `test` and `prod` CAS / Jetty share same code (i.e. `master` branch) and some hard-coded configuration (i.e. sprint configuration, CAS attribute map, etc.). It is possible but inconvenient to switch only `test` without affecting `prod`. This is why this PR adds `callutheran2` as a new institution with a different auth but the same assets. Another benefit is that we can keep both SSO alive at the same time.

## Changes

A new institution `callutheran2`.

## DevOps Notes

- [ ] OSF: run the institution populating script with `-e test -i callutheran callutheran2`
- [ ] CAS / Shibboleth: please refer to the [CAS-PR-171](https://github.com/CenterForOpenScience/cas-overlay/pull/171)

## QA Notes

N / A

## Documentation

N / A

## Side Effects

N / A

## Ticket

No ticket but relates to: https://openscience.atlassian.net/browse/ENG-1110
