### PR TITLE
[ENG-1688] Sloan fixes - take 3

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -231,11 +231,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         if url.startswith('http://localhost:'):
             return 'localhost'
         else:
-            netloc = urlparse(url).netloc
-            if netloc.count('.') > 1:
-                netloc = '.'.join(netloc.split('.'))
-
-            return '.' + netloc
+            return '.' + urlparse(url).netloc
 
     @staticmethod
     def get_provider_from_url(referer_url: str) -> Optional[PreprintProvider]:

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -228,8 +228,8 @@ MIDDLEWARE = (
     # 'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
-    'waffle.middleware.WaffleMiddleware',
-    'api.base.middleware.SloanIdMiddleware',
+    # 'waffle.middleware.WaffleMiddleware',
+    'api.base.middleware.SloanOverrideWaffleMiddleware',  # Delete this and uncomment WaffleMiddleware to revert Sloan
 )
 
 TEMPLATES = [

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from waffle.models import Flag
 from website.settings import DOMAIN
 from api.base.middleware import SloanOverrideWaffleMiddleware
+from django.test.utils import override_settings
 
 from osf_tests.factories import (
     AuthUserFactory,
@@ -41,6 +42,9 @@ def inactive(*args, **kwargs):
 
 @pytest.mark.django_db
 class TestSloanStudyWaffling:
+    """
+    DEV_MODE is mocked so cookies they behave as in they using https.
+    """
 
     @pytest.fixture()
     def user(self):
@@ -59,6 +63,7 @@ class TestSloanStudyWaffling:
     def flags(self, user):
         Flag.objects.filter(name__in=SLOAN_FLAGS, percent=50).update(everyone=None)
 
+    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable(self, app, user, preprint):
@@ -82,6 +87,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
+    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control(self, app, user, preprint):
@@ -106,6 +112,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
+    @override_settings(DEV_MODE=False)
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable_unauth(self, app, user, preprint):
         headers = {'Referer': preprint.absolute_url}
@@ -121,6 +128,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
+    @override_settings(DEV_MODE=False)
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control_unauth(self, app, user, preprint):
         Flag.objects.filter(name__in=SLOAN_FLAGS).update(percent=1)
@@ -160,6 +168,7 @@ class TestSloanStudyWaffling:
         provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
         assert provider is None
 
+    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_provider_custom_domain(self, app, user, preprint):
@@ -185,6 +194,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
 
+    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_unauth_user_logs_in(self, app, user, preprint):
@@ -207,6 +217,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
+    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     def test_user_get_cookie_when_flag_is_everyone(self, app, user, preprint):
         user.add_system_tag(f'no_{SLOAN_PREREG}')

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -3,6 +3,8 @@ import pytest
 from decimal import Decimal
 
 from waffle.models import Flag
+from website.settings import DOMAIN
+from api.base.middleware import SloanOverrideWaffleMiddleware
 
 from osf_tests.factories import (
     AuthUserFactory,
@@ -28,9 +30,6 @@ from osf.system_tags import (
     SLOAN_DATA,
 )
 
-from website.settings import DOMAIN
-
-from api.base.middleware import SloanOverrideWaffleMiddleware
 
 def active(*args, **kwargs):
     return Decimal('0')

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -43,7 +43,7 @@ def inactive(*args, **kwargs):
 @pytest.mark.django_db
 class TestSloanStudyWaffling:
     """
-    DEV_MODE is mocked so cookies they behave as in they using https.
+    DEV_MODE is mocked so cookies they behave as if they were using https.
     """
 
     @pytest.fixture()

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -29,11 +29,8 @@ from osf.system_tags import (
 )
 
 from website.settings import DOMAIN
-from api.base.views import (
-    get_provider_from_url,
-    get_domain_from_refferer
-)
 
+from api.base.middleware import SloanOverrideWaffleMiddleware
 
 def active(*args, **kwargs):
     return Decimal('0')
@@ -153,7 +150,7 @@ class TestSloanStudyWaffling:
         (f'{DOMAIN}preprints/foorxiv/foo/bar/baz/', 'foorxiv')
     ])
     def test_weird_domains(self, reffer_url, expected_provider_id):
-        provider = get_provider_from_url(reffer_url)
+        provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
         assert expected_provider_id == provider._id
 
     @pytest.mark.parametrize('reffer_url', [
@@ -161,7 +158,7 @@ class TestSloanStudyWaffling:
         f'{DOMAIN}not-preprints/',
     ])
     def test_too_weird_domains(self, reffer_url):
-        provider = get_provider_from_url(reffer_url)
+        provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
         assert provider is None
 
     @pytest.mark.enable_quickfiles_creation
@@ -222,12 +219,12 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
-    @pytest.mark.parametrize('reffer_url, expected_domain', [
+    @pytest.mark.parametrize('url, expected_domain', [
         ('https://osf.io/preprints/sdadadsad', '.osf.io'),
         ('https://agrixiv.org/bhzjs/', '.agrixiv.org'),
         ('https://staging-agrixiv.cos.io/', '.staging-agrixiv.cos.io'),
         ('https://staging.osf.io/preprints/', '.staging.osf.io'),
     ])
-    def test_get_domain_from_refferer(self, reffer_url, expected_domain):
-        actual_domain = get_domain_from_refferer(reffer_url)
+    def test_get_domain(self, url, expected_domain):
+        actual_domain = SloanOverrideWaffleMiddleware.get_domain(url)
         assert actual_domain == expected_domain


### PR DESCRIPTION
## Purpose

So this PR changes quite significantly how the Sloan cookie system is implemented, but doesn't change any of the underlying behavior (other then to fix bugs). Now instead of the cookie behavior being unceremoniously shoved in the `/v2/` root view, the cookie code is now all part of a class that Overrides waffle's middleware, special casing only the sloan cookies.

Change was made to address a bug where both Waffle and my own code were creating two sets of cookies, or sending all it's a flags as cookies on every request.


## Changes

- All code overriding `/v2/` root behavior is moved to a `SloanOverrideWaffleMiddleware`
- `SloanIdmiddware` is deleted and added to to new `SloanOverrideWaffleMiddleware`
- Finally resolves problem where local cookies were silently rejected by the browser.

## QA Notes

We'll be dev-testing this initially them if that goes well I think we should do one final test of everything.

## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1688