### PR TITLE
[ENG-1651] Removes 'Authors' from specified Registration Forms

### DIFF
--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -430,7 +430,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
                 'type': 'draft_registrations',
                 'attributes': {
                     'registration_metadata': {
-                        'q2': {
+                        'q3': {
                             'value': 'New response'
                         }
                     }
@@ -442,7 +442,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             url, payload, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['registration_metadata']['q2']['value'] == 'New response'
+        assert res.json['data']['attributes']['registration_metadata']['q3']['value'] == 'New response'
         assert 'q1' not in res.json['data']['attributes']['registration_metadata']
 
     def test_required_registration_responses_questions_not_required_on_update(

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -543,8 +543,6 @@ class TestDraftRegistrationCreate(DraftRegistrationTestCase):
             expect_errors=True)
         assert res.status_code == 201
         data = res.json['data']
-        assert res.json['data']['attributes']['registration_metadata']['q2']['value'] == 'Test response'
-        assert res.json['data']['attributes']['registration_responses']['q2'] == 'Test response'
         assert prereg_schema._id in data['relationships']['registration_schema']['links']['related']['href']
         assert data['embeds']['branched_from']['data']['id'] == project_public._id
         assert data['embeds']['initiator']['data']['id'] == user._id

--- a/osf/migrations/0206_ensure_schemas.py
+++ b/osf/migrations/0206_ensure_schemas.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0205_auto_20200323_1850'),
+    ]
+
+    operations = [
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+    ]

--- a/osf/migrations/0207_ensure_schemas.py
+++ b/osf/migrations/0207_ensure_schemas.py
@@ -6,7 +6,7 @@ from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('osf', '0205_auto_20200323_1850'),
+        ('osf', '0206_auto_20200528_1319'),
     ]
 
     operations = [

--- a/osf_tests/management_commands/test_migration_registration_responses.py
+++ b/osf_tests/management_commands/test_migration_registration_responses.py
@@ -29,7 +29,6 @@ prereg_registration_responses = {
     'q12.question': 'these are my measured variables',
     'q1': 'This is my title',
     'q3': 'research questions',
-    'q2': 'Dawn Pattison, James Brown, Carrie Skinner',
     'q5': 'Registration prior to creation of data',
     'q4': 'this is my hypothesis',
     'q6': 'Explanation of existing data',
@@ -135,11 +134,6 @@ prereg_registration_metadata = {
     'q3': {
         'comments': [],
         'value': 'research questions',
-        'extra': []
-    },
-    'q2': {
-        'comments': [],
-        'value': 'Dawn Pattison, James Brown, Carrie Skinner',
         'extra': []
     },
     'q5': {
@@ -464,11 +458,6 @@ prereg_registration_metadata_built = {
     'q3': {
         'comments': [],
         'value': 'research questions',
-        'extra': []
-    },
-    'q2': {
-        'comments': [],
-        'value': 'Dawn Pattison, James Brown, Carrie Skinner',
         'extra': []
     },
     'q5': {
@@ -1722,7 +1711,6 @@ class TestMigrateDraftRegistrationRegistrationResponses:
         assert responses['q12.question'] == 'these are my measured variables'
         assert responses['q1'] == 'This is my title'
         assert responses['q3'] == 'research questions'
-        assert responses['q2'] == 'Dawn Pattison, James Brown, Carrie Skinner'
         assert responses['q5'] == 'Registration prior to creation of data'
         assert responses['q4'] == 'this is my hypothesis'
         assert responses['q6'] == 'Explanation of existing data'
@@ -1956,7 +1944,6 @@ class TestMigrateRegistrationRegistrationResponses:
         assert responses['q12.question'] == 'these are my measured variables'
         assert responses['q1'] == 'This is my title'
         assert responses['q3'] == 'research questions'
-        assert responses['q2'] == reg_prereg.registered_from.visible_contributors.first().fullname
         assert responses['q5'] == 'Registration prior to creation of data'
         assert responses['q4'] == 'this is my hypothesis'
         assert responses['q6'] == 'Explanation of existing data'

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -2091,8 +2091,6 @@ class TestRegisterNode:
 
         # Author questions are overridden with bibliographic contributors upon registration,
         # so there aren't discrepancies
-        assert registration.registered_meta[registration.registration_schema._id]['q2']['value'] == user.fullname + ', ' + bib_contrib.fullname
-        assert registration.registration_responses['q2'] == user.fullname + ', ' + bib_contrib.fullname
 
         # assert that other registration_metadata not overridden
         assert registration.registered_meta[registration.registration_schema._id]['q3']['value'] == 'research questions'

--- a/osf_tests/test_schemas.py
+++ b/osf_tests/test_schemas.py
@@ -51,7 +51,6 @@ class TestRegistrationSchemaValidation:
     def prereg_test_data(self):
         return {
             'q1': 'This is a test.',
-            # 'q2': 'Grapes McGee',
             'q3': 'Here is an answer to this question.',
             'q4': 'This is a hypothesis',
             'q5': 'Registration prior to creation of data',

--- a/osf_tests/test_schemas.py
+++ b/osf_tests/test_schemas.py
@@ -51,7 +51,7 @@ class TestRegistrationSchemaValidation:
     def prereg_test_data(self):
         return {
             'q1': 'This is a test.',
-            'q2': 'Grapes McGee',
+            # 'q2': 'Grapes McGee',
             'q3': 'Here is an answer to this question.',
             'q4': 'This is a hypothesis',
             'q5': 'Registration prior to creation of data',

--- a/website/project/metadata/egap-registration.json
+++ b/website/project/metadata/egap-registration.json
@@ -18,14 +18,6 @@
 					"required": true
 				},
 				{
-					"qid": "q2",
-					"nav": "Authors",
-					"title": "B2 Authors",
-					"help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo",
-					"format": "textarea",
-					"required": true
-				},
-				{
 					"qid": "q3",
 					"nav": "EGAP Registration ID",
 					"title": "EGAP Registration ID",

--- a/website/project/metadata/osf-preregistration-3.json
+++ b/website/project/metadata/osf-preregistration-3.json
@@ -13,13 +13,6 @@
         "id": "page1",
         "title": "Study Information",
         "questions": [{
-            "qid": "q1",
-            "nav": "Authors",
-            "title": "Authors",
-            "type": "osf-author-import",
-            "format": "textarea",
-            "required": true
-        }, {
             "qid": "q2",
             "nav": "Hypotheses",
             "type": "string",

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -35,16 +35,6 @@
             "help": "Effect of sugar on brownie tastiness. <br /><br />How responses will be evaluated: The title should be a specific and informative description of a project. Vague titles such as 'Fruit fly preregistration plan' are not appropriate.",
             "required": true
         }, {
-            "qid": "q2",
-            "nav": "Authors",
-            "type": "string",
-            "title": "Authors",
-            "description": "The author who submits the preregistration is the recipient of the award money and must also be an author of the published manuscript. Additional authors may be added or removed at any time.",
-            "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo",
-            "type": "osf-author-import",
-            "format": "textarea",
-            "required": true
-        }, {
             "qid": "q3",
             "nav": "Research Questions",
             "type": "string",

--- a/website/project/metadata/registered-report-4.json
+++ b/website/project/metadata/registered-report-4.json
@@ -6,18 +6,6 @@
     },
     "description": "You will be asked a few simple questions about your study and given the chance to attach your accepted manuscript to the form. Use this form after receiving an \"in-principle acceptance\" from a journal offering the Registered Reports format. See https://cos.io/rr for more information.",
     "pages": [{
-        "id": "page1",
-        "title": "Study Information",
-        "questions": [{
-            "qid": "q1",
-            "nav": "Authors",
-            "title": "Authors",
-            "help": "Jimmy Stewart, Ava Gardner, Bob Hope, Greta Garbo",
-            "type": "osf-author-import",
-            "format": "textarea",
-            "required": true
-        }]
-    }, {
         "id": "page2",
         "title": "Publication Information",
         "questions": [{


### PR DESCRIPTION
## Purpose
Registries now have metadata which is redundant with asking for 'authors' on specific registration forms.

## Changes
* Removes the 'author' question json snippet from egap-registration, osf-preregistraton, prereg-challenge, and registered-report
* Adds an ensure_schema migration to update the database representation of the registration schemas

## QA Notes
These changes can be validated through the UI by going through the process of creating registrations with these schemas and ensuring that registrations are created properly and that authors are not asked for. 

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1651)
