### PR TITLE
Fix sloan flags for staging.

### DIFF
--- a/osf/features.py
+++ b/osf/features.py
@@ -43,6 +43,6 @@ SLOAN_DATA_INPUT = 'sloan_data_input'
 SLOAN_PREREG_INPUT = 'sloan_prereg_input'
 
 # The SLOAN_..._DISPLAY values are flags control when those features are visible for individual users.
-SLOAN_COI_DISPLAY = 'sloan_coi_display'
-SLOAN_DATA_DISPLAY = 'sloan_data_display'
-SLOAN_PREREG_DISPLAY = 'sloan_prereg_display'
+SLOAN_COI_DISPLAY = 'dwf_sloan_coi_display'
+SLOAN_DATA_DISPLAY = 'dwf_sloan_data_display'
+SLOAN_PREREG_DISPLAY = 'dwf_sloan_prereg_display'


### PR DESCRIPTION
## Purpose

Sloan flags of staging have different names, this makes them the same.

## Changes

- changes setting file to make sloan flag names the same.

## QA Notes

Should resolve sloan issues

## Documentation

Bug fix, no docs.

## Side Effects

None that I know of

## Ticket

No ticket