### PR TITLE
Fix sorting error and user metrics issue [ENG-1876]

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -442,7 +442,6 @@ class InstitutionImpactList(JSONAPIBaseView, ListFilterMixin, generics.ListAPIVi
         :param departments: Dict {'Department Name': 3} means "Department Name" has 3 users.
         :return: mock_queryset
         """
-
         items = self._format_search(search)
 
         search = self._paginate(search)
@@ -481,6 +480,8 @@ class InstitutionUserMetricsList(InstitutionImpactList):
     view_name = 'institution-user-metrics'
 
     serializer_class = InstitutionUserMetricsSerializer
+
+    ordering = ('user_name',)
 
     def _format_search(self, search):
         results = search.execute()

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -442,9 +442,10 @@ class InstitutionImpactList(JSONAPIBaseView, ListFilterMixin, generics.ListAPIVi
         :param departments: Dict {'Department Name': 3} means "Department Name" has 3 users.
         :return: mock_queryset
         """
-        search = self._paginate(search)
 
         items = self._format_search(search)
+
+        search = self._paginate(search)
 
         queryset = MockQueryset(items, search, default_attrs=kwargs)
         return queryset

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -79,6 +79,8 @@ class TestInstitutionUserMetricList:
             public_project_count=6,
             private_project_count=1,
         ).save()
+        import time
+        time.sleep(2)
 
     @pytest.fixture()
     def url(self, institution):

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -187,3 +187,8 @@ class TestInstitutionUserMetricList:
         resp = app.get(f'{url}?sort=user_name&page=2', auth=admin.auth)
         assert resp.json['links']['meta']['total'] == 11
         assert resp.json['data'][-1]['attributes']['user_name'] == 'Zedd'
+
+    def test_filter_and_pagination(self, app, url, admin, populate_more_counts):
+        resp = app.get(f'{url}?filter[user_name]=Zedd', auth=admin.auth)
+        assert resp.json['links']['meta']['total'] == 1
+        assert resp.json['data'][0]['attributes']['user_name'] == 'Zedd'

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -189,6 +189,9 @@ class TestInstitutionUserMetricList:
         assert resp.json['data'][-1]['attributes']['user_name'] == 'Zedd'
 
     def test_filter_and_pagination(self, app, url, admin, populate_more_counts):
+        resp = app.get(f'{url}?page=2', auth=admin.auth)
+        assert resp.json['links']['meta']['total'] == 11
+        assert resp.json['data'][0]['attributes']['user_name'] == 'Zedd'
         resp = app.get(f'{url}?filter[user_name]=Zedd', auth=admin.auth)
         assert resp.json['links']['meta']['total'] == 1
         assert resp.json['data'][0]['attributes']['user_name'] == 'Zedd'

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -275,17 +275,21 @@ class UserInstitutionProjectCounts(MetricMixin, metrics.Metric):
         """
         last_record_time = cls.get_recent_datetime(institution)
 
-        return cls.filter_institution(
+        search = cls.filter_institution(
             institution
-        ).sort(
-            'timestamp'
         ).filter(
             'range',
             timestamp={
                 'gte': last_record_time
             }
+        ).sort(
+            'user_id'
         )
+        search.update_from_dict({
+            'size': 1000
+        })
 
+        return search
 
 class InstitutionProjectCounts(MetricMixin, metrics.Metric):
     institution_id = metrics.Keyword(index=True, doc_values=True, required=True)

--- a/osf/metrics.py
+++ b/osf/metrics.py
@@ -6,6 +6,8 @@ from django.db import models
 from django.utils import timezone
 import pytz
 
+from api.base.settings import MAX_SIZE_OF_ES_QUERY
+
 
 class MetricMixin(object):
 
@@ -286,7 +288,7 @@ class UserInstitutionProjectCounts(MetricMixin, metrics.Metric):
             'user_id'
         )
         search.update_from_dict({
-            'size': 1000
+            'size': MAX_SIZE_OF_ES_QUERY
         })
 
         return search


### PR DESCRIPTION


## Purpose

The total was not working properly on users when sorting, and the search would only return 10 records.

## Changes

Adding a default ordering to the user metrics. Increased the user metrics search result size.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No.
  - What is the level of risk?
Moderate. Need to ensure this didn't break anything in the institutional metrics.
    - Any permissions code touched?
No.
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
v2/institutions/<institution_id>/metrics/users/
v2/institutions/<institution_id>/metrics/departments/
Make sure all sorting works, and try changing size of pages and make sure the totals stay consistent.
  - What features or workflows might this change impact?
Institutional Dashboard
  - How will this impact performance?
Might increase the time elastic search queries run
-->

## Documentation

N/A

## Side Effects

Elastic search query speed

## Ticket

https://openscience.atlassian.net/browse/ENG-1876