### PR TITLE
[ENG-1630] Share add registration provider info

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -357,7 +357,7 @@ def get_auth(auth, **kwargs):
                                 for flag_name in SLOAN_FLAGS:
                                     value = request.cookies.get(f'dwf_{flag_name}')
                                     if value:
-                                        sloan_flags[flag_name.rstrip('_display')] = strtobool(value)
+                                        sloan_flags[flag_name.replace('_display', '')] = strtobool(value)
 
                                 try:
                                     metric_class.record_for_preprint(

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -277,36 +277,28 @@ class TestNodeReindex(AdminTestCase):
         self.node = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(project=self.node, creator=self.user)
 
-    @mock.patch('website.project.tasks.format_node')
-    @mock.patch('website.project.tasks.format_registration')
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'totaly_real_token')
     @mock.patch('website.project.tasks.send_share_node_data')
-    def test_reindex_node_share(self, mock_update_share, mock_format_registration, mock_format_node):
+    def test_reindex_node_share(self, mock_update_share):
         count = AdminLogEntry.objects.count()
         view = NodeReindexShare()
         view = setup_log_view(view, self.request, guid=self.node._id)
         view.delete(self.request)
 
         nt.assert_true(mock_update_share.called)
-        nt.assert_true(mock_format_node.called)
-        nt.assert_false(mock_format_registration.called)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
-    @mock.patch('website.project.tasks.format_node')
-    @mock.patch('website.project.tasks.format_registration')
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'totaly_real_token')
     @mock.patch('website.project.tasks.send_share_node_data')
-    def test_reindex_registration_share(self, mock_update_share, mock_format_registration, mock_format_node):
+    def test_reindex_registration_share(self, mock_update_share):
         count = AdminLogEntry.objects.count()
         view = NodeReindexShare()
         view = setup_log_view(view, self.request, guid=self.registration._id)
         view.delete(self.request)
 
         nt.assert_true(mock_update_share.called)
-        nt.assert_false(mock_format_node.called)
-        nt.assert_true(mock_format_registration.called)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
     @mock.patch('website.search.search.update_node')

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -50,6 +50,7 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
                                         null=True, blank=True, on_delete=models.CASCADE)
     allow_submissions = models.BooleanField(default=True)
     allow_commenting = models.BooleanField(default=False)
