### PR TITLE
[ENG-1785] Fix so flags work with Travis

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -313,17 +313,18 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
     @staticmethod
     def override_flag_activity(sloan_flag_name, waffles_data, user):
+        active = None
         if waffles_data and waffles_data.get(sloan_flag_name):
             active = Flag.objects.get(name=sloan_flag_name).everyone or waffles_data[sloan_flag_name][0]
 
-            if user and not user.is_anonymous:
-                tag_name = SLOAN_FEATURES[sloan_flag_name]
-                if user.all_tags.filter(name=tag_name).exists():
-                    active = True
-                elif user.all_tags.filter(name=f'no_{tag_name}').exists():
-                    active = False
+        if user and not user.is_anonymous:
+            tag_name = SLOAN_FEATURES[sloan_flag_name]
+            if user.all_tags.filter(name=tag_name).exists():
+                active = True
+            elif user.all_tags.filter(name=f'no_{tag_name}').exists():
+                active = False
 
-            return active
+        return active
 
     @staticmethod
     def set_sloan_tags(user, flag_name: str, flag_value: bool):

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -26,7 +26,7 @@ from api.base import settings as api_settings
 from waffle.middleware import WaffleMiddleware
 from waffle.models import Flag
 
-from website.settings import DOMAIN
+from website.settings import DOMAIN, TRAVIS_MODE
 from osf.models import (
     Preprint,
     PreprintProvider,
@@ -362,5 +362,6 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-        resp.cookies[name]['secure'] = True
-        resp.cookies[name]['samesite'] = 'None'
+        if not TRAVIS_MODE:
+            resp.cookies[name]['secure'] = True
+            resp.cookies[name]['samesite'] = 'None'

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -3,7 +3,7 @@ import pytest
 from decimal import Decimal
 
 from waffle.models import Flag
-from website.settings import DOMAIN, TRAVIS_MODE
+from website.settings import DOMAIN
 from api.base.middleware import SloanOverrideWaffleMiddleware
 
 from osf_tests.factories import (
@@ -40,7 +40,6 @@ def inactive(*args, **kwargs):
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(TRAVIS_MODE, reason='Travis is balking at the idea of sending secure cookies via the testing app.')
 class TestSloanStudyWaffling:
     """
     DEV_MODE is mocked so cookies they behave as if they were using https.

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,5 +137,3 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
-
-TRAVIS_MODE = False

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,3 +137,5 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
+
+TRAVIS_MODE = False

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -103,5 +103,3 @@ POPULAR_LINKS_REGISTRATIONS = 'woooo'
 logging.getLogger('celery.app.trace').setLevel(logging.FATAL)
 
 DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
-
-TRAVIS_MODE = True

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -103,3 +103,5 @@ POPULAR_LINKS_REGISTRATIONS = 'woooo'
 logging.getLogger('celery.app.trace').setLevel(logging.FATAL)
 
 DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
+
+TRAVIS_MODE = True


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Despite what I thought before it's actually the waffle middleware that's not working in Travis, not the cookies being secure. 


## Changes

- ensures we don't need waffle data to set cookie.

## QA Notes

Just effects travis

## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1785