### PR TITLE
[ENG-1782] Draft Registration permissions fix.

### DIFF
--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -25,7 +25,7 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
 
-        if isinstance(obj.branched_from, Node):
+        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
             obj = obj.branched_from
 
         if request.method in permissions.SAFE_METHODS:

--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -10,7 +10,6 @@ from osf.models import (
 )
 from api.nodes.permissions import ContributorDetailPermissions
 
-
 class IsContributorOrAdminContributor(permissions.BasePermission):
     """
     Need to be a contributor on the draft registration to view and make edits.
@@ -24,12 +23,38 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
             obj = obj.get('self', None)
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
+        if not auth:
+            return False
 
         if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
             obj = obj.branched_from
 
         if request.method in permissions.SAFE_METHODS:
-            return obj.can_view(auth)
+            return obj.is_contributor(auth.user)
+        else:
+            return obj.can_edit(auth)
+
+class IsAdminContributor(permissions.BasePermission):
+    """
+    Need to be a contributor on the draft registration to view and make edits.
+    Need to be an admin contributor on the node to create draft registration.
+    """
+
+    acceptable_models = (DraftRegistration, AbstractNode, )
+
+    def has_object_permission(self, request, view, obj):
+        if isinstance(obj, dict):
+            obj = obj.get('self', None)
+        assert_resource_type(obj, self.acceptable_models)
+        auth = get_user_auth(request)
+        if not auth.user:
+            return False
+
+        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
+            obj = obj.branched_from
+
+        if request.method in permissions.SAFE_METHODS:
+            return obj.is_contributor(auth.user)
         else:
             return obj.is_admin_contributor(auth.user)
 

--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -2,6 +2,7 @@ from rest_framework import permissions
 
 from api.base.utils import get_user_auth, assert_resource_type
 from osf.models import (
+    Node,
     DraftRegistration,
     AbstractNode,
     DraftRegistrationContributor,
@@ -23,6 +24,10 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
             obj = obj.get('self', None)
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
+
+        if isinstance(obj.branched_from, Node):
+            obj = obj.branched_from
+
         if request.method in permissions.SAFE_METHODS:
             return obj.can_view(auth)
         else:

--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -12,8 +12,8 @@ from api.nodes.permissions import ContributorDetailPermissions
 
 class IsContributorOrAdminContributor(permissions.BasePermission):
     """
-    Need to be a contributor on the draft registration to view and make edits.
-    Need to be an admin contributor on the node to create draft registration.
+    Need to be a contributor on the branched from node to view.
+    Need to have edit permissions on the branched from node to edit.
     """
 
     acceptable_models = (DraftRegistration, AbstractNode, )
@@ -36,8 +36,8 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
 
 class IsAdminContributor(permissions.BasePermission):
     """
