### PR TITLE
[ENG-1563] Fixing permissions for draft registrations. Adding a test

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -190,7 +190,9 @@ class DraftMixin(object):
             raise ValidationError('This draft registration is not created from the given node.')
 
     def check_resource_permissions(self, resource):
-        # Old workflow checks permissions on attached node, not draft
+        # If branched from a node, use the node's contributor permissions. See [ENG-1563]
+        if resource.branched_from_type == 'Node':
+            resource = resource.branched_from
         return self.check_object_permissions(self.request, resource)
 
     def get_draft(self, draft_id=None, check_object_permissions=True):

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -12,7 +12,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     RegistrationFactory,
 )
-from osf.utils.permissions import WRITE, READ
+from osf.utils.permissions import WRITE, READ, ADMIN
 from rest_framework import exceptions
 from api_tests.nodes.views.test_node_draft_registration_list import DraftRegistrationTestCase
 
@@ -145,6 +145,15 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
         assert data['attributes']['title']
         assert data['attributes']['description']
         assert data['relationships']['affiliated_institutions']
+
+    def test_can_view_after_added(
+            self, app, schema, draft_registration, url_draft_registrations):
+        user = AuthUserFactory()
+        project = draft_registration.branched_from
+        project.add_contributor(user, ADMIN)
+        res = app.get(url_draft_registrations, auth=user.auth)
+        assert res.status_code == 200
+
 
 @pytest.mark.django_db
 class TestDraftRegistrationUpdate(DraftRegistrationTestCase):

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -671,7 +671,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         if isinstance(self.branched_from, (DraftNode, Node)):
             return self.branched_from.__class__.__name__
         else:
-            return ''
+            return DraftRegistrationStateError
 
     @property
     def url(self):

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -671,7 +671,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         if isinstance(self.branched_from, (DraftNode, Node)):
             return self.branched_from.__class__.__name__
         else:
-            return DraftRegistrationStateError
+            raise DraftRegistrationStateError
 
     @property
     def url(self):


### PR DESCRIPTION

## Purpose

Changing Permissions behavior based on what the registration is branched from

## Changes

Modified DraftMixin to check permissions against the branched from node when its not created from a draft node

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Low
    - Any permissions code touched?
Yes
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Create Node, create a draft registration, add a new contributor on the original node, use that contributor to try to access the draft registration
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
N/A
  - How will this impact performance?
N/A
-->

## Documentation

N/A

## Side Effects

Should not be any 

## Ticket

https://openscience.atlassian.net/browse/ENG-1563