+    access_token = EncryptedTextField(null=True, blank=True)
 
     def __repr__(self):
         return ('(name={self.name!r}, default_license={self.default_license!r}, '
@@ -158,7 +159,7 @@ class PreprintProvider(AbstractProvider):
     share_source = models.CharField(blank=True, max_length=200)
     share_title = models.TextField(default='', blank=True)
     additional_providers = fields.ArrayField(models.CharField(max_length=200), default=list, blank=True)
-    access_token = EncryptedTextField(null=True, blank=True)
+
     doi_prefix = models.CharField(blank=True, max_length=32)
     in_sloan_study = models.NullBooleanField(default=True)
 

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -7,7 +7,8 @@ from framework.exceptions import PermissionsError
 from osf.exceptions import UserNotAffiliatedError, DraftRegistrationStateError, NodeStateError
 from osf.models import RegistrationSchema, DraftRegistration, DraftRegistrationContributor, NodeLicense, Node, NodeLog
 from osf.utils.permissions import ADMIN, READ, WRITE
-from osf_tests.test_node import TestNodeEditableFieldsMixin, TestTagging, TestNodeLicenses, TestNodeSubjects
+from osf_tests.test_node import TestNodeEditableFieldsMixin, TestTagging, TestNodeSubjects
+from osf_tests.test_node_license import TestNodeLicenses
 
 from website import settings
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -1,33 +1,24 @@
 import datetime
-import json
 
 import mock
 import pytest
 import pytz
-import random
-import string
-import builtins
 
 from django.utils import timezone
-from django.db.utils import IntegrityError
-from nose.tools import assert_equal, assert_is_not_none, assert_not_equal, assert_false, assert_raises
 from framework.celery_tasks import handlers
 from framework.exceptions import PermissionsError
 from framework.sessions import set_session
 from website.project.model import has_anonymous_link
 from website.project.signals import contributor_added, contributor_removed, after_create_registration
 from osf.exceptions import NodeStateError
-from osf.models.licenses import NodeLicense, serialize_node_license_record, serialize_node_license
 from osf.utils import permissions
 from website.util import api_url_for, web_url_for
 from api_tests.utils import disconnected_from_listeners
 from website.citations.utils import datetime_to_csl
 from website import language, settings
-from website.project.tasks import on_node_updated, format_registration
 from website.project.views.node import serialize_collections
 from website.views import find_bookmark_collection
 
-from osf.utils.migrations import ensure_licenses
 from osf.utils.permissions import READ, WRITE, ADMIN, DEFAULT_CONTRIBUTOR_PERMISSIONS
 
 from osf.models import (
@@ -47,7 +38,6 @@ from osf.models import (
 
 from addons.wiki.models import WikiPage, WikiVersion
 from osf.models.node import AbstractNodeQuerySet
-from osf.models.spam import SpamStatus
 from osf.exceptions import ValidationError, ValidationValueError, UserStateError
 from osf.utils.workflows import DefaultStates
 from framework.auth.core import Auth
@@ -76,7 +66,7 @@ from osf_tests.factories import (
 )
 from .factories import get_default_metaschema
 from addons.wiki.tests.factories import WikiVersionFactory, WikiFactory
-from .utils import capture_signals, assert_datetime_equal, mock_archive, MockShareResponse
+from osf_tests.utils import capture_signals, assert_datetime_equal, mock_archive
 
 pytestmark = pytest.mark.django_db
 
@@ -3846,201 +3836,6 @@ class TestOnNodeUpdate:
         assert 'contributors' in task.kwargs['saved_fields']
         assert 'node_license' in task.kwargs['saved_fields']
 
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    def test_updates_share(self, requests, node, user):
-        on_node_updated(node._id, user._id, False, {'is_public'})
-
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-
-        assert requests.post.called
-        assert kwargs['headers']['Authorization'] == 'Bearer Token'
-        assert graph[0]['uri'] == '{}{}/'.format(settings.DOMAIN, node._id)
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    def test_update_share_correctly_for_projects(self, requests, node, user, request_context):
-        cases = [{
-            'is_deleted': False,
-            'attrs': {'is_public': True, 'is_deleted': False, 'spam_status': SpamStatus.HAM}
-        }, {
-            'is_deleted': True,
-            'attrs': {'is_public': False, 'is_deleted': False, 'spam_status': SpamStatus.HAM}
-        }, {
-            'is_deleted': True,
-            'attrs': {'is_public': True, 'is_deleted': True, 'spam_status': SpamStatus.HAM}
-        }, {
-            'is_deleted': True,
-            'attrs': {'is_public': True, 'is_deleted': False, 'spam_status': SpamStatus.SPAM}
-        }]
-
-        for case in cases:
-            for attr, value in case['attrs'].items():
-                setattr(node, attr, value)
-            node.save()
-
-            on_node_updated(node._id, user._id, False, {'is_public'})
-
-            kwargs = requests.post.call_args[1]
-            graph = kwargs['json']['data']['attributes']['data']['@graph']
-            assert graph[1]['is_deleted'] == case['is_deleted']
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
-    def test_update_share_correctly_for_registrations(self, requests, registration, user, request_context):
-        cases = [{
-            'is_deleted': False,
-            'attrs': {'is_public': True, 'is_deleted': False}
-        }, {
-            'is_deleted': True,
-            'attrs': {'is_public': False, 'is_deleted': False}
-        }, {
-            'is_deleted': True,
-            'attrs': {'is_public': True, 'is_deleted': True}
-        }, {
-            'is_deleted': False,
-            'attrs': {'is_public': True, 'is_deleted': False}
-        }]
-
-        for case in cases:
-            for attr, value in case['attrs'].items():
-                setattr(registration, attr, value)
-            registration.save()
-
-            on_node_updated(registration._id, user._id, False, {'is_public'})
-
-            assert registration.is_registration
-            kwargs = requests.post.call_args[1]
-            graph = kwargs['json']['data']['attributes']['data']['@graph']
-            payload = next((item for item in graph if 'is_deleted' in item.keys()))
-            assert payload['is_deleted'] == case['is_deleted']
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
-    def test_format_registration_gets_parent_hierarchy_for_component_registrations(self, requests, project, component_registration, user, request_context):
-
-        graph = format_registration(component_registration)
-
-        parent_relation = [i for i in graph if i['@type'] == 'ispartof'][0]
-        parent_work_identifier = [i for i in graph if 'creative_work' in i and i['creative_work']['@id'] == parent_relation['subject']['@id']][0]
-
-        # Both must exist to be valid
-        assert parent_relation
-        assert parent_work_identifier
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    def test_update_share_correctly_for_projects_with_qa_tags(self, requests, node, user, request_context):
-        node.add_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user))
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is True
-
-        node.remove_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user), save=True)
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is False
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
-    def test_update_share_correctly_for_registrations_with_qa_tags(self, requests, registration, user, request_context):
-        registration.add_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user))
-        on_node_updated(registration._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is True
-
-        registration.remove_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user), save=True)
-        on_node_updated(registration._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is False
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    def test_update_share_correctly_for_projects_with_qa_titles(self, requests, node, user, request_context):
-        node.title = settings.DO_NOT_INDEX_LIST['titles'][0].join(random.choice(string.ascii_lowercase) for i in range(5))
-        node.save()
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is True
-
-        node.title = 'Not a qa title'
-        node.save()
-        assert node.title not in settings.DO_NOT_INDEX_LIST['titles']
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is False
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
-    def test_update_share_correctly_for_registrations_with_qa_titles(self, requests, registration, user, request_context):
-        registration.title = settings.DO_NOT_INDEX_LIST['titles'][0].join(random.choice(string.ascii_lowercase) for i in range(5))
-        registration.save()
-        on_node_updated(registration._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is True
-
-        registration.title = 'Not a qa title'
-        registration.save()
-        assert registration.title not in settings.DO_NOT_INDEX_LIST['titles']
-        on_node_updated(registration._id, user._id, False, {'is_public'})
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        payload = next((item for item in graph if 'is_deleted' in item.keys()))
-        assert payload['is_deleted'] is False
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', None)
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', None)
-    @mock.patch('website.project.tasks.requests')
-    def test_skips_no_settings(self, requests, node, user, request_context):
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        assert requests.post.called is False
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'a_real_url')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'a_real_token')
-    @mock.patch('website.project.tasks._async_update_node_share.delay')
-    @mock.patch('website.project.tasks.requests')
-    def test_call_async_update_on_500_failure(self, requests, mock_async, node, user, request_context):
-        requests.post.return_value = MockShareResponse(501)
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        assert mock_async.called
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'a_real_url')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'a_real_token')
-    @mock.patch('website.project.tasks.send_desk_share_error')
-    @mock.patch('website.project.tasks._async_update_node_share.delay')
-    @mock.patch('website.project.tasks.requests')
-    def test_no_call_async_update_on_400_failure(self, requests, mock_async, mock_mail, node, user, request_context):
-        requests.post.return_value = MockShareResponse(400)
-        on_node_updated(node._id, user._id, False, {'is_public'})
-        assert mock_mail.called
-        assert not mock_async.called
 
 # copied from tests/test_models.py
 class TestRemoveNode:
