### PR TITLE
Versions Draft Registration Serializers [ENG-1555]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -170,6 +170,7 @@ REST_FRAMEWORK = {
         '2.17',
         '2.18',
         '2.19',
+        '2.20',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.OSFOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/base/versioning.py
+++ b/api/base/versioning.py
@@ -10,6 +10,9 @@ from api.base import utils
 from api.base.renderers import BrowsableAPIRendererNoForms
 from api.base.settings import LATEST_VERSIONS
 
+# Determines API version to rely on new DraftRegistration Serializers
+DRAFT_REGISTRATION_SERIALIZERS_UPDATE_VERSION = '2.20'
+
 # Determines the API version that will start using new
 # fields to create a registration
 CREATE_REGISTRATION_FIELD_CHANGE_VERSION = '2.19'

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -49,10 +49,12 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
         base_permissions.TokenHasScope,
     )
 
-    serializer_class = DraftRegistrationSerializer
-
     view_category = 'draft_registrations'
     view_name = 'draft-registration-list'
+
+    # overrides NodeDraftRegistrationList
+    def get_serializer_class(self):
+        return DraftRegistrationSerializer
 
     # overrides NodeDraftRegistrationList
     def get_queryset(self):
@@ -71,10 +73,12 @@ class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixi
         base_permissions.TokenHasScope,
     )
 
-    serializer_class = DraftRegistrationDetailSerializer
-
     view_category = 'draft_registrations'
     view_name = 'draft-registration-detail'
+
+    # overrides NodeDraftRegistrationList
+    def get_serializer_class(self):
+        return DraftRegistrationDetailSerializer
 
 
 class DraftInstitutionsList(NodeInstitutionsList, DraftRegistrationMixin):

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -49,6 +49,7 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
         base_permissions.TokenHasScope,
     )
 
+    serializer_class = DraftRegistrationSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-list'
 
@@ -73,6 +74,7 @@ class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixi
         base_permissions.TokenHasScope,
     )
 
+    serializer_class = DraftRegistrationDetailSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-detail'
 

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -49,7 +49,6 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
         base_permissions.TokenHasScope,
     )
 
-    # serializer_class = DraftRegistrationSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-list'
 
@@ -74,7 +73,6 @@ class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixi
         base_permissions.TokenHasScope,
     )
 
-    # serializer_class = DraftRegistrationDetailSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-detail'
 

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -49,7 +49,7 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
         base_permissions.TokenHasScope,
     )
 
-    serializer_class = DraftRegistrationSerializer
+    # serializer_class = DraftRegistrationSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-list'
 
@@ -74,11 +74,11 @@ class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixi
         base_permissions.TokenHasScope,
     )
 
-    serializer_class = DraftRegistrationDetailSerializer
+    # serializer_class = DraftRegistrationDetailSerializer
     view_category = 'draft_registrations'
     view_name = 'draft-registration-detail'
 
-    # overrides NodeDraftRegistrationList
+    # overrides NodeDraftRegistrationDetail
     def get_serializer_class(self):
         return DraftRegistrationDetailSerializer
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -618,6 +618,7 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
+    serializer_class = DraftRegistrationLegacySerializer
     view_category = 'nodes'
     view_name = 'node-draft-registrations'
 
@@ -650,6 +651,7 @@ class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestro
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
+    serializer_class = DraftRegistrationDetailLegacySerializer
     view_category = 'nodes'
     view_name = 'node-draft-registration-detail'
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -40,7 +40,7 @@ from api.base.throttling import (
 )
 from api.base.utils import default_node_list_permission_queryset
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, is_truthy
-from api.base.versioning import CREATE_REGISTRATION_FIELD_CHANGE_VERSION
+from api.base.versioning import DRAFT_REGISTRATION_SERIALIZERS_UPDATE_VERSION
 from api.base.views import JSONAPIBaseView
 from api.base.views import (
     BaseChildrenList,
@@ -618,14 +618,13 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
-    # serializer_class = DraftRegistrationLegacySerializer
     view_category = 'nodes'
     view_name = 'node-draft-registrations'
 
     ordering = ('-modified',)
 
     def get_serializer_class(self):
-        if StrictVersion(getattr(self.request, 'version', '2.0')) >= StrictVersion(CREATE_REGISTRATION_FIELD_CHANGE_VERSION):
+        if StrictVersion(getattr(self.request, 'version', '2.0')) >= StrictVersion(DRAFT_REGISTRATION_SERIALIZERS_UPDATE_VERSION):
             return DraftRegistrationSerializer
         return DraftRegistrationLegacySerializer
 
@@ -651,12 +650,11 @@ class NodeDraftRegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestro
     required_read_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NODE_DRAFT_REGISTRATIONS_WRITE]
 
