### PR TITLE
Metadata validation hot fix

### DIFF
--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -141,8 +141,12 @@ class RegistrationSchema(AbstractSchema):
                                     question['title'],
                                 ),
                             )
+                        if 'title' in question:
+                            raise ValidationError(
+                                'For your registration your response to the \'{}\' field is invalid.'.format(question['title']),
+                            )
                         raise ValidationError(
-                            'For your registration your response to the \'{}\' field is invalid.'.format(question['title']),
+                            'For your registration your response to the field with qid: \'{}\' is invalid.'.format(question['qid']),
                         )
             raise ValidationError(e)
         except jsonschema.SchemaError as e:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

There is a 500 error when trying to attach files to registration metadata when the schema does not have a title.

## Changes

osf/models/metaschema.py - Adding a check for the title attribute in the metaschema.

## QA Notes

To test, add a file to a project, and view it. Then make an open ended registration with the viewed file attached to the uploader.

## Documentation

N/A

## Side Effects

N/A