@@ -4854,133 +4649,3 @@ class TestCollectionProperties:
         assert len(collection_summary) == 3
         urls_actual = {summary['url'] for summary in collection_summary}
         assert self._collection_url(bookmark_collection_public) not in urls_actual
-
-
-CHANGED_NAME = 'FOO BAR'
-CHANGED_TEXT = 'Some good new text'
-
-CHANGED_PROPERTIES = ['foo', 'bar']
-LICENSE_TEXT = json.dumps({
-    'MIT': {
-        'name': CHANGED_NAME,
-        'text': CHANGED_TEXT,
-        'properties': CHANGED_PROPERTIES
-    }
-})
-
-@pytest.mark.django_db
-class TestNodeLicenses:
-
-    @pytest.fixture()
-    def user(self):
-        return AuthUserFactory()
-
-    @pytest.fixture()
-    def node(self, node_license, user):
-        node = ProjectFactory(creator=user)
-        node.node_license = NodeLicenseRecordFactory(
-            node_license=node_license,
-            year=self.YEAR,
-            copyright_holders=self.COPYRIGHT_HOLDERS
-        )
-        node.save()
-        return node
-
-    LICENSE_NAME = 'MIT License'
-    YEAR = '2105'
-    COPYRIGHT_HOLDERS = ['Foo', 'Bar']
-
-    @pytest.fixture()
-    def node_license(self):
-        return NodeLicense.objects.get(name=self.LICENSE_NAME)
-
-    def test_serialize_node_license(self, node_license):
-        serialized = serialize_node_license(node_license)
-        assert_equal(serialized['name'], self.LICENSE_NAME)
-        assert_equal(serialized['id'], node_license.license_id)
-        assert_equal(serialized['text'], node_license.text)
-
-    def test_serialize_node_license_record(self, node, node_license):
-        serialized = serialize_node_license_record(node.node_license)
-        assert_equal(serialized['name'], self.LICENSE_NAME)
-        assert_equal(serialized['id'], node_license.license_id)
-        assert_equal(serialized['text'], node_license.text)
-        assert_equal(serialized['year'], self.YEAR)
-        assert_equal(serialized['copyright_holders'], self.COPYRIGHT_HOLDERS)
-
-    def test_serialize_node_license_record_None(self, node):
-        node.node_license = None
-        serialized = serialize_node_license_record(node.node_license)
-        assert_equal(serialized, {})
-
-    def test_copy_node_license_record(self, node):
-        record = node.node_license
-        copied = record.copy()
-        assert_is_not_none(copied._id)
-        assert_not_equal(record._id, copied._id)
-        for prop in ('license_id', 'name', 'node_license'):
-            assert_equal(getattr(record, prop), getattr(copied, prop))
-
-    def test_license_uniqueness_on_id_is_enforced_in_the_database(self):
-        NodeLicense(license_id='foo', name='bar', text='baz').save()
-        with pytest.raises(IntegrityError):
-            NodeLicense(license_id='foo', name='buz', text='boo').save()
-
-    def test_ensure_licenses_updates_existing_licenses(self):
-        assert_equal(ensure_licenses(), (0, 18))
-
-    def test_ensure_licenses_no_licenses(self):
-        before_count = NodeLicense.objects.all().count()
-        NodeLicense.objects.all().delete()
-        assert_false(NodeLicense.objects.all().count())
-
-        ensure_licenses()
-        assert_equal(before_count, NodeLicense.objects.all().count())
-
-    def test_ensure_licenses_some_missing(self):
-        NodeLicense.objects.get(license_id='LGPL3').delete()
-        with assert_raises(NodeLicense.DoesNotExist):
-            NodeLicense.objects.get(license_id='LGPL3')
-        ensure_licenses()
-        found = NodeLicense.objects.get(license_id='LGPL3')
-        assert_is_not_none(found)
-
-    def test_ensure_licenses_updates_existing(self):
-        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=LICENSE_TEXT)):
-            ensure_licenses()
-        MIT = NodeLicense.objects.get(license_id='MIT')
-        assert_equal(MIT.name, CHANGED_NAME)
-        assert_equal(MIT.text, CHANGED_TEXT)
-        assert_equal(MIT.properties, CHANGED_PROPERTIES)
-
-    def test_node_set_node_license(self, node, user):
-        GPL3 = NodeLicense.objects.get(license_id='GPL3')
-        NEW_YEAR = '2014'
-        COPYLEFT_HOLDERS = ['Richard Stallman']
-        node.set_node_license(
-            {
-                'id': GPL3.license_id,
-                'year': NEW_YEAR,
-                'copyrightHolders': COPYLEFT_HOLDERS
-            },
-            auth=Auth(user),
-            save=True
-        )
-
-        assert_equal(node.node_license.license_id, GPL3.license_id)
-        assert_equal(node.node_license.name, GPL3.name)
-        assert_equal(node.node_license.copyright_holders, COPYLEFT_HOLDERS)
-        assert node.logs.latest().action == NodeLog.CHANGED_LICENSE
-
-    def test_node_set_node_license_invalid(self, node, user):
-        with assert_raises(NodeStateError):
-            node.set_node_license(
-                {
-                    'id': 'SOME ID',
-                    'year': 'foo',
-                    'copyrightHolders': []
-                },
-                auth=Auth(user)
-            )
-        action = node.logs.latest().action if node.logs.count() else None
-        assert action != NodeLog.CHANGED_LICENSE

