### PR TITLE
[ENG-1784][Hotfix] Sloan cookies overriding authenticated state in /v2/ request

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -200,12 +200,19 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
                     if active is not None:
                         self.set_sloan_tags(user, sloan_flag_name, active)
-                        self.set_sloan_cookie(f'dwf_{sloan_flag_name}', active, request, response)
+                        self.set_sloan_cookie(
+                            f'dwf_{sloan_flag_name}',
+                            active,
+                            request.environ['HTTP_REFERER'],
+                            request,
+                            response,
+                        )
 
                         if provider.domain_redirect_enabled and provider.domain:
                             self.set_sloan_cookie(
                                 f'dwf_{sloan_flag_name}_custom_domain',
                                 active,
+                                request.environ['HTTP_REFERER'],
                                 request,
                                 response,
                                 custom_domain=provider.domain,
@@ -215,10 +222,33 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
                                 self.set_sloan_cookie(
                                     settings.SLOAN_ID_COOKIE_NAME,
                                     str(uuid.uuid4()),
+                                    request.environ['HTTP_REFERER'],
                                     request,
                                     response,
                                     custom_domain=provider.domain,
                                 )
+
+            elif user and not user.is_anonymous:
+                for sloan_flag_name in SLOAN_FLAGS:
+                    tag = SLOAN_FEATURES[sloan_flag_name]
+                    if user.all_tags.filter(name=tag).exists():
+                        response.data['meta']['active_flags'].append(sloan_flag_name)
+                        self.set_sloan_cookie(
+                            f'dwf_{sloan_flag_name}',
+                            True,
+                            request.environ['SERVER_NAME'],
+                            request,
+                            response,
+                        )
+
+                    elif user.all_tags.filter(name=f'no_{tag}').exists():
+                        self.set_sloan_cookie(
+                            f'dwf_{sloan_flag_name}',
+                            False,
+                            request.environ['SERVER_NAME'],
+                            request,
+                            response,
+                        )
 
                     response.data['meta']['active_flags'].append(sloan_flag_name)
 
@@ -230,7 +260,13 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
         # Give all users a unique id 'sloan_id` cookie, logged in or not.
         if not request.COOKIES.get(settings.SLOAN_ID_COOKIE_NAME):
-            self.set_sloan_cookie(settings.SLOAN_ID_COOKIE_NAME, str(uuid.uuid4()), request, response)
+            self.set_sloan_cookie(
+                settings.SLOAN_ID_COOKIE_NAME,
+                str(uuid.uuid4()),
+                request.environ['SERVER_NAME'] or request.environ.get('HTTP_REFERER'),
+                request,
+                response,
+            )
 
         return super(SloanOverrideWaffleMiddleware, self).process_response(request, response)
 
@@ -313,17 +349,18 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
     @staticmethod
     def override_flag_activity(sloan_flag_name, waffles_data, user):
+        active = None
         if waffles_data and waffles_data.get(sloan_flag_name):
             active = Flag.objects.get(name=sloan_flag_name).everyone or waffles_data[sloan_flag_name][0]
 
-            if user and not user.is_anonymous:
-                tag_name = SLOAN_FEATURES[sloan_flag_name]
-                if user.all_tags.filter(name=tag_name).exists():
-                    active = True
-                elif user.all_tags.filter(name=f'no_{tag_name}').exists():
-                    active = False
+        if user and not user.is_anonymous:
+            tag_name = SLOAN_FEATURES[sloan_flag_name]
+            if user.all_tags.filter(name=tag_name).exists():
+                active = True
+            elif user.all_tags.filter(name=f'no_{tag_name}').exists():
+                active = False
 
-            return active
+        return active
 
     @staticmethod
     def set_sloan_tags(user, flag_name: str, flag_value: bool):
@@ -337,7 +374,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             else:
                 user.add_system_tag(f'no_{tag_name}')
 
-    def set_sloan_cookie(self, name: str, value, request, resp, custom_domain=None):
+    def set_sloan_cookie(self, name: str, value, url, request, resp, custom_domain=None):
         """
         Set sloan cookies to sloan study specifications
         :param name: The name of the flag that will get a cookie
@@ -352,10 +389,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
         resp.cookies[name]['path'] = '/'
 
-        if request.environ.get('HTTP_REFERER') is None:
-            resp.cookies[name]['domain'] = settings.CSRF_COOKIE_DOMAIN
-        else:
-            resp.cookies[name]['domain'] = self.get_domain(request.environ['HTTP_REFERER'])
+        resp.cookies[name]['domain'] = self.get_domain(url)
 
         if custom_domain:
             resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -26,7 +26,7 @@ from api.base import settings as api_settings
 from waffle.middleware import WaffleMiddleware
 from waffle.models import Flag
 
-from website.settings import DOMAIN
+from website.settings import DOMAIN, TRAVIS_MODE
 from osf.models import (
     Preprint,
     PreprintProvider,
@@ -384,8 +384,6 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
         :return:
         """
         resp.cookies[name] = value
-        # ↓ This line seems terrible but is fixed in py 3.8
-        resp.cookies[name]._reserved.update({'samesite': 'samesite'})
 
         resp.cookies[name]['path'] = '/'
 
@@ -395,5 +393,8 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
             resp.cookies[name]['domain'] = '.' + urlparse(custom_domain).netloc
 
         # Browsers won't allow use to use these cookie attributes unless you're sending the data over https.
-        resp.cookies[name]['secure'] = True
-        resp.cookies[name]['samesite'] = 'None'
+        if not TRAVIS_MODE:
+            # ↓ This line seems terrible but is fixed in py 3.8
+            resp.cookies[name]._reserved.update({'samesite': 'samesite'})
+            resp.cookies[name]['secure'] = True
+            resp.cookies[name]['samesite'] = 'None'

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -3,7 +3,7 @@ import pytest
 from decimal import Decimal
 
 from waffle.models import Flag
-from website.settings import DOMAIN, TRAVIS_MODE
+from website.settings import DOMAIN
 from api.base.middleware import SloanOverrideWaffleMiddleware
 
 from osf_tests.factories import (
@@ -40,7 +40,6 @@ def inactive(*args, **kwargs):
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(TRAVIS_MODE, reason='Travis is balking at the idea of sending secure cookies via the testing app.')
 class TestSloanStudyWaffling:
     """
     DEV_MODE is mocked so cookies they behave as if they were using https.
@@ -243,3 +242,16 @@ class TestSloanStudyWaffling:
     def test_get_domain(self, url, expected_domain):
         actual_domain = SloanOverrideWaffleMiddleware.get_domain(url)
         assert actual_domain == expected_domain
+
+    @pytest.mark.enable_quickfiles_creation
+    def test_user_override_cookie(self, app, user, preprint):
+        user.add_system_tag(SLOAN_COI)
+        cookies = {
+            SLOAN_COI_DISPLAY: 'False',
+        }
+
+        resp = app.get('/v2/', auth=user.auth, cookies=cookies)
+
+        cookies = resp.headers.getall('Set-Cookie')
+
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,5 +137,3 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
-
-TRAVIS_MODE = False

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,3 +137,5 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
+
+TRAVIS_MODE = False


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make it so Sloan cookies override when a user is logging and has no refferer, so the author assertion can appear in a single login request.

## Changes

- logic changes with test.

## QA Notes

- no migration, low risk.


## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1784