### PR TITLE
EGAP Import: Ensure Registration object is created before archiver begins

### DIFF
--- a/osf/management/commands/import_EGAP.py
+++ b/osf/management/commands/import_EGAP.py
@@ -9,7 +9,6 @@ import json
 import shutil
 import requests
 import tempfile
-from django.db import transaction
 from django.core.management.base import BaseCommand
 
 from osf.utils.permissions import ADMIN, WRITE
@@ -282,11 +281,10 @@ def main(guid, creator_username):
             sanction_type = 'Embargo'
 
         logger.info(
-            'Beginning atomic transaction to register {}'.format(node._id)
+            'Attempting to register {} silently'.format(node._id)
         )
         try:
-            with transaction.atomic():
-                register_silently(draft_registration, Auth(creator), sanction_type, egap_registration_date, egap_embargo_public_date)
+            register_silently(draft_registration, Auth(creator), sanction_type, egap_registration_date, egap_embargo_public_date)
         except Exception as err:
             logger.error(
                 'Unexpected error raised when attempting to silently register '


### PR DESCRIPTION
## Purpose

Makes the registration creation process in EGAP non-atomic due to a race condition between the registration object being saved to the database and archiver beginning to archive the node. 

## Changes

* Removes the use of an atomic transaction around the `register_silently`

## QA Notes

Testing will be wrapped into general EGAP testing