### PR TITLE
[Hotfix] Fix meeting emails Python 2 problem

### DIFF
--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -67,12 +67,13 @@ def upload_attachment(user, node, attachment):
     attachment.seek(0)
     name = (attachment.filename or settings.MISSING_FILE_NAME)
     content = attachment.read()
-    upload_url = waterbutler_api_url_for(node._id, 'osfstorage', name=name, base_url=node.osfstorage_region.waterbutler_url, cookie=user.get_or_create_cookie(), _internal=True)
+    upload_url = waterbutler_api_url_for(node._id, 'osfstorage', name=name, base_url=node.osfstorage_region.waterbutler_url, cookie=user.get_or_create_cookie().decode(), _internal=True)
 
-    requests.put(
+    resp = requests.put(
         upload_url,
         data=content,
     )
+    resp.raise_for_status()
 
 
 def upload_attachments(user, node, attachments):


### PR DESCRIPTION
## Purpose

Currently meeting nodes are being created without their file attachements, this fixes that.

## Changes

- decodes cookie so it's valid for WB
- add raise_for_status so this won't fail silently anymore

## QA Notes

You should now be able to attach a file to an email and use that to create a meeting node with that attachment uploaded.

## Documentation

🐞 fix, no docs.

## Side Effects

Since this will now throw errors when it fails, we may see new previously occuring, but unreported errors, random 500s etc. 

## Ticket

https://openscience.atlassian.net/browse/ENG-1432