### PR TITLE
[Feature] Update osf-standard-predata schema text

### DIFF
--- a/website/project/metadata/osf-standard-2.json
+++ b/website/project/metadata/osf-standard-2.json
@@ -7,20 +7,20 @@
         "id": "page1",
         "questions": [{
             "qid": "datacompletion",
-            "title": "Has data collection begun for this project?",
+            "title": "Data collection status",
             "nav": "Data Completion",
             "type": "choose",
             "format": "singleselect",
             "options": ["No, data collection has not begun", "Yes, data collection is underway or complete"],
-            "description": "Please choose"
+            "description": "Has data collection begun for this project?"
         },{
             "qid": "looked",
-            "title": "Have you looked at the data?",
+            "title": "Data access status",
             "nav": "Looked at Data",
             "type": "choose",
             "format": "singleselect",
             "options": ["Yes", "No"],
-            "description": "Please choose"
+            "description": "Have you looked at the data?"
         },{
             "qid": "comments",
             "title": "Other Comments",


### PR DESCRIPTION
## Purpose

To change the `title` and `description` text in `osf-standard-predata` to match new wording.

## Changes

- Update the `osf-standard-predata` schema

## QA Notes

Should be tested to make sure wording is accurate against the new changes.

## Documentation

`N/A`

## Side Effects

`N/A`

## Ticket

`N/A`