### PR TITLE
[ENG-1650] Re-index re-mapped metric models

### DIFF
--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -120,8 +120,11 @@ class PreprintMetricMixin(JSONAPIBaseView):
 
         try:
             results = self.execute_search(search, query)
-        except RequestError:
+        except RequestError as e:
+            if e.args:
+                raise ValidationError(e.info['error']['root_cause'][0]['reason'])
             raise ValidationError('Malformed elasticsearch query.')
+
         return JsonResponse(results.to_dict())
 
 

--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -120,8 +120,8 @@ class PreprintMetricMixin(JSONAPIBaseView):
 
         try:
             results = self.execute_search(search, query)
-        except RequestError as e:
-            raise ValidationError(e.info['error']['root_cause'][0]['reason'])
+        except RequestError:
+            raise ValidationError('Malformed elasticsearch query.')
         return JsonResponse(results.to_dict())
 
 

--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -120,8 +120,8 @@ class PreprintMetricMixin(JSONAPIBaseView):
 
         try:
             results = self.execute_search(search, query)
-        except RequestError:
-            raise ValidationError('Misformed elasticsearch query.')
+        except RequestError as e:
+            raise ValidationError(e.info['error']['root_cause'][0]['reason'])
         return JsonResponse(results.to_dict())
 
 

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 from website.app import init_app
 from tests.json_api_test_app import JSONAPITestApp
-from elasticsearch_dsl import connections
 from django.core.management import call_command
 
 
@@ -16,12 +15,6 @@ def app():
 @pytest.fixture(autouse=True, scope='session')
 def app_init():
     init_app(routes=False, set_backends=False)
-
-
-@pytest.fixture(scope='function')
-def es6_client():
-    return connections.get_connection()
-
 
 @pytest.fixture(scope='function', autouse=True)
 def _es_marker(request, es6_client):

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import pytest
+
 from website.app import init_app
 from tests.json_api_test_app import JSONAPITestApp
 from elasticsearch_dsl import connections
@@ -29,11 +30,14 @@ def _es_marker(request, es6_client):
     """
     marker = request.node.get_closest_marker('es')
     if marker:
-        es6_client.indices.delete(index='*')
-        es6_client.indices.delete_template('*')
+
+        def teardown_es():
+            es6_client.indices.delete(index='*')
+            es6_client.indices.delete_template('*')
+
+        teardown_es()
         call_command('sync_metrics')
         yield
-        es6_client.indices.delete(index='*')
-        es6_client.indices.delete_template('*')
+        teardown_es()
     else:
         yield

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import pytest
-
 from website.app import init_app
 from tests.json_api_test_app import JSONAPITestApp
 from elasticsearch_dsl import connections
@@ -30,14 +29,11 @@ def _es_marker(request, es6_client):
     """
     marker = request.node.get_closest_marker('es')
     if marker:
-
-        def teardown_es():
-            es6_client.indices.delete(index='*')
-            es6_client.indices.delete_template('*')
-
-        teardown_es()
+        es6_client.indices.delete(index='*')
+        es6_client.indices.delete_template('*')
         call_command('sync_metrics')
         yield
-        teardown_es()
+        es6_client.indices.delete(index='*')
+        es6_client.indices.delete_template('*')
     else:
         yield

--- a/api_tests/conftest.py
+++ b/api_tests/conftest.py
@@ -4,7 +4,6 @@ import pytest
 
 from website.app import init_app
 from tests.json_api_test_app import JSONAPITestApp
-from django.core.management import call_command
 
 
 @pytest.fixture()
@@ -15,22 +14,3 @@ def app():
 @pytest.fixture(autouse=True, scope='session')
 def app_init():
     init_app(routes=False, set_backends=False)
