### PR TITLE
[No Ticket] Logout URL for Boys Town

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -996,7 +996,7 @@ INSTITUTIONS = {
                 'banner_name': 'bt-banner.png',
                 'logo_name': 'bt-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://sts.windows.net/e2ab7419-36ab-4a95-a19f-ee90b6a9b8ac/')),
-                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://myapps.microsoft.com')),
                 'domains': ['test-osf-bt.cos.io'],
                 'email_domains': [],
                 'delegation_protocol': 'saml-shib',


### PR DESCRIPTION
## Purpose

Boys Town has a special case that they want 1) users to start from their "MyApps" for login and 2) users being redirected back to "MyApps" after logout. We are enabling this feature on the test server for them to test.

- Login
  - [ ] Inform them of the URL they need to directly login from "MyApps" on the test server: `https://accounts.test.osf.io/Shibboleth.sso/Login?entityID=https%3A%2F%2Fsts.windows.net%2Fe2ab7419-36ab-4a95-a19f-ee90b6a9b8ac%2F&target=%2Flogin%3Fservice%3Dhttps%253A%252F%252Ftest.osf.io%252Flogin%252F%253Fnext%253Dhttps%25253A%25252F%25252Ftest.osf.io%25252F`
- Logout
  - Replaced `https://test.osf.io/goodbye` with `https://myapps.microsoft.com`

### DevOps Notes

cc @mfraezz 

- [ ] Merge, deploy and then populate the scripts with `-e test -i bt`.
- [x] No CAS / Shibboleth / Charts

## Changes

Add a dedicated logout URL for BT to test.

> This would be a log out of OSF then go to https://myapps.microsoft.com and stay logged into this.  We can test this and if it works that’s great.

## QA Notes

Boys Town will test this feature.

## Documentation

N / A

## Side Effects

N / A

## Ticket

N / A