--- a/osf_tests/test_node_license.py
+++ b/osf_tests/test_node_license.py
@@ -1,10 +1,158 @@
+import json
+import mock
 import pytest
+import builtins
 
-from osf.models import NodeLicense
+from django.db.utils import IntegrityError
+from nose.tools import assert_equal, assert_is_not_none, assert_not_equal, assert_false, assert_raises
+from osf.models.licenses import serialize_node_license_record, serialize_node_license
+from osf.utils.migrations import ensure_licenses
+from osf.exceptions import NodeStateError
+from framework.auth.core import Auth
 
-pytestmark = pytest.mark.django_db
 
-def test_manager_methods():
-    # Projects can't have CCBYNCND but preprints can
-    assert 'CCBYNCND' not in list(NodeLicense.objects.project_licenses().values_list('license_id', flat=True))
-    assert 'CCBYNCND' in list(NodeLicense.objects.preprint_licenses().values_list('license_id', flat=True))
+from osf.models import (
+    NodeLicense,
+    NodeLog
+)
+
+from osf_tests.factories import (
+    AuthUserFactory,
+    ProjectFactory,
+    NodeLicenseRecordFactory
+)
+
+CHANGED_NAME = 'FOO BAR'
+CHANGED_TEXT = 'Some good new text'
+
+CHANGED_PROPERTIES = ['foo', 'bar']
+LICENSE_TEXT = json.dumps({
+    'MIT': {
+        'name': CHANGED_NAME,
+        'text': CHANGED_TEXT,
+        'properties': CHANGED_PROPERTIES
+    }
+})
+
+
+@pytest.mark.django_db
+class TestNodeLicenses:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, node_license, user):
+        node = ProjectFactory(creator=user)
+        node.node_license = NodeLicenseRecordFactory(
+            node_license=node_license,
+            year=self.YEAR,
+            copyright_holders=self.COPYRIGHT_HOLDERS
+        )
+        node.save()
+        return node
+
+    LICENSE_NAME = 'MIT License'
+    YEAR = '2105'
+    COPYRIGHT_HOLDERS = ['Foo', 'Bar']
+
+    @pytest.fixture()
+    def node_license(self):
+        return NodeLicense.objects.get(name=self.LICENSE_NAME)
+
+    def test_serialize_node_license(self, node_license):
+        serialized = serialize_node_license(node_license)
+        assert_equal(serialized['name'], self.LICENSE_NAME)
+        assert_equal(serialized['id'], node_license.license_id)
+        assert_equal(serialized['text'], node_license.text)
+
+    def test_serialize_node_license_record(self, node, node_license):
+        serialized = serialize_node_license_record(node.node_license)
+        assert_equal(serialized['name'], self.LICENSE_NAME)
+        assert_equal(serialized['id'], node_license.license_id)
+        assert_equal(serialized['text'], node_license.text)
+        assert_equal(serialized['year'], self.YEAR)
+        assert_equal(serialized['copyright_holders'], self.COPYRIGHT_HOLDERS)
+
+    def test_serialize_node_license_record_None(self, node):
+        node.node_license = None
+        serialized = serialize_node_license_record(node.node_license)
+        assert_equal(serialized, {})
+
+    def test_copy_node_license_record(self, node):
+        record = node.node_license
+        copied = record.copy()
+        assert_is_not_none(copied._id)
+        assert_not_equal(record._id, copied._id)
+        for prop in ('license_id', 'name', 'node_license'):
+            assert_equal(getattr(record, prop), getattr(copied, prop))
+
+    def test_license_uniqueness_on_id_is_enforced_in_the_database(self):
+        NodeLicense(license_id='foo', name='bar', text='baz').save()
+        with pytest.raises(IntegrityError):
+            NodeLicense(license_id='foo', name='buz', text='boo').save()
+
+    def test_ensure_licenses_updates_existing_licenses(self):
+        assert_equal(ensure_licenses(), (0, 18))
+
+    def test_ensure_licenses_no_licenses(self):
+        before_count = NodeLicense.objects.all().count()
+        NodeLicense.objects.all().delete()
+        assert_false(NodeLicense.objects.all().count())
+
+        ensure_licenses()
+        assert_equal(before_count, NodeLicense.objects.all().count())
+
+    def test_ensure_licenses_some_missing(self):
+        NodeLicense.objects.get(license_id='LGPL3').delete()
+        with assert_raises(NodeLicense.DoesNotExist):
+            NodeLicense.objects.get(license_id='LGPL3')
+        ensure_licenses()
+        found = NodeLicense.objects.get(license_id='LGPL3')
+        assert_is_not_none(found)
+
+    def test_ensure_licenses_updates_existing(self):
+        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=LICENSE_TEXT)):
+            ensure_licenses()
+        MIT = NodeLicense.objects.get(license_id='MIT')
+        assert_equal(MIT.name, CHANGED_NAME)
+        assert_equal(MIT.text, CHANGED_TEXT)
+        assert_equal(MIT.properties, CHANGED_PROPERTIES)
+
+    def test_node_set_node_license(self, node, user):
+        GPL3 = NodeLicense.objects.get(license_id='GPL3')
+        NEW_YEAR = '2014'
+        COPYLEFT_HOLDERS = ['Richard Stallman']
+        node.set_node_license(
+            {
+                'id': GPL3.license_id,
+                'year': NEW_YEAR,
+                'copyrightHolders': COPYLEFT_HOLDERS
+            },
+            auth=Auth(user),
+            save=True
+        )
+
+        assert_equal(node.node_license.license_id, GPL3.license_id)
+        assert_equal(node.node_license.name, GPL3.name)
+        assert_equal(node.node_license.copyright_holders, COPYLEFT_HOLDERS)
+        assert node.logs.latest().action == NodeLog.CHANGED_LICENSE
+
+    def test_node_set_node_license_invalid(self, node, user):
+        with assert_raises(NodeStateError):
+            node.set_node_license(
+                {
+                    'id': 'SOME ID',
+                    'year': 'foo',
+                    'copyrightHolders': []
+                },
+                auth=Auth(user)
+            )
+        action = node.logs.latest().action if node.logs.count() else None
+        assert action != NodeLog.CHANGED_LICENSE
+
+    def test_manager_methods(self):
+        # Projects can't have CCBYNCND but preprints can
+        assert 'CCBYNCND' not in list(NodeLicense.objects.project_licenses().values_list('license_id', flat=True))
+        assert 'CCBYNCND' in list(NodeLicense.objects.preprint_licenses().values_list('license_id', flat=True))

