### PR TITLE
[ENG-652] Adding the ability to bulk hamify preprints and users

### DIFF
--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -383,10 +383,16 @@ class PreprintFlaggedSpamList(PreprintSpamList, DeleteView):
             pid for pid in request.POST.keys()
             if pid not in ('csrfmiddlewaretoken', 'spam_confirm', 'ham_confirm')
         ]
+
+        if 'spam_confirm' in list(request.POST.keys()):
+            action = 'spam'
+        elif 'ham_confirm' in list(request.POST.keys()):
+            action = 'ham'
+
         for pid in preprint_ids:
             preprint = Preprint.load(pid)
             osf_admin_change_status_identifier(preprint)
-            if ('spam_confirm' in list(request.POST.keys())):
+            if action == 'spam':
                 preprint.confirm_spam(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,
@@ -395,7 +401,7 @@ class PreprintFlaggedSpamList(PreprintSpamList, DeleteView):
                     message='Confirmed SPAM: {}'.format(pid),
                     action_flag=CONFIRM_SPAM
                 )
-            elif ('ham_confirm' in list(request.POST.keys())):
+            elif action == 'ham':
                 preprint.confirm_ham(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,

--- a/admin/templates/preprints/ham_spam_modal.html
+++ b/admin/templates/preprints/ham_spam_modal.html
@@ -1,0 +1,19 @@
+<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirm{{ target_type|capfirst }}ListModal">
+    Confirm {{ target_type|capfirst }}
+</button>
+<div id="confirm{{ target_type|capfirst }}ListModal" class="modal fade well" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">x</button>
+                <h3>Are you sure the selected preprint(s) are {{ target_type }}?</h3>
+            </div>
+            <div class="modal-footer">
+                <input class="btn btn-danger" type="submit" value="Confirm" name={{ target_type|add:"_confirm" }} />
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/admin/templates/preprints/preprint_list.html
+++ b/admin/templates/preprints/preprint_list.html
@@ -58,25 +58,10 @@
     </tbody>
 </table>
 {% if form_action and perms.osf.mark_spam %}
-<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
-    Confirm Spam
-</button>
-<div id="confirmSpamListModal" class="modal fade well" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal">x</button>
-                <h3>Are you sure the selected preprint(s) are spam?</h3>
-            </div>
-            <div class="modal-footer">
-                <input class="btn btn-danger" type="submit" value="Confirm" />
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    Cancel
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
+    {% include 'preprints/ham_spam_modal.html' with target_type="spam" %}
+{% endif %}
+{% if form_action and perms.osf.mark_ham %}
+    {% include 'preprints/ham_spam_modal.html' with target_type="ham" %}
+{% endif %}
 {% csrf_token %}
 </form>
-{% endif %}

--- a/admin/templates/users/ham_spam_modal.html
+++ b/admin/templates/users/ham_spam_modal.html
@@ -1,0 +1,19 @@
+<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirm{{ target_type|capfirst }}ListModal">
+    Confirm {{ target_type|capfirst }}
+</button>
+<div id="confirm{{ target_type|capfirst }}ListModal" class="modal fade well" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">x</button>
+                <h3>Are you sure the selected user(s) are {{ target_type }}?</h3>
+            </div>
+            <div class="modal-footer">
+                <input class="btn btn-danger" type="submit" value="Confirm" name={{ target_type|add:"_confirm" }} />
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/admin/templates/users/user_list.html
+++ b/admin/templates/users/user_list.html
@@ -56,25 +56,10 @@
     </tbody>
 </table>
 {% if form_action and perms.osf.mark_spam %}
-<button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
-    Confirm Spam
-</button>
-<div id="confirmSpamListModal" class="modal fade well" tabindex="-1" role="dialog">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal">x</button>
-                <h3>Are you sure the selected user(s) are spam?</h3>
-            </div>
-            <div class="modal-footer">
-                <input class="btn btn-danger" type="submit" value="Confirm" />
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                    Cancel
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
+    {% include 'users/ham_spam_modal.html' with target_type="spam" %}
+{% endif %}
+{% if form_action and perms.osf.mark_ham %}
+    {% include 'users/ham_spam_modal.html' with target_type="ham" %}
+{% endif %}
 {% csrf_token %}
 </form>
-{% endif %}

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -256,9 +256,15 @@ class UserFlaggedSpamList(UserSpamList, DeleteView):
             uid for uid in request.POST.keys()
             if uid not in ('csrfmiddlewaretoken', 'spam_confirm', 'ham_confirm')
         ]
+
+        if 'spam_confirm' in list(request.POST.keys()):
+            action = 'spam'
+        elif 'ham_confirm' in list(request.POST.keys()):
+            action = 'ham'
+
         for uid in user_ids:
             user = OSFUser.load(uid)
-            if ('spam_confirm' in list(request.POST.keys())):
+            if action == 'spam':
                 if 'spam_flagged' in user.system_tags:
                     user.tags.through.objects.filter(tag__name='spam_flagged').delete()
                 user.confirm_spam()
@@ -270,7 +276,7 @@ class UserFlaggedSpamList(UserSpamList, DeleteView):
                     message='Confirmed SPAM: {}'.format(uid),
                     action_flag=CONFIRM_SPAM
                 )
-            elif ('ham_confirm' in list(request.POST.keys())):
+            elif action == 'ham':
                 user.confirm_ham(save=True)
                 update_admin_log(
                     user_id=self.request.user.id,


### PR DESCRIPTION

## Purpose

Admins need the ability to not only bulk spamify but also hamify preprints and users. 

## Changes

Adding ham spam modals to preprints and users. Updating views.

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Minimal
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Admin app
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
N/A
  - How will this impact performance?
N/A
-->

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-652