### PR TITLE
[ENG-1821] Adding institutional ID to departments.

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -163,9 +163,11 @@ class InstitutionAuthentication(BaseAuthentication):
             logger.info('Institution SSO: new user "{}"'.format(username))
 
         # The `department` field is updated each login when it was changed.
-        if department and user.department != department:
-            user.department = department
-            user.save()
+        if department:
+            department = '{}-{}'.format(institution._id, department)
+            if user.department != department:
+                user.department = department
+                user.save()
 
         # Both created and activated accounts need to be updated and registered
         if created or activation_required:

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -164,7 +164,11 @@ class InstitutionAuthentication(BaseAuthentication):
 
         # The `department` field is updated each login when it was changed.
         if department:
-            department = '{}-{}'.format(institution._id, department)
+            # If the department already has a departmental prefix, don't overwrite it.
+            # We don't want cos-cos-psychology
+            institution_prefix = '{}-'.format(institution._id)
+            if not department.startswith(institution_prefix):
+                department = '{}-{}'.format(institution._id, department)
             if user.department != department:
                 user.department = department
                 user.save()

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -190,7 +190,7 @@ class TestInstitutionAuth:
         assert user.fullname == fullname
         assert user.family_name == 'Bar'
         assert user.given_name == 'Foo'
-        assert user.department == 'Fake Department'
+        assert user.department == '{}-{}'.format(institution._id, 'Fake Department')
         # Existing active user keeps their password
         assert user.has_usable_password()
         assert user.check_password(password)
@@ -232,7 +232,7 @@ class TestInstitutionAuth:
         assert user.fullname == 'Fake User'
         assert user.family_name == 'User'
         assert user.given_name == 'Fake'
-        assert user.department == 'Fake Department'
+        assert user.department == '{}-{}'.format(institution._id, 'Fake Department')
         # Unclaimed records must have been cleared
         assert not user.unclaimed_records
         # Previously unclaimed user must be assigned a usable password during institution auth


### PR DESCRIPTION


## Purpose

Adding ID to department upon CAS login

## Changes

Modifying authentication to create department with ID

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
minimal
    - Any permissions code touched?
no
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Through API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
Institutional dashboard
  - How will this impact performance?
n/a
-->

## Documentation

N/A

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-1821