### PR TITLE
Corrects Institution Metrics User Public Project Counts and Total Project Counts

### DIFF
--- a/osf/management/commands/update_institution_project_counts.py
+++ b/osf/management/commands/update_institution_project_counts.py
@@ -29,8 +29,7 @@ def update_institution_project_counts():
         for user in institution.osfuser_set.all():
             user_public_project_count = Node.objects.get_nodes_for_user(
                 user=user,
-                base_queryset=institution_public_projects_qs,
-                include_public=True
+                base_queryset=institution_public_projects_qs
             ).count()
 
             user_private_project_count = Node.objects.get_nodes_for_user(

--- a/osf/management/commands/update_institution_project_counts.py
+++ b/osf/management/commands/update_institution_project_counts.py
@@ -13,8 +13,8 @@ def update_institution_project_counts():
 
     for institution in Institution.objects.all():
 
-        institution_public_projects_qs = institution.nodes.filter(type='osf.node', parent_nodes=None, is_public=True)
-        institution_private_projects_qs = institution.nodes.filter(type='osf.node', parent_nodes=None, is_public=False)
+        institution_public_projects_qs = institution.nodes.filter(type='osf.node', parent_nodes=None, is_public=True, is_deleted=False)
+        institution_private_projects_qs = institution.nodes.filter(type='osf.node', parent_nodes=None, is_public=False, is_deleted=False)
 
         institution_public_projects_count = institution_public_projects_qs.count()
         institution_private_projects_count = institution_private_projects_qs.count()


### PR DESCRIPTION
## Purpose
Corrects the user public project counts and institutional total public and private project counts written to Elasticsearch Impact daily.

## Changes
* Modifies the public project count per user to not include all public projects that are affiliated with an institution but solely the public projects the users are contributors to (directly or via group permissions)
* Modifies the total public and private project counts per institution to exclude deleted projects

## QA Notes
Can be tested by QA through the UI of the institution dashboard and spot checking the number of projects per user affiliated with the institution and ensuring that the total number of projects for the institution appear reasonable.

Note: The total number of public and private projects if you add them up across users should be at least the displayed total number of public and private projects for the institution. This is because multiple users may contribute to the same project affiliated with an institution.

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1942)