### PR TITLE
[ENG-1784] Sloan cookies overriding authenticated state in /v2/ request

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -211,7 +211,7 @@ class UserSerializer(JSONAPISerializer):
 
     def get_can_view_reviews(self, obj):
         group_qs = AbstractProviderGroupObjectPermission.objects.filter(group__user=obj, permission__codename='view_submissions')
-        return group_qs.exists() or obj.abstractprovideruserobjectpermission_set.filter(permission__codename='view_submissions')
+        return group_qs.exists() or obj.abstractprovideruserobjectpermission_set.filter(permission__codename='view_submissions') or []
 
     def get_default_region_id(self, obj):
         try:

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -252,6 +252,20 @@ class TestSloanStudyWaffling:
 
         resp = app.get('/v2/', auth=user.auth, cookies=cookies)
 
+        assert SLOAN_COI_DISPLAY in resp.json['meta']['active_flags']
         cookies = resp.headers.getall('Set-Cookie')
 
         assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies
+
+    @pytest.mark.enable_quickfiles_creation
+    def test_user_override_cookie_false(self, app, user, preprint):
+        user.add_system_tag(f'no_{SLOAN_COI}')
+        cookies = {
+            SLOAN_COI_DISPLAY: 'True',
+        }
+
+        resp = app.get('/v2/', auth=user.auth, cookies=cookies)
+        assert SLOAN_COI_DISPLAY not in resp.json['meta']['active_flags']
+        cookies = resp.headers.getall('Set-Cookie')
+
+        assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -242,3 +242,16 @@ class TestSloanStudyWaffling:
     def test_get_domain(self, url, expected_domain):
         actual_domain = SloanOverrideWaffleMiddleware.get_domain(url)
         assert actual_domain == expected_domain
+
+    @pytest.mark.enable_quickfiles_creation
+    def test_user_override_cookie(self, app, user, preprint):
+        user.add_system_tag(SLOAN_COI)
+        cookies = {
+            SLOAN_COI_DISPLAY: 'False',
+        }
+
+        resp = app.get('/v2/', auth=user.auth, cookies=cookies)
+
+        cookies = resp.headers.getall('Set-Cookie')
+
+        assert f' dwf_{SLOAN_COI_DISPLAY}=True; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make it so Sloan cookies override when a user is logging and has no refferer, so the author assertion can appear in a single login request.

## Changes

- logic changes with test.

## QA Notes

- no migration, low risk.


## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1784