### PR TITLE
fix typo in waffle flag pages

### DIFF
--- a/osf/migrations/0083_add_ember_waffle_flags.py
+++ b/osf/migrations/0083_add_ember_waffle_flags.py
@@ -7,7 +7,7 @@ from django.db import migrations
 EMBER_WAFFLE_PAGES = [
     'create_draft_registration',
     'dashboard',
-    'edit_draft_registration'
+    'edit_draft_registration',
     'file_detail',
     'home',
     'meeting_detail',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix a broken waffle flag when running migrations

## Changes
Added a missing `,` in `EMBER_WAFFLE_PAGES`
Should fix the waffle flag that comes out as `ember_edit_draft_registrationfile_detail_page` (Big thanks to @adlius !)

## QA Notes
`NA`

## Documentation
`NA`
## Side Effects
`NA`
## Ticket
`NA`