### PR TITLE
[hotfix] Fixing set unions in can view

### DIFF
--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -19,6 +19,8 @@ def registration_with_children(user):
     project = ProjectFactory(creator=user)
     NodeFactory(parent=project, creator=user)
     NodeFactory(parent=project, creator=user)
+    NodeFactory(parent=project, creator=user)
+    NodeFactory(parent=project, creator=user)
     return RegistrationFactory(
         project=project
     )
@@ -56,7 +58,7 @@ def registration_with_children_approved_url(registration_with_children_approved)
 class TestRegistrationsChildrenList:
 
     def test_registrations_children_list(self, user, app, registration_with_children, registration_with_children_url):
-        component_one, component_two = registration_with_children.nodes
+        component_one, component_two, component_three, component_four = registration_with_children.nodes
 
         res = app.get(registration_with_children_url, auth=user.auth)
         ids = [node['id'] for node in res.json['data']]
@@ -67,7 +69,7 @@ class TestRegistrationsChildrenList:
         assert component_two._id in ids
 
     def test_return_registrations_list_no_auth_approved(self, user, app, registration_with_children_approved, registration_with_children_approved_url):
-        component_one, component_two = registration_with_children_approved.nodes
+        component_one, component_two, component_three, component_four = registration_with_children_approved.nodes
 
         res = app.get(registration_with_children_approved_url)
         ids = [node['id'] for node in res.json['data']]
@@ -86,7 +88,7 @@ class TestRegistrationsChildrenList:
     def test_registration_children_no_auth_vol(self, user, app, registration_with_children,
             registration_with_children_url, view_only_link):
         # viewed through private link
-        component_one, component_two = registration_with_children.nodes
+        component_one, component_two, component_three, component_four = registration_with_children.nodes
 
         # get registration related_counts with vol before vol is attached to components
         node_url = '/{}registrations/{}/?related_counts=children&view_only={}'.format(API_BASE,
@@ -106,6 +108,8 @@ class TestRegistrationsChildrenList:
         # view only link now attached to components
         view_only_link.nodes.add(component_one)
         view_only_link.nodes.add(component_two)
+        view_only_link.nodes.add(component_three)
+        view_only_link.nodes.add(component_four)
         res = app.get(view_only_link_url)
         ids = [node['id'] for node in res.json['data']]
         assert res.status_code == 200
@@ -114,13 +118,19 @@ class TestRegistrationsChildrenList:
 
         # get registration related_counts with vol once vol is attached to components
         res = app.get(node_url)
-        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 2
+        assert res.json['data']['relationships']['children']['links']['related']['meta']['count'] == 4
 
         # make private vol anonymous
         view_only_link.anonymous = True
         view_only_link.save()
         res = app.get(view_only_link_url)
         assert 'contributors' not in res.json['data'][0]['relationships']
+
+        child_ids = [item['id'] for item in res.json['data']]
+        assert component_one._id in child_ids
+        assert component_two._id in child_ids
+        assert component_three._id in child_ids
+        assert component_four._id in child_ids
 
         # delete vol
         view_only_link.is_deleted = True
@@ -133,7 +143,7 @@ class TestRegistrationsChildrenList:
 class TestRegistrationChildrenListFiltering:
 
     def test_registration_child_filtering(self, app, user, registration_with_children):
-        component_one, component_two = registration_with_children.nodes
+        component_one, component_two, component_three, component_four = registration_with_children.nodes
 
         url = '/{}registrations/{}/children/?filter[title]={}'.format(
             API_BASE,

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -149,7 +149,8 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
             if not isinstance(private_link, basestring):
                 raise TypeError('"private_link" must be either {} or {}. Got {!r}'.format(str, PrivateLink, private_link))
 
-            qs |= self.filter(private_links__is_deleted=False, private_links__key=private_link)
+            #id_list = [item.id for item in qs]
+            return self.filter(private_links__is_deleted=False, private_links__key=private_link).filter(is_deleted=False)
 
         if user is not None and not isinstance(user, AnonymousUser):
             read_user_query = get_objects_for_user(user, READ_NODE, self, with_superuser=False)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -149,7 +149,6 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
             if not isinstance(private_link, basestring):
                 raise TypeError('"private_link" must be either {} or {}. Got {!r}'.format(str, PrivateLink, private_link))
 
-            #id_list = [item.id for item in qs]
             return self.filter(private_links__is_deleted=False, private_links__key=private_link).filter(is_deleted=False)
 
         if user is not None and not isinstance(user, AnonymousUser):

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -4533,7 +4533,15 @@ class TestAdminImplicitRead(object):
         return ProjectFactory(is_public=False, creator=creator)
 
     @pytest.fixture()
+    def project_public(self, creator):
+        return ProjectFactory(is_public=True, creator=creator)
+
+    @pytest.fixture()
     def lvl1component(self, project):
+        return ProjectFactory(is_public=False, parent=project)
+
+    @pytest.fixture()
+    def lvl1component_two(self, project):
         return ProjectFactory(is_public=False, parent=project)
 
     @pytest.fixture()
@@ -4589,6 +4597,21 @@ class TestAdminImplicitRead(object):
 
         assert lvl1component in qs
         assert project not in qs
+
+    def test_private_link_public(self, project, lvl1component,
+            lvl1component_two, project_public):
+        pl = PrivateLinkFactory()
+
+        lvl1component.private_links.add(pl)
+        lvl1component_two.private_links.add(pl)
+
+        qs = Node.objects.can_view(user=None, private_link=pl)
+
+        assert project not in qs
+        assert project_public not in qs
+        assert lvl1component in qs
+        assert lvl1component_two in qs
+        assert len(qs) == 2
 
 
 class TestNodeProperties:


### PR DESCRIPTION
## Purpose

Fixing anonymous view only links results.

## Changes

Editing osf/models/node.AbstractNodeQuerySet.can_view to fix issues with set union operator.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
Does not require data migration
  - What is the level of risk?
Might affect other view only links, but shouldn't
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive and subtractive. Modifying logic.
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Run API tests.
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version. Endpoint /v2/registration/{reg_id}/children
  - What features or workflows might this change impact?
  - How will this impact performance?
-->

## DevNotes

How I replicated:
Create a project with four children, then register the parent project. On the parent registration, create an anonymous view only link, but don't select all the components for that view only link. Go to /v2/registrations/{reg_id}/children using the view only link key.

## Documentation

N/A

## Side Effects

View only links will now no longer allow public nodes to show unless they're included in the view only link. This means, if you have a node with four children, all public, and you make a view only link for only two of those children plus the parent, then you'll only see the parent and the two children. But also, if you go wandering around the rest of the site, you'll not be able to see any nodes that don't belong to that view only link. 

This behavior was verified to be correct with Product.

## Ticket

https://openscience.atlassian.net/browse/ENG-1493
