### PR TITLE
[fix] handle special question format/type for EGAP

### DIFF
--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -31,6 +31,7 @@ FORMAT_TYPE_TO_TYPE_MAP = {
     ('singleselect', 'choose'): 'single-select-input',
     ('text', 'string'): 'short-text-input',
     ('textarea', 'osf-author-import'): 'contributors-input',
+    ('textarea', None): 'long-text-input',
     ('textarea', 'string'): 'long-text-input',
     ('textarea-lg', None): 'long-text-input',
     ('textarea-lg', 'string'): 'long-text-input',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
the new EGAP registration has questions of format `'textarea'` and type `None`, and this is new. It breaks the schema block migration.
<!-- Describe the purpose of your changes -->
