### PR TITLE
Fixing admin error when hamming registrations [ENG-2023]

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -440,7 +440,7 @@ class NodeConfirmHamView(PermissionRequiredMixin, NodeDeleteBase):
             message='Confirmed HAM: {}'.format(node._id),
             action_flag=CONFIRM_HAM
         )
-        if isinstance(node, Node):
+        if isinstance(node, Node) or isinstance(node, Registration):
             return redirect(reverse_node(self.kwargs.get('guid')))
 
 class NodeReindexShare(PermissionRequiredMixin, NodeDeleteBase):

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -342,9 +342,12 @@ class TestNodeConfirmHamView(AdminTestCase):
     def test_confirm_registration_as_ham(self):
         view = NodeConfirmHamView()
         view = setup_log_view(view, self.request, guid=self.registration._id)
-        view.delete(self.request)
+        resp = view.delete(self.request)
+
+        nt.assert_true(resp.status_code == 302)
 
         self.registration.refresh_from_db()
+        nt.assert_false(self.registration.is_public)
         nt.assert_true(self.registration.spam_status == 4)
 
 


### PR DESCRIPTION


## Purpose

I was unable to get a pending registration to be set public when hamming. However there was an error when hamming registrations individually

## Changes

Modifying the logic to include a reverse lookup for registrations

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? No
  - What is the level of risk? Minimal
    - Any permissions code touched? No
    - Is this an additive or subtractive change, other? Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) Admin app
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs. N/A
  - What features or workflows might this change impact? Hamming registrations individually
  - How will this impact performance? N/A
-->

## Documentation

N/A

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-2023