-
-@pytest.fixture(scope='function', autouse=True)
-def _es_marker(request, es6_client):
-    """Clear out all indices and index templates before and after
-    tests marked with ``es``.
-    """
-    marker = request.node.get_closest_marker('es')
-    if marker:
-
-        def teardown_es():
-            es6_client.indices.delete(index='*')
-            es6_client.indices.delete_template('*')
-
-        teardown_es()
-        call_command('sync_metrics')
-        yield
-        teardown_es()
-    else:
-        yield

--- a/api_tests/metrics/test_composite_query.py
+++ b/api_tests/metrics/test_composite_query.py
@@ -8,7 +8,6 @@ from osf_tests.factories import (
 
 from osf.metrics import PreprintDownload
 from api.base.settings import API_PRIVATE_BASE as API_BASE
-from elasticsearch_dsl import Index
 
 
 @pytest.fixture()
@@ -29,20 +28,11 @@ def user():
 def base_url():
     return '/{}metrics/preprints/'.format(API_BASE)
 
+
+@pytest.mark.es
 @pytest.mark.django_db
-class TestElasticSearch():
+class TestElasticSearch:
 
-    @pytest.fixture(autouse=True)
-    def mock_elastic(self):
-        ind = Index('test_2020')
-        PreprintDownload._index = ind
-        PreprintDownload._template_name = 'test'
-        PreprintDownload._template = 'test_2020'
-        ind.save()
-        yield
-        ind.delete()
-
-    @pytest.mark.skip('Try as I might I could not get to run on Travis, but this should pass against a local server.')
     def test_elasticsearch_agg_query(self, app, user, base_url, preprint):
         post_url = '{}downloads/'.format(base_url)
 

--- a/api_tests/metrics/test_preprint_metrics.py
+++ b/api_tests/metrics/test_preprint_metrics.py
@@ -101,7 +101,7 @@ class TestPreprintMetrics:
         return '/{}metrics/preprints/'.format(API_BASE)
 
     @mock.patch('api.metrics.views.PreprintDownloadMetrics.execute_search')
-    def test_custom_metric_misformed_query(self, mock_execute, app, user, base_url):
+    def test_custom_metric_malformed_query(self, mock_execute, app, user, base_url):
         mock_execute.side_effect = RequestError
         post_url = '{}downloads/'.format(base_url)
         post_data = {
@@ -114,7 +114,7 @@ class TestPreprintMetrics:
         }
         res = app.post_json_api(post_url, post_data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Misformed elasticsearch query.'
+        assert res.json['errors'][0]['detail'] == 'Malformed elasticsearch query.'
 
     @pytest.mark.skip('Return results will be entirely mocked so does not make a lot of sense to run on travis.')
     def test_agg_query(self, app, user, base_url):

--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,8 @@ from website import settings as website_settings
 
 from framework.celery_tasks import app as celery_app
 
+from elasticsearch_dsl.connections import connections
+
 logger = logging.getLogger(__name__)
 
 # Silence some 3rd-party logging and some "loud" internal loggers
@@ -116,3 +118,8 @@ def _test_speedups_disable(request, settings, _test_speedups):
 
     for patcher in patchers:
         patcher.start()
+
+
+@pytest.fixture(scope='function')
+def es6_client():
+    return connections.get_connection()

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from website import settings as website_settings
 from framework.celery_tasks import app as celery_app
 
 from elasticsearch_dsl.connections import connections
+from django.core.management import call_command
 
 logger = logging.getLogger(__name__)
 
@@ -123,3 +124,23 @@ def _test_speedups_disable(request, settings, _test_speedups):
 @pytest.fixture(scope='function')
 def es6_client():
     return connections.get_connection()
+
+
+@pytest.fixture(scope='function', autouse=True)
+def _es_marker(request, es6_client):
+    """Clear out all indices and index templates before and after
+    tests marked with ``es``.
+    """
+    marker = request.node.get_closest_marker('es')
+    if marker:
+
+        def teardown_es():
+            es6_client.indices.delete(index='*')
+            es6_client.indices.delete_template('*')
+
+        teardown_es()
+        call_command('sync_metrics')
+        yield
+        teardown_es()
+    else:
+        yield

--- a/osf/management/commands/reindex_with_current_metrics_mappings.py
+++ b/osf/management/commands/reindex_with_current_metrics_mappings.py
@@ -63,9 +63,13 @@ def reindex_and_alias(old_indices: list):
         }
         client.reindex(body, params={'wait_for_completion': 'true'})
         old_index_name = list(client.indices.get(old_index).keys())[0]  # in case we've already aliased this index
-        client.indices.delete(old_index_name)
-        client.indices.put_alias(new_index, old_index)
 
+        if old_index_name == old_index:  # True if not aliased
+            client.indices.delete(old_index)
+            client.indices.put_alias(new_index, old_index)
+        else:
+            client.indices.put_alias(new_index, old_index)
+            client.indices.close(old_index)
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/osf/management/commands/reindex_with_current_metrics_mappings.py
+++ b/osf/management/commands/reindex_with_current_metrics_mappings.py
@@ -1,0 +1,80 @@
+"""
+Reindex data to use current mapping for ES metrics classes
+"""
+import logging
+
+from django.core.management.base import BaseCommand
+from elasticsearch_dsl import connections
+from elasticsearch_metrics.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def get_metric_class(index_name: str) -> type:
+    app_label, model_name = index_name.split('_')[:2]
+    return registry.all_metrics[app_label][model_name]
+
+
+def increment_index_versions(old_indices: list):
+    """
+    Increment versions numbers for new indices, these kind don't matter because they should always be aliased to
+    the original format of {app_label}_{cls.__name__.lower()}_{year}.
+
+    :param old_indices: indices to be updated
+    :return: indices names that are going to be reindexed into.
+    """
+    new_indices = []
+    for index in old_indices:
+        if '_v' in index and index[-1].isdigit():
+            name, version_num = index.split('_v')
+            new_index = f'{name}_v{int(version_num) + 1}'
+        else:
+            new_index = f'{index}_v2'
+        new_indices.append(new_index)
+
+    return new_indices
+
+
+def reindex_and_alias(old_indices: list):
+    """
+    To migrate data in ES with new mappings is a 4 step process:
+    1) Create an index with new mappings
+    2) Reindex data from old to new
+    3) Delete the old index
+    4) Alias the new index so it references the old.
+
+    :param old_indices: indices with data that has old mappings
+    :return: None
+    """
+    client = connections.get_connection()
+    new_indices = increment_index_versions(old_indices)
+
+    for old_index, new_index in zip(old_indices, new_indices):
+        metric_class = get_metric_class(old_index)
+        client.indices.create(new_index, body=metric_class._index.to_dict(), params={'wait_for_active_shards': 1})
+        body = {
+            'source': {
+                'index': old_index
+            },
+            'dest': {
+                'index': new_index
+            }
+        }
+        client.reindex(body, params={'wait_for_completion': 'true'})
+        client.indices.delete(old_index)
+        client.indices.put_alias(new_index, old_index)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--indices',
+            type=str,
+            nargs='+',
+            help='List of indices to be reindexed and remapped'
+        )
+
+    def handle(self, *args, **options):
+        indices = options.get('indices', [])
+        reindex_and_alias(indices)

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -6,38 +6,11 @@ from elasticsearch.exceptions import NotFoundError
 from elasticsearch_metrics import metrics
 from django.db import models
 from django.utils import timezone
