### PR TITLE
[Hotfix][ENG-1418] fix python 2 error for preprint provider.

### DIFF
--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -55,7 +55,7 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
         return ('(name={self.name!r}, default_license={self.default_license!r}, '
                 'allow_submissions={self.allow_submissions!r}) with id {self.id!r}').format(self=self)
 
-    def __unicode__(self):
+    def __str__(self):
         return '[{}] {} - {}'.format(self.readable_type, self.name, self.id)
 
     @property


### PR DESCRIPTION
## Purpose

Preprint providers are being listed as thier abstract class name, not thier `__str__`.

## Changes

- fix out dated python 3 dunder.

## QA Notes

No migrations just check the list.

## Documentation

Not user facing, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1418