--- a/osf_tests/test_node_share.py
+++ b/osf_tests/test_node_share.py
@@ -1,0 +1,287 @@
+import mock
+import json
+
+import pytest
+import random
+import string
+import responses
+
+from framework.auth.core import Auth
+from framework.sessions import set_session
+from website import settings
+
+from website.project.tasks import on_node_updated, format_registration
+
+from osf.models import (
+    SpamStatus,
+)
+
+from osf_tests.utils import MockShareResponse
+from osf_tests.factories import (
+    UserFactory,
+    NodeFactory,
+    SessionFactory,
+    ProjectFactory,
+    RegistrationFactory,
+    RegistrationProviderFactory
+)
+
+@pytest.mark.django_db
+@pytest.mark.enable_enqueue_task
+class TestSHAREOnNodeUpdate:
+
+    @pytest.fixture(autouse=True)
+    def session(self, user, request_context):
+        s = SessionFactory(user=user)
+        set_session(s)
+        return s
+
+    @pytest.fixture(autouse=True)
+    def mock_share_settings(self):
+        with mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token'):
+            with mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io'):
+                yield
+
+    @pytest.fixture(autouse=True)
+    def mock_share(self):
+        responses.add(
+            responses.Response(
+                responses.POST,
+                'https://share.osf.io/api/normalizeddata/',
+                status=200,
+            )
+        )
+
+    @pytest.fixture()
+    def mock_share_down(self):
+        responses.add(
+            responses.Response(
+                responses.POST,
+                'https://share.osf.io/api/normalizeddata/',
+                MockShareResponse(501)
+            )
+        )
+
+    @pytest.fixture()
+    def user(self):
+        return UserFactory()
+
+    @pytest.fixture()
+    def node(self):
+        return ProjectFactory(is_public=True)
+
+    @pytest.fixture()
+    def registration(self, node):
+        reg_provider = RegistrationProviderFactory(name='test')
+        reg_provider.access_token = 'mock token'
+        reg_provider.save()
+        registration = RegistrationFactory(is_public=True, provider=reg_provider)
+        registration.archive_jobs.clear()
+        registration.save()
+
+        return registration
+
+    @pytest.fixture()
+    def component_registration(self, node):
+        NodeFactory(
+            creator=node.creator,
+            parent=node,
+            title='Title1',
+        )
+        registration = RegistrationFactory(project=node)
+        registration.refresh_from_db()
+        return registration.get_nodes()[0]
+
+    @responses.activate
+    def test_updates_share(self, node, user):
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[0].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+
+        assert responses.calls[0].request.headers['Authorization'] == 'Bearer Token'
+        assert graph[0]['uri'] == f'{settings.DOMAIN}{node._id}/'
+
+    @responses.activate
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
+    def test_on_node_updated_status(self, node, user, request_context):
+
+        cases = [{
+            'is_deleted': False,
+            'attrs': {'is_public': True, 'is_deleted': False, 'spam_status': SpamStatus.HAM}
+        }, {
+            'is_deleted': True,
+            'attrs': {'is_public': False, 'is_deleted': False, 'spam_status': SpamStatus.HAM}
+        }, {
+            'is_deleted': True,
+            'attrs': {'is_public': True, 'is_deleted': True, 'spam_status': SpamStatus.HAM}
+        }, {
+            'is_deleted': True,
+            'attrs': {'is_public': True, 'is_deleted': False, 'spam_status': SpamStatus.SPAM}
+        }]
+
+        for i, case in enumerate(cases):
+            for attr, value in case['attrs'].items():
+                print(attr, value)
+                setattr(node, attr, value)
+            node.save()
+
+            on_node_updated(node._id, user._id, False, {'is_public'})
+
+            data = json.loads(responses.calls[i].request.body)
+            graph = data['data']['attributes']['data']['@graph']
+            assert graph[1]['is_deleted'] == case['is_deleted']
+
+    @responses.activate
+    def test_update_share_registrations(self, registration, user, request_context):
+
+        cases = [{
+            'is_deleted': False,
+            'attrs': {'is_public': True, 'is_deleted': False}
+        }, {
+            'is_deleted': True,
+            'attrs': {'is_public': False, 'is_deleted': False}
+        }, {
+            'is_deleted': True,
+            'attrs': {'is_public': True, 'is_deleted': True}
+        }, {
+            'is_deleted': False,
+            'attrs': {'is_public': True, 'is_deleted': False}
+        }]
+
+        for i, case in enumerate(cases):
+            for attr, value in case['attrs'].items():
+                setattr(registration, attr, value)
+            registration.save()
+
+            on_node_updated(registration._id, user._id, False, {'is_public'})
+
+            assert registration.is_registration
+            data = json.loads(responses.calls[i].request.body)
+            graph = data['data']['attributes']['data']['@graph']
+            payload = next((item for item in graph if 'is_deleted' in item.keys()))
+            assert payload['is_deleted'] == case['is_deleted']
+
+    @responses.activate
+    def test_dont_update_share_with_qa_tags(self, node, user, request_context):
+        node.add_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user))
+        on_node_updated(node._id, user._id, False, {'is_public'})
+
+        data = json.loads(responses.calls[0].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is True
+
+        node.remove_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user), save=True)
+        on_node_updated(node._id, user._id, False, {'is_public'})
+
+        data = json.loads(responses.calls[3].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is False
+
+    @responses.activate
+    def test_dont_update_share_with_qa_tags_registrations(self, registration, user, request_context):
+        registration.add_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user))
+        on_node_updated(registration._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[0].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is True
+
+        registration.remove_tag(settings.DO_NOT_INDEX_LIST['tags'][0], auth=Auth(user), save=True)
+        on_node_updated(registration._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[3].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is False
+
+    @responses.activate
+    def test_update_share_correctly_for_projects_with_qa_titles(self, node, user, request_context):
+
+        node.title = settings.DO_NOT_INDEX_LIST['titles'][0].join(random.choice(string.ascii_lowercase) for i in range(5))
+        node.save()
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[0].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is True
+
+        node.title = 'Not a qa title'
+        node.save()
+        assert node.title not in settings.DO_NOT_INDEX_LIST['titles']
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[1].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is False
+
+    @responses.activate
+    def test_update_share_correctly_for_registrations_with_qa_titles(self, registration, user, request_context):
+        registration.title = settings.DO_NOT_INDEX_LIST['titles'][0].join(random.choice(string.ascii_lowercase) for i in range(5))
+        registration.save()
+        on_node_updated(registration._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[0].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is True
+
+        registration.title = 'Not a qa title'
+        registration.save()
+        assert registration.title not in settings.DO_NOT_INDEX_LIST['titles']
+        on_node_updated(registration._id, user._id, False, {'is_public'})
+        data = json.loads(responses.calls[1].request.body)
+        graph = data['data']['attributes']['data']['@graph']
+        payload = next((item for item in graph if 'is_deleted' in item.keys()))
+        assert payload['is_deleted'] is False
+
+    @responses.activate
+    @mock.patch('website.project.tasks.settings.SHARE_URL', None)
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', None)
+    def test_skips_no_settings(self, node, user, request_context):
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'a_real_url')
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'a_real_token')
+    @mock.patch('website.project.tasks._async_update_node_share.delay')
+    def test_call_async_update_on_500_failure(self, mock_async, node, user, request_context):
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        assert mock_async.called
+
+    @responses.activate
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'a_real_url')
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'a_real_token')
+    @mock.patch('website.project.tasks.send_desk_share_error')
+    @mock.patch('website.project.tasks._async_update_node_share.delay')
+    def test_no_call_async_update_on_400_failure(self, mock_async, mock_mail, node, user, request_context):
+        on_node_updated(node._id, user._id, False, {'is_public'})
+        assert mock_mail.called
+        assert not mock_async.called
+
+    def test_format_registration_gets_parent_hierarchy_for_component_registrations(self, component_registration, user, request_context):
+
+        graph = format_registration(component_registration)
+
+        parent_relation = [i for i in graph if i['@type'] == 'ispartof'][0]
+        parent_work_identifier = [i for i in graph if 'creative_work' in i and i['creative_work']['@id'] == parent_relation['subject']['@id']][0]
+
+        # Both must exist to be valid
+        assert parent_relation
+        assert parent_work_identifier
+
+    @responses.activate
+    def test_registation_provider_sends_token(self, registration, user, request_context):
+        """
+        This test ensures when a registration has a provider that providers token is sent to SHARE instead of the OSF's
+        whole-site token.
+        :param registration:
+        :param user:
+        :param request_context:
+        :return:
+        """
+        on_node_updated(registration._id, user._id, False, {'is_public'})
+        token = responses.calls[0].request.headers['Authorization'].lstrip('Bearer ')
+
+        assert registration.provider.access_token == token

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -427,12 +427,10 @@ class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
         # Reload the registration; else tests won't catch failures to svae
         self.registration.reload()
 
