### PR TITLE
[No ticket] Fix `update_why_no_data`

### DIFF
--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -870,7 +870,7 @@ class TestPreprintUpdate:
         assert res.json['errors'][0]['detail'] == 'You cannot edit this statement while your data links availability' \
                                                   ' is set to true or is unanswered.'
 
-        preprint.has_data_links = 'available'
+        preprint.has_data_links = 'no'
         preprint.save()
         with override_switch(features.SLOAN_DATA_INPUT, active=True):
             res = app.patch_json_api(url, update_payload, auth=user.auth)

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1086,7 +1086,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         if self.why_no_data == why_no_data:
             return
 
-        if not self.has_data_links == 'available':
+        if not self.has_data_links == 'no':
             raise PreprintStateError('You cannot edit this statement while your data links availability is set to true or'
                                   ' is unanswered.')
         else:


### PR DESCRIPTION
## Purpose

Currently, updating `why_no_data` on the preprint model fails when `has_data_links` is `'no'`. This PR fix the problem.

## Changes

Change the conditional to check for whether `why_no_data` is `'no'` instead of `'available'`.
