### PR TITLE
[ENG-1975] Adding back in Date of start of study to EGAP form and migration

### DIFF
--- a/osf/migrations/0208_update_EGAP_schema.py
+++ b/osf/migrations/0208_update_EGAP_schema.py
@@ -3,13 +3,6 @@ from __future__ import unicode_literals
 from django.db import migrations
 from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 
-def make_egap_active_but_invisible(state, schema):
-        RegistrationSchema = state.get_model('osf', 'registrationschema')
-        new_egap_registration = RegistrationSchema.objects.get(name='EGAP Registration', schema_version=3)
-        new_egap_registration.visible = False
-        new_egap_registration.active = True
-        new_egap_registration.save()
-
 def noop(*args, **kwargs):
     pass
 
@@ -21,5 +14,4 @@ class Migration(migrations.Migration):
 
     operations = [
         UpdateRegistrationSchemasAndSchemaBlocks(),
-        migrations.RunPython(make_egap_active_but_invisible, noop),
     ]

--- a/osf/migrations/0208_update_EGAP_schema.py
+++ b/osf/migrations/0208_update_EGAP_schema.py
@@ -1,0 +1,25 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
+
+def make_egap_active_but_invisible(state, schema):
+        RegistrationSchema = state.get_model('osf', 'registrationschema')
+        new_egap_registration = RegistrationSchema.objects.get(name='EGAP Registration', schema_version=3)
+        new_egap_registration.visible = False
+        new_egap_registration.active = True
+        new_egap_registration.save()
+
+def noop(*args, **kwargs):
+    pass
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osf', '0207_update_schemas2'),
+    ]
+
+    operations = [
+        UpdateRegistrationSchemasAndSchemaBlocks(),
+        migrations.RunPython(make_egap_active_but_invisible, noop),
+    ]

--- a/scripts/EGAP/create_EGAP_json.py
+++ b/scripts/EGAP/create_EGAP_json.py
@@ -27,6 +27,7 @@ schema_to_spreadsheet_mapping = [
     {'q6': 'B4 FACULTY MEMBER?'},
     {'q8': 'B5 PROSPECTIVE OR RETROSPECTIVE?'},
     {'q10': 'B6 EXPERIMENTAL STUDY?'},
+    {'q11': 'B7 DATE OF START OF STUDY'},
     {'q12': 'B8 GATE DATE'},
     {'q13': 'B9 PRESENTED AT EGAP MEETING?'},
     {'q14': 'B10 PRE-ANALYSIS PLAN WITH REGISTRATION?'},

--- a/website/project/metadata/egap-registration-3.json
+++ b/website/project/metadata/egap-registration-3.json
@@ -100,6 +100,15 @@
 					]
 				},
 				{
+					"qid": "q11",
+					"title": "Date of start of study",
+					"nav": "Date of start of study",
+					"type": "string",
+					"format": "text",
+					"description": "Understood as first date of treatment assignment or equivalent for observational study",
+					"help": "E.g., 06/02/2018"
+				},
+				{
 					"qid": "q13",
 					"title": "Was this design presented at an EGAP meeting?",
 					"nav": "Presented at an EGAP meeting?",


### PR DESCRIPTION

## Purpose

Date of start of study needed to be in the new version of the EGAP schema

## Changes

Adding it back into the schema. Adding migration to update the schema. Updating the script to pull the date into the reg data

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
Yes. This will just change the existing schema for future EGAP registrations, not past.
  - What is the level of risk?
Minimal
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
UI
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
N/A
  - What features or workflows might this change impact?
EGAP registrations
  - How will this impact performance?
Shouldn't
-->

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-1975