### PR TITLE
[ENG-2204]  Branded Registries where the EGAP schema is showing for all providers when you have the flag set, not just the provider who has it as an acceptable schema

### DIFF
--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -615,7 +615,7 @@ class RegistrationProviderSchemaList(JSONAPIBaseView, generics.ListAPIView, List
         return RegistrationProvider.objects.get(_id=self.kwargs['provider_id'])
 
     def get_default_queryset(self):
-        return self.get_provider().schemas.get_latest_versions(request=self.request).filter(active=True)
+        return self.get_provider().schemas.get_latest_versions(request=self.request, invisible=True).filter(active=True)
 
     def get_queryset(self):
         return self.get_queryset_from_request()

--- a/api_tests/providers/registrations/views/test_registration_provider_schemas.py
+++ b/api_tests/providers/registrations/views/test_registration_provider_schemas.py
@@ -92,6 +92,8 @@ class TestRegistrationProviderSchemas:
             app,
             url,
             schema,
+            egap_schema,
+            invisible_schema,
             user,
             url_with_v2_prereg_only,
             url_with_egap_only
@@ -100,9 +102,10 @@ class TestRegistrationProviderSchemas:
         assert res.status_code == 200
         data = res.json['data']
 
-        assert len(data) == 1
-        assert data[0]['id'] == schema._id
-        assert data[0]['attributes']['name'] == schema.name
+        assert len(data) == 2
+        assert schema._id in [item['id'] for item in data]
+        assert invisible_schema._id in [item['id'] for item in data]
+        assert schema.name in [item['attributes']['name'] for item in data]
 
         res = app.get(url_with_v2_prereg_only, auth=user.auth)
         assert res.status_code == 200
@@ -116,7 +119,8 @@ class TestRegistrationProviderSchemas:
         assert res.status_code == 200
         data = res.json['data']
 
-        assert len(data) == 0
+        assert len(data) == 1
+        assert data[0]['id'] == egap_schema._id
 
     def test_egap_registration_schema(
             self,

--- a/api_tests/providers/registrations/views/test_registration_provider_schemas.py
+++ b/api_tests/providers/registrations/views/test_registration_provider_schemas.py
@@ -119,8 +119,7 @@ class TestRegistrationProviderSchemas:
         assert res.status_code == 200
         data = res.json['data']
 
-        assert len(data) == 1
-        assert data[0]['id'] == egap_schema._id
+        assert len(data) == 0
 
     def test_egap_registration_schema(
             self,

--- a/api_tests/providers/registrations/views/test_registration_provider_schemas.py
+++ b/api_tests/providers/registrations/views/test_registration_provider_schemas.py
@@ -142,11 +142,17 @@ class TestRegistrationProviderSchemas:
             self,
             app,
             user,
-            egap_flag,
+            egap_admin,
             egap_schema,
             url_with_egap_only
     ):
         res = app.get(url_with_egap_only, auth=user.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+
+        assert len(data) == 0
+
+        res = app.get(url_with_egap_only, auth=egap_admin.auth)
         assert res.status_code == 200
         data = res.json['data']
 

--- a/api_tests/schemas/views/test_registration_schemas_list.py
+++ b/api_tests/schemas/views/test_registration_schemas_list.py
@@ -71,7 +71,3 @@ class TestSchemaList:
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
         assert not [data for data in res.json['data'] if data['attributes']['name'] == 'EGAP Registration']
-
-        res = app.get(url, auth=egap_admin.auth)
-        assert res.status_code == 200
-        assert [data for data in res.json['data'] if data['attributes']['name'] == 'EGAP Registration']

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -36,12 +36,9 @@ def allow_egap_admins(queryset, request):
     Allows egap admins to see EGAP registrations as visible, should be deleted when when the EGAP registry goes
     live.
     """
-    queryset = queryset.exclude(name='EGAP Registration')
-    if hasattr(request, 'user') and waffle.flag_is_active(request, EGAP_ADMINS):
-        return queryset | RegistrationSchema.objects.filter(name='EGAP Registration').distinct('name')
-    else:
-        return queryset
-
+    if hasattr(request, 'user') and not waffle.flag_is_active(request, EGAP_ADMINS):
+        return queryset.exclude(name='EGAP Registration')
+    return queryset
 
 class AbstractSchemaManager(models.Manager):
 

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -52,14 +52,17 @@ class AbstractSchemaManager(models.Manager):
         """
         return self.filter(name=name).order_by('schema_version').last()
 
-    def get_latest_versions(self, request=None):
+    def get_latest_versions(self, request=None, invisible=False):
         """
         Return the latest version of the given schema
 
         :param request: the request object needed for waffling
         :return: queryset
         """
-        queryset = self.filter(visible=True).order_by('name', '-schema_version').distinct('name')
+        queryset = self.order_by('name', '-schema_version').distinct('name')
+
+        if not invisible:
+            queryset = queryset.filter(visible=True)
 
         if request:
             return allow_egap_admins(queryset, request)

--- a/osf/models/metaschema.py
+++ b/osf/models/metaschema.py
@@ -36,6 +36,7 @@ def allow_egap_admins(queryset, request):
     Allows egap admins to see EGAP registrations as visible, should be deleted when when the EGAP registry goes
     live.
     """
+    queryset = queryset.exclude(name='EGAP Registration')
     if hasattr(request, 'user') and waffle.flag_is_active(request, EGAP_ADMINS):
         return queryset | RegistrationSchema.objects.filter(name='EGAP Registration').distinct('name')
     else:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This should fix the issue where the EGAP schema was showing up for every superuser withour effecting non-super users.

## Changes

- simple logic change

## QA Notes

  - Does this change require a data migration? If so, what data will we migrate?
No
  - What is the level of risk?
Low
    - Any permissions code touched?
Kinda?
    - Is this an additive or subtractive change, other?
other
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)

Aside from testing the bug you explicitly found, please check the traditional registration workflow (through the project's Registrations tab) and verify that nobody, including EGAP Admins, can submit an egap registration through that path.

## Documentation

Bug fix, no docs.

## Side Effects

EGAP Schema may have to be made `visible` to be usable.

## Ticket

https://openscience.atlassian.net/browse/ENG-2204