### PR TITLE
Adding prefix to share source. [ENG-2115]

### DIFF
--- a/admin_tests/registration_providers/test_views.py
+++ b/admin_tests/registration_providers/test_views.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import mock
 
 from django.test import RequestFactory
 
@@ -164,6 +165,34 @@ class TestShareSourceRegistrationProvider:
         assert res.status_code == 302
         provider.refresh_from_db()
         assert provider.share_source == 'test source'
+        assert provider.access_token == 'test access token'
+
+    @mock.patch.object(settings, 'SPAM_FLAGGED_MAKE_NODE_PRIVATE', 'testenv')
+    def test_share_source_prefix(self, mock_share, view, provider, req):
+        mock_share.reset()
+        mock_share.add(
+            responses.POST,
+            f'{settings.SHARE_URL}api/v2/sources/',
+            json.dumps(
+                {
+                    'data': {
+                        'attributes': {
+                            'longTitle': 'testenv-test source'
+                        }
+                    },
+                    'included': [{
+                        'attributes': {
+                            'token': 'test access token',
+                        },
+                        'type': 'ShareUser',
+                    }]
+                }
+            )
+        )
+        res = view.get(req)
+        assert res.status_code == 302
+        provider.refresh_from_db()
+        assert provider.share_source == 'testenv-test source'
         assert provider.access_token == 'test access token'
 
 

--- a/admin_tests/registration_providers/test_views.py
+++ b/admin_tests/registration_providers/test_views.py
@@ -167,7 +167,7 @@ class TestShareSourceRegistrationProvider:
         assert provider.share_source == 'test source'
         assert provider.access_token == 'test access token'
 
-    @mock.patch.object(settings, 'SPAM_FLAGGED_MAKE_NODE_PRIVATE', 'testenv')
+    @mock.patch.object(settings, 'SHARE_PROVIDER_PREPEND', 'testenv')
     def test_share_source_prefix(self, mock_share, view, provider, req):
         mock_share.reset()
         mock_share.add(

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -23,7 +23,6 @@ from osf.utils.fields import EncryptedTextField
 from osf.utils.permissions import REVIEW_PERMISSIONS
 from website import settings
 from website.util import api_v2_url
-from website.settings import SHARE_PROVIDER_PREPEND
 from functools import reduce
 
 
@@ -144,8 +143,8 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
         if not self.get_asset_url('square_color_no_transparent'):
             raise ValueError('Unable to find "square_color_no_transparent" icon for provider')
 
-        if SHARE_PROVIDER_PREPEND:
-            share_provider_name = f'{SHARE_PROVIDER_PREPEND}_{self.name}'
+        if settings.SHARE_PROVIDER_PREPEND:
+            share_provider_name = f'{settings.SHARE_PROVIDER_PREPEND}_{self.name}'
         else:
             share_provider_name = self.name
 

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -23,6 +23,7 @@ from osf.utils.fields import EncryptedTextField
 from osf.utils.permissions import REVIEW_PERMISSIONS
 from website import settings
 from website.util import api_v2_url
+from website.settings import SHARE_PROVIDER_PREPEND
 from functools import reduce
 
 
@@ -143,6 +144,11 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
         if not self.get_asset_url('square_color_no_transparent'):
             raise ValueError('Unable to find "square_color_no_transparent" icon for provider')
 
+        if SHARE_PROVIDER_PREPEND:
+            share_provider_name = f'{SHARE_PROVIDER_PREPEND}_{self.name}'
+        else:
+            share_provider_name = self.name
+
         resp = requests.post(
             f'{settings.SHARE_URL}api/v2/sources/',
             json={
@@ -150,7 +156,7 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
                     'type': 'Source',
                     'attributes': {
                         'homePage': provider_home_page,
-                        'longTitle': self.name,
+                        'longTitle': share_provider_name,
                         'iconUrl': self.get_asset_url('square_color_no_transparent')
                     }
                 }

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -346,7 +346,7 @@ CROSSREF_JSON_API_URL = 'https://api.crossref.org/'
 
 
 # Leave as `None` for production, test/staging/local envs must set
-SHARE_PREPRINT_PROVIDER_PREPEND = None
+SHARE_PROVIDER_PREPEND = None
 
 SHARE_ENABLED = True  # This should be False for most local development
 SHARE_REGISTRATION_URL = ''


### PR DESCRIPTION

## Purpose

Adding a prefix to the share source name

## Changes

Modifying setup_share_source. Adding tests

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? N/A
  - What is the level of risk? Minimal, just for staging environments
    - Any permissions code touched? no
    - Is this an additive or subtractive change, other? additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) UI/Admin app
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs. N/A
  - What features or workflows might this change impact? Provider creation. And share
  - How will this impact performance? Shouldn't
-->

## Documentation

N/A

## Side Effects

Shouldn't be.
## Ticket

https://openscience.atlassian.net/browse/ENG-2115