-from elasticsearch_dsl import connections
 
 import pytz
 
 
 class MetricMixin(object):
-
-    @classmethod
-    def _reindex_and_alias(cls, after: datetime = None) -> None:
-        """
-        Re-index (that means migrate outside of ES world) an index to the new mapping.
-        :param Datetime after: get all indices after this date, if none do all indices.
-        :return:
-        """
-        #
-        old_indices = cls._get_relevant_indices(after)
-        new_indices = [f'remapped_{index}' for index in old_indices]
-        client = connections.get_connection()
-
-        for old_index, new_index in zip(old_indices, new_indices):
-            client.indices.create(new_index, body=cls._index.to_dict(), params={'wait_for_active_shards': 1})
-            body = {
-                'source': {
-                    'index': old_index
-                },
-                'dest': {
-                    'index': new_index
-                }
-            }
-            client.reindex(body, params={'wait_for_completion': 'true'})
-            client.indices.delete(old_index)
-            client.indices.put_alias(new_index, old_index)
 
     @classmethod
     def _get_relevant_indices(cls, after: datetime = None) -> List[str]:

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -1,29 +1,17 @@
 import datetime as dt
-from datetime import datetime
-from typing import List
 
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_metrics import metrics
 from django.db import models
 from django.utils import timezone
-
 import pytz
