### PR TITLE
[ENG-2149] Modify preprint provider re-index command to handle all providers

### DIFF
--- a/api_tests/providers/test_reindex_provider.py
+++ b/api_tests/providers/test_reindex_provider.py
@@ -1,0 +1,50 @@
+import pytest
+import json
+
+from django.core.management import call_command
+
+from osf_tests.factories import (
+    PreprintFactory,
+    PreprintProviderFactory,
+    RegistrationProviderFactory,
+    RegistrationFactory,
+    AuthUserFactory
+)
+
+
+@pytest.mark.django_db
+class TestReindexProvider:
+
+    @pytest.fixture()
+    def preprint_provider(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture()
+    def preprint(self, preprint_provider):
+        return PreprintFactory(provider=preprint_provider)
+
+    @pytest.fixture()
+    def registration_provider(self):
+        return RegistrationProviderFactory()
+
+    @pytest.fixture()
+    def registration(self, registration_provider):
+        return RegistrationFactory(provider=registration_provider)
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    def test_reindex_provider_preprint(self, mock_share, preprint_provider, preprint):
+        call_command('reindex_provider', preprint_provider._id)
+        data = json.loads(mock_share.calls[-1].request.body)
+
+        assert any(graph for graph in data['data']['attributes']['data']['@graph']
+                   if graph['@type'] == preprint_provider.share_publish_type.lower())
+
+    def test_reindex_provider_registration(self, mock_share, registration_provider, registration):
+        call_command('reindex_provider', registration_provider._id)
+        data = json.loads(mock_share.calls[-1].request.body)
+
+        assert any(graph for graph in data['data']['attributes']['data']['@graph']
+                   if graph['@type'] == registration_provider.share_publish_type.lower())

--- a/api_tests/providers/test_reindex_provider.py
+++ b/api_tests/providers/test_reindex_provider.py
@@ -36,14 +36,14 @@ class TestReindexProvider:
         return AuthUserFactory()
 
     def test_reindex_provider_preprint(self, mock_share, preprint_provider, preprint):
-        call_command('reindex_provider', preprint_provider._id)
+        call_command('reindex_provider', f'--providers={preprint_provider._id}')
         data = json.loads(mock_share.calls[-1].request.body)
 
         assert any(graph for graph in data['data']['attributes']['data']['@graph']
                    if graph['@type'] == preprint_provider.share_publish_type.lower())
 
     def test_reindex_provider_registration(self, mock_share, registration_provider, registration):
-        call_command('reindex_provider', registration_provider._id)
+        call_command('reindex_provider', f'--providers={registration_provider._id}')
         data = json.loads(mock_share.calls[-1].request.body)
 
         assert any(graph for graph in data['data']['attributes']['data']['@graph']

--- a/osf/management/commands/reindex_provider.py
+++ b/osf/management/commands/reindex_provider.py
@@ -1,16 +1,22 @@
-"""Resend all preprints for given providers to SHARE."""
+"""Resend all resources (nodes, registrations, preprints) for given providers to SHARE."""
 import logging
 
 from django.core.management.base import BaseCommand
-from osf.models import PreprintProvider
+from osf.models import AbstractProvider, AbstractNode, Preprint
 from api.share.utils import update_share
 
 logger = logging.getLogger(__name__)
 
+
 def reindex_provider(provider):
     logger.info('Sending {} preprints to SHARE...'.format(provider.preprints.count()))
-    for preprint in provider.preprints.all():
+    for preprint in Preprint.objects.filter(provider=provider):
         update_share(preprint)
+
+    logger.info('Sending {} AbstractNodes to SHARE...'.format(AbstractNode.objects.filter(provider=provider).count()))
+    for abstract_node in AbstractNode.objects.filter(provider=provider):
+        update_share(abstract_node)
+
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
@@ -19,6 +25,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         provider_ids = options.get('providers', [])
-        for provider in PreprintProvider.objects.filter(_id__in=provider_ids):
+        for provider in AbstractProvider.objects.filter(_id__in=provider_ids):
             logger.info('Reindexing {}...'.format(provider._id))
             reindex_provider(provider)

--- a/osf/management/commands/reindex_provider.py
+++ b/osf/management/commands/reindex_provider.py
@@ -9,22 +9,34 @@ logger = logging.getLogger(__name__)
 
 
 def reindex_provider(provider):
-    logger.info('Sending {} preprints to SHARE...'.format(provider.preprints.count()))
-    for preprint in Preprint.objects.filter(provider=provider):
-        update_share(preprint)
+    preprints = Preprint.objects.filter(provider=provider)
+    if preprints:
+        logger.info('Sending {} preprints to SHARE...'.format(provider.preprints.count()))
+        for preprint in preprints:
+            update_share(preprint)
 
-    logger.info('Sending {} AbstractNodes to SHARE...'.format(AbstractNode.objects.filter(provider=provider).count()))
-    for abstract_node in AbstractNode.objects.filter(provider=provider):
-        update_share(abstract_node)
+    nodes = AbstractNode.objects.filter(provider=provider)
+    if nodes:
+        logger.info('Sending {} AbstractNodes to SHARE...'.format(AbstractNode.objects.filter(provider=provider).count()))
+        for abstract_node in nodes:
+            update_share(abstract_node)
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
-        parser.add_argument('providers', type=str, nargs='+', help='Provider _ids')
+        parser.add_argument('--providers', type=str, nargs='+', help='Provider _ids')
+        parser.add_argument('--type', type=str, help='what type of provider to reindex', default=None)
 
     def handle(self, *args, **options):
         provider_ids = options.get('providers', [])
-        for provider in AbstractProvider.objects.filter(_id__in=provider_ids):
+        type = options.get('type', None)
+
+        if type:
+            providers = AbstractProvider.objects.filter(type__contains=type, _id__in=provider_ids)
+        else:
+            providers = AbstractProvider.objects.filter(_id__in=provider_ids)
+
+        for provider in providers:
             logger.info('Reindexing {}...'.format(provider._id))
             reindex_provider(provider)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This should allow us to re-index `OSF Registries`.

## Changes

- changes `reindex_preprint_provider.py` to handle all providers and adds tests.
- cleans up preprint factory

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
Yes, kind of, but only SHARE data.
  - What is the level of risk?
Low
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
Devtest
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
Not
-->

## Documentation

tech task, no new docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2149