### PR TITLE
[ENG-1437] EGAP emails folders fix

### DIFF
--- a/osf/management/commands/import_EGAP.py
+++ b/osf/management/commands/import_EGAP.py
@@ -70,7 +70,9 @@ def create_node_from_project_json(egap_assets_path, egap_project_dir, creator):
             email = ''
             if contributor.get('email'):
                 email = contributor.get('email').strip()
-                email = email.split('\\u00a0')[0]
+                email = email.split('\\u00a0')[0].split(',')[0]
+                if '<' in email:
+                    email = email.split('<')[1].replace('>', '')
 
             node.add_contributor_registered_or_not(
                 Auth(creator),
@@ -197,6 +199,7 @@ def main(guid, creator_username):
     # __MACOSX is a hidden file created by the os when zipping
     directory_list = [directory for directory in os.listdir(egap_assets_path) if directory not in ('egap_assets.zip', '__MACOSX') and not directory.startswith('.')]
 
+    directory_list.sort()
     for egap_project_dir in directory_list:
         logger.info(
             'Attempting to import the follow directory: {}'.format(egap_project_dir)
@@ -230,22 +233,30 @@ def main(guid, creator_username):
         with open(os.path.join(egap_assets_path, egap_project_dir, 'registration-schema.json'), 'r') as fp:
             registration_metadata = json.load(fp)
 
-        # add selectedFileName Just so filenames are listed in the UI
+        # add selectedFileName Just so filenames are listed in the UIj
+        non_anon_metadata_dict = []
         for data in non_anon_metadata:
+            if data['data']['attributes']['kind'] == 'folder':
+                continue
             data['selectedFileName'] = data['data']['attributes']['name']
             data['sha256'] = data['data']['attributes']['extra']['hashes']['sha256']
             data['nodeId'] = node._id
+            non_anon_metadata_dict.append(data)
 
+        anon_metadata_dict = []
         for data in anon_metadata:
+            if data['data']['attributes']['kind'] == 'folder':
+                continue
             data['selectedFileName'] = data['data']['attributes']['name']
             data['sha256'] = data['data']['attributes']['extra']['hashes']['sha256']
             data['nodeId'] = node._id
+            anon_metadata_dict.append(data)
 
-        non_anon_titles = ', '.join([data['data']['attributes']['name'] for data in non_anon_metadata])
-        registration_metadata['q37'] = {'comments': [], 'extra': non_anon_metadata, 'value': non_anon_titles}
+        non_anon_titles = ', '.join([data['data']['attributes']['name'] for data in non_anon_metadata_dict])
+        registration_metadata['q37'] = {'comments': [], 'extra': non_anon_metadata_dict, 'value': non_anon_titles}
 
-        anon_titles = ', '.join([data['data']['attributes']['name'] for data in anon_metadata])
-        registration_metadata['q38'] = {'comments': [], 'extra': anon_metadata, 'value': anon_titles}
+        anon_titles = ', '.join([data['data']['attributes']['name'] for data in anon_metadata_dict])
+        registration_metadata['q38'] = {'comments': [], 'extra': anon_metadata_dict, 'value': anon_titles}
 
         # DraftRegistration Creation
         draft_registration = DraftRegistration.create_from_node(


### PR DESCRIPTION

## Purpose

Folders in EGAP projects were causing the import EGAP script to fail. These aren't necessary, for the metadata, so we'll just remove them. Some emails were also failing out, so I added some trimming for those. Also added a .sort() to the directories so they would process in order of directory name

## Changes

Various fixes in import_EGAP.py

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
Nope
  - What is the level of risk?
Shouldn't be any
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Mostly additive. Adding functionality to remove any folders from the metadata, as well as additional email grooming.
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Ensure links to files are still working in the metadata.
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
  - How will this impact performance?
n/A
-->

## Documentation

N/A

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-1437
