### PR TITLE
[ENG-2142] Fix share sending bad payloads

### DIFF
--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -243,6 +243,7 @@ def format_registration(registration, *args, **kwargs):
             'date_published': registration.registered_date.isoformat() if registration.registered_date else None,
             'registration_type': registration.registered_schema.first().name if registration.registered_schema.exists() else None,
             'justification': registration.retraction.justification if registration.retraction else None,
+            'withdrawn': registration.is_retracted,
         }
     )
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

SHARE is sending 400s when recieiving registration data. 

<img width="774" alt="Screen Shot 2020-08-18 at 10 18 09 AM" src="https://user-images.githubusercontent.com/9688518/90532883-c1e19180-e145-11ea-9b42-34fb6741a593.png">


~~ as you can see the payload is being retried 5 times with the `registration_format` portion being converted to json each time. (you can see this is probably the case by looking at the sequence of slashes which is the previous number of slashes*2 + 1). I believe this is some kind of mutable argument problem within celery.  ~~


So really all that was happening here was we were sending a bad payload which was somehow repeatably json-ifing itself, but as long as the payload is valid initially the problem doesn't express itself.

 ## Changes

- remove `registration_type` from SHARE payload

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Low
    - Any permissions code touched?
No
    - Is this an additive or subtractive change, other?
other
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
reindex it on share and check sentry

## Documentation

🐞  fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2142