### PR TITLE
[ENG-1723] Sets Up Instititutional Metrics Script Scheduling

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -490,6 +490,7 @@ class CeleryConfig:
         'scripts.premigrate_created_modified',
         'scripts.add_missing_identifiers_to_preprints',
         'osf.management.commands.deactivate_requested_accounts',
+        'osf.management.commands.update_institution_project_counts',
     )
 
     # Modules that need metrics and release requirements

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -628,10 +628,10 @@ class CeleryConfig:
                 'task': 'management.commands.check_crossref_dois',
                 'schedule': crontab(minute=0, hour=4),  # Daily 11:00 p.m.
             },
-            # 'update_institutional_metrics': {
-            #     'task': 'management.commands.update_institution_project_counts',
-            #     'schedule': crontab(minute=0, hour=9), # Daily 05:00 a.m. EDT
-            # },
+            'update_institutional_metrics': {
+                'task': 'management.commands.update_institution_project_counts',
+                'schedule': crontab(minute=0, hour=9), # Daily 05:00 a.m. EDT
+            },
         }
 
         # Tasks that need metrics and release requirements

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -627,6 +627,10 @@ class CeleryConfig:
                 'task': 'management.commands.check_crossref_dois',
                 'schedule': crontab(minute=0, hour=4),  # Daily 11:00 p.m.
             },
+            # 'update_institutional_metrics': {
+            #     'task': 'management.commands.update_institution_project_counts',
+            #     'schedule': crontab(minute=0, hour=9), # Daily 05:00 a.m. EDT
+            # },
         }
 
         # Tasks that need metrics and release requirements


### PR DESCRIPTION
## Purpose
Set up the scheduling of the `update_institutional_project_counts.py` script in the celery beats schedule

## Changes
* Adds a dictionary for the script and schedule it should run at to the celery beats schedule dictionary in `website.settings.defaults.py`

## QA Notes
This change can be verified on production by looking at the data of the institutional dashboards via the OSF UI. 

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1723)

## Deployment Notes
Configs need to be updated in order to actually schedule the script.
