### PR TITLE
[ENG-2122] NodeStorage API Endpoint

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -65,6 +65,12 @@ SLOAN_FLAGS = (
     SLOAN_PREREG_DISPLAY
 )
 
+STORAGE_LIMIT_RESTRICTED_FILE_OPS = [
+    'upload',
+    'moveto',
+    'copyto'
+]
+
 # import so that associated listener is instantiated and gets emails
 from website.notifications.events.files import FileEvent  # noqa
 
@@ -221,24 +227,31 @@ def check_access(node, auth, action, cas_resp):
 
     raise HTTPError(http_status.HTTP_403_FORBIDDEN if auth.user else http_status.HTTP_401_UNAUTHORIZED)
 
-def check_storage_availability(node, provider, action):
+def check_storage_availability(node, provider, action, intent):
     """Verify that the requested action may be performed on the resource based
     upon the resource's storage usage status
     """
+    # Storage limits are only on OSF Storage
     if provider == 'osfstorage':
         if permission_map.get(action, None) == permissions.READ:
             return True
-        #if write
+
         if node.is_public:
             if node.storage_limit_status.value < 4:
                 return True
+            # Node has restricted file operations because it has exceeded public storage limits
             else:
-                raise HTTPError(http_status.HTTP_507_INSUFFICIENT_STORAGE)
+                if intent in STORAGE_LIMIT_RESTRICTED_FILE_OPS:
+                    raise HTTPError(http_status.HTTP_507_INSUFFICIENT_STORAGE)
+                return True
         else:
             if node.storage_limit_status.value < 2:
                 return True
+            # Node has restricted file operations because it has exceeded private storage limits
             else:
-                raise HTTPError(http_status.HTTP_507_INSUFFICIENT_STORAGE)
+                if intent in STORAGE_LIMIT_RESTRICTED_FILE_OPS:
+                    raise HTTPError(http_status.HTTP_507_INSUFFICIENT_STORAGE)
+                return True
     return True
 
 def make_auth(user):
@@ -309,6 +322,7 @@ def get_auth(auth, **kwargs):
 
     try:
         action = data['action']
+        intent = data['intent']
         node_id = data['nid']
         provider_name = data['provider']
     except KeyError:
@@ -321,7 +335,7 @@ def get_auth(auth, **kwargs):
         raise HTTPError(http_status.HTTP_404_NOT_FOUND)
 
     check_access(node, auth, action, cas_resp)
-    check_storage_availability(node, provider_name, action)
+    check_storage_availability(node, provider_name, action, intent)
     provider_settings = None
     if hasattr(node, 'get_addon'):
         provider_settings = node.get_addon(provider_name)

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -316,6 +316,15 @@ class ReadOnlyIfRegistration(permissions.BasePermission):
         return True
 
 
+class WriteAdmin(permissions.BasePermission):
+
+    acceptable_models = (AbstractNode,)
+
+    def has_object_permission(self, request, view, obj):
+        auth = get_user_auth(request)
+        return obj.can_edit(auth)
+
+
 class ShowIfVersion(permissions.BasePermission):
 
     def __init__(self, min_version, max_version, deprecated_message):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -280,6 +280,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'registration',
         'root',
         'settings',
+        'storage',
         'subjects',
         'tags',
         'template_from',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -525,6 +525,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view_kwargs={'node_id': '<_id>'},
     ))
 
