### PR TITLE
[ENG-1720] Remove wildcard from custom domain cookies

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -202,7 +202,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
                         self.set_sloan_tags(user, sloan_flag_name, active)
                         self.set_sloan_cookie(f'dwf_{sloan_flag_name}', active, request, response)
 
-                        if provider.domain:
+                        if provider.domain_redirect_enabled and provider.domain:
                             self.set_sloan_cookie(
                                 f'dwf_{sloan_flag_name}_custom_domain',
                                 active,
@@ -349,7 +349,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
 
         if custom_domain:
-            resp.cookies[name]['domain'] = custom_domain
+            resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[name]['secure'] = True

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -2,6 +2,7 @@ import re
 import gc
 import uuid
 from io import StringIO
+from urllib.parse import urlparse
 import cProfile
 import pstats
 import threading
@@ -26,7 +27,10 @@ from waffle.middleware import WaffleMiddleware
 from waffle.models import Flag
 
 from website.settings import DOMAIN
-from osf.models import PreprintProvider
+from osf.models import (
+    Preprint,
+    PreprintProvider,
+)
 from typing import Optional
 
 from osf.features import (
@@ -276,6 +280,13 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         provider_ids_regex = '|'.join(
             [re.escape(id) for id in PreprintProvider.objects.all().values_list('_id', flat=True)],
         )
+        # matches:
+        # /ispp0  (preprint id)
+        path = urlparse(referer_url).path.replace('/', '')
+        preprint = Preprint.load(path)
+        if preprint:
+            return preprint.provider
+
         # matches:
         # /preprints
         # /preprints/

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -5,7 +5,6 @@ from io import StringIO
 import cProfile
 import pstats
 import threading
-from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
@@ -339,7 +338,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
 
         if custom_domain:
-            resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc
+            resp.cookies[name]['domain'] = custom_domain
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
         resp.cookies[name]['secure'] = True

--- a/api_tests/sloan/test_sloan_metrics.py
+++ b/api_tests/sloan/test_sloan_metrics.py
@@ -65,8 +65,8 @@ class TestSloanMetrics(OsfTestCase):
         sloan_cookie_value = resp.headers['Set-Cookie'].split('=')[1].split(';')[0]
 
         # tests cookies get sent to impact
-        self.app.set_cookie(SLOAN_COI_DISPLAY, 'True')
-        self.app.set_cookie(SLOAN_DATA_DISPLAY, 'False')
+        self.app.set_cookie(f'dwf_{SLOAN_COI_DISPLAY}', 'True')
+        self.app.set_cookie(f'dwf_{SLOAN_DATA_DISPLAY}', 'False')
         self.app.set_cookie(SLOAN_ID_COOKIE_NAME, sloan_cookie_value)
         with override_switch(ELASTICSEARCH_METRICS, active=True):
             self.app.get(self.build_url(path=test_file.path))
@@ -76,10 +76,9 @@ class TestSloanMetrics(OsfTestCase):
             preprint=self.preprint,
             user=None,
             version='1',
-            sloan_coi='True',
-            sloan_data='False',
+            sloan_coi=1,
+            sloan_data=0,
             sloan_id=sloan_cookie_value,
-            sloan_prereg=None,
         )
 
 


### PR DESCRIPTION
## Purpose

Fix some behavior where chrome was creating some cookies incorrect and using two wild card domains for custom branded domain registries.

## Changes

- made all custom domains never use wildcard
- made "path only" custom domains resolve properly

## QA Notes

dev-test first

## Documentation

🐞  fix, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1720