### PR TITLE
[ENG-1452] api::guids::files - Return referent relationship with referent._id as id

### DIFF
--- a/api/guids/serializers.py
+++ b/api/guids/serializers.py
@@ -28,13 +28,16 @@ def get_related_view(record):
 
 def get_related_view_kwargs(record):
     kind = get_type(record)
+    related_id = '<_id>'
     # slight hack, works for existing types
     singular = kind.rstrip('s')
     # The registration view_kwarg is node_id
     if singular == 'registration':
         singular = 'node'
+    elif singular == 'file':
+        related_id = '<referent._id>'
     return {
-        '{}_id'.format(singular): '<_id>',
+        '{}_id'.format(singular): related_id,
     }
 
 class GuidSerializer(JSONAPISerializer):


### PR DESCRIPTION
# Purpose
Front end - PR: https://github.com/CenterForOpenScience/ember-osf-web/pull/942
Due to recent upgrades ember-data, the frontend errors when
we lookup file detail using the guid `/v2/files/wsfvj` and return id as the long _id.
If the file record is present in the store with identifier (ember-data) `file:file_long_id` (say you've loaded the list of quickfiles before the detail view),  ember-data IdentifierCache triesto make a new identifier (`file:guid`) but realize that record already exists and fails to merge both identifiers. 
 
## Changes

Fix consist of returning the guid referent relationship with file_long_id (referent._id) as id when we look up the guid. This allow us to look up the file detail using `/v2/files/file_long_id`. 

## QA Notes

Assuming we have good test coverage on the backend and all travis tests pass, test this changes with the accompanying frontend ticket for ENG-1452.

## Documentation

Probably

## Ticket
[ENG-1452](https://openscience.atlassian.net/browse/ENG-1452)