-    Need to be a contributor on the draft registration to view and make edits.
-    Need to be an admin contributor on the node to create draft registration.
+    Need to be a contributor on the branched from node to view.
+    Need to be an admin contributor on the branched from node to make edits
     """
 
     acceptable_models = (DraftRegistration, AbstractNode, )

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -7,6 +7,7 @@ from api.base.pagination import DraftRegistrationContributorPagination
 from api.draft_registrations.permissions import (
     DraftContributorDetailPermissions,
     IsContributorOrAdminContributor,
+    IsAdminContributor,
 )
 from api.draft_registrations.serializers import (
     DraftRegistrationSerializer,
@@ -49,7 +50,7 @@ class DraftRegistrationMixin(DraftMixin):
 
 class DraftRegistrationList(NodeDraftRegistrationsList):
     permission_classes = (
-        IsContributorOrAdminContributor,
+        IsAdminContributor,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
@@ -72,7 +73,7 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
 
 class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixin):
     permission_classes = (
-        ContributorOrPublic,
+        IsContributorOrAdminContributor,
         AdminDeletePermissions,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
@@ -157,7 +158,7 @@ class DraftSubjectsRelationship(SubjectRelationshipBaseView, DraftRegistrationMi
 
 class DraftContributorsList(NodeContributorsList, DraftRegistrationMixin):
     permission_classes = (
-        IsContributorOrAdminContributor,
+        IsAdminContributor,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -50,7 +50,7 @@ class DraftRegistrationMixin(DraftMixin):
 
 class DraftRegistrationList(NodeDraftRegistrationsList):
     permission_classes = (
-        IsAdminContributor,
+        IsContributorOrAdminContributor,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -34,6 +34,10 @@ class ContributorOrPublic(permissions.BasePermission):
             obj = obj.get('self', None)
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
+
+        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
+            obj = obj.branched_from
+
         if request.method in permissions.SAFE_METHODS:
             return obj.is_public or obj.can_view(auth)
         else:

--- a/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
@@ -1,5 +1,6 @@
 import pytest
 import mock
+import random
 
 from framework.auth.core import Auth
 from api.base.settings.defaults import API_BASE
@@ -80,6 +81,10 @@ class TestDraftRegistrationContributorList(DraftRegistrationCRUDTestCase, TestNo
             url_public, url_private, make_contrib_id):
 
         #   test_return_public_contributor_list_logged_in
+        res = app.get(url_public, auth=user.auth)
+        assert res.status_code == 200
+        #   test_return_public_contributor_list_logged_in
+        # Since permissions are based on the branched from node, this will not pass
         res = app.get(url_public, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
 
@@ -165,6 +170,27 @@ class TestDraftRegistrationContributorList(DraftRegistrationCRUDTestCase, TestNo
         id_two = [item['id'] for item in req_two.json['data']]
         for a, b in zip(id_one, id_two):
             assert a == b
+
+    def test_permissions_work_with_many_users(
+            self, app, user, project_private, url_private):
+        users = {
+            permissions.ADMIN: [user._id],
+            permissions.WRITE: []
+        }
+        for i in range(0, 25):
+            perm = random.choice(list(users.keys()))
+            user = AuthUserFactory()
+
+            project_private.add_contributor(user, permissions=perm)
+            users[perm].append(user._id)
+
+        res = app.get(url_private, auth=user.auth)
+        data = res.json['data']
+        for user in data:
+            api_perm = user['attributes']['permission']
+            user_id = user['id'].split('-')[1]
+            assert user_id in users[api_perm], 'Permissions incorrect for {}. Should not have {} permission.'.format(
+                user_id, api_perm)
 
 
 class TestDraftRegistrationContributorAdd(DraftRegistrationCRUDTestCase, TestNodeContributorAdd):

--- a/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
@@ -81,9 +81,6 @@ class TestDraftRegistrationContributorList(DraftRegistrationCRUDTestCase, TestNo
             url_public, url_private, make_contrib_id):
 
         #   test_return_public_contributor_list_logged_in
-        res = app.get(url_public, auth=user.auth)
-        assert res.status_code == 200
-        #   test_return_public_contributor_list_logged_in
         # Since permissions are based on the branched from node, this will not pass
         res = app.get(url_public, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -34,8 +34,7 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(url_draft_registrations, auth=group_mem.auth, expect_errors=True)
         assert res.status_code == 403
 
-    # Overrides TestDraftRegistrationDetail
-    def test_cannot_view_draft(
+    def test_can_view_draft(
             self, app, user_write_contrib, project_public,
             user_read_contrib, user_non_contrib,
             url_draft_registrations, group, group_mem):
@@ -47,21 +46,25 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
             expect_errors=True)
         assert res.status_code == 200
 
-    #   test_read_write_contributor_can_view_draft
+        #   test_read_write_contributor_can_view_draft
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth,
             expect_errors=True)
         assert res.status_code == 200
 
-    #   test_logged_in_non_contributor_cannot_view_draft
+    def test_cannot_view_draft(
+            self, app, project_public,
+            user_non_contrib, url_draft_registrations):
+
+        #   test_logged_in_non_contributor_cannot_view_draft
         res = app.get(
             url_draft_registrations,
             auth=user_non_contrib.auth,
             expect_errors=True)
         assert res.status_code == 403
 
-    #   test_unauthenticated_user_cannot_view_draft
+        #   test_unauthenticated_user_cannot_view_draft
         res = app.get(url_draft_registrations, expect_errors=True)
         assert res.status_code == 401
 

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -123,27 +123,27 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         project_public.add_contributor(node_admin, ADMIN)
         assert project_public.has_permission(node_admin, ADMIN) is True
         assert draft_registration.has_permission(node_admin, ADMIN) is False
-        res = app.get(url_draft_registrations, auth=node_admin.auth, expect_errors=True)
-        assert res.status_code == 403
+        res = app.get(url_draft_registrations, auth=node_admin.auth)
+        assert res.status_code == 200
 
         # Admin on draft but not node
         draft_admin = AuthUserFactory()
         draft_registration.add_contributor(draft_admin, ADMIN)
         assert project_public.has_permission(draft_admin, ADMIN) is False
         assert draft_registration.has_permission(draft_admin, ADMIN) is True
-        res = app.get(url_draft_registrations, auth=draft_admin.auth)
-        assert res.status_code == 200
+        res = app.get(url_draft_registrations, auth=draft_admin.auth, expect_errors=True)
+        assert res.status_code == 403
 
     # Overwrites TestDraftRegistrationDetail
     def test_can_view_after_added(
             self, app, schema, draft_registration, url_draft_registrations):
-        # Draft Registration permissions should be independent of the branched_from node
+        # Draft Registration permissions are based on the branched from node
 
         user = AuthUserFactory()
         project = draft_registration.branched_from
         project.add_contributor(user, ADMIN)
-        res = app.get(url_draft_registrations, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+        res = app.get(url_draft_registrations, auth=user.auth)
+        assert res.status_code == 200
 
     # Overrides TestDraftRegistrationDetail
     def test_reviewer_can_see_draft_registration(

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -40,9 +40,7 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
             auth=user_read_contrib.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['id'] == draft_registration._id
-        assert draft_registration.get_permissions(user_read_contrib) == [READ]
+        assert len(res.json['data']) == 0
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
@@ -50,9 +48,7 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
             auth=user_write_contrib.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['id'] == draft_registration._id
-        assert draft_registration.get_permissions(user_write_contrib) == [READ, WRITE]
+        assert len(res.json['data']) == 0
 
         #   test_logged_in_non_contributor_can_view_draft_list
         res = app.get(

--- a/api_tests/users/views/test_user_draft_registration_list.py
+++ b/api_tests/users/views/test_user_draft_registration_list.py
@@ -70,13 +70,13 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json['data']) == 0
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json['data']) == 0
 
         #   test_logged_in_non_contributor_cannot_view_draft_list
         res = app.get(

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2147,7 +2147,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         else:
             return []
 
-    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True):
+    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True, contributors=True):
         """
         Copy various editable fields from the 'resource' object to the current object.
         Includes, title, description, category, contributors, node_license, tags, subjects, and affiliated_institutions
