### PR TITLE
[ENG-1915] Sloan API cleanup part 2.

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -262,6 +262,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         ser.ChoiceField(
             Preprint.PREREG_LINK_INFO_CHOICES,
             required=False,
+            allow_blank=True,
         ),
     )
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -260,7 +260,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
     prereg_link_info = DisableIfSwitch(
         SLOAN_PREREG_INPUT,
         ser.ChoiceField(
-            Preprint.PREREG_LINK_INFO_CHIOCES,
+            Preprint.PREREG_LINK_INFO_CHOICES,
             required=False,
         ),
     )

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -129,7 +129,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         'tags',
     }
 
-    PREREG_LINK_INFO_CHIOCES = [('prereg_designs', 'Pre-registration of study designs'),
+    PREREG_LINK_INFO_CHOICES = [('prereg_designs', 'Pre-registration of study designs'),
                                 ('prereg_analysis', 'Pre-registration of study analysis'),
                                 ('prereg_both', 'Pre-registration of study designs and study analysis')
                                 ]
@@ -229,7 +229,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         null=True
     )
     prereg_link_info = models.TextField(
-        choices=PREREG_LINK_INFO_CHIOCES,
+        choices=PREREG_LINK_INFO_CHOICES,
         null=True,
         blank=True
     )
@@ -1005,7 +1005,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
             return
 
         if not self.has_coi:
-            raise PreprintStateError('You do not have ability to edit a conflict of interest while the has_coi field is '
+            raise PreprintStateError('You do not have the ability to edit a conflict of interest while the has_coi field is '
                                   'set to false or unanswered')
 
         self.conflict_of_interest_statement = coi_statement
@@ -1144,6 +1144,9 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
                 },
                 auth=auth
             )
+        if has_prereg_links != 'available':
+            self.update_prereg_links(auth, prereg_links=[], log=False)
+            self.update_prereg_link_info(auth, prereg_link_info=None, log=False)
         if save:
             self.save()
 
@@ -1196,7 +1199,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         if prereg_links == self.prereg_links:
             return
 
-        if not self.has_prereg_links == 'available':
+        if not self.has_prereg_links == 'available' and prereg_links:
             raise PreprintStateError('You cannot edit this field while your prereg links'
                                   ' availability is set to false or is unanswered.')
 
@@ -1216,7 +1219,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
     def update_prereg_link_info(self, auth: Auth, prereg_link_info: str, log: bool = True, save: bool = True):
         """
         This method updates the field `prereg_link_info` that contains a one of a finite number of choice strings in
-        contained in the list in the static member `PREREG_LINK_INFO_CHIOCES` that describe the nature of the preprint's
+        contained in the list in the static member `PREREG_LINK_INFO_CHOICES` that describe the nature of the preprint's
         prereg links.
 
         :param auth: Auth object
@@ -1230,7 +1233,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         if self.prereg_link_info == prereg_link_info:
             return
 
-        if not self.has_prereg_links == 'available':
+        if not self.has_prereg_links == 'available' and prereg_link_info:
             raise PreprintStateError('You cannot edit this field while your prereg links'
                                   ' availability is set to false or is unanswered.')
 

--- a/website/language.py
+++ b/website/language.py
@@ -220,4 +220,4 @@ DISK_SAVING_MODE = 'Forks, registrations, and uploads to OSF Storage uploads are
 
 #log out and revisit the link to confirm emails
 CONFIRM_ALTERNATE_EMAIL_ERROR = 'The email address has <b>NOT</b> been added to your account. Please log out and revisit the link in your email. Thank you.'
-SWITCH_VALIDATOR_ERROR = 'You do not have ability to edit this field at this time.'
+SWITCH_VALIDATOR_ERROR = 'You do not have the ability to edit this field at this time.'


### PR DESCRIPTION

## Purpose

When `has_prereg_links` is set, the `prereg_links` field should be nulled out, as should `prereg_link_info`. Also doing some additional cleanup

## Changes

Adding functionality to the preprint model. Adding a test. Cleaning up some language and variable names

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Minimal
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
v2/preprints/<preprint_id>/
  - What features or workflows might this change impact?
Sloan
  - How will this impact performance?
Shouldn't
-->

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1915