### PR TITLE
[ENG-1824] Fixing relationship field

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -889,6 +889,9 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                     elif related_type == 'users' and related_class.view_name == 'user_settings':
                         related_id = resolved_url.kwargs['user_id']
                         related_type = 'user-settings'
+                    elif related_type == 'institutions' and related_class.view_name == 'institution-summary-metrics':
+                        related_id = resolved_url.kwargs['institution_id']
+                        related_type = 'institution-summary-metrics'
                     else:
                         related_id = resolved_url.kwargs[related_type[:-1] + '_id']
                 except KeyError:


### PR DESCRIPTION


## Purpose

The type on the summary metrics relationship in the institution detail endpoint needs to be `institution-summary-metrics`, not `institution`.

## Changes

Added a case to the JSON API serializer for the summary metrics relation.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
None
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API (v2/institutions/<institution_id>/)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version
  - What features or workflows might this change impact?
None
  - How will this impact performance?
Shouldn't
-->

## Documentation

Institutional metrics won't be available to the general public, so there won't be any documentation

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1824