### PR TITLE
[ENG-2111] Unregistered Contributor Claim on Registration also claims on Project

### DIFF
--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -20,7 +20,7 @@ from framework.transactions.handlers import no_auto_transaction
 from framework.utils import get_timestamp, throttle_period_expired
 from osf.models import Tag
 from osf.exceptions import NodeStateError
-from osf.models import AbstractNode, DraftRegistration, OSFGroup, OSFUser, Preprint, PreprintProvider, RecentlyAddedContributor
+from osf.models import AbstractNode, DraftRegistration, OSFGroup, OSFUser, Preprint, PreprintProvider, RecentlyAddedContributor, Registration
 from osf.utils import sanitize
 from osf.utils.permissions import ADMIN
 from website import mails, language, settings
@@ -733,6 +733,9 @@ def claim_user_registered(auth, node, **kwargs):
     if should_claim:
         node.replace_contributor(old=unreg_user, new=current_user)
         node.save()
+        if isinstance(node, Registration):
+            project = node.registered_from
+            project.replace_contributor(old=unreg_user, new=current_user)
         if isinstance(node, OSFGroup):
             status.push_status_message(
                 'You are now a member of this OSFGroup.',


### PR DESCRIPTION
## Purpose
Currently, when an unregistered contributor is claimed by a registered user, the unregistered contributor is not also claimed on the project the registration is based upon.

## Changes
* If the node the unregistered contributor is being claimed upon is a registration, in addition to the contributor being replaced on the registration, they are also replaced on the origin project.
* Adds a test 


## QA Notes
This can be tested through the UI. Follow the same workflow specified in the JIRA ticket expecting the contributor to be modified on the project as well.

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2111)