@@ -2156,7 +2156,6 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
-        from osf.models import DraftRegistration
 
         self.set_editable_attribute('title', resource, alternative_resource)
         self.set_editable_attribute('description', resource, alternative_resource)
@@ -2165,7 +2164,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
 
         # Contributors will always come from "resource", as contributor constraints
         # will require contributors to be present on the resource
-        if not isinstance(self, DraftRegistration):
+        if contributors:
             self.copy_contributors_from(resource)
         # Copy unclaimed records for unregistered users
         self.copy_unclaimed_records(resource)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2156,6 +2156,8 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
+        from osf.models import DraftRegistration
+
         self.set_editable_attribute('title', resource, alternative_resource)
         self.set_editable_attribute('description', resource, alternative_resource)
         self.set_editable_attribute('category', resource, alternative_resource)
@@ -2163,7 +2165,8 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
 
         # Contributors will always come from "resource", as contributor constraints
         # will require contributors to be present on the resource
-        self.copy_contributors_from(resource)
+        if not isinstance(self, DraftRegistration):
+            self.copy_contributors_from(resource)
         # Copy unclaimed records for unregistered users
         self.copy_unclaimed_records(resource)
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2156,7 +2156,6 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
-
         self.set_editable_attribute('title', resource, alternative_resource)
         self.set_editable_attribute('description', resource, alternative_resource)
         self.set_editable_attribute('category', resource, alternative_resource)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1036,6 +1036,7 @@ class TaxonomizableMixin(models.Model):
         Preprint = apps.get_model('osf.Preprint')
         CollectionSubmission = apps.get_model('osf.CollectionSubmission')
         DraftRegistration = apps.get_model('osf.DraftRegistration')
