### PR TITLE
[ENG-1816][Clone] Better exclude browseable API for Sloan

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -190,7 +190,7 @@ class SloanOverrideWaffleMiddleware(WaffleMiddleware):
 
     def process_response(self, request, response):
         waffles = getattr(request, 'waffles', None)
-        if request.path == '/v2/' and not request.GET.get('format') == 'api':  # exclude browserable api
+        if request.path == '/v2/' and not getattr(response, 'accepted_media_type', None) == 'text/html':  # exclude browserable api
             content_data = json.loads(response.content.decode())
 
             # clear flags initially

--- a/api_tests/base/test_sloan_study.py
+++ b/api_tests/base/test_sloan_study.py
@@ -269,3 +269,8 @@ class TestSloanStudyWaffling:
         cookies = resp.headers.getall('Set-Cookie')
 
         assert f' dwf_{SLOAN_COI_DISPLAY}=False; Domain=.osf.io; Path=/; samesite=None; Secure' in cookies
+
+    def test_browseable_api(self, app):
+        headers = {'accept': 'text/html'}
+        resp = app.get('/v2/', headers=headers)
+        assert resp.status_code == 200


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The browsable api 502s! That's bad!

## Changes

- improve check for browsable api 

## QA Notes

The browsable api should now not 502.

## Documentation

Bug fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1816