### PR TITLE
[ENG-1560] [OSF Institutions] Logout URL for Boys Town (Prod OSF)

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -138,7 +138,7 @@ INSTITUTIONS = {
                 'banner_name': 'bt-banner.png',
                 'logo_name': 'bt-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://sts.windows.net/e2ab7419-36ab-4a95-a19f-ee90b6a9b8ac/')),
-                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://myapps.microsoft.com')),
                 'domains': ['osf.boystownhospital.org'],
                 'email_domains': [],
                 'delegation_protocol': 'saml-shib',


### PR DESCRIPTION
## Purpose

Boys Town has a special case that they want 1) users to start from their "MyApps" for login and 2) users being redirected back to "MyApps" after logout. Test server works as expected so we move forward to production. See https://github.com/CenterForOpenScience/osf.io/pull/9301

- Login
  - [x] Informed Boys Town  of the URL they need in order to directly log in from "MyApps" on the prod server:https://accounts.osf.io/login?campaign=institution&service=https%3A%2F%2Fosf.io%2Flogin%2F%3Fnext%3Dhttps%253A%252F%252Fosf.io%252F. Explicit user consent is still required.
- Logout
  - Replaced `https://test.osf.io/goodbye` with `https://myapps.microsoft.com`

### DevOps Notes

cc @mfraezz 

- [ ] Merge, deploy and then populate the scripts with `-e prod -i bt`.
- [ ] No CAS / Shibboleth / Charts

## Changes

Add a dedicated logout URL for BT prod.

## QA Notes

Boys Town will confirm this feature on prod.

## Documentation

N / A

## Side Effects

N / A

## Ticket

https://openscience.atlassian.net/browse/ENG-1560
