### PR TITLE
[ENG-1943] Fixing spam/ham for preprints

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -24,25 +24,16 @@ from osf.exceptions import (
     UserStateError,
     UserNotAffiliatedError,
     InvalidTagError,
-    BlacklistedEmailError
+    BlacklistedEmailError,
 )
-from osf.models import (
-    NodeRelation,
-    NodeLog,
-    Subject,
-    SpamMixin,
-    SpamStatus,
-    Tag,
-    Node,
-    Preprint,
-)
-from osf.models.validators import (
-    validate_title,
-    validate_subject_hierarchy,
-    validate_email,
-    expand_subject_hierarchy,
-)
+from osf.models.node_relation import NodeRelation
+from osf.models.nodelog import NodeLog
+from osf.models.subject import Subject
+from osf.models.spam import SpamMixin, SpamStatus
+from osf.models.validators import validate_title
+from osf.models.tag import Tag
 from osf.utils import sanitize
+from osf.models.validators import validate_subject_hierarchy, validate_email, expand_subject_hierarchy
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.machines import ReviewsMachine, NodeRequestMachine, PreprintRequestMachine
@@ -1999,6 +1990,9 @@ class SpamOverrideMixin(SpamMixin):
         :return:
         """
         super().confirm_ham()
+
+        Node = apps.get_model('osf.Node')
+        Preprint = apps.get_model('osf.Preprint')
 
         if self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]):
             spam_log = self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]).latest()

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1969,11 +1969,12 @@ class SpamOverrideMixin(SpamMixin):
         """
         super().confirm_spam(save=save)
         self.deleted = timezone.now()
+        was_public = self.is_public
         self.set_privacy('private', auth=None, log=False, save=False)
 
         log = self.add_log(
             action=self.log_class.CONFIRM_SPAM,
-            params=self.log_params,
+            params={**self.log_params, 'was_public': was_public},
             auth=None,
             save=False
         )
@@ -1990,10 +1991,10 @@ class SpamOverrideMixin(SpamMixin):
         """
         super().confirm_ham()
 
-        if self.logs.filter(action=self.log_class.FLAG_SPAM):
-            flag_spam_log = self.logs.filter(action=self.log_class.FLAG_SPAM).latest()
+        if self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]):
+            spam_log = self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]).latest()
             # ensures only 'accepted' status preprints/any nodes get made public
-            if flag_spam_log.params['was_public'] and self.type == 'osf.node' or (self.type == 'osf.preprint' and self.machine_state == DefaultStates.ACCEPTED.value):
+            if spam_log.params.get('was_public', False) and self.type == 'osf.node' or (self.type == 'osf.preprint' and self.machine_state == DefaultStates.ACCEPTED.value):
                 self.set_privacy('public', log=False)
 
             self.is_deleted = False

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -323,7 +323,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
     def log_params(self):
         # Property needed for ContributorMixin
         return {
-            'preprint': self._id
+            'preprint': self._id,
         }
 
     @property
@@ -623,7 +623,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         first_save = not bool(self.pk)
         saved_fields = self.get_dirty_fields() or []
         old_subjects = kwargs.pop('old_subjects', [])
-        if saved_fields:
+        if saved_fields and (not settings.SPAM_CHECK_PUBLIC_ONLY or self.is_public):
             request, user_id = get_request_and_user_id()
             request_headers = string_type_request_headers(request)
             user = OSFUser.load(user_id)


### PR DESCRIPTION
## Purpose

Preprints aren't checking for spam properly, also they need to be able to be reverted when they are confirmed to be HAM

## Changes

- Adding new log for preprint spam. Only checking for spam when is public or SPAM_CHECK_PUBLIC_ONLY is inactive.
- Fix [preprints being checked as typed models](https://sentry2.cos.io/cos/admin/issues/28590/)

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
low
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
UI and admin app
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
Spam and Ham processing for preprints
  - How will this impact performance?
N/A

## Documentation

N/A

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-1943