### PR TITLE
[ENG-1748] Adds Bibliographic Contributor Relationship to Preprints

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -137,6 +137,10 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         related_view='preprints:preprint-contributors',
         related_view_kwargs={'preprint_id': '<_id>'},
     )
+    bibliographic_contributors = RelationshipField(
+        related_view='preprints:preprint-bibliographic-contributors',
+        related_view_kwargs={'preprint_id': '<_id>'},
+    )
     reviews_state = ser.CharField(source='machine_state', read_only=True, max_length=15)
     date_last_transitioned = NoneIfWithdrawal(VersionedDateTimeField(read_only=True))
 

--- a/api/preprints/urls.py
+++ b/api/preprints/urls.py
@@ -7,6 +7,7 @@ app_name = 'osf'
 urlpatterns = [
     url(r'^$', views.PreprintList.as_view(), name=views.PreprintList.view_name),
     url(r'^(?P<preprint_id>\w+)/$', views.PreprintDetail.as_view(), name=views.PreprintDetail.view_name),
+    url(r'^(?P<preprint_id>\w+)/bibliographic_contributors/$', views.PreprintBibliographicContributorsList.as_view(), name=views.PreprintBibliographicContributorsList.view_name),
     url(r'^(?P<preprint_id>\w+)/citation/$', views.PreprintCitationDetail.as_view(), name=views.PreprintCitationDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/citation/(?P<style_id>[-\w]+)/$', views.PreprintCitationStyleDetail.as_view(), name=views.PreprintCitationStyleDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/contributors/$', views.PreprintContributorsList.as_view(), name=views.PreprintContributorsList.view_name),

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -416,7 +416,7 @@ class PreprintContributorDetail(NodeContributorDetail, PreprintMixin):
         return context
 
 
-class PreprintBibliographicContributorsList(PreprintContributorsList, generics.ListAPIView):
+class PreprintBibliographicContributorsList(PreprintContributorsList):
     permission_classes = (
         AdminOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -2,7 +2,7 @@ import re
 from distutils.version import StrictVersion
 
 from rest_framework import generics
-from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticated
+from rest_framework.exceptions import MethodNotAllowed, NotFound, PermissionDenied, NotAuthenticated
 from rest_framework import permissions as drf_permissions
 
 from framework.auth.oauth_scopes import CoreScopes
@@ -414,6 +414,27 @@ class PreprintContributorDetail(NodeContributorDetail, PreprintMixin):
         context['resource'] = self.get_preprint()
         context['default_email'] = 'preprint'
         return context
+
+
+class PreprintBibliographicContributorsList(PreprintContributorsList, generics.ListAPIView):
+    permission_classes = (
+        AdminOrPublic,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    pagination_class = PreprintContributorPagination
+    serializer_class = PreprintContributorsSerializer
+
+    view_category = 'preprints'
+    view_name = 'preprint-bibliographic-contributors'
+
+    def get_default_queryset(self):
+        contributors = super().get_default_queryset()
+        return contributors.filter(visible=True)
+
+    def post(self, request, *args, **kwargs):
+        raise MethodNotAllowed(method=request.method)
 
 
 class PreprintSubjectsList(BaseResourceSubjectsList, PreprintMixin):

--- a/api_tests/preprints/views/test_preprint_bibliographic_contributors_list.py
+++ b/api_tests/preprints/views/test_preprint_bibliographic_contributors_list.py
@@ -1,0 +1,88 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    PreprintFactory,
+    AuthUserFactory,
+)
+from osf.utils.permissions import READ, WRITE, ADMIN
+
+
+@pytest.mark.django_db
+@pytest.mark.enable_quickfiles_creation
+class TestNodeBibliographicContributors:
+    @pytest.fixture()
+    def admin_contributor_bib(self):
+        return AuthUserFactory(given_name='Oranges')
+
+    @pytest.fixture()
+    def write_contributor_non_bib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def read_contributor_bib(self):
+        return AuthUserFactory(given_name='Grapes')
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def preprint(self, admin_contributor_bib, write_contributor_non_bib, read_contributor_bib):
+        preprint = PreprintFactory(
+            creator=admin_contributor_bib
+        )
+        preprint.add_contributor(write_contributor_non_bib, WRITE, visible=False)
+        preprint.add_contributor(read_contributor_bib, READ)
+        preprint.save()
+        return preprint
+
+    @pytest.fixture()
+    def url(self, preprint):
+        return '/{}preprints/{}/bibliographic_contributors/'.format(API_BASE, preprint._id)
+
+    def test_list_and_filter_bibliographic_contributors(self, app, url, preprint, admin_contributor_bib,
+            write_contributor_non_bib, read_contributor_bib, non_contributor):
+
+        # Test GET unauthenticated
+        res = app.get(url)
+        assert res.status_code == 200
+
+        # Test GET non_contributor
+        res = app.get(url, auth=non_contributor.auth)
+        assert res.status_code == 200
+
+        # Test GET read contrib
+        res = app.get(url, auth=read_contributor_bib.auth, expect_errors=True)
+        assert res.status_code == 200
+
+        # Test GET write contrib
+        res = app.get(url, auth=write_contributor_non_bib.auth, expect_errors=True)
+        assert res.status_code == 200
+
+        # Test POST not allowed
+        res = app.post_json_api(url, auth=write_contributor_non_bib.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # Test GET contributor, only bibliographic contribs included
+        res = app.get(url, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+        actual = [contrib['id'].split('-')[1] for contrib in res.json['data']]
+        assert admin_contributor_bib._id in actual
+        assert write_contributor_non_bib._id not in actual
+        assert read_contributor_bib._id in actual
+
+        # Test filter contributors on perms
+        perm_filter = '{}?filter[permission]={}'.format(url, READ)
+        res = app.get(perm_filter, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 2
+
+        perm_filter = '{}?filter[permission]={}'.format(url, ADMIN)
+        res = app.get(perm_filter, auth=admin_contributor_bib.auth)
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == '{}-{}'.format(preprint._id, admin_contributor_bib._id)


### PR DESCRIPTION
## Purpose
Adds a bibliographic contributor relationship to Preprint's list/detail API views and creates a PreprintBibliographicContributor endpoint

## Changes
* Creation of PreprintBibliographicContributors endpoint
* Adds a bibliographic contributor relationship to Preprint list/detail api views
* Adds tests for PreprintBibliographicContributors endpoint

## QA Notes
This requires testing through the API of: 
* `/preprints/` - For bibliographic_contributors relationship links in the results
* `/preprints/<preprint_id>/` - For a bibliographic_contributors relationship link
* `/preprints/<preprint_id>/bibliographic_contributors/` - For a list of all bibliographic contributors for the preprint

## Documentation
External API documentation should be updated to reflect the addition of the PreprintBibliographicContributors and the relationship for bibliographic contributors

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1748)