+    storage = RelationshipField(
+        related_view='nodes:node-storage',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
+
     @property
     def subjects_related_view(self):
         # Overrides TaxonomizableSerializerMixin
@@ -1353,6 +1358,28 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     def update(self, instance, validated_data):
         pass
+
+
+class NodeStorageSerializer(JSONAPISerializer):
+    id = IDField(source='_id', required=True)
+    storage_limit_status = ser.CharField(source='storage_limit_status.name', read_only=True, allow_null=True)
+    storage_usage = ser.CharField(source='formatted_storage_usage', read_only=True, allow_null=True)
+
+    class Meta:
+        type_ = 'node-storage'
+
+    links = LinksField({
+        'self': 'get_absolute_url',
+    })
+
+    def get_absolute_url(self, obj):
+        return absolute_reverse(
+            'nodes:node-storage',
+            kwargs={
+                'node_id': obj._id,
+                'version': self.context['request'].parser_context['kwargs']['version'],
+            },
+        )
 
 
 class NodeStorageProviderSerializer(JSONAPISerializer):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1364,7 +1364,7 @@ class NodeLinksSerializer(JSONAPISerializer):
 class NodeStorageSerializer(JSONAPISerializer):
     id = IDField(source='_id', required=True)
     storage_limit_status = ser.CharField(source='storage_limit_status.name', read_only=True, allow_null=True)
-    storage_usage = ser.CharField(source='formatted_storage_usage', read_only=True, allow_null=True)
+    storage_usage = ser.CharField(read_only=True, allow_null=True)
 
     class Meta:
         type_ = 'node-storage'

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -48,6 +48,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/relationships/subjects/$', views.NodeSubjectsRelationship.as_view(), name=views.NodeSubjectsRelationship.view_name),
     url(r'^(?P<node_id>\w+)/requests/$', views.NodeRequestListCreate.as_view(), name=views.NodeRequestListCreate.view_name),
     url(r'^(?P<node_id>\w+)/settings/$', views.NodeSettings.as_view(), name=views.NodeSettings.view_name),
+    url(r'^(?P<node_id>\w+)/storage/$', views.NodeStorage.as_view(), name=views.NodeStorage.view_name),
     url(r'^(?P<node_id>\w+)/subjects/$', views.NodeSubjectsList.as_view(), name=views.NodeSubjectsList.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/$', views.NodeViewOnlyLinksList.as_view(), name=views.NodeViewOnlyLinksList.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/(?P<link_id>\w+)/$', views.NodeViewOnlyLinkDetail.as_view(), name=views.NodeViewOnlyLinkDetail.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -140,10 +140,6 @@ from addons.osfstorage.models import Region
 from osf.utils.permissions import ADMIN, WRITE_NODE
 from website import mails
 
-import logging
-logger = logging.getLogger(__name__)
-
-
 # This is used to rethrow v1 exceptions as v2
 HTTP_CODE_MAP = {
     400: ValidationError(detail='This add-on has made a bad request.'),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -73,6 +73,7 @@ from api.nodes.permissions import (
     IsAdminContributor,
     IsPublic,
     AdminOrPublic,
+    WriteAdmin,
     ContributorOrPublic,
     AdminContributorOrPublic,
     RegistrationAndPermissionCheckForPointers,
@@ -1732,7 +1733,7 @@ class NodeStorage(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic,
+        WriteAdmin,
     )
 
     required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_WRITE]

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1736,6 +1736,7 @@ class NodeStorage(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin):
     )
 
     required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_WRITE]
+    required_write_scopes = [CoreScopes.NULL]
 
     view_category = 'nodes'
     view_name = 'node-storage'

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -196,7 +196,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'subjects',
             'wiki_enabled']
         # fields that do not appear on registrations
-        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'children', 'groups']
+        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'storage', 'children', 'groups']
 
         for field in NodeSerializer._declared_fields:
             assert_in(field, RegistrationSerializer._declared_fields)

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -155,6 +155,7 @@ class TestNodeRegistrationSerializer:
             'registration_schema',
             'region',
             'provider',
+            'storage',
             'groups',
         ]
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -824,7 +824,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
             project_private.reload()
             assert project_private.is_public
 
