### PR TITLE
[ENG-1569] Allow updating draft registration with blank titles

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -38,7 +38,7 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
     category_choices = list(settings.NODE_CATEGORY_MAP.items())
     category_choices_string = ', '.join(["'{}'".format(choice[0]) for choice in category_choices])
 
-    title = ser.CharField(required=False, allow_blank=False)
+    title = ser.CharField(required=False, allow_blank=True)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True)
 
     category = ser.ChoiceField(required=False, choices=category_choices, help_text='Choices: ' + category_choices_string)

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -382,6 +382,28 @@ class TestDraftRegistrationUpdateWithNode(TestDraftRegistrationUpdate, TestUpdat
             'comments': 'This is my first registration.'
         }
 
+    def test_write_contributor_can_update_draft_no_title(
+            self, app, user_write_contrib, schema, project_public,
+            payload, url_draft_registrations):
+
+        payload['data']['attributes']['title'] = ''
+        res = app.put_json_api(
+            url_draft_registrations,
+            payload,
+            auth=user_write_contrib.auth
+        )
+
+        assert res.status_code == 200
+        data = res.json['data']
+        assert schema._id in data['relationships']['registration_schema']['links']['related']['href']
+        assert data['attributes']['registration_metadata'] == payload['data']['attributes']['registration_metadata']
+        # A write to registration_metadata, also updates registration_responses
+        assert data['attributes']['registration_responses'] == {
+            'datacompletion': 'No, data collection has not begun',
+            'looked': 'No',
+            'comments': 'This is my first registration.'
+        }
+
 
 @pytest.mark.django_db
 class TestDraftRegistrationUpdateWithDraftNode(TestDraftRegistrationUpdate):

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -147,13 +147,13 @@ class TitleMixin(models.Model):
     def log_params(self):
         raise NotImplementedError()
 
-    def set_title(self, title, auth, save=False):
+    def set_title(self, title, auth, save=False, allow_blank=False):
         """Set the title of this resource and log it.
         :param str title: The new title.
         :param auth: All the auth information including user, API key.
         """
         # Called so validation does not have to wait until save.
-        validate_title(title)
+        validate_title(title, allow_blank=allow_blank)
 
         original_title = self.title
         new_title = sanitize.strip_html(title)

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1068,7 +1068,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             if key not in self.WRITABLE_WHITELIST:
                 continue
             if key == 'title':
-                self.set_title(title=value, auth=auth, save=False)
+                self.set_title(title=value, auth=auth, save=False, allow_blank=True)
             elif key == 'description':
                 self.set_description(description=value, auth=auth, save=False)
             elif key == 'category':

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -992,6 +992,9 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
     def register(self, auth, save=False, child_ids=None):
         node = self.branched_from
 
+        if not self.title:
+            raise NodeStateError('Draft Registration must have title to be registered')
+
         # Create the registration
         register = node.register_node(
             schema=self.registration_schema,

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -55,17 +55,20 @@ def validate_subscription_type(value):
         raise ValidationValueError
 
 
-def validate_title(value):
+def validate_title(value, allow_blank=False):
     """Validator for Node#title. Makes sure that the value exists and is not
     above 512 characters.
     """
-    if value is None or not value.strip():
-        raise ValidationValueError('Title cannot be blank.')
+
+    if not allow_blank:
+        if value is None or not value.strip():
+            raise ValidationValueError('Title cannot be blank.')
 
     value = strip_html(value)
 
-    if value is None or not value.strip():
-        raise ValidationValueError('Invalid title.')
+    if not allow_blank:
+        if value is None or not value.strip():
+            raise ValidationValueError('Invalid title.')
 
     if len(value) > 512:
         raise ValidationValueError('Title cannot exceed 512 characters.')

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -4,7 +4,7 @@ import datetime
 
 from framework.auth.core import Auth
 from framework.exceptions import PermissionsError
-from osf.exceptions import UserNotAffiliatedError, DraftRegistrationStateError
+from osf.exceptions import UserNotAffiliatedError, DraftRegistrationStateError, NodeStateError
 from osf.models import RegistrationSchema, DraftRegistration, DraftRegistrationContributor, NodeLicense, Node, NodeLog
 from osf.utils.permissions import ADMIN, READ, WRITE
 from osf_tests.test_node import TestNodeEditableFieldsMixin, TestTagging, TestNodeLicenses, TestNodeSubjects
@@ -77,6 +77,19 @@ class TestDraftRegistrations:
         with pytest.raises(PermissionsError):
             draft_2.register(Auth(member))
         assert not draft_2.registered_node
+
+    @mock.patch('website.settings.ENABLE_ARCHIVER', False)
+    def test_register_no_title_fails(self):
+        user = factories.UserFactory()
+        auth = Auth(user)
+        project = factories.ProjectFactory(creator=user)
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+        draft.title = ''
+        draft.save()
+        with pytest.raises(NodeStateError) as e:
+            draft.register(auth)
+
+        assert str(e.value) == 'Draft Registration must have title to be registered'
 
     def test_update_metadata_updates_registration_responses(self, project):
         schema = RegistrationSchema.objects.get(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=osf_tests.settings --tb=short --reuse-db --allow-hosts=127.0.0.1,192.168.168.167
+addopts = --ds=osf_tests.settings --tb=short --reuse-db --allow-hosts=127.0.0.1
 filterwarnings =
     once::UserWarning
     ignore:.*U.*mode is deprecated:DeprecationWarning


### PR DESCRIPTION
## Purpose

Allow updating draft registration with blank titles via API.

## Changes

- changes the serializer to allow blank titles 
- adds test

## QA Notes

No migrations, dev test only

## Documentation

No user facing changes, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1569