### PR TITLE
[ENG-1366] Add cookie setting to track logged out users

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -227,6 +227,7 @@ MIDDLEWARE = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    'api.base.middleware.SloanIdMiddleware',
 )
 
 TEMPLATES = [
@@ -328,3 +329,5 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
 }
+
+SLOAN_ID_COOKIE_NAME = 'sloan_id'

--- a/api_tests/sloan/test_sloan_metrics.py
+++ b/api_tests/sloan/test_sloan_metrics.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+import datetime
+
+import itsdangerous
+import jwe
+import jwt
+import mock
+from django.utils import timezone
+from framework.auth.core import Auth
+from tests.base import OsfTestCase
+from api_tests.utils import create_test_preprint_file
+from osf_tests.factories import (
+    AuthUserFactory,
+    PreprintFactory,
+)
+from website import settings
+from website.util import api_url_for
+from waffle.testutils import override_switch
+
+from osf.models import Session
+from osf.features import (
+    ELASTICSEARCH_METRICS,
+    SLOAN_COI_DISPLAY,
+    SLOAN_DATA_DISPLAY
+)
+
+from api.base.settings.defaults import SLOAN_ID_COOKIE_NAME
+from tests.json_api_test_app import JSONAPITestApp
+
+django_app = JSONAPITestApp()
+
+
+class TestSloanMetrics(OsfTestCase):
+
+    def setUp(self):
+        super(TestSloanMetrics, self).setUp()
+        self.user = AuthUserFactory()
+        self.auth_obj = Auth(user=self.user)
+        self.preprint = PreprintFactory(creator=self.user, is_public=True)
+        self.session = Session(data={'auth_user_id': self.user._id})
+        self.session.save()
+        self.cookie = itsdangerous.Signer(settings.SECRET_KEY).sign(self.session._id).decode()
+        self.JWE_KEY = jwe.kdf(settings.WATERBUTLER_JWE_SECRET.encode('utf-8'), settings.WATERBUTLER_JWE_SALT.encode('utf-8'))
+
+    def build_url(self, **kwargs):
+        options = {'payload': jwe.encrypt(jwt.encode({'data': dict(dict(
+            action='download',
+            nid=self.preprint._id,
+            metrics={'uri': settings.MFR_SERVER_URL},
+            provider='osfstorage'), **kwargs),
+            'exp': timezone.now() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
+        }, settings.WATERBUTLER_JWT_SECRET, algorithm=settings.WATERBUTLER_JWT_ALGORITHM), self.JWE_KEY)}
+        return api_url_for('get_auth', **options)
+
+    @mock.patch('osf.metrics.PreprintDownload.record_for_preprint')
+    def test_unauth_user_downloads_preprint(self, mock_record):
+        test_file = create_test_preprint_file(self.preprint, self.user)
+        resp = django_app.get('/v2/')
+
+        # tests unauthenticated user gets cookie.
+        assert f'{SLOAN_ID_COOKIE_NAME}=' in resp.headers.get('Set-Cookie')
+        sloan_cookie_value = resp.headers['Set-Cookie'].split('=')[1].split(';')[0]
+
+        # tests cookies get sent to impact
+        self.app.set_cookie(SLOAN_COI_DISPLAY, 'True')
+        self.app.set_cookie(SLOAN_DATA_DISPLAY, 'False')
+        self.app.set_cookie(SLOAN_ID_COOKIE_NAME, sloan_cookie_value)
+        with override_switch(ELASTICSEARCH_METRICS, active=True):
+            self.app.get(self.build_url(path=test_file.path))
+
+        mock_record.assert_called_with(
+            path=test_file.path,
+            preprint=self.preprint,
+            user=None,
+            version='1',
+            sloan_coi='True',
+            sloan_data='False',
+            sloan_id=sloan_cookie_value,
+            sloan_prereg=None,
+        )

--- a/framework/csrf/handlers.py
+++ b/framework/csrf/handlers.py
@@ -31,7 +31,7 @@ def before_request():
 
 
 def after_request(resp):
-    """Set a cookie specified by api_settings.CSRF_COOKI_NAME so that
+    """Set a cookie specified by api_settings.CSRF_COOKIE_NAME so that
     session-authenticated requests from the legacy frontend can pass
     CSRF verification.
     """

--- a/osf/features.py
+++ b/osf/features.py
@@ -9,6 +9,17 @@ OSF_PREREGISTRATION = 'osf_preregistration'
 OSF_GROUPS = 'osf_groups'
 ENABLE_CHRONOS = 'enable_chronos'
 
+
+# The SLOAN_..._INPUT values are the names of switches that allow users to input their sloan info,
+SLOAN_COI_INPUT = 'sloan_coi_input'
+SLOAN_DATA_INPUT = 'sloan_data_input'
+SLOAN_PREREG_INPUT = 'sloan_prereg_input'
+
+# The SLOAN_..._DISPLAY values are flags control when those features are visible for individual users.
+SLOAN_COI_DISPLAY = 'sloan_coi_display'
+SLOAN_DATA_DISPLAY = 'sloan_data_display'
+SLOAN_PREREG_DISPLAY = 'sloan_prereg_display'
+
 EMBER_AB_TESTING_HOME_PAGE_VERSION_B = 'ab_testing_home_page_version_b'
 EMBER_AB_TESTING_HOME_PAGE_HERO_TEXT_VERSION_B = 'ab_testing_home_page_hero_text_version_b'
 EMBER_AUTH_REGISTER = 'ember_auth_register'


### PR DESCRIPTION
## Purpose

Make sure user information is recorded for preprints as part of our Sloan study.

## Changes

- adds a cookie to identify logged out users
- adds a cookie value to preprints metrics info

## QA Notes

Dev test only

The best way to test this is to create a preprint and then view/download it* and then check in the shell that the metrics were recorded correctly. https://elasticsearch-py.readthedocs.io/en/master/
`PreprintDownload.search().filter('exists', field='cookie').execute()` will return all downloads with a cookie. 

* with a user who isn't a contributor!

* We should verify that there is existing Impact data on staging before rolling this out, to verify that it transitions properly to having the new, additional data when this is added.

## Documentation

Not user facing, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1366