### PR TITLE
[hotfix][ENG-1963][ENG-2010] Keen logging updates

### DIFF
--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -219,8 +219,16 @@ var KeenTracker = (function() {
 
             self.trackPageView = function () {
                 var self = this;
+                var guid;
                 if (lodashGet(window, 'contextVars.node.isPublic', false) &&
                     lodashGet(window, 'contextVars.analyticsMeta.pageMeta.public', false)) {
+
+                    guid = lodashGet(window, 'contextVars.node.id', null);
+                    if (guid) {
+                        var partitioned_collection = 'pageviews-' + guid.charAt(0);
+                        self.trackPublicEvent(partitioned_collection, {});
+                    }
+
                     self.trackPublicEvent('pageviews', {});
                 }
                 self.trackPrivateEvent('pageviews', {});

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -987,16 +987,6 @@ var extractContributorNamesFromAPIData = function(contributor){
 var trackClick = function(category, action, label){
     window.ga('send', 'event', category, action, label);
 
-    KeenTracker.getInstance().trackPrivateEvent(
-        'front-end-events', {
-            interaction: {
-                category: category,
-                action: action,
-                label: label,
-            },
-        }
-    );
-
     //in order to make the href redirect work under knockout onclick binding
     return true;
 };


### PR DESCRIPTION
## Purpose

* Stop logging unused events to keen
* Log public pageview into partitioned collections for smaller/faster scans

## Changes

* Stop logging `front-end-events` to Keen.  These should only be sent to GA.
* Start sending pageviews for public projects to collections partitioned by the first letter of the guid.  These collections will be created automatically by Keen.  We will switch over to them after collecting a month of data after which scans should be much faster.

## QA Notes

* No data migration required.
* Fix will be manually dev-tested.

## Documentation

No documentation needs to be updated.

## Side Effects

Unlikely.  Changes are highly restricted to keen tracking code.

## Ticket

https://openscience.atlassian.net/browse/ENG-1963
https://openscience.atlassian.net/browse/ENG-2010
