### PR TITLE
[ENG-1375] Feature/import egap fix

### DIFF
--- a/osf/management/commands/import_EGAP.py
+++ b/osf/management/commands/import_EGAP.py
@@ -233,9 +233,13 @@ def main(guid, creator_username):
         # add selectedFileName Just so filenames are listed in the UI
         for data in non_anon_metadata:
             data['selectedFileName'] = data['data']['attributes']['name']
+            data['sha256'] = data['data']['attributes']['extra']['hashes']['sha256']
+            data['nodeId'] = node._id
 
         for data in anon_metadata:
             data['selectedFileName'] = data['data']['attributes']['name']
+            data['sha256'] = data['data']['attributes']['extra']['hashes']['sha256']
+            data['nodeId'] = node._id
 
         non_anon_titles = ', '.join([data['data']['attributes']['name'] for data in non_anon_metadata])
         registration_metadata['q37'] = {'comments': [], 'extra': non_anon_metadata, 'value': non_anon_titles}

--- a/website/project/metadata/egap-registration.json
+++ b/website/project/metadata/egap-registration.json
@@ -1,6 +1,9 @@
 {
 	"name": "EGAP Registration",
 	"version": 2,
+	"config": {
+        "hasFiles": true
+    },
 	"description": "The EGAP registry focuses on designs for experiments and observational studies in governance and politics.",
 	"pages": [{
 			"id": "page1",


### PR DESCRIPTION
## Purpose

EGAP files are not functioning properly on registration pages. What was being returned by water butler did not have the required information for the archiver, causing KeyErrors.

## Changes

Made changes to the import egap script to provider archiver with the necessary field data.

## QA Notes

-This does not require a data migration. The data will be fixed by a re-import of EGAP
-Level of risk
-There is no risk. No permissions code is touched. This is an additive change.
-Ensure file links are working properly now on the EGAP schema. This only affects the EGAP registrations, not any other registrations. Fixes for other registration schemas are coming in another PR.
-Performance should be not affected upon testing.

## Documentation

N/A

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-1375

# DevOps Notes

N/A