### PR TITLE
[ENG-888] [OSF Institutions] Add University of British Columbia - Prod

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -645,6 +645,18 @@ INSTITUTIONS = {
                 'delegation_protocol': 'saml-shib',
             },
             {
+                '_id': 'ubc',
+                'name': 'University of British Columbia',
+                'description': 'Users are reminded to ensure their use of this service is in compliance with all <a href="https://universitycounsel.ubc.ca/policies/">UBC Policies and Standards</a>. Please refer specifically to <a href="https://universitycounsel.ubc.ca/files/2015/08/policy85.pdf">Policy 85</a>, <a href="https://universitycounsel.ubc.ca/files/2013/06/policy104.pdf">Policy 104</a>, and the <a href="https://cio.ubc.ca/node/1073">Information Security Standards</a>. Find out more about <a href="http://openscience.ubc.ca">OSF</a>. Get help with <a href="https://researchdata.library.ubc.ca/">Research Data Management</a>.',
+                'banner_name': 'ubc-banner.png',
+                'logo_name': 'ubc-shield.png',
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://authentication.ubc.ca')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
+                'domains': ['osf.openscience.ubc.ca'],
+                'email_domains': [],
+                'delegation_protocol': 'saml-shib',
+            },
+            {
                 '_id': 'uc',
                 'name': 'University of Cincinnati',
                 'description': 'In partnership with the <a href="https://research.uc.edu/home/officeofresearch/administrativeoffices.aspx">Office of Research</a>, <a href="https://www.libraries.uc.edu/">UC Libraries</a> and <a href="https://www.uc.edu/ucit.html">IT&#64;UC</a>. Projects must abide by <a href="http://www.uc.edu/infosec/policies.html">Security (9.1.27) and Data Protection (9.1.1) Policies.</a> Learn more by visiting <a href="https://libraries.uc.edu/digital-scholarship/data-services.html">Research Data & GIS services</a>.',


### PR DESCRIPTION
## Purpose

Add University of British Columbia - Prod Server Only

cc @mfraezz 

- Auth is SAML2 / Shibboleth, IdP is not in InCommon and IdP has customized attributes.

  - [x] CAS Prod: Add the following XSL to `institutions-auth.xsl` in the section for institutions using the SAML protocol.

```
<!-- University of British Columbia (UBC) -->
<xsl:when test="$idp='https://authentication.ubc.ca'">
    <id>ubc</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <fullname><xsl:value-of select="//attribute[@name='displayName']/@value"/></fullname>
        <familyName/>
        <givenName/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

  - [x] Shibboleth Prod: `shibboleth2.xml`

```
<!-- University of British Columbia (UBC) -->
<MetadataProvider type="XML"
                  uri="https://authentication.ubc.ca/idp/shibboleth"
                  backingFilePath="ubc-idp-metadata.xml"
                  reloadInterval="86400" />
```

  - [x] Shibboleth Prod: `attribute-map.xml`

```
<!-- University of British Columbia (UBC)  -->
<Attribute name="urn:oid:1.3.6.1.4.1.60.1.7.1" name="ubcEduPersistentID" id="persistent-id"/>
```

</br>

- [x] Branded / redirect domain: `osf.openscience.ubc.ca`

- [ ] Run `python -m scripts.populate_institutions -e prod -i ubc` on OSF Prod

FYI, here is the [PR](https://github.com/CenterForOpenScience/osf.io/pull/9143) and the [ticket](https://openscience.atlassian.net/browse/ENG-813) for previous `test` server setup.

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-888
