### PR TITLE
Branded registries fixes [ENG-2096]

### DIFF
--- a/admin/brands/views.py
+++ b/admin/brands/views.py
@@ -95,6 +95,25 @@ class BrandCreate(PermissionRequiredMixin, CreateView):
     permission_required = 'osf.modify_brand'
     raise_exception = True
     template_name = 'brands/create.html'
-    success_url = reverse_lazy('brands:list')
     model = Brand
     form_class = BrandForm
+
+    def get_success_url(self, *args, **kwargs):
+        brand = Brand.objects.filter(name=self.request.POST['name']).first()
+        return reverse_lazy('brands:detail', kwargs={'brand_id': brand.id})
+
+    def get_context_data(self, *args, **kwargs):
+        kwargs['change_form'] = BrandForm()
+        return kwargs
+
+    def post(self, request, *args, **kwargs):
+        primary_color = request.POST.get('primary_color')
+        secondary_color = request.POST.get('secondary_color')
+
+        if not is_a11y(primary_color):
+            messages.warning(request, """The selected primary color is not a11y compliant.
+                For more information, visit https://color.a11y.com/""")
+        if not is_a11y(secondary_color):
+            messages.warning(request, """The selected secondary color is not a11y compliant.
+                For more information, visit https://color.a11y.com/""")
+        return super(BrandCreate, self).post(request, *args, **kwargs)

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -174,14 +174,14 @@
                   </ul>
               </div>
           {% endif %}
-          {% if perms.osf.view_brands %}
+          {% if perms.osf.view_brand %}
               <li><a role="button" data-toggle="collapse" href="#collapseBrands">
                   <i class='fa fa-caret-down'></i> Brands
               </a></li>
               <div class="collapse" id="collapseBrands">
                   <ul class="sidebar-menu sidebar-menu-inner">
                       <li><a href="{% url 'brands:list' %}"><i class='fa fa-link'></i><span> List</span> </a></li>
-                      {% if perms.osf.change_brands %}
+                      {% if perms.osf.modify_brand %}
                       <li><a href="{% url 'brands:create' %}"><i class='fa fa-link'></i><span> Create</span> </a></li>
                       {% endif %}
                   </ul>

--- a/admin/templates/brands/create.html
+++ b/admin/templates/brands/create.html
@@ -7,7 +7,6 @@
 {% endblock title %}
 
 {% block content %}
-    <form action="{% url 'brands:create' %}" method="post">
     {% if messages %}
     <ul class="messages">
         {% for message in messages %}
@@ -19,20 +18,18 @@
     {% endif %}
     {{ form.non_field_errors }}
     {% csrf_token %}
-    {% for field in form %}
-        {% if not field.is_hidden %}
-        <div class="fieldWrapper">
-            <span class="text-danger">{{ field.errors }}</span>
-            {{ field.label_tag }} <br>
-            {{ field }}
-        </div>
-        {% endif %}
-        <br>
-    {% endfor %}
+    <div class="col-md-7">
+        <form action="{% url 'brands:create' %}" method="post">
+            {% csrf_token %}
+            {{ change_form.as_p }}
+            <input class="form-button" type="submit" value="Submit" />
+
+        </form>
+    </div>
+    <br>
     {% for hidden in form.hidden_fields %}
         {{ hidden }}
     {% endfor %}
-    <input type="submit" class="btn btn-primary" value="Save">
     </form>
 {% endblock content %}
 {% block bottom_js %}

--- a/admin_tests/brands/test_views.py
+++ b/admin_tests/brands/test_views.py
@@ -1,0 +1,112 @@
+import pytest
+
+from admin.brands import views
+
+from django.test import RequestFactory
+from django.core.exceptions import PermissionDenied
+
+from osf.models import Brand
+from django.contrib.auth.models import Permission
+from osf_tests.factories import BrandFactory, AuthUserFactory
+
+from admin_tests.utilities import setup_view
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def test_brand():
+    return BrandFactory()
+
+@pytest.fixture()
+def test_brand_two():
+    return BrandFactory()
+
+@pytest.fixture()
+def perm_user():
+    user = AuthUserFactory()
+    view_permission = Permission.objects.get(codename='view_brand')
+    modify_permission = Permission.objects.get(codename='modify_brand')
+    user.user_permissions.add(view_permission)
+    user.user_permissions.add(modify_permission)
+    user.save()
+    return user
+
+@pytest.fixture()
+def perm_req(perm_user):
+    req = RequestFactory().get('/fake_path')
+    req.user = perm_user
+    return req
+
+@pytest.fixture()
+def user():
+    return AuthUserFactory()
+
+@pytest.fixture()
+def req(user):
+    req = RequestFactory().get('/fake_path')
+    req.user = user
+    return req
+
+
+class TestBrandList:
+
+    @pytest.fixture()
+    def brand_list_view(self):
+        return views.BrandList
+
+    def test_get_queryset(self, test_brand, test_brand_two, brand_list_view):
+        brands = list(brand_list_view().get_queryset())
+        assert len(brands) == 2
+
+    def test_failed_permissions(self, user, brand_list_view, req):
+        with pytest.raises(PermissionDenied):
+            brand_list_view.as_view()(req)
+
+    def test_correct_view_permissions(self, perm_req, perm_user, brand_list_view):
+        res = brand_list_view.as_view()(perm_req)
+        assert res.status_code == 200
+
+
+@pytest.mark.django_db
+class TestBannerDisplay:
+
+    @pytest.fixture()
+    def brand_display_view(self):
+        return views.BrandDisplay
+
+    def test_get_object(self, brand_display_view, test_brand, req):
+        view = brand_display_view()
+        setup_view(view, req, brand_id=test_brand.id)
+        obj = view.get_object()
+        assert type(obj) is Brand
+        assert obj.name == test_brand.name
+
+    def test_context_data(self, perm_user, perm_req, brand_display_view, test_brand):
+        view = brand_display_view()
+        setup_view(view, req, brand_id=test_brand.id)
+        data = view.get_context_data()
+        assert data['brand']['name'] == test_brand.name
+
+    def test_no_user_permissions_raises_error(self, req, brand_display_view, test_brand):
+        with pytest.raises(PermissionDenied):
+            brand_display_view.as_view()(req, brand_id=test_brand.id)
+
+    def test_correct_view_permissions(self, perm_req, brand_display_view, test_brand):
+        res = brand_display_view.as_view()(perm_req, brand_id=test_brand.id)
+        assert res.status_code == 200
+
+
+class TestCreateBrand:
+
+    @pytest.fixture()
+    def brand_create_view(self):
+        return views.BrandCreate
+
+    def test_no_user_permissions_raises_error(self, req, brand_create_view):
+        with pytest.raises(PermissionDenied):
+            brand_create_view.as_view()(req)
+
+    def test_correct_view_permissions(self, perm_req, perm_user, brand_create_view):
+        res = brand_create_view.as_view()(perm_req)
+        assert res.status_code == 200


### PR DESCRIPTION


## Purpose

1. Color picker doesn't validate for a11y noncompliant colors upon Create/save.  (But, does validate upon Edit/submit).
2. Boxes are shorter in Create/save mode (compared to Edit/submit). Make the boxes on the edit screen the same width as the create screen.
3. Make permissions fix

## Changes

Fixing permissions, modifying create template, modifying view for admin brand create

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? No
  - What is the level of risk? Minimal
    - Any permissions code touched? Yes, an improvement
    - Is this an additive or subtractive change, other? Modification
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) Admin app
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs. N/A
  - What features or workflows might this change impact? Brands
  - How will this impact performance? Shouldn't
-->

## Documentation

N/A

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-2096
