### PR TITLE
[No Ticket] Update docker-compose readme to use python3

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -147,28 +147,28 @@
     - _NOTE: CTRL-c will exit_
 - Run migrations:
   - After creating migrations, resetting your database, or starting on a fresh install you will need to run migrations to make the needed changes to database. This command looks at the migrations on disk and compares them to the list of migrations in the `django_migrations` database table and runs any migrations that have not been run.
-    - `docker-compose run --rm web python manage.py migrate`
+    - `docker-compose run --rm web python3 manage.py migrate`
 - Populate institutions:
   - After resetting your database or with a new install you will need to populate the table of institutions. **You must have run migrations first.**
-    - `docker-compose run --rm web python -m scripts.populate_institutions -e test -a`
+    - `docker-compose run --rm web python3 -m scripts.populate_institutions -e test -a`
 - Populate preprint, registration, and collection providers:
   - After resetting your database or with a new install, the required providers and subjects will be created automatically **when you run migrations.** To create more:
-    - `docker-compose run --rm web python manage.py populate_fake_providers`
+    - `docker-compose run --rm web python3 manage.py populate_fake_providers`
 - Populate citation styles
   - Needed for api v2 citation style rendering.
-    - `docker-compose run --rm web python -m scripts.parse_citation_styles`
+    - `docker-compose run --rm web python3 -m scripts.parse_citation_styles`
 - Start ember_osf_web
   - Needed for quickfiles feature:
     - `docker-compose up -d ember_osf_web`
 - OPTIONAL: Register OAuth Scopes
   - Needed for things such as the ember-osf dummy app
-    - `docker-compose run --rm web python -m scripts.register_oauth_scopes`
+    - `docker-compose run --rm web python3 -m scripts.register_oauth_scopes`
 - OPTIONAL: Create migrations:
   - After changing a model you will need to create migrations and apply them. Migrations are python code that changes either the structure or the data of a database. This will compare the django models on disk to the database, find the differences, and create migration code to change the database. If there are no changes this command is a noop.
-    - `docker-compose run --rm web python manage.py makemigrations`
+    - `docker-compose run --rm web python3 manage.py makemigrations`
 - OPTIONAL: Destroy and recreate an empty database:
   - **WARNING**: This will delete all data in your database.
-    - `docker-compose run --rm web python manage.py reset_db --noinput`
+    - `docker-compose run --rm web python3 manage.py reset_db --noinput`
 
 ## Application Debugging
 
@@ -211,8 +211,8 @@ $ docker-compose run --rm --service-ports web
   - Local host name: `192.168.168.167`
   - Port: `11000`
   - Path mappings: (It is recommended to use absolute path. `~/` may not work.)
-    - `/Users/<your username>/Projects/cos/osf : /code`
-    - (Optional) `/Users/<your username>/.virtualenvs/osf/lib/python2.7/site-packages : /usr/local/lib/python2.7/site-packages`
+    - `/Users/<your username>/Projects/cos/osf:/code`
+    - (Optional) `/Users/<your username>/.virtualenvs/<your virtualenv>/lib/python3.6/site-packages:/usr/local/lib/python3.6/site-packages`
   - `Single Instance only`
 - Configure `.docker-compose.env` `<APP>_REMOTE_DEBUG` environment variables to match these settings.
 
@@ -307,7 +307,7 @@ $ docker-compose pull
 
 $ docker-compose up requirements mfr_requirements wb_requirements
 # Run db migrations
-$ docker-compose run --rm web python manage.py migrate
+$ docker-compose run --rm web python3 manage.py migrate
 ```
 
 ## Miscellaneous
@@ -328,7 +328,7 @@ When using `docker-compose`, set `privileged: true` for individual containers in
 
 ```yml
 wb:
-  image: quay.io/centerforopenscience/waterbutler:develop
+  image: quay.io/centerforopenscience/wb:develop
   command: invoke server
   privileged: true
   restart: unless-stopped


### PR DESCRIPTION
## Purpose

The readme for docker-compose is outdated due to Python 3. `python` is no longer available in the containers: `web`, `api` and `worker`. We must use `python3` when running scripts and migrations.

```
bash-4.4# which python
bash-4.4# which python3
/usr/bin/python3
bash-4.4# ls -la $(which python3)
lrwxrwxrwx    1 root     root             9 Jan 16 16:13 /usr/bin/python3 -> python3.6
bash-4.4# ls -la /usr/bin/ | grep python
lrwxrwxrwx    1 root     root             9 Jan 16 16:13 python3 -> python3.6
-rwxr-xr-x    2 root     root         14144 Oct 17 11:13 python3.6
-rwxr-xr-x    2 root     root         14144 Oct 17 11:13 python3.6m
```

## Changes

Instead of modify the docker file to create a soft link for `python`, we decided to simply update the guide. 

* Updated all scripts and migration commands to use `python3`
* Updated the remote debugging guide to map the new version and the correct folder

## QA Notes

N / A

## Documentation

## Side Effects

N / A

## Ticket

N / A