-    @mock.patch('website.project.tasks.format_node')
-    @mock.patch('website.project.tasks.format_registration')
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'totaly_real_token')
     @mock.patch('website.project.tasks.send_share_node_data')
-    def test_approval_retracts_descendant_nodes(self, mock_update_share, mock_format_registration, mock_format_node):
+    def test_approval_retracts_descendant_nodes(self, mock_update_share):
         # Initiate retraction for parent registration
         self.registration.retract_registration(self.user)
         self.registration.save()
@@ -455,8 +453,6 @@ class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
             assert_true(node.is_retracted)
 
         assert mock_update_share.called
-        assert mock_format_registration.called
-        assert not mock_format_node.called
 
     def test_disapproval_cancels_retraction_on_descendant_nodes(self):
         # Initiate retraction for parent registration
@@ -577,12 +573,10 @@ class RegistrationRetractionShareHook(OsfTestCase):
         # Reload the registration; else tests won't catch failures to svae
         self.registration.reload()
 
-    @mock.patch('website.project.tasks.format_node')
-    @mock.patch('website.project.tasks.format_registration')
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'totaly_real_token')
     @mock.patch('website.project.tasks.send_share_node_data')
-    def test_approval_calls_share_hook(self, mock_update_share, mock_format_registration, mock_format_node):
+    def test_approval_calls_share_hook(self, mock_update_share):
         # Initiate retraction for parent registration
         self.registration.retract_registration(self.user)
         self.registration.save()
