### PR TITLE
[ENG-1462][ENG-1482] Return proper type for user::user-settings relationship

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -871,6 +871,9 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                     elif related_type == 'schemas' and related_class.view_name == 'registration-schema-detail':
                         related_id = resolved_url.kwargs['schema_id']
                         related_type = 'registration-schemas'
+                    elif related_type == 'users' and related_class.view_name == 'user_settings':
+                        related_id = resolved_url.kwargs['user_id']
+                        related_type = 'user-settings'
                     else:
                         related_id = resolved_url.kwargs[related_type[:-1] + '_id']
                 except KeyError:


### PR DESCRIPTION
## Purpose

With recent  ember-data upgrade, this inconsistency in resource types is not taken lightly and causes undesirable issues on the front-end.

## Changes

- Update base serializer to return `user-settings` (instead of `users`) as type for user_settings relationship.

## QA Notes
- This change should fix issues outlined in on the frontend.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
 [ENG-1462](https://openscience.atlassian.net/browse/ENG-1462)
[ENG-1482](https://openscience.atlassian.net/browse/ENG-1482)
