### PR TITLE
Adding errors for new API Version [ENG-1490]

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -6,7 +6,7 @@ from distutils.version import StrictVersion
 from django.core.exceptions import ValidationError
 from rest_framework import serializers as ser
 from rest_framework import exceptions
-from api.base.exceptions import Conflict, InvalidModelValueError
+from api.base.exceptions import Conflict, InvalidModelValueError, JSONAPIException
 from api.base.serializers import is_anonymized
 from api.base.utils import absolute_reverse, get_user_auth, is_truthy
 from api.base.versioning import CREATE_REGISTRATION_FIELD_CHANGE_VERSION
@@ -549,9 +549,9 @@ class RegistrationCreateSerializer(RegistrationSerializer):
         """
         if self.expect_cleaner_attributes(self.context['request']):
             if validated_data.get('registration_choice'):
-                raise exceptions.ValidationError(
-                    f'The field registration_choice was '
-                    f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
+                raise JSONAPIException(
+                    source={'pointer': '/data/attributes/registration_choice'},
+                    detail=f'Deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
                 )
             return 'embargo' if validated_data.get('embargo_end_date', None) else 'immediate'
         return validated_data.get('registration_choice', 'immediate')
@@ -563,9 +563,9 @@ class RegistrationCreateSerializer(RegistrationSerializer):
         """
         if self.expect_cleaner_attributes(self.context['request']):
             if validated_data.get('lift_embargo'):
-                raise exceptions.ValidationError(
-                    f'The field lift_embargo was '
-                    f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
+                raise JSONAPIException(
+                    source={'pointer': '/data/attributes/lift_embargo'},
+                    detail=f'Deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
                 )
             return validated_data.get('embargo_end_date', None)
         return validated_data.get('lift_embargo')

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -526,7 +526,6 @@ class RegistrationCreateSerializer(RegistrationSerializer):
             self.fields['draft_registration_id'] = ser.CharField(write_only=True)
         else:
             self.fields['draft_registration'] = ser.CharField(write_only=True)
-            self.fields['registration_choice'] = ser.ChoiceField(write_only=True, choices=['immediate', 'embargo'])
 
     # For newer versions
     embargo_end_date = VersionedDateTimeField(write_only=True, allow_null=True, default=None)
@@ -534,6 +533,7 @@ class RegistrationCreateSerializer(RegistrationSerializer):
     # For older versions
     lift_embargo = VersionedDateTimeField(write_only=True, default=None, input_formats=['%Y-%m-%dT%H:%M:%S'])
     children = ser.ListField(write_only=True, required=False)
+    registration_choice = ser.ChoiceField(write_only=True, required=False, choices=['immediate', 'embargo'])
 
     users = RelationshipField(
         related_view='users:user-detail',
@@ -548,6 +548,11 @@ class RegistrationCreateSerializer(RegistrationSerializer):
         New API versions should pass in an "embargo_end_date" if it should be embargoed, else it will be None
         """
         if self.expect_cleaner_attributes(self.context['request']):
+            if validated_data.get('registration_choice'):
+                raise exceptions.ValidationError(
+                    f'The field registration_choice was '
+                    f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
+                )
             return 'embargo' if validated_data.get('embargo_end_date', None) else 'immediate'
         return validated_data.get('registration_choice', 'immediate')
 
@@ -557,6 +562,11 @@ class RegistrationCreateSerializer(RegistrationSerializer):
         New API versions should pass in "embargo_end_date"
         """
         if self.expect_cleaner_attributes(self.context['request']):
+            if validated_data.get('lift_embargo'):
+                raise exceptions.ValidationError(
+                    f'The field lift_embargo was '
+                    f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.',
+                )
             return validated_data.get('embargo_end_date', None)
         return validated_data.get('lift_embargo')
 

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1287,8 +1287,9 @@ class TestNodeRegistrationCreate(DraftRegistrationTestCase):
             auth=user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert (res.json['errors'][0]['detail'] == f'The field lift_embargo was '
-            f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+        assert (res.json['errors'][0]['detail'] ==
+            f'Deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes/lift_embargo'
 
     def test_new_API_version_errors_on_registration_choice(
             self, app, user, draft_registration, url_registrations_ver):
@@ -1307,8 +1308,9 @@ class TestNodeRegistrationCreate(DraftRegistrationTestCase):
             auth=user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert (res.json['errors'][0]['detail'] == f'The field registration_choice was '
-            f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+        assert (res.json['errors'][0]['detail'] ==
+            f'Deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+        assert res.json['errors'][0]['source']['pointer'] == '/data/attributes/registration_choice'
 
     def test_new_API_version_uses_included_node_ids_instead_of_children(
             self, app, user, draft_registration, url_registrations_ver, project_public,

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1264,6 +1264,52 @@ class TestNodeRegistrationCreate(DraftRegistrationTestCase):
         assert res.status_code == 201
         assert res.json['data']['attributes']['pending_embargo_approval'] is True
 
+    def test_new_API_version_errors_on_lift_embargo(
+            self, app, user, draft_registration, url_registrations_ver):
+        today = timezone.now()
+        three_years = (
+            today +
+            dateutil.relativedelta.relativedelta(
+                years=3)).strftime('%Y-%m-%dT%H:%M:%S')
+
+        payload = {
+            'data': {
+                'type': 'registrations',
+                'attributes': {
+                    'draft_registration_id': draft_registration._id,
+                    'lift_embargo': three_years
+                }
+            }
+        }
+        res = app.post_json_api(
+            url_registrations_ver,
+            payload,
+            auth=user.auth,
+            expect_errors=True)
+        assert res.status_code == 400
+        assert (res.json['errors'][0]['detail'] == f'The field lift_embargo was '
+            f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+
+    def test_new_API_version_errors_on_registration_choice(
+            self, app, user, draft_registration, url_registrations_ver):
+        payload = {
+            'data': {
+                'type': 'registrations',
+                'attributes': {
+                    'draft_registration_id': draft_registration._id,
+                    'registration_choice': 'embargo'
+                }
+            }
+        }
+        res = app.post_json_api(
+            url_registrations_ver,
+            payload,
+            auth=user.auth,
+            expect_errors=True)
+        assert res.status_code == 400
+        assert (res.json['errors'][0]['detail'] == f'The field registration_choice was '
+            f'deprecated in version {CREATE_REGISTRATION_FIELD_CHANGE_VERSION}. Use embargo_end_date instead.')
+
     def test_new_API_version_uses_included_node_ids_instead_of_children(
             self, app, user, draft_registration, url_registrations_ver, project_public,
             project_public_child, project_public_grandchild, project_public_excluded_sibling):
@@ -1488,8 +1534,7 @@ class TestRegistrationCreate(TestNodeRegistrationCreate):
             'data': {
                 'type': 'registrations',
                 'attributes': {
-                    'draft_registration_id': draft_registration._id,
-                    'registration_choice': 'immediate'
+                    'draft_registration_id': draft_registration._id
                 }
             }
         }


### PR DESCRIPTION

## Purpose

Currently the new API version doesn't throw an error when the deprecated fields `lift_embargo` or `registration_choice` are specified, which is a problem because a user might utilize these fields to embargo their registration, but then its not registered because they are deprecated.

## Changes

Adding error handling to the serializers. Adding tests to ensure these two fields have errors thrown on them

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Low
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
2.19
  - What features or workflows might this change impact?
Registration creation
  - How will this impact performance?
Shouldn't
-->

## Documentation

I'm not sure if the new registration workflow was ever documented.

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1490