### PR TITLE
Place text area and file input directly under `questions` field

### DIFF
--- a/website/project/metadata/osf-open-ended-3.json
+++ b/website/project/metadata/osf-open-ended-3.json
@@ -5,24 +5,20 @@
     "pages": [{
         "id": "page1",
         "title": "Summary",
-        "questions": [{
-            "qid": "summary",
-            "nav": "Summary",
-            "type": "object",
-            "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here.",
-            "properties": [
-                {
-                    "id": "question",
-                    "type": "string",
-                    "format": "textarea",
-                    "required": true
-                },
-                {
-                    "id": "uploader",
-                    "type": "osf-upload",
-                    "format": "osf-upload-toggle"
-                }
-            ]
-        }]
+        "questions": [
+            {
+                "qid": "summary",
+                "type": "string",
+                "format": "textarea",
+                "nav": "Summary",
+                "description": "Provide a narrative summary of what is contained in this registration or how it differs from prior registrations. If this project contains documents for a preregistration, please note that here.",
+                "required": true
+            },
+            {
+                "qid": "uploader",
+                "type": "osf-upload",
+                "format": "osf-upload-toggle"
+            }
+        ]
     }]
 }


### PR DESCRIPTION
## Purpose
Change structure of V3 open-ended schema.

## Changes
Put text input and file input directly under `questions` property of schema
## QA Notes
There should be no duplicate text when viewing the open-ended schema. Please verify that this is the case :)

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
