### PR TITLE
[ENG-1688] Sloan fixes take 4

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -347,9 +347,9 @@ def get_auth(auth, **kwargs):
                             metric_class = get_metric_class_for_action(action, from_mfr=from_mfr)
                             if metric_class:
                                 sloan_flag = {
-                                    'sloan_coi': request.cookies.get(f'dwf_{SLOAN_COI_DISPLAY}'),
-                                    'sloan_data': request.cookies.get(f'dwf_{SLOAN_DATA_DISPLAY}'),
-                                    'sloan_prereg': request.cookies.get(f'dwf_{SLOAN_PREREG_DISPLAY}'),
+                                    'sloan_coi': bool(request.cookies.get(f'dwf_{SLOAN_COI_DISPLAY}')),
+                                    'sloan_data': bool(request.cookies.get(f'dwf_{SLOAN_DATA_DISPLAY}')),
+                                    'sloan_prereg': bool(request.cookies.get(f'dwf_{SLOAN_PREREG_DISPLAY}')),
                                     'sloan_id': request.cookies.get(SLOAN_ID_COOKIE_NAME)
                                 }
                                 try:

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -308,6 +308,6 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         resp.cookies[f'dwf_{name}']['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-        resp.cookies[f'dwf_{name}']['secure'] = not settings.DEV_MODE
-        if not settings.DEV_MODE:
+        resp.cookies[f'dwf_{name}']['secure'] = not settings.SESSION_COOKIE_SECURE
+        if not settings.SESSION_COOKIE_SECURE:
             resp.cookies[f'dwf_{name}']['samesite'] = None

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -302,13 +302,12 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         :return:
         """
         resp.cookies[f'dwf_{name}'] = active
-        resp.cookies[f'dwf_{name}']._reserved.update({'samesite': 'samesite'})  # This seems terrible but is fixed in py 3.8
+        # ↓ This line seems terrible but is fixed in py 3.8
+        resp.cookies[f'dwf_{name}']._reserved.update({'samesite': 'samesite'})
 
         resp.cookies[f'dwf_{name}']['path'] = '/'
         resp.cookies[f'dwf_{name}']['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
-        resp.cookies[f'dwf_{name}']['httponly'] = settings.SESSION_COOKIE_HTTPONLY
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-        resp.cookies[f'dwf_{name}']['secure'] = not settings.SESSION_COOKIE_SECURE
-        if not settings.SESSION_COOKIE_SECURE:
-            resp.cookies[f'dwf_{name}']['samesite'] = settings.SESSION_COOKIE_HTTPONLY
+        resp.cookies[f'dwf_{name}']['secure'] = settings.SESSION_COOKIE_SECURE
+        resp.cookies[f'dwf_{name}']['samesite'] = settings.SESSION_COOKIE_SAMESITE

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -306,11 +306,9 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
         resp.cookies[f'dwf_{name}']['path'] = '/'
         resp.cookies[f'dwf_{name}']['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
-
-        # ↓ Magical mystery line that doesn't effect local tests at all but makes test pass on travis.
-        resp.cookies[f'dwf_{name}']['httponly'] = settings.CSRF_COOKIE_HTTPONLY
+        resp.cookies[f'dwf_{name}']['httponly'] = settings.SESSION_COOKIE_HTTPONLY
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[f'dwf_{name}']['secure'] = not settings.SESSION_COOKIE_SECURE
         if not settings.SESSION_COOKIE_SECURE:
-            resp.cookies[f'dwf_{name}']['samesite'] = None
+            resp.cookies[f'dwf_{name}']['samesite'] = settings.SESSION_COOKIE_HTTPONLY

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -307,6 +307,9 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         resp.cookies[f'dwf_{name}']['path'] = '/'
         resp.cookies[f'dwf_{name}']['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
 
+        # ↓ Magical mystery line that doesn't effect local tests at all but makes test pass on travis.
+        resp.cookies[f'dwf_{name}']['httponly'] = settings.CSRF_COOKIE_HTTPONLY
+
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[f'dwf_{name}']['secure'] = not settings.SESSION_COOKIE_SECURE
         if not settings.SESSION_COOKIE_SECURE:

--- a/api/base/settings/local-travis.py
+++ b/api/base/settings/local-travis.py
@@ -1,7 +1,5 @@
 from .defaults import *  # noqa
 
-DEV_MODE = True
-
 VARNISH_SERVERS = ['http://127.0.0.1:8080']
 ENABLE_VARNISH = True
 ENABLE_ESI = False

--- a/api/base/settings/local-travis.py
+++ b/api/base/settings/local-travis.py
@@ -1,5 +1,6 @@
 from .defaults import *  # noqa
 
+DEV_MODE = True
 
 VARNISH_SERVERS = ['http://127.0.0.1:8080']
 ENABLE_VARNISH = True

--- a/api/base/settings/local-travis.py
+++ b/api/base/settings/local-travis.py
@@ -1,5 +1,6 @@
 from .defaults import *  # noqa
 
+
 VARNISH_SERVERS = ['http://127.0.0.1:8080']
 ENABLE_VARNISH = True
 ENABLE_ESI = False

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -80,9 +80,9 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
 
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', inactive)
@@ -102,9 +102,9 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
 
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable_unauth(self, app, user, preprint):
@@ -117,9 +117,9 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
 
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control_unauth(self, app, user, preprint):
@@ -132,9 +132,9 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
 
     @pytest.mark.parametrize('reffer_url, expected_provider_id', [
         (f'{DOMAIN}preprints', 'osf'),
@@ -179,9 +179,9 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None' in cookies
 
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
@@ -202,8 +202,8 @@ class TestSloanStudyWaffling:
 
         cookies = resp.headers.getall('Set-Cookie')
 
-        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
 
     @pytest.mark.enable_quickfiles_creation
     def test_user_get_cookie_when_flag_is_everyone(self, app, user, preprint):
@@ -213,8 +213,8 @@ class TestSloanStudyWaffling:
         resp = app.get('/v2/', auth=user.auth, headers=headers)
 
         cookies = resp.headers.getall('Set-Cookie')
-        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None' in cookies
+        assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None' in cookies
 
     @pytest.mark.parametrize('url, expected_domain', [
         ('https://osf.io/preprints/sdadadsad', '.osf.io'),

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -67,7 +67,6 @@ class TestSloanStudyWaffling:
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable(self, app, user, preprint):
-
         headers = {'Referer': preprint.absolute_url}
         resp = app.get('/v2/', auth=user.auth, headers=headers)
 
@@ -91,8 +90,6 @@ class TestSloanStudyWaffling:
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control(self, app, user, preprint):
-        Flag.objects.filter(name__in=SLOAN_FLAGS).update(percent=1)
-
         headers = {'Referer': preprint.absolute_url}
         resp = app.get('/v2/', auth=user.auth, headers=headers)
 
@@ -131,8 +128,6 @@ class TestSloanStudyWaffling:
     @override_settings(DEV_MODE=False)
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control_unauth(self, app, user, preprint):
-        Flag.objects.filter(name__in=SLOAN_FLAGS).update(percent=1)
-
         headers = {'Referer': preprint.absolute_url}
         resp = app.get('/v2/', headers=headers)
 

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from waffle.models import Flag
 from website.settings import DOMAIN
 from api.base.middleware import SloanOverrideWaffleMiddleware
-from django.test.utils import override_settings
 
 from osf_tests.factories import (
     AuthUserFactory,
@@ -63,7 +62,6 @@ class TestSloanStudyWaffling:
     def flags(self, user):
         Flag.objects.filter(name__in=SLOAN_FLAGS, percent=50).update(everyone=None)
 
-    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable(self, app, user, preprint):
@@ -86,7 +84,6 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
-    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control(self, app, user, preprint):
@@ -109,7 +106,6 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
-    @override_settings(DEV_MODE=False)
     @mock.patch('waffle.models.Decimal', active)
     def test_sloan_study_variable_unauth(self, app, user, preprint):
         headers = {'Referer': preprint.absolute_url}
@@ -125,7 +121,6 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
-    @override_settings(DEV_MODE=False)
     @mock.patch('waffle.models.Decimal', inactive)
     def test_sloan_study_control_unauth(self, app, user, preprint):
         headers = {'Referer': preprint.absolute_url}
@@ -163,7 +158,6 @@ class TestSloanStudyWaffling:
         provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
         assert provider is None
 
-    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_provider_custom_domain(self, app, user, preprint):
@@ -189,7 +183,6 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
 
-    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
     def test_unauth_user_logs_in(self, app, user, preprint):
@@ -212,7 +205,6 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
-    @override_settings(DEV_MODE=False)
     @pytest.mark.enable_quickfiles_creation
     def test_user_get_cookie_when_flag_is_everyone(self, app, user, preprint):
         user.add_system_tag(f'no_{SLOAN_PREREG}')


### PR DESCRIPTION
## Purpose

So this PR changes quite significantly how the Sloan cookie system is implemented, but doesn't change any of the underlying behavior (other then to fix bugs). Now instead of the cookie behavior being unceremoniously shoved in the `/v2/` root view, the cookie code is now all part of a class that Overrides waffle's middleware, special casing only the sloan cookies.

Change was made to address a bug where both Waffle and my own code were creating two sets of cookies, or sending all it's a flags as cookies on every request.


## Changes

- All code overriding `/v2/` root behavior is moved to a `SloanOverrideWaffleMiddleware`
- `SloanIdmiddware` is deleted and added to to new `SloanOverrideWaffleMiddleware`
- Finally resolves problem where local cookies were silently rejected by the browser
- Resovle other problem where Travis would reject non-httponly cookies

## QA Notes

We'll be dev-testing this initially them if that goes well I think we should do one final test of everything.

Also once in production cookies should have their `Secure` tags.

## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1688