### PR TITLE
[ENG-1850] Draft registration title not being saved

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -115,7 +115,7 @@ from api.osf_groups.views import OSFGroupMixin
 from api.preprints.serializers import PreprintSerializer
 from api.registrations.serializers import (
     RegistrationSerializer,
-    RegistrationCreateLegacySerializer,
+    RegistrationCreateSerializer,
 )
 from api.requests.permissions import NodeRequestPermission
 from api.requests.serializers import NodeRequestSerializer, NodeRequestCreateSerializer
@@ -691,7 +691,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
 
     def get_serializer_class(self):
         if self.request.method in ('PUT', 'POST'):
-            return RegistrationCreateLegacySerializer
+            return RegistrationCreateSerializer
         return RegistrationSerializer
 
     # overrides ListCreateAPIView

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -675,20 +675,6 @@ class RegistrationCreateSerializer(RegistrationSerializer):
         return True
 
 
-class RegistrationCreateLegacySerializer(RegistrationCreateSerializer):
-    """
-    Overrides RegistrationCreateSerializer for the old registration workflow
-    to copy editable fields.
-    """
-
-    def create(self, validated_data):
-        auth = get_user_auth(self.context['request'])
-        draft = validated_data.get('draft', None)
-        draft.copy_editable_fields(draft.branched_from, auth=auth)
-        registration = super(RegistrationCreateLegacySerializer, self).create(validated_data)
-        return registration
-
-
 class RegistrationDetailSerializer(RegistrationSerializer):
     """
     Overrides RegistrationSerializer make _id required and other fields writeable

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -768,7 +768,7 @@ class TestNodeRegistrationCreate(DraftRegistrationTestCase):
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_old_workflow_node_editable_metadata_copied(
             self, mock_enqueue, app, user, url_registrations, payload, project_public, draft_registration):
-        # New workflow allows you to edit fields on draft registration, but old workflow does not.
+        # Ensure that modifying the parent project for the draft registration doesn't affect the title of the draft reg
         project_public.title = 'Recently updated title'
         project_public.save()
         res = app.post_json_api(url_registrations, payload, auth=user.auth, expect_errors=True)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2160,10 +2160,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
-
-        DraftRegistration = apps.get_model('osf.DraftRegistration')
-        if isinstance(self, DraftRegistration):
-            self.set_editable_attribute('title', self.title)
+        self.set_editable_attribute('title', resource, alternative_resource)
         self.set_editable_attribute('description', resource, alternative_resource)
         self.set_editable_attribute('category', resource, alternative_resource)
         self.set_editable_attribute('node_license', resource, alternative_resource)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2160,7 +2160,10 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
-        self.set_editable_attribute('title', resource, alternative_resource)
+
+        DraftRegistration = apps.get_model('osf.DraftRegistration')
+        if isinstance(self, DraftRegistration):
+            self.set_editable_attribute('title', self.title)
         self.set_editable_attribute('description', resource, alternative_resource)
         self.set_editable_attribute('category', resource, alternative_resource)
         self.set_editable_attribute('node_license', resource, alternative_resource)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1452,6 +1452,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
         registered.copy_contributors_from(self)
+        registered.copy_unclaimed_records(self)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -389,16 +389,16 @@ class TestRegisterNodeContributors:
         with mock_archive(project_two, autoapprove=True) as registration:
             return registration
 
-    def test_unregistered_contributors_unclaimed_records_dont_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
+    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
         contributor_unregistered.refresh_from_db()
         contributor_unregistered_no_email.refresh_from_db()
         assert registration.contributors.filter(id=contributor_unregistered.id).exists()
-        assert registration._id not in contributor_unregistered.unclaimed_records
+        assert registration._id in contributor_unregistered.unclaimed_records
 
         # component
         component_registration = registration.nodes[0]
         assert component_registration.contributors.filter(id=contributor_unregistered_no_email.id).exists()
-        assert component_registration._id not in contributor_unregistered_no_email.unclaimed_records
+        assert component_registration._id in contributor_unregistered_no_email.unclaimed_records
 
 
 # copied from tests/test_registrations


### PR DESCRIPTION
## Purpose

Draft registration titles are being overwritten when the draft registration is registered.

## Changes

This is occurring because the title is overwritten on the draft registration model, and therefore not being copied over in register_node.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No.
  - What is the level of risk?
Minimal
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version
  - What features or workflows might this change impact?
Draft Registration metadata workflow
  - How will this impact performance?
Shouldn't
-->

## Documentation

N/A

## Side Effects
n/a
## Ticket

https://openscience.atlassian.net/browse/ENG-1850