### PR TITLE
Ensure script runs on all versions of the egap schema

### DIFF
--- a/osf/management/commands/move_egap_regs_to_provider.py
+++ b/osf/management/commands/move_egap_regs_to_provider.py
@@ -12,23 +12,19 @@ from osf.models import (
     RegistrationSchema,
     Registration
 )
-from django.conf import settings
+
 
 def main(dry_run):
-    epag_provider = RegistrationProvider.objects.get(name=settings.EGAP_PROVIDER_NAME)
+    egap_provider = RegistrationProvider.objects.get(_id='egap')
+    egap_schemas = RegistrationSchema.objects.filter(name='EGAP Registration').order_by('-schema_version')
 
-    egap_schema = RegistrationSchema.objects.filter(
-        name='EGAP Registration'
-    ).order_by(
-        '-schema_version'
-    )[0]
+    for egap_schema in egap_schemas:
+        egap_regs = Registration.objects.filter(registered_schema=egap_schema.id, provider___id='osf')
 
-    egap_regs = Registration.objects.filter(registered_schema=egap_schema.id, provider___id='osf')
-
-    if dry_run:
-        logger.info(f'[DRY RUN] {egap_regs.count()} updated to {epag_provider} with id {epag_provider.id}')
-    else:
-        egap_regs.update(provider_id=epag_provider.id)
+        if dry_run:
+            logger.info(f'[DRY RUN] {egap_regs.count()} updated to {egap_provider} with id {egap_provider.id}')
+        else:
+            egap_regs.update(provider_id=egap_provider.id)
 
 
 class Command(BaseCommand):

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -354,7 +354,7 @@ class RegistrationProviderFactory(DjangoModelFactory):
                 pass
             else:
                 raise e
-        if _id:
+        if _id and _id != 'osf':
             obj._id = _id
 
         obj._creator = user or models.OSFUser.objects.first() or UserFactory()  # Generates primary_collection

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -331,6 +331,7 @@ class CollectionProviderFactory(DjangoModelFactory):
         obj.save()
         return obj
 
+
 class RegistrationProviderFactory(DjangoModelFactory):
     name = factory.Faker('company')
     description = factory.Faker('bs')
@@ -353,6 +354,8 @@ class RegistrationProviderFactory(DjangoModelFactory):
                 pass
             else:
                 raise e
+        if _id:
+            obj._id = _id
 
         obj._creator = user or models.OSFUser.objects.first() or UserFactory()  # Generates primary_collection
         obj.save()

--- a/osf_tests/management_commands/test_move_egap_regs_to_provider.py
+++ b/osf_tests/management_commands/test_move_egap_regs_to_provider.py
@@ -23,7 +23,7 @@ class TestEGAPMoveToProvider:
 
     @pytest.fixture()
     def egap_provider(self):
-        return RegistrationProviderFactory(name=settings.EGAP_PROVIDER_NAME, _id='egap')
+        return RegistrationProviderFactory(_id='egap')
 
     @pytest.fixture()
     def non_egap_provider(self):

--- a/osf_tests/management_commands/test_move_egap_regs_to_provider.py
+++ b/osf_tests/management_commands/test_move_egap_regs_to_provider.py
@@ -23,7 +23,7 @@ class TestEGAPMoveToProvider:
 
     @pytest.fixture()
     def egap_provider(self):
-        return RegistrationProviderFactory(name=settings.EGAP_PROVIDER_NAME)
+        return RegistrationProviderFactory(name=settings.EGAP_PROVIDER_NAME, _id='egap')
 
     @pytest.fixture()
     def non_egap_provider(self):

--- a/osf_tests/management_commands/test_move_egap_regs_to_provider.py
+++ b/osf_tests/management_commands/test_move_egap_regs_to_provider.py
@@ -15,8 +15,6 @@ from osf.management.commands.move_egap_regs_to_provider import (
     main as move_egap_regs
 )
 
-from django.conf import settings
-
 
 @pytest.mark.django_db
 class TestEGAPMoveToProvider:


### PR DESCRIPTION
## Purpose

The egap migration script only got version 3 of the EGAP schema, so the 1536 EGAP registrations with version 2 of the schema wouldn't be migrated. This fixes that. 

## Changes

1. Loop over all of the versions of the schema
2. Assume the `_id` of the EGAP registry will be 'egap' (because it will be).
3. Rename `epag_provider` to `egap_provider`

## QA Notes

This will be tested on Staging2 as part of branded registries submission. It shouldn't be any more problematic than it would have been otherwise.

## Documentation

N/A

## Side Effects

None.

## Ticket

N/A