-
 
 class MetricMixin(object):
 
     @classmethod
-    def _get_relevant_indices(cls, after: datetime = None) -> List[str]:
-        """
-        This will only work for yearly indices. This logic will need to be updated if we change to monthly or daily
-        indices
-
-        :param after: datetime get indices after this datetime
-        :return: list of indices for this class, or a list of index names, or is there a difference?
-        """
-        #
-        if not after:
-            after = cls.search().sort('-timestamp').execute()[0].timestamp
+    def _get_relevant_indices(cls, after):
+        # NOTE: This will only work for yearly indices. This logic
+        # will need to be updated if we change to monthly or daily indices
         year_range = range(after.year, timezone.now().year + 1)
         return [
             # get_index_name takes a datetime, so get Jan 1 for each relevant year

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -15,7 +15,12 @@ class MetricMixin(object):
 
     @classmethod
     def _reindex_and_alias(cls, after: datetime = None) -> None:
-        # First re-index to the new mapping (that means migrate outside of ES world
+        """
+        Re-index (that means migrate outside of ES world) an index to the new mapping.
+        :param Datetime after: get all indices after this date, if none do all indices.
+        :return:
+        """
+        #
         old_indices = cls._get_relevant_indices(after)
         new_indices = [f'remapped_{index}' for index in old_indices]
         client = connections.get_connection()

--- a/osf_tests/conftest.py
+++ b/osf_tests/conftest.py
@@ -23,6 +23,11 @@ def app():
     return test_app
 
 
+@pytest.fixture(autouse=True, scope='session')
+def app_init():
+    init_app(routes=False, set_backends=False)
+
+
 @pytest.yield_fixture()
 def request_context(app):
     context = app.test_request_context(headers={

--- a/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
+++ b/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
@@ -89,7 +89,7 @@ class TestReindexingMetrics:
                                                   ' Alternatively use a keyword field instead.'
 
         call_command('reindex_with_current_metrics_mappings', f'--indices={preprint_download.meta["index"]}')
-        time.sleep(2)  # ES is slow
+        time.sleep(20)  # This is set for Travis, a 1-2 second latency should be good for testing locally.
 
         res = app.post_json_api(url, payload, auth=admin.auth)
         assert res.status_code == 200

--- a/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
+++ b/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
@@ -97,3 +97,16 @@ class TestReindexingMetrics:
 
         # Just checking version number incremented properly
         es6_client.indices.get(f'{preprint_download.meta["index"]}_v2')
+
+        # Just check it was aliased properly
+        es6_client.indices.get(f'{preprint_download.meta["index"]}')
+
+        call_command('reindex_with_current_metrics_mappings', f'--indices={preprint_download.meta["index"]}')
+
+        # Just checking version number incremented properly again
+        es6_client.indices.get(f'{preprint_download.meta["index"]}_v3')
+
+        # Just check it was aliased properly again (to the OG index, not the v2 index)
+        data = es6_client.indices.get(f'{preprint_download.meta["index"]}')
+
+        assert data[f'{preprint_download.meta["index"]}_v3']['aliases'] == {'osf_preprintdownload_2020': {}}

--- a/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
+++ b/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
@@ -1,0 +1,99 @@
+import time
+import pytest
+from website import settings
+
+from osf.metrics import PreprintDownload
+from django.core.management import call_command
+
+from osf_tests.factories import (
+    PreprintFactory,
+    AuthUserFactory
+)
+
+from elasticsearch_metrics.field import Keyword
+
+from tests.json_api_test_app import JSONAPITestApp
+
+
+@pytest.fixture()
+def app():
+    return JSONAPITestApp()
+
+
+@pytest.mark.django_db
+class TestReindexingMetrics:
+
+    @pytest.fixture()
+    def preprint(self):
+        return PreprintFactory()
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def admin(self):
+        user = AuthUserFactory()
+        user.is_staff = True
+        user.add_system_tag('preprint_metrics')
+        user.save()
+        return user
+
+    @pytest.fixture()
+    def url(self):
+        return f'{settings.API_DOMAIN}_/metrics/preprints/downloads/'
+
+    @pytest.mark.es
+    def test_reindexing(self, app, url, preprint, user, admin, es6_client):
+        preprint_download = PreprintDownload.record_for_preprint(
+            preprint,
+            user,
+            version=1,
+            path='/MalcolmJenkinsKnockedBrandinCooksOutColdInTheSuperbowl',
+            random_new_field='Hi!'  # Here's our unmapped field! It's a text field by default.
+        )
+        preprint_download.save()
+
+        query = {
+            'aggs': {
+                'random_new_field': {
+                    'terms': {
+                        'field': 'random_new_field',  # Oh no, this is a text field, you can't query it like that!
+                    }
+                }
+            }
+        }
+
+        payload = {
+            'data': {
+                'type': 'preprint_metrics',
+                'attributes': {
+                    'query': query
+                }
+            }
+        }
+
+        # Hacky way to simulate a re-mapped index template
+        index_template = preprint_download._index
+        mapping = index_template._mapping
+        mapping.properties._params['properties']['random_new_field'] = Keyword(doc_values=True, index=True)
+        index_template._mapping._update_from_dict(mapping.to_dict())
+
+        # This should 400 because random_new_field is still stored as a text field despite the our index being remapped.
+        res = app.post_json_api(url, payload, auth=admin.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Fielddata is disabled on text fields by default. Set ' \
+                                                  'fielddata=true on [random_new_field] in order to load' \
+                                                  ' fielddata in memory by uninverting the inverted inde' \
+                                                  'x. Note that this can however use significant memory.' \
+                                                  ' Alternatively use a keyword field instead.'
+
+        call_command('reindex_with_current_metrics_mappings', f'--indices={preprint_download.meta["index"]}')
+        time.sleep(2)  # ES is slow
+
+        res = app.post_json_api(url, payload, auth=admin.auth)
+        assert res.status_code == 200
+        assert res.json['hits']['hits'][0]['_source']['random_new_field'] == 'Hi!'
+
+        # Just checking version number incremented properly
+        es6_client.indices.get(f'{preprint_download.meta["index"]}_v2')

--- a/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
+++ b/osf_tests/management_commands/test_reindex_with_current_metrics_mappings.py
@@ -102,6 +102,7 @@ class TestReindexingMetrics:
         es6_client.indices.get(f'{preprint_download.meta["index"]}')
 
         call_command('reindex_with_current_metrics_mappings', f'--indices={preprint_download.meta["index"]}')
+        time.sleep(20)  # This is set for Travis, a 1-2 second latency should be good for testing locally.
 
         # Just checking version number incremented properly again
         es6_client.indices.get(f'{preprint_download.meta["index"]}_v3')


### PR DESCRIPTION
## Purpose

Re-index old data with newly synced template.

## Changes

- adds method that re-indexes old data.

## QA Notes

Devtest and Courtney test only

## Documentation
 
Not user facing, no new docs.

## Side Effects

WIP

## Ticket

https://openscience.atlassian.net/browse/ENG-1650