### PR TITLE
[Fix] osf-standard-predata tests

### DIFF
--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -339,7 +339,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\'' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\'' \
                                    ' field is invalid, your response must be one of the provided options.'
 
     def test_registration_metadata_question_keys_must_be_value(
@@ -353,7 +353,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\'' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\'' \
                                    ' field is invalid, your response must be one of the provided options.'
 
     def test_question_in_registration_metadata_must_be_in_schema(
@@ -382,7 +382,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\' field' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\' field' \
                                    ' is invalid, your response must be one of the provided options.'
 
     def test_cannot_update_registration_schema(

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -663,7 +663,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\' field' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\' field' \
                                    ' is invalid, your response must be one of the provided options.'
 
     def test_registration_metadata_question_keys_must_be_value(
@@ -683,7 +683,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\' ' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\' ' \
                                    'field is invalid, your response must be one of the provided options.'
 
     def test_question_in_registration_metadata_must_be_in_schema(
@@ -724,7 +724,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         errors = res.json['errors'][0]
         assert res.status_code == 400
-        assert errors['detail'] == 'For your registration your response to the \'Has data collection begun for this project?\'' \
+        assert errors['detail'] == 'For your registration your response to the \'Data collection status\'' \
                                    ' field is invalid, your response must be one of the provided options.'
 
     def test_registration_responses_must_be_a_dictionary(


### PR DESCRIPTION
## Purpose

To update the tests using the `osf-standard-predata` schema

## Changes

- Update wording in `test_node_draft_registration_detail.py`
- Update wording in `test_node_draft_registration_list.py`

## QA Notes

`N/A`

## Documentation

`N/A`

## Side Effects

`N/A`

## Ticket

`N/A`