### PR TITLE
[ENG-1711] Filter out non-redirect preprint providers from sloan custom domains

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -249,7 +249,16 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         """
 
         # matches custom domains:
-        provider_domains = list(PreprintProvider.objects.exclude(domain='').values_list('domain', flat=True))
+        provider_domains = list(
+            PreprintProvider.objects.exclude(
+                domain='',
+            ).filter(
+                domain_redirect_enabled=True,  # must exclude our native domains like https://staging2.osf.io/
+            ).values_list(
+                'domain',
+                flat=True,
+            ),
+        )
         provider_domains = [domains for domains in provider_domains if referer_url.startswith(domains)]
         if provider_domains:
             return PreprintProvider.objects.get(domain=provider_domains[0])

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -58,7 +58,8 @@ class TestSloanStudyWaffling:
     def providers(self, user):
         PreprintProviderFactory(_id='foorxiv').save()
         PreprintProviderFactory(_id='osf').save()
-        PreprintProviderFactory(_id='burdixiv', domain='https://burdixiv.burds/').save()
+        PreprintProviderFactory(_id='burdixiv', domain='https://burdixiv.burds/', domain_redirect_enabled=True).save()
+        PreprintProviderFactory(_id='shady', domain='https://staging2.osf.io/', domain_redirect_enabled=False).save()
 
     @pytest.fixture(autouse=True)
     def flags(self, user):
@@ -139,6 +140,7 @@ class TestSloanStudyWaffling:
         assert f' dwf_{SLOAN_PREREG_DISPLAY}=False; Domain=localhost; Path=/; samesite=None; Secure' in cookies
 
     @pytest.mark.parametrize('reffer_url, expected_provider_id', [
+        (f'https://staging2.osf.io/', None),
         (f'https://burdixiv.burds/', 'burdixiv'),
         (f'https://burdixiv.burds/guid0', 'burdixiv'),
         (f'{DOMAIN}preprints', 'osf'),
@@ -152,7 +154,7 @@ class TestSloanStudyWaffling:
     ])
     def test_weird_domains(self, reffer_url, expected_provider_id):
         provider = SloanOverrideWaffleMiddleware.get_provider_from_url(reffer_url)
-        assert expected_provider_id == provider._id
+        assert expected_provider_id == getattr(provider, '_id', None)
 
     @pytest.mark.parametrize('reffer_url', [
         DOMAIN,


### PR DESCRIPTION
## Purpose

Currently staging2 would mysteriously always return flags, no matter if you were viewing a preprint or not, staging1 had no should error.

## Changes

- filters out non-redirect preprint providers and changes test

## QA Notes

 Dev test, then Courtney test

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1711