### PR TITLE
[ENG-1162] Fix 502 on filtering on parent with [ne] operator

### DIFF
--- a/api/nodes/filters.py
+++ b/api/nodes/filters.py
@@ -34,7 +34,6 @@ class NodesFilterMixin(ListFilterMixin):
         return super(NodesFilterMixin, self).param_queryset(query_params, queryset)
 
     def build_query_from_field(self, field_name, operation):
-        # import ipdb; ipdb.set_trace()
         if field_name == 'parent':
             if operation['op'] == 'eq':
                 if operation['value']:

--- a/api/nodes/filters.py
+++ b/api/nodes/filters.py
@@ -34,6 +34,7 @@ class NodesFilterMixin(ListFilterMixin):
         return super(NodesFilterMixin, self).param_queryset(query_params, queryset)
 
     def build_query_from_field(self, field_name, operation):
+        # import ipdb; ipdb.set_trace()
         if field_name == 'parent':
             if operation['op'] == 'eq':
                 if operation['value']:
@@ -47,7 +48,6 @@ class NodesFilterMixin(ListFilterMixin):
                     child_ids = (
                         NodeRelation.objects.filter(
                             is_node_link=False,
-                            child___contributors=self.get_user(),
                         )
                         .exclude(parent__type='osf.collection')
                         .exclude(child__is_deleted=True)

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -85,6 +85,10 @@ class NodesListFilteringMixin(object):
         return '{}filter[parent]='.format(url)
 
     @pytest.fixture()
+    def parent_url_ne(self, url):
+        return '{}filter[parent][ne]=null'.format(url)
+
+    @pytest.fixture()
     def root_url(self, url):
         return '{}filter[root]='.format(url)
 
@@ -108,7 +112,7 @@ class NodesListFilteringMixin(object):
             great_grandchild_node_two,
             root_ne_url, parent_url, root_url,
             contributors_url, parent_project_one,
-            child_project_one
+            child_project_one, parent_url_ne
     ):
 
         #   test_parent_filter_null
@@ -134,6 +138,16 @@ class NodesListFilteringMixin(object):
             '{}{}'.format(
                 parent_url,
                 parent_project._id
+            ),
+            auth=user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert set(expected) == set(actual)
+
+    #   test_parent_filter_ne_null
+        expected = [child_node_one._id, child_node_two._id]
+        res = app.get(
+            '{}'.format(
+                parent_url_ne
             ),
             auth=user.auth)
         actual = [node['id'] for node in res.json['data']]

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -144,7 +144,8 @@ class NodesListFilteringMixin(object):
         assert set(expected) == set(actual)
 
     #   test_parent_filter_ne_null
