### PR TITLE
[ENG-1710] Sloan fix custom domain problems

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -355,7 +355,7 @@ def get_auth(auth, **kwargs):
                             if metric_class:
                                 sloan_flags = {'sloan_id': request.cookies.get(SLOAN_ID_COOKIE_NAME)}
                                 for flag_name in SLOAN_FLAGS:
-                                    value = request.cookies.get(f'dwf_{flag_name}')
+                                    value = request.cookies.get(f'dwf_{flag_name}_custom_domain') or request.cookies.get(f'dwf_{flag_name}')
                                     if value:
                                         sloan_flags[flag_name.replace('_display', '')] = strtobool(value)
 

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -5,6 +5,7 @@ from io import StringIO
 import cProfile
 import pstats
 import threading
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
@@ -198,6 +199,15 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
                         self.set_sloan_tags(user, sloan_flag_name, active)
                         self.set_sloan_cookie(f'dwf_{sloan_flag_name}', active, request, response)
 
+                        if provider.domain:
+                            self.set_sloan_cookie(
+                                f'dwf_{sloan_flag_name}_custom_domain',
+                                active,
+                                request,
+                                response,
+                                custom_domain=provider.domain,
+                            )
+
                     response.data['meta']['active_flags'].append(sloan_flag_name)
 
         # `set_sloan_cookies` has set the cookies, make sure WaffleMiddleware doesn't try to set them again.
@@ -250,7 +260,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
         # matches custom domains:
         provider_domains = list(PreprintProvider.objects.exclude(domain='').values_list('domain', flat=True))
-        provider_domains = [domains for domains in provider_domains if referer_url.startswith(domains)]
+        provider_domains = [domain for domain in provider_domains if referer_url.startswith(domain)]
         if provider_domains:
             return PreprintProvider.objects.get(domain=provider_domains[0])
 
@@ -298,7 +308,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             else:
                 user.add_system_tag(f'no_{tag_name}')
 
-    def set_sloan_cookie(self, name: str, value, request, resp):
+    def set_sloan_cookie(self, name: str, value, request, resp, custom_domain=None):
         """
         Set sloan cookies to sloan study specifications
         :param name: The name of the flag that will get a cookie
@@ -312,10 +322,14 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         resp.cookies[name]._reserved.update({'samesite': 'samesite'})
 
         resp.cookies[name]['path'] = '/'
-        if request.environ.get('HTTP_REFERER'):
-            resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
-        else:
+
+        if request.environ.get('HTTP_REFERER') is None:
             resp.cookies[name]['domain'] = settings.CSRF_COOKIE_DOMAIN
+        else:
+            resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
+
+        if custom_domain:
+            resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[name]['secure'] = True

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -59,6 +59,7 @@ class TestSloanStudyWaffling:
         PreprintProviderFactory(_id='foorxiv').save()
         PreprintProviderFactory(_id='osf').save()
         PreprintProviderFactory(_id='burdixiv', domain='https://burdixiv.burds/').save()
+        PreprintProviderFactory(_id='shady', domain='https://staging2-engrxiv.cos.io/').save()
 
     @pytest.fixture(autouse=True)
     def flags(self, user):
@@ -141,6 +142,8 @@ class TestSloanStudyWaffling:
     @pytest.mark.parametrize('reffer_url, expected_provider_id', [
         (f'https://burdixiv.burds/', 'burdixiv'),
         (f'https://burdixiv.burds/guid0', 'burdixiv'),
+        (f'https://burdixiv.burds/guid0', 'burdixiv'),
+        (f'https://staging2.osf.io/', None),
         (f'{DOMAIN}preprints', 'osf'),
         (f'{DOMAIN}preprints/', 'osf'),
         (f'{DOMAIN}preprints/not/a/valid/path/', 'osf'),
@@ -152,7 +155,7 @@ class TestSloanStudyWaffling:
     ])
     def test_weird_domains(self, reffer_url, expected_provider_id):
         provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
-        assert expected_provider_id == provider._id
+        assert expected_provider_id == getattr(provider, '_id', None)
 
     @pytest.mark.parametrize('reffer_url', [
         DOMAIN,
@@ -171,18 +174,13 @@ class TestSloanStudyWaffling:
         tags = user.all_tags.all().values_list('name', flat=True)
 
         assert SLOAN_COI in tags
-        assert SLOAN_DATA in tags
-        assert SLOAN_PREREG in tags
 
         assert SLOAN_COI_DISPLAY in resp.json['meta']['active_flags']
-        assert SLOAN_DATA_DISPLAY in resp.json['meta']['active_flags']
-        assert SLOAN_PREREG_DISPLAY in resp.json['meta']['active_flags']
 
         cookies = resp.headers.getall('Set-Cookie')
 
         assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_DATA_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies
-        assert f' dwf_{SLOAN_PREREG_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies
+        assert f' dwf_{SLOAN_COI_DISPLAY}_custom_domain=True; Domain=.burdixiv.burds; Path=/; samesite=None; Secure' in cookies
 
     @pytest.mark.enable_quickfiles_creation
     @mock.patch('waffle.models.Decimal', active)
@@ -225,6 +223,7 @@ class TestSloanStudyWaffling:
         ('https://staging2.osf.io/preprints/', '.staging2.osf.io'),
         ('https://staging3.osf.io/preprints/', '.staging3.osf.io'),
         ('https://test.osf.io/preprints/', '.test.osf.io'),
+        ('https://staging2-engrxiv.cos.io/', '.staging2.osf.io'),
     ])
     def test_get_domain(self, url, expected_domain):
         actual_domain = SloanOverrideWaffleMiddleware.get_domain(url)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently though the OSF creates cookies for the api `/v2/` endpoint on every preprint view they don't stick to the a custom domain if the refferer is a custom domain, this fixes that.

## Changes

- Makes an extra set of cookies on custom domains so they send view/download info from that domain, not api.
- add some extra test cases

## QA Notes

Dev then Courtney test.

## Documentation

🐞 fix, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1710