### PR TITLE
[No Ticket] Remove mutable argument for EGAP

### DIFF
--- a/osf/management/commands/import_EGAP.py
+++ b/osf/management/commands/import_EGAP.py
@@ -102,7 +102,11 @@ def rollback_node_from_project_json(egap_assets_path, egap_project_dir, creator)
     return
 
 
-def recursive_upload(auth, node, dir_path, parent='', metadata=list()):
+def recursive_upload(auth, node, dir_path, parent='', metadata=None):
+
+    if metadata is None:
+        metadata = []
+
     try:
         for item in os.listdir(dir_path):
             item_path = os.path.join(dir_path, item)


### PR DESCRIPTION
## Purpose

There's a mutable argument which is holding up the EGAP migration.

## Changes

Make mutable argument non-mutable.

## QA Notes

Draft registrations for EGAP projects should have all their appropriate files.

## Documentation

Not user facing

## Side Effects

None that I know of.

## Ticket

None