-        expected = [child_node_two._id, grandchild_node_one, grandchild_node_two, great_grandchild_node_two, child_project_one]
+        expected = [child_node_two._id, grandchild_node_one._id, grandchild_node_two,
+            great_grandchild_node_two._id, child_project_one._id]
         res = app.get(
             '{}'.format(
                 parent_url_ne

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -144,7 +144,7 @@ class NodesListFilteringMixin(object):
         assert set(expected) == set(actual)
 
     #   test_parent_filter_ne_null
-        expected = [child_node_one._id, child_node_two._id]
+        expected = [child_node_two._id, grandchild_node_one, grandchild_node_two, great_grandchild_node_two, child_project_one]
         res = app.get(
             '{}'.format(
                 parent_url_ne

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -144,7 +144,7 @@ class NodesListFilteringMixin(object):
         assert set(expected) == set(actual)
 
     #   test_parent_filter_ne_null
-        expected = [child_node_two._id, grandchild_node_one._id, grandchild_node_two,
+        expected = [child_node_one._id, child_node_two._id, grandchild_node_one._id, grandchild_node_two._id,
             great_grandchild_node_two._id, child_project_one._id]
         res = app.get(
             '{}'.format(

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -32,6 +32,7 @@ class RegistrationListFilteringMixin(object):
 
         self.node_A = RegistrationFactory(project=self.A, creator=self.user)
         self.node_B2 = RegistrationFactory(project=self.B2, creator=self.user)
+        self.node_B3 = RegistrationFactory(project=self.B2, creator=self.user, parent=self.node_B2)
 
         self.parent_url = '{}filter[parent]='.format(self.url)
         self.parent_url_ne = '{}filter[parent][ne]='.format(self.url)
@@ -49,10 +50,10 @@ class RegistrationListFilteringMixin(object):
         assert_equal(set(expected), set(actual))
 
     def test_parent_filter_ne_null(self):
-        expected = [self.node_A._id, self.node_B2._id]
+        expected = [self.node_B3._id]
         res = self.app.get(
             '{}null'.format(
-                self.parent_url),
+                self.parent_url_ne),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
         assert_equal(set(expected), set(actual))

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -51,7 +51,7 @@ class RegistrationListFilteringMixin(object):
         assert_equal(set(expected), set(actual))
 
     def test_parent_filter_ne_null(self):
-        expected = []
+        expected = [self.node_C._id]
         res = self.app.get(
             '{}null'.format(
                 self.parent_url_ne),

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -34,11 +34,21 @@ class RegistrationListFilteringMixin(object):
         self.node_B2 = RegistrationFactory(project=self.B2, creator=self.user)
 
         self.parent_url = '{}filter[parent]='.format(self.url)
+        self.parent_url_ne = '{}filter[parent][ne]='.format(self.url)
         self.root_url = '{}filter[root]='.format(self.url)
         self.tags_url = '{}filter[tags]='.format(self.url)
         self.contributors_url = '{}filter[contributors]='.format(self.url)
 
     def test_parent_filter_null(self):
+        expected = [self.node_A._id, self.node_B2._id]
+        res = self.app.get(
+            '{}null'.format(
+                self.parent_url),
+            auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(set(expected), set(actual))
+
+    def test_parent_filter_ne_null(self):
         expected = [self.node_A._id, self.node_B2._id]
         res = self.app.get(
             '{}null'.format(

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -32,7 +32,8 @@ class RegistrationListFilteringMixin(object):
 
         self.node_A = RegistrationFactory(project=self.A, creator=self.user)
         self.node_B2 = RegistrationFactory(project=self.B2, creator=self.user)
-        self.node_B3 = RegistrationFactory(project=self.B2, creator=self.user, parent=self.node_B2)
+        self.node_C = RegistrationFactory(project=self.B2, creator=self.user)
+        self.node_C.parent_node = self.B2
 
         self.parent_url = '{}filter[parent]='.format(self.url)
         self.parent_url_ne = '{}filter[parent][ne]='.format(self.url)
@@ -50,7 +51,7 @@ class RegistrationListFilteringMixin(object):
         assert_equal(set(expected), set(actual))
 
     def test_parent_filter_ne_null(self):
-        expected = [self.node_B3._id]
+        expected = []
         res = self.app.get(
             '{}null'.format(
                 self.parent_url_ne),

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # noqa:
 
-from osf.models import Node
+from osf.models import Node, Registration
 from framework.auth.core import Auth
 from osf_tests.factories import (
     AuthUserFactory,
@@ -32,11 +32,9 @@ class RegistrationListFilteringMixin(object):
 
         self.node_A = RegistrationFactory(project=self.A, creator=self.user)
         self.node_B2 = RegistrationFactory(project=self.B2, creator=self.user)
-        self.node_C = RegistrationFactory(project=self.B2, creator=self.user)
-        self.node_C.parent_node = self.B2
 
         self.parent_url = '{}filter[parent]='.format(self.url)
-        self.parent_url_ne = '{}filter[parent][ne]='.format(self.url)
+        self.parent_url_ne = '{}filter[parent][ne]=null'.format(self.url)
         self.root_url = '{}filter[root]='.format(self.url)
         self.tags_url = '{}filter[tags]='.format(self.url)
         self.contributors_url = '{}filter[contributors]='.format(self.url)
@@ -51,10 +49,8 @@ class RegistrationListFilteringMixin(object):
         assert_equal(set(expected), set(actual))
 
     def test_parent_filter_ne_null(self):
-        expected = [self.node_C._id]
-        res = self.app.get(
-            '{}null'.format(
-                self.parent_url_ne),
+        expected = list(Registration.objects.exclude(parent_nodes=None).values_list('guids___id', flat=True))
+        res = self.app.get(self.parent_url_ne,
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
         assert_equal(set(expected), set(actual))


### PR DESCRIPTION

## Purpose

When filtering using [parent][ne]=null on nodes, registrations, sparse or otherwise, the API gives a 502 error. This was caused because of a self.user, which is unnecessary since the endpoint should return all nodes where parent is not equal, not just the ones where the user is a contributor. 

## Changes

api.nodes.filters.py - Removing `child__contributor = self.user`

## QA Notes

Ensure the end point is functional, that all nodes with parent nodes are appearing.

## Documentation

I don't think there is any mention of this filtering on the documentation. Might be nice to add.

## Side Effects

There shouldn't be. The query I changed was specifically used for `filter[parent][ne]`.

## Ticket

https://openscience.atlassian.net/browse/ENG-1162
