### PR TITLE
Adding branded_discovery_page field to registration provider serializer. [ENG-2150]

### DIFF
--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -115,6 +115,8 @@ class RegistrationProviderSerializer(ProviderSerializer):
     class Meta:
         type_ = 'registration-providers'
 
+    branded_discovery_page = ser.BooleanField(read_only=True)
+
     brand = RelationshipField(
         related_view='brands:brand-detail',
         related_view_kwargs={'brand_id': '<brand.id>'},

--- a/api_tests/providers/registrations/views/test_registration_provider_detail.py
+++ b/api_tests/providers/registrations/views/test_registration_provider_detail.py
@@ -49,7 +49,7 @@ class TestRegistrationProviderExists(ProviderDetailViewTestBaseMixin):
         return '/{}providers/registrations/{}/'.format(
             API_BASE, provider_with_brand._id)
 
-    def test_registration_provider_with_brand(self, app, provider_with_brand, brand, provider_url_w_brand):
+    def test_registration_provider_with_special_fields(self, app, provider_with_brand, brand, provider_url_w_brand):
         # Ensures brand data is included for registration providers
         res = app.get(provider_url_w_brand)
 
@@ -57,3 +57,4 @@ class TestRegistrationProviderExists(ProviderDetailViewTestBaseMixin):
         data = res.json['data']
 
         assert data['relationships']['brand']['data']['id'] == str(brand.id)
+        assert data['attributes']['branded_discovery_page'] == provider_with_brand.branded_discovery_page


### PR DESCRIPTION


## Purpose

The front end needs the registration provider serialized in the API.

## Changes

Adding the field to the serializer, adding test

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate? No
  - What is the level of risk? Minimal
    - Any permissions code touched? No
    - Is this an additive or subtractive change, other? Additive
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?) API
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs. v2/providers/registrations
  - What features or workflows might this change impact? Branded registries
  - How will this impact performance? Shouldn't
-->

## Documentation

I don't think this will be necessary to add to the docs.

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-2150