@@ -592,8 +586,6 @@ class RegistrationRetractionShareHook(OsfTestCase):
         self.registration.retraction.approve_retraction(self.user, approval_token)
         assert_true(self.registration.is_retracted)
         assert mock_update_share.called
-        assert mock_format_registration.called
-        assert not mock_format_node.called
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'totaly_real_token')

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -101,7 +101,10 @@ def send_share_node_data(node):
     """
     data = serialize_share_node_data(node)
 
-    token = node.provider.access_token if getattr(node, 'provider') else settings.SHARE_API_TOKEN
+    if node.provider and getattr(node.provider, 'access_token'):
+        token = node.provider.access_token
+    else:
+        token = settings.SHARE_API_TOKEN
 
     resp = requests.post(
         f'{settings.SHARE_URL}/api/normalizeddata/',

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -50,7 +50,6 @@ def update_collecting_metadata(node, saved_fields):
 
 def update_node_share(node):
     # Any modifications to this function may need to change _async_update_node_share
-    print('settings', not settings.SHARE_URL or not settings.SHARE_API_TOKEN)
     if not settings.SHARE_URL or not settings.SHARE_API_TOKEN:
         logger.warning(f'SHARE_API_TOKEN not set. Could not send "{node._id}" to SHARE.')
         return
@@ -79,6 +78,7 @@ def _async_update_node_share(self, node_id):
     request = self.request
 
     resp = send_share_node_data(node)
+
     try:
         resp.raise_for_status()
     except requests.exceptions.RequestException as e:

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -38,6 +38,7 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
     if node.get_identifier_value('doi') and bool(node.IDENTIFIER_UPDATE_FIELDS.intersection(saved_fields)):
         node.request_identifier_update(category='doi')
 
+
 def update_collecting_metadata(node, saved_fields):
     from website.search.search import update_collected_metadata
     if node.is_collected:
@@ -47,6 +48,7 @@ def update_collecting_metadata(node, saved_fields):
             if 'is_public' in saved_fields:
                 update_collected_metadata(node._id, op='delete')
 
+
 def update_node_share(node):
     # Wrapper that ensures share_url and token exist
     if settings.SHARE_URL:
@@ -54,10 +56,10 @@ def update_node_share(node):
             return logger.warning('SHARE_API_TOKEN not set. Could not send "{}" to SHARE.'.format(node._id))
         _update_node_share(node)
 
+
 def _update_node_share(node):
     # Any modifications to this function may need to change _async_update_node_share
-    data = serialize_share_node_data(node)
-    resp = send_share_node_data(data)
+    resp = send_share_node_data(node)
     try:
         resp.raise_for_status()
     except Exception:
@@ -66,6 +68,7 @@ def _update_node_share(node):
         else:
             send_desk_share_error(node, resp, 0)
 
+
 @celery_app.task(bind=True, max_retries=4, acks_late=True)
 def _async_update_node_share(self, node_id):
     # Any modifications to this function may need to change _update_node_share
@@ -73,8 +76,7 @@ def _async_update_node_share(self, node_id):
     AbstractNode = apps.get_model('osf.AbstractNode')
     node = AbstractNode.load(node_id)
 
-    data = serialize_share_node_data(node)
-    resp = send_share_node_data(data)
+    resp = send_share_node_data(node)
     try:
         resp.raise_for_status()
     except Exception as e:
@@ -88,10 +90,28 @@ def _async_update_node_share(self, node_id):
         else:
             send_desk_share_error(node, resp, self.request.retries)
 
-def send_share_node_data(data):
-    resp = requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json=data, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
-    logger.debug(resp.content)
+
+def send_share_node_data(node):
+    """
+    Sends data about an updating node/registration data to SHARE for indexing.
+    :param data: dictionary of XML data.
+    :return:
+    """
+    data = serialize_share_node_data(node)
+
+    token = node.provider.access_token if hasattr(node, 'provider') else settings.SHARE_API_TOKEN
+
+    resp = requests.post(
+        f'{settings.SHARE_URL}api/normalizeddata/',
+        json=data,
+        headers={
+            'Authorization': f'Bearer {token}',
+            'Content-Type': 'application/vnd.api+json'
+        }
+    )
+
     return resp
+
 
 def serialize_share_node_data(node):
     return {
@@ -105,9 +125,9 @@ def serialize_share_node_data(node):
         }
     }
 
+
 def format_node(node):
-    is_qa_node = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(node.tags.all().values_list('name', flat=True))) \
-        or any(substring in node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
+    is_qa_node = check_if_qa_node(node)
     return [
         {
             '@id': '_:123',
@@ -121,9 +141,9 @@ def format_node(node):
         }
     ]
 
+
 def format_registration(node):
-    is_qa_node = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(node.tags.all().values_list('name', flat=True))) \
-        or any(substring in node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
+    is_qa_node = check_if_qa_node(node)
 
     registration_graph = GraphNode('registration', **{
         'title': node.title,
@@ -170,6 +190,7 @@ def format_registration(node):
 
     return [node_.serialize() for node_ in visited]
 
+
 def send_desk_share_error(node, resp, retries):
     mails.send_mail(
         to_addr=settings.OSF_SUPPORT_EMAIL,
@@ -179,3 +200,19 @@ def send_desk_share_error(node, resp, retries):
         retries=retries,
         can_change_preferences=False,
     )
+
+
+def check_if_qa_node(node) -> bool:
+    """
+    Checks if a node or registration has a tag or title that shouldn't be indexed. QA uses these to test things on prod
+    without effecting search results.
+    :param node:
+    :return: bool whether this is a QA test node.
+    """
+    node_tags = node.tags.all().values_list('name', flat=True)
+    don_not_index_tags = set(settings.DO_NOT_INDEX_LIST['tags'])
+    has_forbid_index_tags = bool(don_not_index_tags.intersection(node_tags))
+
+    has_forbid_index_title = (substring in node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
+
+    return has_forbid_index_tags or has_forbid_index_title

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -104,7 +104,7 @@ def send_share_node_data(node):
     token = node.provider.access_token if getattr(node, 'provider') else settings.SHARE_API_TOKEN
 
     resp = requests.post(
-        f'{settings.SHARE_URL}api/normalizeddata/',
+        f'{settings.SHARE_URL}/api/normalizeddata/',
         json=data,
         headers={
             'Authorization': f'Bearer {token}',


### PR DESCRIPTION
## Purpose

This ticket should ensure the access token is passed from the node provider object to SHARE.

## Changes

So I had to renovate some of this code, because there was multiple bugs in the tests and because the code itself was old and doesn't fit our current conventions. So I 

0) Moved `access_token` field to `AbstractProvider` instead of previous weird situation
1) Moved node license tests to `osf_tests/test_node_license.py`
2) Move node SHARE tests to `osf_tests/test_node_share.py`
3) Fixed and DRY-ed up most of the mocking for `test_node_share.py`

## QA Notes

Dev test only.

## Documentation

tech task, no new docs.

## Side Effects

Detours:

## Ticket

https://openscience.atlassian.net/browse/ENG-1630