### PR TITLE
Fix children relationship on sparse node endpoint [ENG-1849]

### DIFF
--- a/api/sparse/serializers.py
+++ b/api/sparse/serializers.py
@@ -31,7 +31,7 @@ class SparseNodeSerializer(NodeSerializer):
         related_view_kwargs={'node_id': '<_id>'},
     )
     children = RelationshipField(
-        related_view='sparse:node-children',
+        related_view='nodes:node-children',
         related_view_kwargs={'node_id': '<_id>'},
         related_meta={'count': 'get_node_count'},
     )

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -133,7 +133,7 @@ class TestSparseNodeSerializer:
         assert urlparse(parent_link).path == '/{}sparse/nodes/{}/'.format(API_BASE, parent._id)
         assert 'sparse' not in relationships['detail']['links']['related']['href']
         sparse_children_path = urlparse(relationships['children']['links']['related']['href']).path
-        assert sparse_children_path == '/{}sparse/nodes/{}/children/'.format(API_BASE, node._id)
+        assert sparse_children_path == '/{}nodes/{}/children/'.format(API_BASE, node._id)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION

## Purpose

All relationships on the sparse node point to non-sparse endpoints except for children. This is an issue because there is no sparse children endpoint, so it points to nothing.

## Changes

Changing the view that the children relationship points to. Modifying test to check for this new endpoint

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
n/A
  - What is the level of risk?
N/A
    - Any permissions code touched?
N/A
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version. Use v2/sparse/nodes/<nid>/
  - What features or workflows might this change impact?
It shouldn't
  - How will this impact performance?
Shouldn't
-->

## Documentation

We don't document sparse endpoints.

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1849