### PR TITLE
[Hotfix][ENG-1745] ES private collection update fix

### DIFF
--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3906,33 +3906,15 @@ class TestOnNodeUpdate:
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
+    @mock.patch('website.search.search.update_collected_metadata')
     @mock.patch('website.project.tasks.requests')
-    def test_update_collection_elasticsearch_deleted(self, requests, node_in_collection, collection, user, request_context):
-        now = datetime.datetime.now()
-
-        node_in_collection.deleted = now
-
-        on_node_updated(node_in_collection._id, user._id, False, {'deleted'})
-
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        assert graph[1]['is_deleted']
-
-    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
-    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
-    @mock.patch('website.project.tasks.requests')
-    def test_update_collection_elasticsearch_make_private(self, requests, node_in_collection, collection, user, request_context):
-        node_in_collection.is_public = True
-        node_in_collection.save()
-
+    def test_update_collection_elasticsearch_make_private(self, requests, mock_update_collected_metadata, node_in_collection, collection, user, request_context):
         node_in_collection.is_public = False
         node_in_collection.save()
 
         on_node_updated(node_in_collection._id, user._id, False, {'is_public'})
 
-        kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['data']['attributes']['data']['@graph']
-        assert graph[1]['is_deleted']
+        mock_update_collected_metadata.assert_called_with(node_in_collection._id, op='delete')
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3791,7 +3791,7 @@ class TestOnNodeUpdate:
 
     @pytest.fixture()
     def node_in_collection(self, collection):
-        node = ProjectFactory()
+        node = ProjectFactory(is_public=True)
         CollectionSubmission(
             guid=node.guids.first(),
             collection=collection,

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -43,6 +43,7 @@ from osf.models import (
     Registration,
     DraftRegistration,
     DraftRegistrationApproval,
+    CollectionSubmission
 )
 
 from addons.wiki.models import WikiPage, WikiVersion
@@ -3784,6 +3785,21 @@ class TestOnNodeUpdate:
         return s
 
     @pytest.fixture()
+    def collection(self):
+        collection_provider = CollectionProviderFactory()
+        return CollectionFactory(provider=collection_provider)
+
+    @pytest.fixture()
+    def node_in_collection(self, collection):
+        node = ProjectFactory()
+        CollectionSubmission(
+            guid=node.guids.first(),
+            collection=collection,
+            creator=node.creator,
+        ).save()
+        return node
+
+    @pytest.fixture()
     def node(self):
         return ProjectFactory(is_public=True)
 
@@ -3887,6 +3903,36 @@ class TestOnNodeUpdate:
             kwargs = requests.post.call_args[1]
             graph = kwargs['json']['data']['attributes']['data']['@graph']
             assert graph[1]['is_deleted'] == case['is_deleted']
+
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
+    @mock.patch('website.project.tasks.requests')
+    def test_update_collection_elasticsearch_deleted(self, requests, node_in_collection, collection, user, request_context):
+        now = datetime.datetime.now()
+
+        node_in_collection.deleted = now
+
+        on_node_updated(node_in_collection._id, user._id, False, {'deleted'})
+
+        kwargs = requests.post.call_args[1]
+        graph = kwargs['json']['data']['attributes']['data']['@graph']
+        assert graph[1]['is_deleted']
+
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
+    @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')
+    @mock.patch('website.project.tasks.requests')
+    def test_update_collection_elasticsearch_make_private(self, requests, node_in_collection, collection, user, request_context):
+        node_in_collection.is_public = True
+        node_in_collection.save()
+
+        node_in_collection.is_public = False
+        node_in_collection.save()
+
+        on_node_updated(node_in_collection._id, user._id, False, {'is_public'})
+
+        kwargs = requests.post.call_args[1]
+        graph = kwargs['json']['data']['attributes']['data']['@graph']
+        assert graph[1]['is_deleted']
 
     @mock.patch('website.project.tasks.settings.SHARE_URL', 'https://share.osf.io')
     @mock.patch('website.project.tasks.settings.SHARE_API_TOKEN', 'Token')

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -25,7 +25,7 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
 
     need_update = bool(node.SEARCH_UPDATE_FIELDS.intersection(saved_fields))
     # due to async nature of call this can issue a search update for a new record (acceptable trade-off)
-    if bool({'spam_status', 'is_deleted'}.intersection(saved_fields)):
+    if bool({'spam_status', 'is_deleted', 'deleted'}.intersection(saved_fields)):
         need_update = True
     elif not node.is_public and 'is_public' not in saved_fields:
         need_update = False
@@ -44,7 +44,7 @@ def update_collecting_metadata(node, saved_fields):
         if node.is_public:
             update_collected_metadata(node._id)
         else:
-            if 'is_public' in saved_fields:
+            if set(saved_fields).intersection({'spam_status', 'is_deleted', 'deleted', 'is_public'}):
                 update_collected_metadata(node._id, op='delete')
 
 def update_node_share(node):

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -44,8 +44,7 @@ def update_collecting_metadata(node, saved_fields):
         if node.is_public:
             update_collected_metadata(node._id)
         else:
-            if set(saved_fields).intersection({'spam_status', 'is_deleted', 'deleted', 'is_public'}):
-                update_collected_metadata(node._id, op='delete')
+            update_collected_metadata(node._id, op='delete')
 
 def update_node_share(node):
     # Wrapper that ensures share_url and token exist


### PR DESCRIPTION
## Purpose

Current deleted collections are not being updated as such for ES, this fixes that.

## Changes

- simple logic changes

## QA Notes

1. Submit a project to a collection
2. Ensure the project appears in the search results for the collection
3. Now make the project private

Expected behavior: the project would no longer appear in the collection search results

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1745