-    # serializer_class = DraftRegistrationDetailLegacySerializer
     view_category = 'nodes'
     view_name = 'node-draft-registration-detail'
 
     def get_serializer_class(self):
-        if StrictVersion(getattr(self.request, 'version', '2.0')) >= StrictVersion(CREATE_REGISTRATION_FIELD_CHANGE_VERSION):
+        if StrictVersion(getattr(self.request, 'version', '2.0')) >= StrictVersion(DRAFT_REGISTRATION_SERIALIZERS_UPDATE_VERSION):
             return DraftRegistrationDetailSerializer
         return DraftRegistrationDetailLegacySerializer
 

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -21,7 +21,7 @@ from osf.utils.permissions import READ, WRITE, ADMIN
 class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
-        return '/{}draft_registrations/'.format(API_BASE)
+        return '/{}draft_registrations/?'.format(API_BASE)
 
     # Overrides TestDraftRegistrationList
     def test_osf_group_with_admin_permissions_can_view(self):
@@ -70,7 +70,7 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
 class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
-        return '/{}draft_registrations/'.format(API_BASE)
+        return '/{}draft_registrations/?'.format(API_BASE)
 
     @pytest.fixture()
     def payload(self, metaschema_open_ended, provider, project_public):
@@ -177,13 +177,13 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
 class TestDraftRegistrationCreateWithoutNode(TestDraftRegistrationCreate):
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
-        return '/{}draft_registrations/'.format(API_BASE)
+        return '/{}draft_registrations/?'.format(API_BASE)
 
     # Overrides TestDraftRegistrationList
     def test_admin_can_create_draft(
             self, app, user, project_public, url_draft_registrations,
             payload, metaschema_open_ended):
-        url = '{}?embed=branched_from&embed=initiator'.format(url_draft_registrations)
+        url = '{}embed=branched_from&embed=initiator'.format(url_draft_registrations)
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         data = res.json['data']

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -132,6 +132,19 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
         assert data['id'] == draft_registration._id
         assert data['attributes']['registration_metadata'] == {}
 
