### PR TITLE
[ENG-1915] Fix Sloan API Inconsistencies

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1530,9 +1530,13 @@ class JSONAPISerializer(BaseAPISerializer):
         try:
             ret = super(JSONAPISerializer, self).is_valid(**kwargs)
         except exceptions.ValidationError as e:
+
+            # The following is for special error handling for ListFields.
+            # Without the following, the error detail on the API response would be
+            # a list instead of a string.
             for key in e.detail.keys():
                 if isinstance(e.detail[key], dict):
-                    e.detail[key] = e.detail[key][0]
+                    e.detail[key] = next(iter(e.detail[key].values()))
             raise e
 
         if clean_html is True:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1527,7 +1527,13 @@ class JSONAPISerializer(BaseAPISerializer):
         Exclude 'type' and '_id' from validated_data.
 
         """
-        ret = super(JSONAPISerializer, self).is_valid(**kwargs)
+        try:
+            ret = super(JSONAPISerializer, self).is_valid(**kwargs)
+        except exceptions.ValidationError as e:
+            for key in e.detail.keys():
+                if isinstance(e.detail[key], dict):
+                    e.detail[key] = e.detail[key][0]
+            raise e
 
         if clean_html is True:
             self._validated_data = self.sanitize_data()

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -937,7 +937,7 @@ class TestPreprintUpdate:
 
         res = app.patch_json_api(url, update_payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == ['Enter a valid URL.']
+        assert res.json['errors'][0]['detail'] == 'Enter a valid URL.'
 
     def test_update_has_prereg_links(self, app, user, preprint, url):
         update_payload = build_preprint_update_payload(preprint._id, attributes={'has_prereg_links': 'available'})
@@ -974,7 +974,21 @@ class TestPreprintUpdate:
         res = app.patch_json_api(url, update_payload, auth=user.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == ['Enter a valid URL.']
+        assert res.json['errors'][0]['detail'] == 'Enter a valid URL.'
+
+    @override_switch(features.SLOAN_DATA_INPUT, active=True)
+    def test_no_data_links_clears_links(self, app, user, preprint, url):
+        preprint.has_data_links = 'available'
+        preprint.data_links = 'http://www.apple.com'
+        preprint.save()
+
+        update_payload = build_preprint_update_payload(preprint._id, attributes={'has_data_links': 'no'})
+
+        res = app.patch_json_api(url, update_payload, auth=user.auth, expect_errors=True)
+
+        assert res.status_code == 400
+        assert res.json['data']['attributes']['has_data_links'] == 'no'
+        assert res.json['data']['attributes']['data_links'] == []
 
     def test_update_why_no_prereg(self, app, user, preprint, url):
         update_payload = build_preprint_update_payload(preprint._id, attributes={'why_no_prereg': 'My dog ate it.'})

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -979,14 +979,14 @@ class TestPreprintUpdate:
     @override_switch(features.SLOAN_DATA_INPUT, active=True)
     def test_no_data_links_clears_links(self, app, user, preprint, url):
         preprint.has_data_links = 'available'
-        preprint.data_links = 'http://www.apple.com'
+        preprint.data_links = ['http://www.apple.com']
         preprint.save()
 
         update_payload = build_preprint_update_payload(preprint._id, attributes={'has_data_links': 'no'})
 
-        res = app.patch_json_api(url, update_payload, auth=user.auth, expect_errors=True)
+        res = app.patch_json_api(url, update_payload, auth=user.auth)
 
-        assert res.status_code == 400
+        assert res.status_code == 200
         assert res.json['data']['attributes']['has_data_links'] == 'no'
         assert res.json['data']['attributes']['data_links'] == []
 

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1048,6 +1048,8 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
                 },
                 auth=auth
             )
+        if has_data_links != 'available':
+            self.update_data_links(auth, data_links=[], log=False)
         if save:
             self.save()
 
@@ -1067,7 +1069,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         if self.data_links == data_links:
             return
 
-        if not self.has_data_links == 'available':
+        if not self.has_data_links == 'available' and data_links:
             raise PreprintStateError('You cannot edit this statement while your data links availability is set to false'
                                      ' or is unanswered.')
 


### PR DESCRIPTION


## Purpose

There are two issues with Sloan API changes. One is an issue with the data links error message showing as a list instead of just a string. The other is emptying out the data links field when the has_data_links is set to not be something other than 'available'

## Changes

Added error handling to the base serializer for validation issues stemming from array fields.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Low
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
No new version. Run PATCH against /v2/preprint/<preprint_id>
  - What features or workflows might this change impact?
Sloan
  - How will this impact performance?
Shouldn't
-->

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1915