### PR TITLE
[ENG-2087] Add egap to registration provider schemas

### DIFF
--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -615,7 +615,7 @@ class RegistrationProviderSchemaList(JSONAPIBaseView, generics.ListAPIView, List
         return RegistrationProvider.objects.get(_id=self.kwargs['provider_id'])
 
     def get_default_queryset(self):
-        return self.get_provider().schemas.get_latest_versions().filter(active=True)
+        return self.get_provider().schemas.get_latest_versions(request=self.request).filter(active=True)
 
     def get_queryset(self):
         return self.get_queryset_from_request()


### PR DESCRIPTION
## Purpose

EGAP was not showing in the registration provider schama list. This fixes that.

## Changes

- Pass `request` to `get_latest_versions()` so that EGAP would be returned if it's supposed to be
- Tests

## QA Notes

  - Does this change require a data migration? No
  - What is the level of risk? Minimal
    - Any permissions code touched? Not as such. It does take advantage of the `egap_admins` waffle flag, though.
    - Is this an additive or subtractive change, other? Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) Through API or integrated testing
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs. Not versioned, but you can use `/v2/providers/registrations/egap/schemas/` if you have egap set up to use the EGAP Registration schema v3.
  - What features or workflows might this change impact? Branded registries submission
  - How will this impact performance? It won't.


## Documentation

No need for documentation changes

## Side Effects

No

## Ticket

https://openscience.atlassian.net/browse/ENG-2087
