### PR TITLE
[ENG-1312] Raise Errors for Invalid Registration Metadata upon Registration Creation

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -605,9 +605,9 @@ class RegistrationCreateSerializer(RegistrationSerializer):
             # Still validating metadata, but whether `registration_responses` or `registration_metadata` were populated
             # on the draft, the other field was built and populated as well.  Both should exist.
             draft.validate_metadata(metadata=draft.registration_metadata, required_fields=True)
-        except ValidationValueError:
+        except ValidationValueError as e:
             log_exception()  # Probably indicates a bug on our end, so log to sentry
-            # TODO: Raise an error once our JSON schemas are updated
+            raise exceptions.ValidationError(e.message)
 
         try:
             registration = draft.register(auth, save=True, child_ids=children)


### PR DESCRIPTION
## Purpose
Disallows registrations with invalid metadata to be created by raising an exception. 

### Analysis
Based off of the following PR (https://github.com/CenterForOpenScience/osf.io/commit/f04adf076fc4bb744a357c24322c703cf21dc173), it looks like originally an exception was being raised in addition to being logged to sentry if validate_metadata being called by create of the RegistrationCreateSerializer. This was changed with the intention of being a temporary change until JSON schemas for registrations were updated but the temporary change was never reverted. Simply reverting the changes in the PR should re-enforce validation by raising exceptions as they were previously.

## Changes
* If `validate_metadata` results in an exception, the RegistrationCreation serializer will raise an error instead of logging the exception to sentry and continuing with the creation process.

## QA Notes
* Validate that invalid registration metadata is not permitted in the registration creation process via the API

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-1312)
