### PR TITLE
[ENG-1747] Upgrade GitHub3.py library to 1.3.0

### DIFF
--- a/addons/github/api.py
+++ b/addons/github/api.py
@@ -40,7 +40,9 @@ class GitHubClient(object):
         :return dict: GitHub API response
         """
         if user is None:
-            return self.gh3.me()
+            url = self.gh3._build_url('user')
+            json = self.gh3._json(self.gh3._get(url), 200)
+            return self.gh3._instance_or_null(github3.users.User, json)
         return self.gh3.user(user)
 
     def repo(self, user, repo):

--- a/addons/github/api.py
+++ b/addons/github/api.py
@@ -40,9 +40,7 @@ class GitHubClient(object):
         :return dict: GitHub API response
         """
         if user is None:
-            url = self.gh3._build_url('user')
-            json = self.gh3._json(self.gh3._get(url), 200)
-            return self.gh3._instance_or_null(github3.users.User, json)
+            return self.gh3.me()
         return self.gh3.user(user)
 
     def repo(self, user, repo):

--- a/addons/github/requirements.txt
+++ b/addons/github/requirements.txt
@@ -1,4 +1,4 @@
 cachecontrol==0.10.2
-github3.py==1.0.0a4
+github3.py==1.3.0
 python-magic==0.4.6
 uritemplate.py==2.0.0

--- a/addons/github/settings/defaults.py
+++ b/addons/github/settings/defaults.py
@@ -3,7 +3,7 @@ CLIENT_ID = None
 CLIENT_SECRET = None
 
 # GitHub access scope
-SCOPE = ['repo']
+SCOPE = ['repo', 'user']
 
 # GitHub hook domain
 HOOK_DOMAIN = None

--- a/addons/github/tests/test_models.py
+++ b/addons/github/tests/test_models.py
@@ -25,7 +25,6 @@ from addons.github.exceptions import NotFoundError
 
 from .utils import create_mock_github, create_session_mock
 mock_github = create_mock_github()
-session = create_session_mock()
 
 pytestmark = pytest.mark.django_db
 
@@ -103,20 +102,20 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     @mock.patch('addons.github.api.GitHubClient.repos')
     @mock.patch('addons.github.api.GitHubClient.check_authorization')
     def test_get_folders(self, mock_check_authorization, mock_repos):
-        mock_repos.return_value = [mock_repos.repo.return_value]
+        mock_repos.return_value = [mock_github.repo.return_value]
         result = self.node_settings.get_folders()
 
         assert_equal(len(result), 1)
-        assert_equal(result[0]['id'], '12345')
-        assert_equal(result[0]['name'], 'test')
-        assert_equal(result[0]['path'], 'test name/test')
+        assert_equal(result[0]['id'], 11075275)
+        assert_equal(result[0]['name'], 'mock-repo')
+        assert_equal(result[0]['path'], 'octo-cat/mock-repo')
         assert_equal(result[0]['kind'], 'repo')
 
 
     @mock.patch('addons.github.api.GitHubClient.repos')
     @mock.patch('addons.github.api.GitHubClient.check_authorization')
     def test_get_folders_not_have_auth(self, mock_repos, mock_check_authorization):
-        mock_repos.return_value = [mock_repos.repo.return_value]
+        mock_repos.return_value = mock_github.repo.return_value
         self.node_settings.user_settings = None
         with pytest.raises(exceptions.InvalidAuthError):
             self.node_settings.get_folders()
@@ -176,7 +175,7 @@ class TestCallbacks(OsfTestCase):
     def test_before_page_load_osf_public_gh_public(self, mock_repo):
         self.project.is_public = True
         self.project.save()
