### PR TITLE
[ENG-1961] Fix styling on SPAM Data pre in preprints.html

### DIFF
--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -90,7 +90,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-12 table-responsive">
                 <table class="table table-striped">
                 <thead>
                     <tr>
@@ -255,7 +255,7 @@
                     <tr>
                         <td>SPAM Data</td>
                         <td>
-                            <pre>{{ serialized_preprint.spam_data }}</pre>
+                            <pre style="white-space:pre-wrap;">{{ serialized_preprint.spam_data }}</pre>
                         </td>
                     </tr>
                     {% if perms.osf.change_preprintrequest %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the Admin App styling issues from ENG-1961

## Changes
Add white-space:pre-wrap styling to the pre tag for SPAM data
- Contents of the SPAM Data pre exceeding the width of the display were causing the table distortions (as the table elements tried to stretch out to match the full width of the un-displayed text).
- Text wrapping resolves this issue by limiting length of lines within the pre

Added a table-responsive class to the div containing the top-level table
- This causes a horizontal scroll-bar to appear in the case that something else stretches out the page in the future.

## QA Notes

  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    -  https://admin.staging.osf.io/preprints/bar76/ is a good example of a previously broken page

## Documentation
 N/A

## Side Effects

N/A

## Ticket
https://openscience.atlassian.net/browse/ENG-1961