+        Node = apps.get_model('osf.Node')
 
         if isinstance(self, AbstractNode):
             if not self.has_permission(auth.user, ADMIN):
@@ -1043,6 +1044,9 @@ class TaxonomizableMixin(models.Model):
         elif isinstance(self, Preprint):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have admin or write permissions to change a preprint\'s subjects.')
+        if isinstance(self, DraftRegistration) and isinstance(self.branched_from, Node):
+            if not self.branched_from.has_permission(auth.user, WRITE):
+                raise PermissionsError('Must have admin on parent node to update draft registration\'s subjects.')
         elif isinstance(self, DraftRegistration):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have write permissions to change a draft registration\'s subjects.')

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1450,7 +1450,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource)
+        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
         registered.copy_contributors_from(self)
 
         if settings.ENABLE_ARCHIVER:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1451,6 +1451,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             alternative_resource = None
 
         registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource)
+        registered.copy_contributors_from(self)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1009,6 +1009,10 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         )
         self.registered_node = register
         self.add_status_log(auth.user, DraftRegistrationLog.REGISTERED)
+
+        if isinstance(node, Node):
+            self.copy_contributors_from(node)
+
         if save:
             self.save()
         return register

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -911,7 +911,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True)
+        draft.copy_editable_fields(node, Auth(user), save=True, contributors=False)
         draft.update(data)
         return draft
 
@@ -1010,8 +1010,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         self.registered_node = register
         self.add_status_log(auth.user, DraftRegistrationLog.REGISTERED)
 
-        if isinstance(node, Node):
-            self.copy_contributors_from(node)
+        self.copy_contributors_from(node)
 
         if save:
             self.save()

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -307,12 +307,12 @@ class TestDraftRegistrations:
         assert draft.description == description
         assert draft.category == category
         assert user in draft.contributors.all()
-        assert write_contrib in draft.contributors.all()
+        assert write_contrib not in draft.contributors.all()
         assert member not in draft.contributors.all()
         assert not draft.has_permission(member, 'read')
 
         assert draft.get_permissions(user) == [READ, WRITE, ADMIN]
-        assert draft.get_permissions(write_contrib) == [READ, WRITE]
+        assert draft.get_permissions(write_contrib) == []
 
         assert draft.node_license.license_id == GPL3.license_id
         assert draft.node_license.name == GPL3.name

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -389,11 +389,11 @@ class TestRegisterNodeContributors:
         with mock_archive(project_two, autoapprove=True) as registration:
             return registration
 
-    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
+    def test_unregistered_contributors_unclaimed_records_dont_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
         contributor_unregistered.refresh_from_db()
         contributor_unregistered_no_email.refresh_from_db()
         assert registration.contributors.filter(id=contributor_unregistered.id).exists()
-        assert registration._id in contributor_unregistered.unclaimed_records
+        assert registration._id not in contributor_unregistered.unclaimed_records
 
         # component
         component_registration = registration.nodes[0]

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -398,7 +398,7 @@ class TestRegisterNodeContributors:
         # component
         component_registration = registration.nodes[0]
         assert component_registration.contributors.filter(id=contributor_unregistered_no_email.id).exists()
-        assert component_registration._id in contributor_unregistered_no_email.unclaimed_records
+        assert component_registration._id not in contributor_unregistered_no_email.unclaimed_records
 
 
 # copied from tests/test_registrations


### PR DESCRIPTION

## Purpose

After much discussion, it has been decided that draft registration contributors will not be carried over when the draft registration is created. Rather, they will be copied over upon time of registration. Also, draft registration permissions need to be based on the branched from node. 

## Changes

Changing when the contributors are carried over. Modifying api permission classes to check permissions against the branched from node. Modifying tests to work with this new scheme.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No.
  - What is the level of risk?
Moderate. Just need to ensure permissions are right for all draft registration related things.
    - Any permissions code touched?
yes
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
UI and API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version
  - What features or workflows might this change impact?
Creation of draft registration and management of contributors.
  - How will this impact performance?
Shouldn't

## Documentation

None

## Side Effects

Perhaps some weird edge case permissions thing might break that we didn't think of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1782