### PR TITLE
Update wording for Open-ended schema

### DIFF
--- a/website/project/metadata/osf-open-ended-2.json
+++ b/website/project/metadata/osf-open-ended-2.json
@@ -7,11 +7,10 @@
         "title": "Summary",
         "questions": [{
             "qid": "summary",
-            "title": "Summary",
             "nav": "Summary",
             "type": "string",
             "format": "textarea",
-            "description": "Provide a narrative summary of what is contained in this registration, or how it differs from prior registrations."
+            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here."
         }]
     }]
 }

--- a/website/project/metadata/osf-open-ended-2.json
+++ b/website/project/metadata/osf-open-ended-2.json
@@ -10,7 +10,8 @@
             "nav": "Summary",
             "type": "string",
             "format": "textarea",
-            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here."
+            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here.",
+            "required": true
         }]
     }]
 }

--- a/website/project/metadata/osf-open-ended-2.json
+++ b/website/project/metadata/osf-open-ended-2.json
@@ -10,8 +10,7 @@
             "nav": "Summary",
             "type": "string",
             "format": "textarea",
-            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here.",
-            "required": true
+            "description": "Provide a narrative summary of what is contained in this registration, or how it differs from prior registrations."
         }]
     }]
 }

--- a/website/project/metadata/osf-open-ended-3.json
+++ b/website/project/metadata/osf-open-ended-3.json
@@ -1,0 +1,28 @@
+{
+    "name": "Open-Ended Registration",
+    "version": 3,
+    "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length.",
+    "pages": [{
+        "id": "page1",
+        "title": "Summary",
+        "questions": [{
+            "qid": "summary",
+            "nav": "Summary",
+            "type": "object",
+            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here.",
+            "properties": [
+                {
+                    "id": "question",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true
+                },
+                {
+                    "id": "uploader",
+                    "type": "osf-upload",
+                    "format": "osf-upload-toggle"
+                }
+            ]
+        }]
+    }]
+}


### PR DESCRIPTION
## Purpose

- Update the wording of the Open-ended Registration Schema.
- Make question required

## Changes

- Removed redundant question header
- Update description text
- make question required
## QA Notes

- Since the question was made to `required` there may be some issues with existing registrations. If it breaks some registrations, this (input required version) may need to be added as a new schema

## Documentation

N/A

## Side Effects

- Potential weirdness with existing registrations that have no content
- Since the question heading is now removed, this may cause visual weirdness potentially?

## Ticket

N/A