-        mock_repo.return_value = mock_repo.repo.return_value
+        mock_repo.return_value = mock_github.repo.return_value
         message = self.node_settings.before_page_load(self.project, self.project.creator)
         mock_repo.assert_called_with(
             self.node_settings.user,
@@ -188,7 +187,8 @@ class TestCallbacks(OsfTestCase):
     def test_before_page_load_osf_public_gh_private(self, mock_repo):
         self.project.is_public = True
         self.project.save()
-        mock_repo.return_value = mock_repo.repo.return_value
+        private_mock_github = create_mock_github(private=True)
+        mock_repo.return_value = private_mock_github.repo.return_value
         message = self.node_settings.before_page_load(self.project, self.project.creator)
         mock_repo.assert_called_with(
             self.node_settings.user,
@@ -198,7 +198,7 @@ class TestCallbacks(OsfTestCase):
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_public(self, mock_repo):
-        mock_repo.return_value = mock_repo.repo.return_value
+        mock_repo.return_value = mock_github.repo.return_value
         message = self.node_settings.before_page_load(self.project, self.project.creator)
         mock_repo.assert_called_with(
             self.node_settings.user,
@@ -208,7 +208,8 @@ class TestCallbacks(OsfTestCase):
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_private(self, mock_repo):
-        mock_repo.return_value = mock_repo.repo.return_value
+        private_mock_github = create_mock_github(private=True)
+        mock_repo.return_value = private_mock_github.repo.return_value
         message = self.node_settings.before_page_load(self.project, self.project.creator)
         mock_repo.assert_called_with(
             self.node_settings.user,

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -492,22 +492,7 @@ class TestGithubSettings(OsfTestCase):
     @mock.patch('addons.github.api.GitHubClient.branches')
     def test_link_repo_registration(self, mock_branches):
 
-        mock_branches.return_value = [
-            Branch.from_json(dumps({
-                'name': 'master',
-                'commit': {
-                    'sha': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
-                    'url': 'https://api.github.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc',
-                }
-            })),
-            Branch.from_json(dumps({
-                'name': 'develop',
-                'commit': {
-                    'sha': '6dcb09b5b57875asdasedawedawedwedaewdwdass',
-                    'url': 'https://api.github.com/repos/octocat/Hello-World/commits/cdcb09b5b57875asdasedawedawedwedaewdwdass',
-                }
-            }))
-        ]
+        mock_branches.return_value = self.github.branches.return_value
 
         registration = self.project.register_node(
             schema=get_default_metaschema(),

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -129,7 +129,7 @@ class TestGithubViews(OsfTestCase):
     def _get_sha_for_branch(self, branch=None, mock_branches=None):
         github_mock = self.github
         if mock_branches is None:
-            mock_branches = github_mock.branches
+            mock_branches = self.github.branches
         if branch is None:  # Get default branch name
             branch = self.github.repo.return_value.default_branch
         for each in mock_branches.return_value:

--- a/addons/github/tests/utils.py
+++ b/addons/github/tests/utils.py
@@ -8,7 +8,6 @@ from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
 from addons.github.models import GitHubProvider
 from addons.github.tests.factories import GitHubAccountFactory
 
-
 class GitHubAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
     ADDON_SHORT_NAME = 'github'
     ExternalAccountFactory = GitHubAccountFactory
@@ -19,6 +18,9 @@ class GitHubAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
         settings.repo = 'abc'
         settings.user = 'octo-cat'
         settings.save()
+
+    def build_url(self):
+        return github3.session.GitHubSession().build_url(*args, **kwargs)
 
 # TODO: allow changing the repo name
 def create_mock_github(user='octo-cat', private=False):
@@ -42,6 +44,8 @@ def create_mock_github(user='octo-cat', private=False):
     :return: An autospecced GitHub Mock object
     """
     github_mock = mock.create_autospec(GitHubClient)
+    session = create_session_mock()
+
     github_mock.repo.return_value = github3.repos.Repository.from_json(dumps({
      u'archive_url': u'https://api.github.com/repos/{user}/mock-repo/{{archive_format}}{{/ref}}'.format(user=user),
      u'assignees_url': u'https://api.github.com/repos/{user}/mock-repo/assignees{{/user}}'.format(user=user),
@@ -54,6 +58,7 @@ def create_mock_github(user='octo-cat', private=False):
      u'compare_url': u'https://api.github.com/repos/{user}/mock-repo/compare/{{base}}...{{head}}',
      u'contents_url': u'https://api.github.com/repos/{user}/mock-repo/contents/{{+path}}'.format(user=user),
      u'contributors_url': u'https://api.github.com/repos/{user}/mock-repo/contributors'.format(user=user),
+     u'deployments_url': u'https://api.github.com/repos/{user}/mock-repo/deployments'.format(user=user),
      u'created_at': u'2013-06-30T18:29:18Z',
      u'default_branch': u'dev',
      u'description': u'Simple, Pythonic, text processing--Sentiment analysis, part-of-speech tagging, noun phrase extraction, translation, and more.',
@@ -69,7 +74,10 @@ def create_mock_github(user='octo-cat', private=False):
      u'git_tags_url': u'https://api.github.com/repos/{user}/mock-repo/git/tags{{/sha}}'.format(user=user),
      u'git_url': u'git://github.com/{user}/mock-repo.git'.format(user=user),
      u'has_downloads': True,
+     u'archived': False,
      u'has_issues': True,
+     u'has_pages': False,
+     u'has_projects': False,
      u'has_wiki': True,
      u'homepage': u'https://mock-repo.readthedocs.org/',
      u'hooks_url': u'https://api.github.com/repos/{user}/mock-repo/hooks'.format(user=user),
@@ -130,18 +138,304 @@ def create_mock_github(user='octo-cat', private=False):
      u'watchers_count': 1469,
      # NOTE: permissions are only available if authorized on the repo
      'permissions': { 'push': True }
-     }))
+     }), session)
 
-    github_mock.branches.return_value = [
-        Branch.from_json(dumps({u'commit': {u'sha': u'e22d92d5d90bb8f9695e9a5e2e2311a5c1997230',
-           u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/e22d92d5d90bb8f9695e9a5e2e2311a5c1997230'.format(user=user)},
-          u'name': u'dev'})),
-         Branch.from_json(dumps({u'commit': {u'sha': u'444a74d0d90a4aea744dacb31a14f87b5c30759c',
-           u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/444a74d0d90a4aea744dacb31a14f87b5c30759c'.format(user=user)},
-          u'name': u'master'})),
-         Branch.from_json(dumps({u'commit': {u'sha': u'c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6',
-           u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6'.format(user=user)},
-          u'name': u'no-bundle'}))
-      ]
+
+
+    branch_1 = Branch.from_json(dumps({
+        u'commit': {
+         u'commit': {
+          u'author': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'committer': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'message': u'Merge pull request #388 from jonathanwcrane/patch-1\n\nCall out proper name of module in import statent',
+          u'tree': {
+           u'sha': u'49d7464ad951e0e0e13bf073b06d8eed217c6e74',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/git/trees/49d7464ad951e0e0e13bf073b06d8eed217c6e74'
+          },
+          u'url': u'https://api.github.com/repos/{user}/github3.py/git/commits/749656b8b3b282d11a4221bb84e48291ca23ecc6',
+          u'comment_count': 0
+         },
+         u'sha': u'e22d92d5d90bb8f9695e9a5e2e2311a5c1997230',
+         u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/e22d92d5d90bb8f9695e9a5e2e2311a5c1997230'.format(user=user),
+         u'author': {
+          u'login': user,
+          u'id': 2379650,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'committer': {
+          u'login': user,
+          u'id': 240830,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'parents': [
+          {
+           u'sha': u'b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/commits/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'html_url': u'https://github.com/{user}/github3.py/commit/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56'
+          }
+         ],
+         u'url': u'https://api.github.com/repos/{user}/github3.py/commits/e22d92d5d90bb8f9695e9a5e2e2311a5c1997230'.format(user=user),
+         u'html_url': u'https://github.com/{user}/github3.py/commit/e22d92d5d90bb8f9695e9a5e2e2311a5c1997230'.format(user=user),
+         u'comments_url': u'https://api.github.com/repos/{user}/github3.py/commits/e22d92d5d90bb8f9695e9a5e2e2311a5c1997230/comments'.format(user=user)
+        },
+        u'_links': {
+         u'self': u'https://api.github.com/repos/{user}/github3.py/branches/master',
+         u'html': u'https://github.com/{user}/github3.py/tree/master'
+        },
+        u'protection': {
+         u'enabled': False,
+          u'required_status_checks': {
+           u'enforcement_level': u'off',
+           u'contexts': [
+           ]
+          }
+        },
+        u'protected': False,
+        u'protection_url': u'https://api.github.com/repos/{user}/github3.py/branches/master/protection'.format(user=user),
+        u'name': u'dev'
+    }), session)
+
+    branch_2 = Branch.from_json(dumps({
+        u'commit': {
+         u'commit': {
+          u'author': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'committer': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'message': u'Merge pull request #388 from jonathanwcrane/patch-1\n\nCall out proper name of module in import statent',
+          u'tree': {
+           u'sha': u'49d7464ad951e0e0e13bf073b06d8eed217c6e74',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/git/trees/49d7464ad951e0e0e13bf073b06d8eed217c6e74'
+          },
+          u'url': u'https://api.github.com/repos/{user}/github3.py/git/commits/749656b8b3b282d11a4221bb84e48291ca23ecc6',
+          u'comment_count': 0
+         },
+         u'sha': u'444a74d0d90a4aea744dacb31a14f87b5c30759c',
+         u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/444a74d0d90a4aea744dacb31a14f87b5c30759c'.format(user=user),
+         u'author': {
+          u'login': user,
+          u'id': 2379650,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'committer': {
+          u'login': user,
+          u'id': 240830,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'parents': [
+          {
+           u'sha': u'b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/commits/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'html_url': u'https://github.com/{user}/github3.py/commit/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56'
+          }
+         ],
+         u'url': u'https://api.github.com/repos/{user}/github3.py/commits/444a74d0d90a4aea744dacb31a14f87b5c30759c'.format(user=user),
+         u'html_url': u'https://github.com/{user}/github3.py/commit/444a74d0d90a4aea744dacb31a14f87b5c30759c'.format(user=user),
+         u'comments_url': u'https://api.github.com/repos/{user}/github3.py/commits/444a74d0d90a4aea744dacb31a14f87b5c30759c/comments'.format(user=user)
+        },
+        u'_links': {
+         u'self': u'https://api.github.com/repos/{user}/github3.py/branches/master',
+         u'html': u'https://github.com/{user}/github3.py/tree/master'
+        },
+        u'protection': {
+         u'enabled': False,
+          u'required_status_checks': {
+           u'enforcement_level': u'off',
+           u'contexts': [
+           ]
+          }
+        },
+        u'protected': False,
+        u'protection_url': u'https://api.github.com/repos/{user}/github3.py/branches/master/protection'.format(user=user),
+        u'name': u'dev'
+    }), session)
+
+    branch_3 = Branch.from_json(dumps({
+        u'commit': {
+         u'commit': {
+          u'author': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'committer': {
+           u'name': u'Ian Cordasco',
+           u'email': u'{user}@users.noreply.github.com',
+           u'date': u'2015-06-19T22:37:18Z'
+          },
+          u'message': u'Merge pull request #388 from jonathanwcrane/patch-1\n\nCall out proper name of module in import statent',
+          u'tree': {
+           u'sha': u'49d7464ad951e0e0e13bf073b06d8eed217c6e74',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/git/trees/49d7464ad951e0e0e13bf073b06d8eed217c6e74'
+          },
+          u'url': u'https://api.github.com/repos/{user}/github3.py/git/commits/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6',
+          u'comment_count': 0
+         },
+         u'sha': u'c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6',
+         u'url': u'https://api.github.com/repos/{user}/mock-repo/commits/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6'.format(user=user),
+         u'author': {
+          u'login': user,
+          u'id': 2379650,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'committer': {
+          u'login': user,
+          u'id': 240830,
+          u'avatar_url': u'https://avatars.githubusercontent.com/u/240830?v=3',
+          u'gravatar_id': u'',
+          u'url': u'https://api.github.com/users/{user}'.format(user=user),
+          u'html_url': u'https://github.com/{user}'.format(user=user),
+          u'followers_url': u'https://api.github.com/users/{user}/followers'.format(user=user),
+          u'following_url': u'https://api.github.com/users/{user}/following{{/other_user}}'.format(user=user),
+          u'gists_url': u'https://api.github.com/users/{user}/gists{{/gist_id}}'.format(user=user),
+          u'starred_url': u'https://api.github.com/users/{user}/starred{{/owner}}{{/repo}}'.format(user=user),
+          u'subscriptions_url': u'https://api.github.com/users/{user}/subscriptions'.format(user=user),
+          u'organizations_url': u'https://api.github.com/users/{user}/orgs'.format(user=user),
+          u'repos_url': u'https://api.github.com/users/{user}/repos'.format(user=user),
+          u'events_url': u'https://api.github.com/users/{user}/events{{/privacy}}'.format(user=user),
+          u'received_events_url': u'https://api.github.com/users/{user}/received_events'.format(user=user),
+          u'type': u'User',
+          u'site_admin': False
+         },
+         u'parents': [
+          {
+           u'sha': u'b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'url': u'https://api.github.com/repos/{user}/github3.py/commits/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56',
+           u'html_url': u'https://github.com/{user}/github3.py/commit/b26841b7f083f9b7b3e3658fbc2fcc2e2f94db56'
+          }
+         ],
+         u'url': u'https://api.github.com/repos/{user}/github3.py/commits/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6'.format(user=user),
+         u'html_url': u'https://github.com/{user}/github3.py/commit/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6'.format(user=user),
+         u'comments_url': u'https://api.github.com/repos/{user}/github3.py/commits/c6eaaf6708561c3d4439c0c8dd99c2e33525b1e6/comments'.format(user=user)
+        },
+        u'_links': {
+         u'self': u'https://api.github.com/repos/{user}/github3.py/branches/master',
+         u'html': u'https://github.com/{user}/github3.py/tree/master'
+        },
+        u'protection': {
+         u'enabled': False,
+          u'required_status_checks': {
+           u'enforcement_level': u'off',
+           u'contexts': [
+           ]
+          }
+        },
+        u'protected': False,
+        u'protection_url': u'https://api.github.com/repos/{user}/github3.py/branches/master/protection'.format(user=user),
+        u'name': u'dev'
+    }), session)
+
+    github_mock.branches.return_value =[branch_1, branch_2, branch_3]
 
     return github_mock
+
+"""Below mock session functions come from github3.py library: tests.unit.helper.py"""
+
+def get_build_url_proxy(*args, **kwargs):
+    return github3.session.GitHubSession().build_url(*args, **kwargs)
+
+def create_mocked_session():
+    """Use mock to auto-spec a GitHubSession and return an instance."""
+    MockedSession = mock.create_autospec(github3.session.GitHubSession)
+    return MockedSession()
+
+def create_session_mock(*args):
+    """Create a mocked session and add headers and auth attributes."""
+    session = create_mocked_session()
+    base_attrs = ['headers', 'auth']
+    attrs = dict(
+        (key, mock.Mock()) for key in set(args).union(base_attrs)
+    )
+    session.configure_mock(**attrs)
+    session.delete.return_value = None
+    session.get.return_value = None
+    session.patch.return_value = None
+    session.post.return_value = None
+    session.put.return_value = None
+    session.has_auth.return_value = True
+    session.build_url = get_build_url_proxy
+    return session

--- a/addons/github/tests/utils.py
+++ b/addons/github/tests/utils.py
@@ -317,7 +317,7 @@ def create_mock_github(user='octo-cat', private=False):
         },
         u'protected': False,
         u'protection_url': u'https://api.github.com/repos/{user}/github3.py/branches/master/protection'.format(user=user),
-        u'name': u'dev'
+        u'name': u'master'
     }), session)
 
     branch_3 = Branch.from_json(dumps({
@@ -406,7 +406,7 @@ def create_mock_github(user='octo-cat', private=False):
         },
         u'protected': False,
         u'protection_url': u'https://api.github.com/repos/{user}/github3.py/branches/master/protection'.format(user=user),
-        u'name': u'dev'
+        u'name': u'1.3.0'
     }), session)
 
     github_mock.branches.return_value =[branch_1, branch_2, branch_3]

--- a/addons/github/tests/utils.py
+++ b/addons/github/tests/utils.py
@@ -68,7 +68,7 @@ def create_mock_github(user='octo-cat', private=False):
      u'forks': 89,
      u'forks_count': 89,
      u'forks_url': u'https://api.github.com/repos/{user}/mock-repo/forks',
-     u'full_name': u'{user}/mock-repo',
+     u'full_name': u'{user}/mock-repo'.format(user=user),
      u'git_commits_url': u'https://api.github.com/repos/{user}/mock-repo/git/commits{{/sha}}'.format(user=user),
      u'git_refs_url': u'https://api.github.com/repos/{user}/mock-repo/git/refs{{/sha}}'.format(user=user),
      u'git_tags_url': u'https://api.github.com/repos/{user}/mock-repo/git/tags{{/sha}}'.format(user=user),

--- a/addons/github/utils.py
+++ b/addons/github/utils.py
@@ -52,7 +52,7 @@ def get_path(kwargs, required=True):
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
 
 
-def get_refs(addon, branch=None, sha=None, connection=None):
+def get_refs(addon, branch=None, sha=None, connection=None, session=None):
     """Get the appropriate branch name and sha given the addon settings object,
     and optionally the branch and sha from the request arguments.
     :param str branch: Branch name. If None, return the default branch from the
@@ -66,6 +66,9 @@ def get_refs(addon, branch=None, sha=None, connection=None):
     if sha and not branch:
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
 
+    if not session:
+        session = connection.gh3.session
+
     # Get default branch if not provided
     if not branch:
         repo = connection.repo(addon.user, addon.repo)
@@ -74,7 +77,7 @@ def get_refs(addon, branch=None, sha=None, connection=None):
         branch = repo.default_branch
     # Get registered branches if provided
     registered_branches = (
-        [Branch.from_json(b) for b in addon.registration_data.get('branches', [])]
+        [Branch.from_json(b, session) for b in addon.registration_data.get('branches', [])]
         if addon.owner.is_registration
         else []
     )

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -6,6 +6,7 @@ import datetime
 import pytest
 import unittest
 from json import dumps
+import github3
 
 from nose.tools import *  # noqa (PEP8 asserts)
 from tests.base import OsfTestCase, get_default_metaschema

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -23,7 +23,7 @@ from addons.gitlab import utils
 from addons.gitlab.api import GitLabClient
 from addons.gitlab.serializer import GitLabSerializer
 from addons.gitlab.utils import check_permissions
-from addons.gitlab.tests.utils import create_mock_gitlab, GitLabAddonTestCase
+from addons.gitlab.tests.utils import create_mock_gitlab, GitLabAddonTestCase, create_session_mock
 from addons.gitlab.tests.factories import GitLabAccountFactory
 
 pytestmark = pytest.mark.django_db
@@ -452,6 +452,7 @@ class TestGitLabSettings(OsfTestCase):
         self.project = ProjectFactory()
         self.auth = self.project.creator.auth
         self.consolidated_auth = Auth(user=self.project.creator)
+        self.session = create_session_mock()
 
         self.project.add_addon('gitlab', auth=self.consolidated_auth)
         self.project.creator.add_addon('gitlab')
@@ -535,20 +536,8 @@ class TestGitLabSettings(OsfTestCase):
     def test_link_repo_registration(self, mock_branches):
 
         mock_branches.return_value = [
-            Branch.from_json(dumps({
-                'name': 'master',
-                'commit': {
-                    'sha': '6dcb09b5b57875f334f61aebed695e2e4193db5e',
-                    'url': 'https://api.gitlab.com/repos/octocat/Hello-World/commits/c5b97d5ae6c19d5c5df71a34c7fbeeda2479ccbc',
-                }
-            })),
-            Branch.from_json(dumps({
-                'name': 'develop',
-                'commit': {
-                    'sha': '6dcb09b5b57875asdasedawedawedwedaewdwdass',
-                    'url': 'https://api.gitlab.com/repos/octocat/Hello-World/commits/cdcb09b5b57875asdasedawedawedwedaewdwdass',
-                }
-            }))
+            Branch.from_json(self.gitlab.branch, self.session),
+            Branch.from_json(self.gitlab.branch_2, self.session)
         ]
 
         registration = self.project.register_node(

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -535,11 +535,9 @@ class TestGitLabSettings(OsfTestCase):
 
     @mock.patch('addons.gitlab.api.GitLabClient.branches')
     def test_link_repo_registration(self, mock_branches):
+        mock_gitlab = create_mock_gitlab()
 
-        mock_branches.return_value = [
-            Branch.from_json(self.gitlab.branch, self.session),
-            Branch.from_json(self.gitlab.branch_2, self.session)
-        ]
+        mock_branches.return_value = mock_gitlab.branches.return_value
 
         registration = self.project.register_node(
             schema=get_default_metaschema(),

--- a/addons/gitlab/tests/utils.py
+++ b/addons/gitlab/tests/utils.py
@@ -108,9 +108,55 @@ def create_mock_gitlab(user='osfio', private=False):
         u'protected': True
     })
 
+    branch_2 = mock.Mock(**{
+        u'commit': {u'author_email': u'{}@yahoo.com'.format(user),
+            u'author_name': u''.format(user),
+            u'authored_date': u'2017-03-05T16:43:04.000+00:00',
+            u'committed_date': u'2017-09-05T16:43:04.000+00:00',
+            u'committer_email': u'{}@yahoo.com'.format(user),
+            u'committer_name': u'{}'.format(user),
+            u'created_at': u'2017-011-05T16:43:04.000+00:00',
+            u'id': u'f064566f133ddfad636ceec72c5937cc0044c371',
+            u'message': u'Fixing tests',
+            u'parent_ids': [],
+            u'short_id': u'f0633345',
+            u'title': u'Add readme.md'},
+        u'developers_can_merge': False,
+        u'developers_can_push': False,
+        u'merged': False,
+        u'protected': True
+    })
+
     # Hack because 'name' is a reserved keyword in a Mock object
     type(branch).name = 'master'
 
     gitlab_mock.branches.return_value = [branch]
 
     return gitlab_mock
+
+"""Below mock session functions come from github3.py library: tests.unit.helper.py"""
+
+def get_build_url_proxy(*args, **kwargs):
+    return github3.session.GitHubSession().build_url(*args, **kwargs)
+
+def create_mocked_session():
+    """Use mock to auto-spec a GitHubSession and return an instance."""
+    MockedSession = mock.create_autospec(github3.session.GitHubSession)
+    return MockedSession()
+
+def create_session_mock(*args):
+    """Create a mocked session and add headers and auth attributes."""
+    session = create_mocked_session()
+    base_attrs = ['headers', 'auth']
+    attrs = dict(
+        (key, mock.Mock()) for key in set(args).union(base_attrs)
+    )
+    session.configure_mock(**attrs)
+    session.delete.return_value = None
+    session.get.return_value = None
+    session.patch.return_value = None
+    session.post.return_value = None
+    session.put.return_value = None
+    session.has_auth.return_value = True
+    session.build_url = get_build_url_proxy
+    return session

--- a/addons/gitlab/tests/utils.py
+++ b/addons/gitlab/tests/utils.py
@@ -2,6 +2,8 @@ import mock
 from addons.gitlab.api import GitLabClient
 import github3
 
+from github3.repos.branch import Branch
+
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
 from addons.gitlab.models import GitLabProvider
 from addons.gitlab.tests.factories import GitLabAccountFactory
@@ -38,6 +40,7 @@ def create_mock_gitlab(user='osfio', private=False):
     :return: An autospecced GitLab Mock object
     """
     gitlab_mock = mock.create_autospec(GitLabClient)
+    session = create_session_mock()
 
     gitlab_mock.repo = mock.Mock(**{
         u'approvals_before_merge': 0,
@@ -131,7 +134,7 @@ def create_mock_gitlab(user='osfio', private=False):
     # Hack because 'name' is a reserved keyword in a Mock object
     type(branch).name = 'master'
 
-    gitlab_mock.branches.return_value = [branch]
+    gitlab_mock.branches.return_value = [branch, branch_2]
 
     return gitlab_mock
 

--- a/addons/gitlab/tests/utils.py
+++ b/addons/gitlab/tests/utils.py
@@ -1,5 +1,6 @@
 import mock
 from addons.gitlab.api import GitLabClient
+import github3
 
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
 from addons.gitlab.models import GitLabProvider

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -743,11 +743,11 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
 
     @property
     def _mock_folder_result(self):
-        return {u'path': u'test name/test',
+        return {u'path': u'octo-cat/mock-repo',
                 u'kind': u'repo',
-                u'name': u'test',
+                u'name': u'mock-repo',
                 u'provider': u'github',
-                u'id': u'12345'}
+                u'id': u'11075275'}
 
 
 class TestNodeMendeleyAddon(

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 import abc
-from json import dumps
 
 import mock
 import pytest
 import mendeley
 from nose.tools import *  # noqa:
-from github3.repos import Repository
 
 
 from addons.bitbucket.tests.factories import BitbucketAccountFactory, BitbucketNodeSettingsFactory
@@ -14,6 +12,7 @@ from addons.box.tests.factories import BoxAccountFactory, BoxNodeSettingsFactory
 from addons.dataverse.tests.factories import DataverseAccountFactory, DataverseNodeSettingsFactory
 from addons.dropbox.tests.factories import DropboxAccountFactory, DropboxNodeSettingsFactory
 from addons.github.tests.factories import GitHubAccountFactory, GitHubNodeSettingsFactory
+from addons.github.tests.utils import create_mock_github
 from addons.googledrive.tests.factories import GoogleDriveAccountFactory, GoogleDriveNodeSettingsFactory
 from addons.owncloud.tests.factories import OwnCloudAccountFactory, OwnCloudNodeSettingsFactory
 from addons.s3.tests.factories import S3AccountFactory, S3NodeSettingsFactory
@@ -711,6 +710,7 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'github'
     AccountFactory = GitHubAccountFactory
     NodeSettingsFactory = GitHubNodeSettingsFactory
+    mock_github = create_mock_github()
 
     def _settings_kwargs(self, node, user_settings):
         return {
@@ -722,12 +722,7 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
 
     @mock.patch('addons.github.models.GitHubClient')
     def test_folder_list_GET_expected_behavior(self, mock_client):
-        mock_repo = Repository.from_json(dumps({
-            'name': 'test',
-            'id': '12345',
-            'owner':
-                {'login': 'test name'}
-        }))
+        mock_repo = self.mock_github.repo.return_value
 
         mock_connection = mock.MagicMock()
         mock_client.return_value = mock_connection


### PR DESCRIPTION

## Purpose

We are currently on 1.0.0a, which was released in 2016. We really should upgrade.

## Changes

Modified addons/github/requirements.txt to include most recent version (1.3.0). Added user scope to settings. Modified a bunch of tests to include a mocked session, which is now required for the from_json method.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
High, please test all GitHub related functionality.
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
UI
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
GitHub addon
  - How will this impact performance?
Shouldn't
-->

## Documentation

N/A

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-1747