### PR TITLE
[ENG-1822] Add more filterable fields to user institutions.

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -251,6 +251,14 @@ class InstitutionUserMetricsSerializer(JSONAPISerializer):
         'self': 'get_absolute_url',
     })
 
+    filterable_fields = frozenset([
+        'id',
+        'user_name',
+        'public_projects',
+        'private_projects',
+        'department',
+    ])
+
     def get_absolute_url(self, obj):
         return absolute_reverse(
             'institutions:institution-user-metrics',

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -34,22 +34,7 @@ class TestInstitutionUserMetricList:
         return user
 
     @pytest.fixture()
-    def url(self, institution):
-        return f'/{API_BASE}institutions/{institution._id}/metrics/users/'
-
-    def test_get(self, app, url, user, user2, admin, institution):
-
-        resp = app.get(url, expect_errors=True)
-        assert resp.status_code == 401
-
-        resp = app.get(url, auth=user.auth, expect_errors=True)
-        assert resp.status_code == 403
-
-        resp = app.get(url, auth=admin.auth)
-        assert resp.status_code == 200
-
-        assert resp.json['data'] == []
-
+    def populate_counts(self, institution, user, user2):
         # Old data that shouldn't appear in responses
         UserInstitutionProjectCounts.record(
             user_id=user._id,
@@ -80,6 +65,24 @@ class TestInstitutionUserMetricList:
         import time
         time.sleep(2)
 
+    @pytest.fixture()
+    def url(self, institution):
+        return f'/{API_BASE}institutions/{institution._id}/metrics/users/'
+
+    def test_auth(self, app, url, user, admin):
+
+        resp = app.get(url, expect_errors=True)
+        assert resp.status_code == 401
+
+        resp = app.get(url, auth=user.auth, expect_errors=True)
+        assert resp.status_code == 403
+
+        resp = app.get(url, auth=admin.auth)
+        assert resp.status_code == 200
+
+        assert resp.json['data'] == []
+
+    def test_get(self, app, url, user, user2, admin, institution, populate_counts):
         resp = app.get(url, auth=admin.auth)
 
         assert resp.json['data'] == [
@@ -138,3 +141,7 @@ class TestInstitutionUserMetricList:
                 }
             }
         ]
+
+    def test_filter(self, app, url, admin, populate_counts):
+        resp = app.get(f'{url}?filter[department]=Psychology dept', auth=admin.auth)
+        assert resp.json['data'][0]['attributes']['department'] == 'Psychology dept'


### PR DESCRIPTION
…the tests slightly

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently the user institutions metrics endpoint doesn't filter on department, it should do that!

## Changes

- add to filter field set
- dry up and add new tests

## QA Notes

You should know be able to in filter by department for example `?filter[department]=Psychology dept` on 

## Documentation

technical task, no new docs.

## Side Effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/ENG-1822