### PR TITLE
[hotfix][ENG-2147] stop logging to joint keen collection

### DIFF
--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Various node-related utilities."""
+from string import ascii_lowercase, digits
+
 from django.apps import apps
 from django.db.models import Q
 
@@ -32,32 +34,37 @@ def get_keen_activity():
         read_key=settings.KEEN['public']['read_key'],
     )
 
-    node_pageviews = client.count(
-        event_collection='pageviews',
-        timeframe='this_7_days',
-        group_by='node.id',
-        filters=[
-            {
-                'property_name': 'node.id',
-                'operator': 'exists',
-                'property_value': True
-            }
-        ]
-    )
+    node_pageviews = []
+    node_visits = []
+    for character in list(digits + ascii_lowercase):
+        partial_node_pageviews = client.count(
+            event_collection='pageviews-{}'.format(character),
+            timeframe='this_7_days',
+            group_by='node.id',
+            filters=[
+                {
+                    'property_name': 'node.id',
+                    'operator': 'exists',
+                    'property_value': True
+                }
+            ]
+        )
+        node_pageviews += partial_node_pageviews
 
-    node_visits = client.count_unique(
-        event_collection='pageviews',
-        target_property='anon.id',
-        timeframe='this_7_days',
-        group_by='node.id',
-        filters=[
-            {
-                'property_name': 'node.id',
-                'operator': 'exists',
-                'property_value': True
-            }
-        ]
-    )
+        partial_node_visits = client.count_unique(
+            event_collection='pageviews-{}'.format(character),
+            target_property='anon.id',
+            timeframe='this_7_days',
+            group_by='node.id',
+            filters=[
+                {
+                    'property_name': 'node.id',
+                    'operator': 'exists',
+                    'property_value': True
+                }
+            ]
+        )
+        node_visits += partial_node_visits
 
     return {'node_pageviews': node_pageviews, 'node_visits': node_visits}
 

--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -228,8 +228,6 @@ var KeenTracker = (function() {
                         var partitioned_collection = 'pageviews-' + guid.charAt(0);
                         self.trackPublicEvent(partitioned_collection, {});
                     }
-
-                    self.trackPublicEvent('pageviews', {});
                 }
                 self.trackPrivateEvent('pageviews', {});
             };


### PR DESCRIPTION
## Purpose

Stop sending pageview events to monolithic collection.  It's no longer needed.

## Changes

* Stop sending pageview events to monolithic collection.  There is enough data in the partitioned collections to switch fully over to those.

* Update `website.project.utlils.get_keen_activity` to query partitioned collections.

## QA Notes

* No data migration required.
* Fix will be manually dev-tested.

## Documentation

nope nope nope

## Side Effects

None expected.

## Ticket

[ENG-2147](https://openscience.atlassian.net/browse/ENG-2147)
