### PR TITLE
[ENG-1688] Sloan take 5

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -6,6 +6,7 @@ import markupsafe
 from future.moves.urllib.parse import quote
 from django.utils import timezone
 
+from distutils.util import strtobool
 from flask import make_response
 from flask import redirect
 from flask import request
@@ -52,6 +53,12 @@ from website.project.utils import serialize_node
 from website.util import rubeus
 
 from osf.features import (
+    SLOAN_COI_DISPLAY,
+    SLOAN_DATA_DISPLAY,
+    SLOAN_PREREG_DISPLAY
+)
+
+SLOAN_FLAGS = (
     SLOAN_COI_DISPLAY,
     SLOAN_DATA_DISPLAY,
     SLOAN_PREREG_DISPLAY
@@ -346,19 +353,19 @@ def get_auth(auth, **kwargs):
                         if isinstance(node, Preprint):
                             metric_class = get_metric_class_for_action(action, from_mfr=from_mfr)
                             if metric_class:
-                                sloan_flag = {
-                                    'sloan_coi': bool(request.cookies.get(f'dwf_{SLOAN_COI_DISPLAY}')),
-                                    'sloan_data': bool(request.cookies.get(f'dwf_{SLOAN_DATA_DISPLAY}')),
-                                    'sloan_prereg': bool(request.cookies.get(f'dwf_{SLOAN_PREREG_DISPLAY}')),
-                                    'sloan_id': request.cookies.get(SLOAN_ID_COOKIE_NAME)
-                                }
+                                sloan_flags = {'sloan_id': request.cookies.get(SLOAN_ID_COOKIE_NAME)}
+                                for flag_name in SLOAN_FLAGS:
+                                    value = request.cookies.get(f'dwf_{flag_name}')
+                                    if value:
+                                        sloan_flags[flag_name] = strtobool(value)
+
                                 try:
                                     metric_class.record_for_preprint(
                                         preprint=node,
                                         user=auth.user,
                                         version=fileversion.identifier if fileversion else None,
                                         path=path,
-                                        **sloan_flag
+                                        **sloan_flags
                                     )
                                 except es_exceptions.ConnectionError:
                                     log_exception()

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,3 +137,5 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
+
+TRAVIS_MODE = False

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -103,3 +103,5 @@ POPULAR_LINKS_REGISTRATIONS = 'woooo'
 logging.getLogger('celery.app.trace').setLevel(logging.FATAL)
 
 DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
+
+TRAVIS_MODE = True


### PR DESCRIPTION
## Purpose

This ensures once and for all that the bool values for the sloan cookies are good and makes it so now cookies default to secure.

## Changes

- changes so secure is always True for cookies
- fix custom domains to always attach to osf.io or staging.io

## QA Notes

Dev test only, QA will able to see if this works on the front-end.

## Documentation

Not user facing, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1688