### PR TITLE
fix: avoid using typedmodels in migrations

### DIFF
--- a/osf/management/commands/migrate_registration_responses.py
+++ b/osf/management/commands/migrate_registration_responses.py
@@ -33,17 +33,19 @@ def get_registration_schema(registration_or_draft):
         schema = registration_or_draft.registered_schema.first()
     return schema
 
-def migrate_registrations(dry_run, rows='all', RegistrationModel=None):
+def migrate_registrations(dry_run, rows='all', AbstractNodeModel=None):
     """
     Loops through registrations whose registration_responses have not been migrated,
     and pulls this information from the "registered_meta" and flattens it, with
     keys being the "registration_response_key"s and values being the most deeply
     nested user response in registered_meta
     """
-    if RegistrationModel is None:
-        RegistrationModel = apps.get_model('osf.Registration')
+    if AbstractNodeModel is None:
+        AbstractNodeModel = apps.get_model('osf', 'abstractnode')
 
-    registrations = RegistrationModel.objects.exclude(
+    registrations = AbstractNodeModel.objects.filter(
+        type='osf.registration',
+    ).exclude(
         registration_responses_migrated=True,
     )
     return migrate_responses(registrations, 'registrations', dry_run, rows)
@@ -56,7 +58,7 @@ def migrate_draft_registrations(dry_run, rows='all', DraftRegistrationModel=None
     :params rows
     """
     if DraftRegistrationModel is None:
-        DraftRegistrationModel = apps.get_model('osf.DraftRegistration')
+        DraftRegistrationModel = apps.get_model('osf', 'draftregistration')
 
     draft_registrations = DraftRegistrationModel.objects.exclude(
         registration_responses_migrated=True

--- a/osf/migrations/0193_migrate_registered_meta.py
+++ b/osf/migrations/0193_migrate_registered_meta.py
@@ -45,7 +45,7 @@ def migrate_registration_registered_meta(state, schema):
     migrate_registrations(
         dry_run=False,
         rows='all',
-        RegistrationModel=state.get_model('osf', 'registration')
+        AbstractNodeModel=state.get_model('osf', 'abstractnode')
     )
 
 class Migration(migrations.Migration):


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Avoid an error when migrating registration responses -- historical models in django don't have custom managers, so `Registration.objects.all()` will apparently return `Node`s of *any* type, not just `Registration`
<!-- Describe the purpose of your changes -->

## Changes
In code used by migrations, use `AbstractNode` filtered by `type='osf.registration'` instead of `Registration`.
<!-- Briefly describe or list your changes  -->
