### PR TITLE
[ENG-1688] Sloan take 8

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -196,7 +196,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
                     if active is not None:
                         self.set_sloan_tags(user, sloan_flag_name, active)
-                        self.set_sloan_cookie(sloan_flag_name, active, request, response)
+                        self.set_sloan_cookie(f'dwf_{sloan_flag_name}', active, request, response)
 
                     response.data['meta']['active_flags'].append(sloan_flag_name)
 
@@ -208,17 +208,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
         # Give all users a unique id 'sloan_id` cookie, logged in or not.
         if not request.COOKIES.get(settings.SLOAN_ID_COOKIE_NAME):
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME] = str(uuid.uuid4())
-
-            # ↓ This line seems terrible but is fixed in py 3.8
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME]._reserved.update({'samesite': 'samesite'})
-
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME]['path'] = '/'
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
-
-            # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME]['secure'] = True
-            response.cookies[settings.SLOAN_ID_COOKIE_NAME]['samesite'] = 'None'
+            self.set_sloan_cookie(settings.SLOAN_ID_COOKIE_NAME, str(uuid.uuid4()), request, response)
 
         return super(SloanOverrideWaffleMiddleware, self).process_response(request, response)
 
@@ -308,22 +298,22 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             else:
                 user.add_system_tag(f'no_{tag_name}')
 
-    def set_sloan_cookie(self, name: str, active: bool, request, resp):
+    def set_sloan_cookie(self, name: str, value, request, resp):
         """
         Set sloan cookies to sloan study specifications
         :param name: The name of the flag that will get a cookie
-        :param active: Is the flag active?
+        :param value: Is the flag active, what's it's value if sloan_id
         :param request:
         :param resp:
         :return:
         """
-        resp.cookies[f'dwf_{name}'] = active
+        resp.cookies[name] = value
         # ↓ This line seems terrible but is fixed in py 3.8
-        resp.cookies[f'dwf_{name}']._reserved.update({'samesite': 'samesite'})
+        resp.cookies[name]._reserved.update({'samesite': 'samesite'})
 
-        resp.cookies[f'dwf_{name}']['path'] = '/'
-        resp.cookies[f'dwf_{name}']['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
+        resp.cookies[name]['path'] = '/'
+        resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-        resp.cookies[f'dwf_{name}']['secure'] = True
-        resp.cookies[f'dwf_{name}']['samesite'] = 'None'
+        resp.cookies[name]['secure'] = True
+        resp.cookies[name]['samesite'] = 'None'

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -312,7 +312,10 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         resp.cookies[name]._reserved.update({'samesite': 'samesite'})
 
         resp.cookies[name]['path'] = '/'
-        resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
+        if request.environ.get('HTTP_REFERER'):
+            resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
+        else:
+            resp.cookies[name]['domain'] = settings.CSRF_COOKIE_DOMAIN
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[name]['secure'] = True


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

With all this scramble to set sloan flag cookie to the correct domain, we ding dang forgot all about the `sloan_id` cookies, they fail on custom domains and staging and staging2 and staging3 and test.

## Changes

- makes sloan_id and other sloan flag cookies use the same domain setting system.

## QA Notes

Now all domains should be sending sloan_id to their correct domains.

## Documentation

🐞 fix, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1688