### PR TITLE
[ENG-1785] Fix so flags work with Travis

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -313,8 +313,9 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
     @staticmethod
     def override_flag_activity(sloan_flag_name, waffles_data, user):
+        active = None
         if waffles_data and waffles_data.get(sloan_flag_name):
-            active = Flag.objects.get(name=sloan_flag_name).everyone or waffles_data[sloan_flag_name][0]
+            active = waffles_data[sloan_flag_name][0]
 
             if user and not user.is_anonymous:
                 tag_name = SLOAN_FEATURES[sloan_flag_name]
@@ -323,7 +324,10 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
                 elif user.all_tags.filter(name=f'no_{tag_name}').exists():
                     active = False
 
-            return active
+        if Flag.objects.get(name=sloan_flag_name).everyone:
+            active = True
+
+        return active
 
     @staticmethod
     def set_sloan_tags(user, flag_name: str, flag_value: bool):

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -43,7 +43,7 @@ from framework.auth.oauth_scopes import CoreScopes
 from osf.models import Contributor, MaintenanceState, BaseFileNode
 from osf.utils.permissions import API_CONTRIBUTOR_PERMISSIONS, READ, WRITE, ADMIN
 from waffle.models import Flag, Switch, Sample
-from waffle import sample_is_active, flag_is_active
+from waffle import sample_is_active
 
 
 class JSONAPIBaseView(generics.GenericAPIView):
@@ -411,7 +411,7 @@ def root(request, format=None, **kwargs):
     else:
         current_user = None
 
-    flags = [name for name in Flag.objects.values_list('name', flat=True) if flag_is_active(request._request, name)]
+    flags = [flag.name for flag in Flag.objects.all() if flag.is_active(request._request)]
     samples = [name for name in Sample.objects.values_list('name', flat=True) if sample_is_active(name)]
     switches = list(Switch.objects.filter(active=True).values_list('name', flat=True))
 

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -3,7 +3,7 @@ import pytest
 from decimal import Decimal
 
 from waffle.models import Flag
-from website.settings import DOMAIN, TRAVIS_MODE
+from website.settings import DOMAIN
 from api.base.middleware import SloanOverrideWaffleMiddleware
 
 from osf_tests.factories import (
@@ -40,7 +40,6 @@ def inactive(*args, **kwargs):
 
 
 @pytest.mark.django_db
-@pytest.mark.skipif(TRAVIS_MODE, reason='Travis is balking at the idea of sending secure cookies via the testing app.')
 class TestSloanStudyWaffling:
     """
     DEV_MODE is mocked so cookies they behave as if they were using https.

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -137,5 +137,3 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 
 # Show sent emails in console
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
-
-TRAVIS_MODE = False

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -103,5 +103,3 @@ POPULAR_LINKS_REGISTRATIONS = 'woooo'
 logging.getLogger('celery.app.trace').setLevel(logging.FATAL)
 
 DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
-
-TRAVIS_MODE = True


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Despite what I thought before it's actually the waffle middleware that's not working in Travis, not the cookies being secure. 


## Changes

- ensures we don't need waffle data to set cookie.
- fix problems with `test_user_get_cookie_when_flag_is_everyone` failing

## QA Notes

Just effects travis

## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1785