### PR TITLE
[ENG-1820] Changes representation of username in InstitutionUserMetrics API Endpoint

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -237,7 +237,7 @@ class InstitutionUserMetricsSerializer(JSONAPISerializer):
         type_ = 'institution-users'
 
     id = IDField(source='user_id', read_only=True)
-    user_name = ser.CharField(source='user', read_only=True)
+    user_name = ser.CharField(read_only=True)
     public_projects = ser.IntegerField(source='public_project_count', read_only=True)
     private_projects = ser.IntegerField(source='private_project_count', read_only=True)
     department = ser.CharField(read_only=True)

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -42,6 +42,10 @@ from api.institutions.serializers import (
 from api.institutions.permissions import UserIsAffiliated
 from rest_framework.settings import api_settings
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class InstitutionMixin(object):
     """Mixin with convenience method get_institution
@@ -485,7 +489,7 @@ class InstitutionUserMetricsList(InstitutionImpactList):
             record_dict = user_record.to_dict()
             user_id = user_record.user_id
             fullname = OSFUser.objects.get(guids___id=user_id).fullname
-            record_dict['user'] = f'({user_id}) {fullname}'
+            record_dict['user'] = fullname
             users.append(record_dict)
 
         return users

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -489,7 +489,7 @@ class InstitutionUserMetricsList(InstitutionImpactList):
             record_dict = user_record.to_dict()
             user_id = user_record.user_id
             fullname = OSFUser.objects.get(guids___id=user_id).fullname
-            record_dict['user'] = fullname
+            record_dict['user_name'] = fullname
             users.append(record_dict)
 
         return users

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -87,7 +87,7 @@ class TestInstitutionUserMetricList:
                 'id': user._id,
                 'type': 'institution-users',
                 'attributes': {
-                    'user_name': f'({user._id}) {user.fullname}',
+                    'user_name': user.fullname,
                     'public_projects': 6,
                     'private_projects': 5,
                     'department': 'Biology dept'
@@ -114,7 +114,7 @@ class TestInstitutionUserMetricList:
                 'id': user2._id,
                 'type': 'institution-users',
                 'attributes': {
-                    'user_name': f'({user2._id}) {user2.fullname}',
+                    'user_name': user2.fullname,
                     'public_projects': 3,
                     'private_projects': 2,
                     'department': 'Psychology dept'


### PR DESCRIPTION
## Purpose
Currently, the username in the response of the InstitutionUserMetrics API endpoint is a combination of the user guid and fullname. Solely providing the user fullname will make things easier for the front end.

## Changes
* Modifies the user_name string for the InstitutionUserMetrics endpoint to only include the user fullname

## QA Notes
The modification to `user_name` can be verified by the API

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1820)
