### PR TITLE
[ENG-1943] Spam and Ham properly on preprints [WIP]

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1950,6 +1950,8 @@ class SpamOverrideMixin(SpamMixin):
     # Override on model
     SPAM_CHECK_FIELDS = {}
 
+    state_before_spam = {}
+
     @property
     def log_class(self):
         return NotImplementedError()
@@ -1960,6 +1962,10 @@ class SpamOverrideMixin(SpamMixin):
 
     def get_spam_fields(self):
         return NotImplementedError()
+
+    def confirm_ham(self, save=False):
+        super(SpamOverrideMixin, self).confirm_ham(save=False)
+        self.make_ham()
 
     def confirm_spam(self, save=False):
         super(SpamOverrideMixin, self).confirm_spam(save=False)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1964,7 +1964,7 @@ class SpamOverrideMixin(SpamMixin):
         return NotImplementedError()
 
     def confirm_ham(self, save=False):
-        super(SpamOverrideMixin, self).confirm_ham(save=False)
+        super(SpamOverrideMixin, self).confirm_ham(save)
         self.make_ham()
 
     def confirm_spam(self, save=False):

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -553,9 +553,9 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
             raise ValueError('Cannot unpublish preprint.')
 
         if auth.user:
+            user = auth.user
             request, user_id = get_request_and_user_id()
             request_headers = string_type_request_headers(request)
-            user = OSFUser.load(user_id)
             self.check_spam(user, self.SPAM_CHECK_FIELDS, request_headers)
 
         self.is_published = published


### PR DESCRIPTION

## Purpose

The way preprints ham and spam is wonky. The machine state isn't affected.

## Changes

Adding a before_spam state that can be referenced when something is marked as ham to reset it to the previous state. Adding machine state to spam and ham

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Medium. This is just for spam
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
UI and Admin App for ham
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
Spam workflow. Marking things as Ham
  - How will this impact performance?
Shouldn't, besides how often we're checking preprints for spam.
-->

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1943