### PR TITLE
[ENG-1971] Spam should never be checked on admin app based requests

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2041,6 +2041,8 @@ class SpamOverrideMixin(SpamMixin):
             return False
         if user.spam_status == SpamStatus.HAM:
             return False
+        if request_headers['Host'].startswith('admin') or ':8001' in request_headers['Host']:
+            return False
 
         content = self._get_spam_content(saved_fields)
         if not content:

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2041,7 +2041,10 @@ class SpamOverrideMixin(SpamMixin):
             return False
         if user.spam_status == SpamStatus.HAM:
             return False
-        if request_headers and (request_headers['Host'].startswith('admin') or ':8001' in request_headers['Host']):
+        host = ''
+        if request_headers:
+            host = request_headers.get('Host', '')
+        if host.startswith('admin') or ':8001' in host:
             return False
 
         content = self._get_spam_content(saved_fields)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2041,7 +2041,7 @@ class SpamOverrideMixin(SpamMixin):
             return False
         if user.spam_status == SpamStatus.HAM:
             return False
-        if request_headers['Host'].startswith('admin') or ':8001' in request_headers['Host']:
+        if request_headers and (request_headers['Host'].startswith('admin') or ':8001' in request_headers['Host']):
             return False
 
         content = self._get_spam_content(saved_fields)


### PR DESCRIPTION


## Purpose

We shouldn't run spam checks against fields submitted by the admin app.

## Changes

Adding an exemption for the admin app for spam checks

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? No
  - What is the level of risk? Minmal
    - Any permissions code touched? No
    - Is this an additive or subtractive change, other? Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) Devtest, though this might be hard to test
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
Admin app
  - How will this impact performance? N/A
-->

## Documentation

N/A

## Side Effects

Shouldn't be.
## Ticket

https://openscience.atlassian.net/browse/ENG-1971