-    def test_make_project_private(
+    def test_make_project_private_over_storage_limit(
         self, app, url_public, project_public, user
     ):
         # If the public node exceeds the the private storage limit
@@ -842,7 +842,11 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'This project exceeds private project storage limits and thus cannot be converted into a private project.'
 
+    def test_make_project_private_under_storage_limit(
+        self, app, url_public, project_public, user
+    ):
         # If the public node does not exceed the private storage limit
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project_public._id)
         storage_usage_cache.set(key, (settings.STORAGE_LIMIT_PRIVATE - 1) * settings.GBs, settings.STORAGE_USAGE_CACHE_TIMEOUT)
         res = app.patch_json_api(url_public, {
             'data': {

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -827,19 +827,6 @@ class TestNodeUpdate(NodeCRUDTestCase):
     def test_make_project_private(
         self, app, url_public, project_public, user
     ):
-        # If the node's storage hasn't been calculated yet
-        res = app.patch_json_api(url_public, {
-            'data': {
-                'type': 'nodes',
-                'id': project_public._id,
-                'attributes': {
-                    'public': False
-                }
-            }
-        }, auth=user.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'This project\'s node storage usage could not be calculated. Please try again.'
-
         # If the public node exceeds the the private storage limit
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project_public._id)
         storage_usage_cache.set(key, 7500000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -7,6 +7,8 @@ from nose.tools import *  # noqa:
 
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 from api.base.settings.defaults import API_BASE
+from api.caching import settings as cache_settings
+from api.caching.utils import storage_usage_cache
 from api.taxonomies.serializers import subjects_as_relationships_version
 from api_tests.subjects.mixins import UpdateSubjectsMixin
 from framework.auth.core import Auth
@@ -35,6 +37,7 @@ from rest_framework import exceptions
 from tests.base import fake
 from tests.utils import assert_latest_log, assert_latest_log_not
 from website.views import find_bookmark_collection
+from website import settings
 
 
 @pytest.fixture()
@@ -820,6 +823,50 @@ class TestNodeUpdate(NodeCRUDTestCase):
             assert res.status_code == 200
             project_private.reload()
             assert project_private.is_public
+
+    def test_make_project_private(
+        self, app, url_public, project_public, user
+    ):
+        # If the node's storage hasn't been calculated yet
+        res = app.patch_json_api(url_public, {
+            'data': {
+                'type': 'nodes',
+                'id': project_public._id,
+                'attributes': {
+                    'public': False
+                }
+            }
+        }, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'This project\'s node storage usage could not be calculated. Please try again.'
+
+        # If the public node exceeds the the private storage limit
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project_public._id)
+        storage_usage_cache.set(key, 7500000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+        res = app.patch_json_api(url_public, {
+            'data': {
+                'type': 'nodes',
+                'id': project_public._id,
+                'attributes': {
+                    'public': False
+                }
+            }
+        }, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'This project exceeds private project storage limits and thus cannot be converted into a private project.'
+
+        storage_usage_cache.set(key, 4900000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+        res = app.patch_json_api(url_public, {
+            'data': {
+                'type': 'nodes',
+                'id': project_public._id,
+                'attributes': {
+                    'public': False
+                }
+            }
+        }, auth=user.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['public'] is False
 
     def test_update_errors(
             self, app, user, user_two, title_new, description_new,

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -829,7 +829,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
     ):
         # If the public node exceeds the the private storage limit
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project_public._id)
-        storage_usage_cache.set(key, 7500000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+        storage_usage_cache.set(key, (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs, settings.STORAGE_USAGE_CACHE_TIMEOUT)
         res = app.patch_json_api(url_public, {
             'data': {
                 'type': 'nodes',
@@ -843,7 +843,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert res.json['errors'][0]['detail'] == 'This project exceeds private project storage limits and thus cannot be converted into a private project.'
 
         # If the public node does not exceed the private storage limit
-        storage_usage_cache.set(key, 4900000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+        storage_usage_cache.set(key, (settings.STORAGE_LIMIT_PRIVATE - 1) * settings.GBs, settings.STORAGE_USAGE_CACHE_TIMEOUT)
         res = app.patch_json_api(url_public, {
             'data': {
                 'type': 'nodes',

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -855,6 +855,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'This project exceeds private project storage limits and thus cannot be converted into a private project.'
 
+        # If the public node does not exceed the private storage limit
         storage_usage_cache.set(key, 4900000000, settings.STORAGE_USAGE_CACHE_TIMEOUT)
         res = app.patch_json_api(url_public, {
             'data': {

--- a/api_tests/nodes/views/test_node_storage.py
+++ b/api_tests/nodes/views/test_node_storage.py
@@ -1,0 +1,103 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api.caching import settings as cache_settings
+from api.caching.utils import storage_usage_cache
+from osf_tests.factories import (
+    ProjectFactory,
+    AuthUserFactory
+)
+from osf.utils.permissions import READ, WRITE
+from website import settings
+from website.project.utils import sizeof_fmt
+
+
+@pytest.mark.django_db
+@pytest.mark.enable_quickfiles_creation
+class TestNodeStorage:
+    @pytest.fixture()
+    def admin_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def write_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def read_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def project(self, admin_contributor, write_contributor, read_contributor):
+        project = ProjectFactory(
+            creator=admin_contributor
+        )
+        project.add_contributor(write_contributor, WRITE, visible=False)
+        project.add_contributor(read_contributor, READ)
+        project.save()
+        return project
+
+    @pytest.fixture()
+    def url(self, project):
+        return '/{}nodes/{}/storage/'.format(API_BASE, project._id)
+
+    @pytest.fixture()
+    def embed_url(self, project):
+        return '/{}nodes/{}/?embed=storage'.format(API_BASE, project._id)
+
+    def test_node_storage(self, app, url, embed_url, project, admin_contributor,
+            write_contributor, read_contributor, non_contributor):
+
+        # Test GET unauthenticated
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 401
+
+        # Test GET non_contributor
+        res = app.get(url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Test GET read contrib
+        res = app.get(url, auth=read_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Test GET write contrib
+        # Initial request results in a 202 response, intitiating calculation of storage usage
+        res = app.get(url, auth=write_contributor.auth, expect_errors=True)
+        assert res.status_code == 202
+        data = res.json['data']
+        assert data['attributes']['storage_limit_status'] is None
+        assert data['attributes']['storage_usage'] is None
+
+        # Test POST not allowed
+        res = app.post_json_api(url, auth=write_contributor.auth, expect_errors=True)
+        assert res.status_code == 405
+
+        # Tests Node Storage fo Nodes without Storage Usage
+        res = app.get(url, auth=write_contributor.auth, expect_errors=True)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['attributes']['storage_limit_status'] == 'DEFAULT'
+        assert data['attributes']['storage_usage'] == '0.0B'
+
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
+        storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
+        formatted_storage_usage = sizeof_fmt(storage_usage)
+        storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+
+        # Tests Node Storage for Nodes with Storage Usage
+        res = app.get(url, auth=admin_contributor.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
+        assert data['attributes']['storage_usage'] == formatted_storage_usage
+
+        # Tests Node Storage Embed
+        res = app.get(embed_url, auth=admin_contributor.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['embeds']['storage']['data']['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
+        assert data['embeds']['storage']['data']['attributes']['storage_usage'] == formatted_storage_usage

--- a/api_tests/nodes/views/test_node_storage.py
+++ b/api_tests/nodes/views/test_node_storage.py
@@ -52,6 +52,8 @@ class TestNodeStorage:
     def test_node_storage(self, app, url, embed_url, project, admin_contributor,
             write_contributor, read_contributor, non_contributor):
 
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
+
         # Test GET unauthenticated
         res = app.get(url, expect_errors=True)
         assert res.status_code == 401
@@ -66,6 +68,8 @@ class TestNodeStorage:
 
         # Test GET write contrib
         # Initial request results in a 202 response, intitiating calculation of storage usage
+        storage_usage_cache.delete(key)
+
         res = app.get(url, auth=write_contributor.auth, expect_errors=True)
         assert res.status_code == 202
         data = res.json['data']
@@ -83,7 +87,6 @@ class TestNodeStorage:
         assert data['attributes']['storage_limit_status'] == 'DEFAULT'
         assert data['attributes']['storage_usage'] == '0.0B'
 
-        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
         storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
         formatted_storage_usage = sizeof_fmt(storage_usage)
         storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)

--- a/api_tests/nodes/views/test_node_storage.py
+++ b/api_tests/nodes/views/test_node_storage.py
@@ -9,7 +9,6 @@ from osf_tests.factories import (
 )
 from osf.utils.permissions import READ, WRITE
 from website import settings
-from website.project.utils import sizeof_fmt
 
 
 @pytest.mark.django_db
@@ -69,7 +68,7 @@ class TestNodeStorage:
         assert res.status_code == 200
         data = res.json['data']
         assert data['attributes']['storage_limit_status'] == 'DEFAULT'
-        assert data['attributes']['storage_usage'] == '0.0B'
+        assert data['attributes']['storage_usage'] == '0'
 
     def test_node_storage_request_type(self, app, url, project, write_contributor):
 
@@ -81,7 +80,6 @@ class TestNodeStorage:
 
         # Test Node Storage with OSFStorage Usage
         storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
-        formatted_storage_usage = sizeof_fmt(storage_usage)
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
         storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)
 
@@ -89,13 +87,12 @@ class TestNodeStorage:
         assert res.status_code == 200
         data = res.json['data']
         assert data['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
-        assert data['attributes']['storage_usage'] == formatted_storage_usage
+        assert data['attributes']['storage_usage'] == str(storage_usage)
 
     def test_node_storage_embed(self, app, embed_url, project, admin_contributor):
 
         # Tests Node Storage Embed
         storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
-        formatted_storage_usage = sizeof_fmt(storage_usage)
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
         storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)
 
@@ -103,4 +100,4 @@ class TestNodeStorage:
         assert res.status_code == 200
         data = res.json['data']
         assert data['embeds']['storage']['data']['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
-        assert data['embeds']['storage']['data']['attributes']['storage_usage'] == formatted_storage_usage
+        assert data['embeds']['storage']['data']['attributes']['storage_usage'] == str(storage_usage)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2126,6 +2126,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             elif key == 'category':
                 self.set_category(category=value, auth=auth, save=False)
             elif key == 'is_public':
+                if value is False:
+                    if self.storage_limit_status is not None:
+                        if self.is_public and self.storage_limit_status.value >= 2:
+                            raise NodeUpdateError(reason='This project exceeds private project storage limits and thus cannot be converted into a private project.', key=key)
+                    else:
+                        raise NodeUpdateError(reason='This project\'s node storage usage could not be calculated. Please try again.', key=key)
                 self.set_privacy(
                     Node.PUBLIC if value else Node.PRIVATE,
                     auth=auth,

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2394,7 +2394,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             return storage_usage_total
         else:
             update_storage_usage(self)  # sets cache
-            return storage_usage_cache.get(key) or 0
+            return storage_usage_cache.get(key)
 
     # Overrides ContributorMixin
     # TODO: Deprecate this when we emberize contributors management for nodes

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1232,11 +1232,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 raise NodeStateError('Public registrations must be withdrawn, not made private.')
 
             if auth:
-                if self.storage_limit_status is not None:
-                    if self.storage_limit_status.value >= settings.StorageLimits.OVER_PRIVATE:
-                        raise NodeStateError('This project exceeds private project storage limits and thus cannot be converted into a private project.')
-                else:
+                if self.storage_limit_status is None:
                     raise NodeStateError('This project\'s node storage usage could not be calculated. Please try again.')
+                elif self.storage_limit_status.value >= settings.StorageLimits.OVER_PRIVATE:
+                    raise NodeStateError('This project exceeds private project storage limits and thus cannot be converted into a private project.')
 
             self.is_public = False
             self.keenio_read_key = ''

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -63,7 +63,6 @@ from website.citations.utils import datetime_to_csl
 from website.project import signals as project_signals
 from website.project import tasks as node_tasks
 from website.project.model import NodeUpdateError
-from website.project.utils import sizeof_fmt
 from website.identifiers.tasks import update_doi_metadata_on_change
 from website.identifiers.clients import DataCiteClient
 from osf.utils.permissions import (
@@ -2396,12 +2395,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         else:
             update_storage_usage(self)  # sets cache
             return storage_usage_cache.get(key) or 0
-
-    @property
-    def formatted_storage_usage(self):
-        if self.storage_usage is not None:
-            return sizeof_fmt(self.storage_usage)
-        return None
 
     # Overrides ContributorMixin
     # TODO: Deprecate this when we emberize contributors management for nodes

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1234,9 +1234,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             if auth:
                 if self.storage_limit_status is not None:
                     if self.storage_limit_status.value >= settings.StorageLimits.OVER_PRIVATE:
-                        raise NodeStateError(reason='This project exceeds private project storage limits and thus cannot be converted into a private project.')
+                        raise NodeStateError('This project exceeds private project storage limits and thus cannot be converted into a private project.')
                 else:
-                    raise NodeStateError(reason='This project\'s node storage usage could not be calculated. Please try again.')
+                    raise NodeStateError('This project\'s node storage usage could not be calculated. Please try again.')
 
             self.is_public = False
             self.keenio_read_key = ''

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2128,7 +2128,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             elif key == 'is_public':
                 if value is False:
                     if self.storage_limit_status is not None:
-                        if self.is_public and self.storage_limit_status.value >= 2:
+                        if self.is_public and self.storage_limit_status.value >= settings.StorageLimits.OVER_PRIVATE:
                             raise NodeUpdateError(reason='This project exceeds private project storage limits and thus cannot be converted into a private project.', key=key)
                     else:
                         raise NodeUpdateError(reason='This project\'s node storage usage could not be calculated. Please try again.', key=key)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1982,8 +1982,9 @@ class StorageLimits(enum.IntEnum):
     DEFAULT = 0
     APPROACHING_PRIVATE = 1
     OVER_PRIVATE = 2
-    OVER_PUBLIC = 3
-    APPROACHING_PUBLIC = 4
+    APPROACHING_PUBLIC = 3
+    OVER_PUBLIC = 4
+
 
     @classmethod
     def from_node_usage(cls,  usage_bytes, private_limit=None, public_limit=None):

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1967,6 +1967,8 @@ STORAGE_WARNING_THRESHOLD = .9  # percent of maximum storage used before users g
 STORAGE_LIMIT_PUBLIC = 50
 STORAGE_LIMIT_PRIVATE = 5
 
+GBs = 10 ** 9
+
 
 #  Needs to be here so the enum can be used in the admin template
 def forDjango(cls):


### PR DESCRIPTION
## Purpose
Adds a node storage endpoint to access the storage usage (on OSFStorage) and storage limit status of a node and disallows a public project from being converted to a private project if it exceeds private storage limits.

## Changes
* Adds a `formatted_storage_usage` property to the Node model
* Adds checks to ensure the `storage_usage` property exists before calculating dependent properties
* Creates a NodeStorage API Endpoint
  * Adds NodeStorage relationship to NodeSerializer (creating an embeddable relationship)
  * Adds a WriteAdmin permission for any actions
* Ensures private storage limits are respected before converting a public node into a private node

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the NodeStorage endpoint (`/v2/nodes/<node_id>/storage`) works for those with Write/Admin rights to the Node
  - If the `storage_usage` or `storage_limit_status` is not available, the results will be `null` with a `202` status code. If they are available, the results will be available with a `200` status code.
- Verify the `storage` endpoint is available on NodeDetail endpoint
  - Verify `?embed=storage` works on NodeDetail endpoints
- Verify that public projects exceeding private storage usage limits cannot be converted to private projects and that public projects under private storage usage limits may be converted.

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation
API Documentation should be added for the new NodeStorage endpoint

## Side Effects
None Anticipated

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2122)
