### PR TITLE
fix: registered-report schema typo

### DIFF
--- a/website/project/metadata/registered-report-3.json
+++ b/website/project/metadata/registered-report-3.json
@@ -4,7 +4,7 @@
     "config": {
       "hasFiles": true
     },
-    "description": "You will be asked a few simple questions about your study and given the chance to attach your accepted manuscript to the form. Use this form after receiving an \"in-principle acceptance\" from a journal the offers the Registered Reports format. See https://cos.io/rr for more information.",
+    "description": "You will be asked a few simple questions about your study and given the chance to attach your accepted manuscript to the form. Use this form after receiving an \"in-principle acceptance\" from a journal offering the Registered Reports format. See https://cos.io/rr for more information.",
     "pages": [{
         "id": "page1",
         "title": "Study Information",

--- a/website/project/metadata/registered-report.json
+++ b/website/project/metadata/registered-report.json
@@ -4,7 +4,7 @@
     "config": {
       "hasFiles": true
     },
-    "description": "You will be asked a few simple questions about your study and given the chance to attach your accepted manuscript to the form. Use this form after receiving an \"in-principle acceptance\" from a journal the offers the Registered Reports format. See https://cos.io/rr for more information.",
+    "description": "You will be asked a few simple questions about your study and given the chance to attach your accepted manuscript to the form. Use this form after receiving an \"in-principle acceptance\" from a journal offering the Registered Reports format. See https://cos.io/rr for more information.",
     "pages": [{
         "id": "page1",
         "title": "Study Information",


### PR DESCRIPTION
## Purpose

Fix a typo.

## Changes

Update descriptions text in both versions of the Registered Reports schema.

## QA Notes

Low risk.

## Documentation

n/a

## Side Effects

n/a

## Ticket

n/a
