### PR TITLE
Update celery settings and add task decorator

### DIFF
--- a/osf/management/commands/update_institution_project_counts.py
+++ b/osf/management/commands/update_institution_project_counts.py
@@ -2,10 +2,12 @@ import datetime as dt
 
 from django.core.management.base import BaseCommand
 
+from framework.celery_tasks import app as celery_app
 from osf.metrics import InstitutionProjectCounts, UserInstitutionProjectCounts
 from osf.models import Institution, Node
 
 
+@celery_app.task(name='management.commands.update_institution_project_counts')
 def update_institution_project_counts():
     now = dt.datetime.now()
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -492,6 +492,7 @@ class CeleryConfig:
         'scripts.premigrate_created_modified',
         'scripts.add_missing_identifiers_to_preprints',
         'osf.management.commands.deactivate_requested_accounts',
+        'osf.management.commands.check_crossref_dois',
         'osf.management.commands.update_institution_project_counts',
     )
 
@@ -630,7 +631,7 @@ class CeleryConfig:
                 'task': 'management.commands.check_crossref_dois',
                 'schedule': crontab(minute=0, hour=4),  # Daily 11:00 p.m.
             },
-            'update_institutional_metrics': {
+            'update_institution_project_counts': {
                 'task': 'management.commands.update_institution_project_counts',
                 'schedule': crontab(minute=0, hour=9), # Daily 05:00 a.m. EDT
             },

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -409,6 +409,7 @@ class CeleryConfig:
         'osf.management.commands.migrate_deleted_date',
         'osf.management.commands.addon_deleted_date',
         'osf.management.commands.migrate_registration_responses',
+        'osf.management.commands.update_institution_project_counts'
     }
 
     med_pri_modules = {


### PR DESCRIPTION
## Purpose

Update celery settings so the institutional dashboard metrics gathering script will run on schedule.

## Changes

1. Rename task key
2. Add task decorator to management command update_institution_project_counts
3. Add command to low priority queue
4. While we're here, add import for check_crossref_doi command

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? *No*
  - What is the level of risk? *Low*
    - Any permissions code touched? *No*
    - Is this an additive or subtractive change, other? *Other, mostly additive*
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) - *In the app, wait until 5AM the next day and the institutional dashboard values should update*
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact? *Institutional dashboard, checking crossref dois*
  - How will this impact performance? *Shouldn't* 
## Side Effects

This should also cause crossref dois to be checked on their schedule.

## Ticket

N/A
