### PR TITLE
[ENG-2002] redirect user who is already registered

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -505,6 +505,8 @@ def external_login_confirm_email_get(auth, uid, token):
     """
 
     user = OSFUser.load(uid)
+    service_url = request.url
+
     if not user:
         sentry.log_message('external_login_confirm_email_get::400 - Cannot find user')
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
@@ -531,10 +533,13 @@ def external_login_confirm_email_get(auth, uid, token):
             status.push_status_message(language.WELCOME_MESSAGE, kind='default', jumbotron=True, trust=True, id='welcome_message')
         return redirect(web_url_for('dashboard'))
 
-    # token is invalid
     if token not in user.email_verifications:
-        sentry.log_message('external_login_confirm_email_get::400 - bad token')
-        raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
+        if user.is_registered:
+            # User is registered with account already linked, probably button mashing.
+            return redirect(web_url_for('dashboard'))
+        else:
+            sentry.log_message('external_login_confirm_email_get::400 - bad token')
+            raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
     verification = user.email_verifications[token]
     email = verification['email']
     provider = list(verification['external_identity'].keys())[0]
@@ -563,8 +568,6 @@ def external_login_confirm_email_get(auth, uid, token):
     del user.email_verifications[token]
     user.verification_key = generate_verification_key()
     user.save()
-
-    service_url = request.url
 
     if external_status == 'CREATE':
         mails.send_mail(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4026,6 +4026,20 @@ class TestExternalAuthViews(OsfTestCase):
         assert_in('/logout?service=', res.location)
         assert_in(url, res.location)
 
+    def test_external_login_confirm_email_twice(self):
+        url = self.user.get_confirmation_url(self.user.username, external_id_provider='orcid', destination='dashboard')
+        print(self.user.email_verifications)
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 302, 'redirects to cas logout')
+        assert_in('/login?service=', res.location)
+
+        self.user.refresh_from_db()
+        assert_equal(self.user.email_verifications, {})
+
+        res = self.app.get(url, auth=self.auth)
+        assert_equal(res.status_code, 302, 'redirects to cas logout')
+        assert_in('/dashboard/', res.location)
+
     def test_external_login_confirm_email_get_without_destination(self):
         url = self.user.get_confirmation_url(self.user.username, external_id_provider='orcid')
         res = self.app.get(url, auth=self.auth, expect_errors=True)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4028,16 +4028,15 @@ class TestExternalAuthViews(OsfTestCase):
 
     def test_external_login_confirm_email_twice(self):
         url = self.user.get_confirmation_url(self.user.username, external_id_provider='orcid', destination='dashboard')
-        print(self.user.email_verifications)
         res = self.app.get(url, auth=self.auth)
-        assert_equal(res.status_code, 302, 'redirects to cas logout')
+        assert_equal(res.status_code, 302, 'redirects to cas login')
         assert_in('/login?service=', res.location)
 
         self.user.refresh_from_db()
         assert_equal(self.user.email_verifications, {})
 
         res = self.app.get(url, auth=self.auth)
-        assert_equal(res.status_code, 302, 'redirects to cas logout')
+        assert_equal(res.status_code, 302, 'redirects to logged in dashboard')
         assert_in('/dashboard/', res.location)
 
     def test_external_login_confirm_email_get_without_destination(self):


### PR DESCRIPTION
## Purpose

Orcid sign on causing "bad token" sentry errors, I believe this is because the `email_verifications` is cleared when the user registers, so users attempting to register twice (knowingly do to button mashings or unknowingly due to email spam checking) have no token in `email_verifications` hence the error.

## Changes

- prevented clicking the link multiple times from leading to a bad request error.

## QA Notes

No Migration, low risk

To reproduce replicate steps 1, 3 and 4 from this doc: https://docs.google.com/document/d/1wCk_nHQKCVozGk0j0UrU2VFWiF6Qk4qsIYaDzNezjvU/edit

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2002