+    def test_draft_registration_serializer_usage(self, app, user, project_public, draft_registration):
+        # Tests the usage of DraftRegistrationDetailSerializer for version 2.20
+        url_draft_registrations = '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration._id, 'version=2.20')
+
+        res = app.get(url_draft_registrations, auth=user.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+
+        # Set of fields that DraftRegistrationDetailLegacySerializer does not provide
+        assert data['attributes']['title']
+        assert data['attributes']['description']
+        assert data['relationships']['affiliated_institutions']
 
 @pytest.mark.django_db
 class TestDraftRegistrationUpdate(DraftRegistrationTestCase):

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -42,8 +42,8 @@ class TestDraftRegistrationDetail(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public, draft_registration):
-        return '/{}nodes/{}/draft_registrations/{}/'.format(
-            API_BASE, project_public._id, draft_registration._id)
+        return '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration._id, 'version=2.19')
 
     def test_admin_can_view_draft(
             self, app, user, draft_registration, project_public,
@@ -176,8 +176,8 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public, draft_registration):
-        return '/{}nodes/{}/draft_registrations/{}/'.format(
-            API_BASE, project_public._id, draft_registration._id)
+        return '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration._id, 'version=2.19')
 
     @pytest.fixture()
     def payload(self, draft_registration):
@@ -700,8 +700,8 @@ class TestDraftRegistrationPatch(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public, draft_registration):
-        return '/{}nodes/{}/draft_registrations/{}/'.format(
-            API_BASE, project_public._id, draft_registration._id)
+        return '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration._id, 'version=2.19')
 
     @pytest.fixture()
     def payload(self, draft_registration):
@@ -794,8 +794,8 @@ class TestDraftRegistrationDelete(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public, draft_registration):
-        return '/{}nodes/{}/draft_registrations/{}/'.format(
-            API_BASE, project_public._id, draft_registration._id)
+        return '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration._id, 'version=2.19')
 
     def test_admin_can_delete_draft(self, app, user, url_draft_registrations, project_public):
         res = app.delete_json_api(url_draft_registrations, auth=user.auth)
@@ -894,8 +894,8 @@ class TestDraftPreregChallengeRegistrationMetadataValidation(
     def url_draft_registrations(
             self, project_public,
             draft_registration_prereg):
-        return '/{}nodes/{}/draft_registrations/{}/'.format(
-            API_BASE, project_public._id, draft_registration_prereg._id)
+        return '/{}nodes/{}/draft_registrations/{}/?{}'.format(
+            API_BASE, project_public._id, draft_registration_prereg._id, 'version=2.19')
 
     @pytest.fixture()
     def payload(self, draft_registration_prereg):

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -103,8 +103,9 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
-        return '/{}nodes/{}/draft_registrations/'.format(
-            API_BASE, project_public._id)
+        # Specifies version to test functionality when using DraftRegistrationLegacySerializer
+        return '/{}nodes/{}/draft_registrations/?{}'.format(
+            API_BASE, project_public._id, 'version=2.19')
 
     def test_admin_can_view_draft_list(
             self, app, user, draft_registration, project_public,
@@ -242,8 +243,8 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
-        return '/{}nodes/{}/draft_registrations/'.format(
-            API_BASE, project_public._id)
+        return '/{}nodes/{}/draft_registrations/?{}'.format(
+            API_BASE, project_public._id, 'version=2.19')
 
     def test_type_is_draft_registrations(
             self, app, user, metaschema_open_ended,
@@ -272,7 +273,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
     def test_admin_can_create_draft(
             self, app, user, project_public, url_draft_registrations,
             payload, metaschema_open_ended):
-        url = '{}?embed=branched_from&embed=initiator'.format(url_draft_registrations)
+        url = '{}&embed=branched_from&embed=initiator'.format(url_draft_registrations)
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         data = res.json['data']
@@ -487,7 +488,7 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             branched_from=project_public
         )
 
-        url = '{}?embed=initiator&embed=branched_from'.format(url_draft_registrations)
+        url = '{}&embed=initiator&embed=branched_from'.format(url_draft_registrations)
 
         registration_metadata = prereg_metadata(prereg_draft_registration)
         del registration_metadata['q1']

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -203,6 +203,21 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         assert data[0]['id'] == draft_registration._id
         assert data[0]['attributes']['registration_metadata'] == {}
 
+    def test_draft_registration_serializer_usage(self, app, user, project_public, draft_registration):
+        # Tests the usage of DraftRegistrationDetailSerializer for version 2.20
+        url_draft_registrations = '/{}nodes/{}/draft_registrations/?{}'.format(
+            API_BASE, project_public._id, 'version=2.20')
+
+        res = app.get(url_draft_registrations, auth=user.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 1
+
+        # Set of fields that DraftRegistrationLegacySerializer does not provide
+        assert data[0]['attributes']['title']
+        assert data[0]['attributes']['description']
+        assert data[0]['relationships']['affiliated_institutions']
+
 
 @pytest.mark.django_db
 @pytest.mark.enable_quickfiles_creation


### PR DESCRIPTION
## Purpose

Creates a new API version that differentiates the use of DraftRegistration Legacy serializers and the updated DraftRegistration serializers when using either `/nodes/<node_id>/draft_registrations/` or `/nodes/<node_id>/draft_registrations/<draft_registration_id>/`

## Changes

* Updated the views for NodeDraftRegistrationList and Detail to check for version specified in the request and set the serializer class accordingly
* Created a global versioning variable to represent the version that new DraftRegistration serializers are used
* Added `2.20` as an allowed version to the API because OSF is currently using `2.19`

## QA Notes

This change could benefit from QA checking the functionality of the `/nodes/<node_id>/draft_registrations/` and `/nodes/<node_id>/draft_registrations/<draft_registration_id>/` endpoints with versions <=2.19 and 2.20 and ensuring that there is parity in what is returned by these endpoints with version 2.20 and the newer `/v2/draft_registrations/` and `/v2/draft_registrations/<draft_registration_id>/` endpoints.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
Updates will need to be made to the developer.osf.io changelog to reflect the new API version

## Side Effects

<!-- Any possible side effects? -->
We will need to ensure that the API version being requested is not updated to 2.20 unwittingly or that parts of OSF that are not ready for the new DraftRegistration serializers are pinned to 2.19.

## Ticket

https://openscience.atlassian.net/browse/ENG-1555
