### PR TITLE
[ENG-1843] Fix null brand embeds

### DIFF
--- a/api/brands/views.py
+++ b/api/brands/views.py
@@ -19,6 +19,12 @@ class BrandMixin(object):
     def get_brand(self):
         brand_id = self.kwargs[self.brand_lookup_url_kwarg]
 
+        # This conditional intended to be temporary until we can address issues that are causing brand_id to be
+        # stringified IRL but not in the test app. Remove this comment if test app does no longer gives false positive
+        # for this function when registration provider with `.brand is None` is embedded or issue is conclusively fixed.
+        if self.kwargs.get('is_embedded') and brand_id == 'None':
+            raise NotFound
+
         try:
             inst = Brand.objects.get(id=int(brand_id))
         except ObjectDoesNotExist:

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -58,12 +58,6 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
     advertises_on_discovery = models.BooleanField(default=True)
     has_landing_page = models.BooleanField(default=False)
 
-    brand = models.ForeignKey('Brand', related_name='providers', null=True, blank=True, on_delete=models.SET_NULL)
-
-    branded_discovery_page = models.BooleanField(default=True)
-    advertises_on_discovery = models.BooleanField(default=True)
-    has_landing_page = models.BooleanField(default=False)
-
     def __repr__(self):
         return ('(name={self.name!r}, default_license={self.default_license!r}, '
                 'allow_submissions={self.allow_submissions!r}) with id {self.id!r}').format(self=self)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To stop embedding null brands from 500ing, remove duplicate code I noticed.


## Changes

- conditional that checks if NoneType embed is stringify with comment explaining context.
- random drive-by removal of duplicate code I noticed.

## QA Notes

This is a temporary fix for a larger issue with the test app, though user behavior should return to expected immediately after this is merge and remain unchanged.

## Documentation

long comment in code.

## Side Effects

This is a stopgap which specifically effects the test app giving it false positives, so no new tests. Any suggestions are welcome to add tests.

## Ticket

https://openscience.atlassian.net/browse/ENG-1843