### PR TITLE
[ENG-1542] Creates a script to migrate preprints between providers

### DIFF
--- a/osf/management/commands/migrate_preprint_providers.py
+++ b/osf/management/commands/migrate_preprint_providers.py
@@ -1,0 +1,45 @@
+from django.core.management.base import BaseCommand
+
+from osf.models import Preprint, PreprintProvider
+
+
+"""
+A management command to migrate preperints from one provider to another.
+
+i.e. docker-compose run --rm web python3 manage.py migrate_preprint_providers --source_provider lawarxiv --destination_provider osf
+"""
+
+
+def migrate_preprint_providers(source_provider_guid, destination_provider_guid):
+    source_provider = PreprintProvider.load(source_provider_guid)
+    destination_provider = PreprintProvider.load(destination_provider_guid)
+    migration_count = 0
+
+    for preprint in Preprint.objects.filter(provider=source_provider):
+        preprint.provider = destination_provider
+        preprint.save()
+        migration_count += 1
+
+    return migration_count
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--source_provider',
+            help='The preprint provider to migrate from',
+        )
+        parser.add_argument(
+            '--destination_provider',
+            help='The preprint provider to migrate to',
+        )
+
+    def handle(self, *args, **options):
+        source_provider_guid = options.get('source_provider', False)
+        destination_provider_guid = options.get('destination_provider', False)
+
+        if source_provider_guid and destination_provider_guid:
+            migration_count = migrate_preprint_providers(source_provider_guid, destination_provider_guid)
+
+        print(f'{migration_count} preprints were migrated from {source_provider_guid} to {destination_provider_guid}')

--- a/osf_tests/management_commands/test_migrate_preprint_providers.py
+++ b/osf_tests/management_commands/test_migrate_preprint_providers.py
@@ -1,0 +1,69 @@
+# encoding: utf-8
+import pytest
+
+from osf_tests.factories import (
+    PreprintFactory,
+    PreprintProviderFactory
+)
+
+from osf.management.commands.migrate_preprint_providers import (
+    migrate_preprint_providers
+)
+
+from osf.models import Preprint
+
+
+@pytest.fixture()
+def source_provider():
+    return PreprintProviderFactory()
+
+@pytest.fixture()
+def destination_provider():
+    return PreprintProviderFactory()
+
+@pytest.fixture()
+def empty_provider():
+    return PreprintProviderFactory()
+
+@pytest.fixture()
+def preprint1(source_provider):
+    return PreprintFactory(provider=source_provider)
+
+@pytest.fixture()
+def preprint2(source_provider):
+    return PreprintFactory(provider=source_provider)
+
+@pytest.fixture()
+def preprint3(source_provider):
+    return PreprintFactory(provider=source_provider)
+
+@pytest.fixture()
+def preprint4(destination_provider):
+    return PreprintFactory(provider=destination_provider)
+
+@pytest.fixture()
+def preprint5(destination_provider):
+    return PreprintFactory(provider=destination_provider)
+
+
+@pytest.mark.django_db
+class TestPreprintProviderMigration:
+
+    def test_preprint_provider_migration(self, source_provider, destination_provider, empty_provider, preprint1, preprint2, preprint3, preprint4, preprint5):
+        assert Preprint.objects.filter(provider=source_provider).count() == 3
+        assert Preprint.objects.filter(provider=destination_provider).count() == 2
+
+        migration_count = migrate_preprint_providers(source_provider._id, destination_provider._id)
+
+        assert migration_count == 3
+        assert Preprint.objects.filter(provider=source_provider).count() == 0
+        assert Preprint.objects.filter(provider=destination_provider).count() == 5
+
+        updated_preprint1 = Preprint.load(preprint1._id)
+        updated_preprint5 = Preprint.load(preprint5._id)
+        assert updated_preprint1.provider == destination_provider
+        assert updated_preprint5.provider == destination_provider
+
+        empty_migration_count = migrate_preprint_providers(empty_provider._id, destination_provider._id)
+        assert empty_migration_count == 0
+        assert Preprint.objects.filter(provider=destination_provider).count() == 5


### PR DESCRIPTION
## Purpose
Creates a management command to migrate preprints between two preprint providers. This will be used to migrate preprints from Marxiv to OSF Preprints. 

## Changes
* Management command to migrate preprints
* Tests for preprint migration management command

## QA Notes
Should be dev tested

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1542)
