### PR TITLE
[ENG-1429] [OSF Institutions] Shared SSO and The Policy Lab

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -24,6 +24,43 @@ from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
 
 logger = logging.getLogger(__name__)
 
+# This map defines how to find the secondary institution IdP which uses the shared SSO of a primary
+# IdP. Each map entry has the following format.
+#
+#    '<ID of the primary institution A>': {
+#        'criteria': 'attribute',
+#        'attribute': '<the attribute name for identifying secondary institutions>',
+#        'institutions': {
+#            '<attribute value for identifying institution A1>': '<ID of secondary institution A1>',
+#            '<attribute value for identifying institution A2>': '<ID of secondary institution A2>',
+#            ...
+#        },
+#        ...
+#    }
+#
+# Currently, the only active criteria is "attribute", which the primary institution IdP releases to
+# OSF for us to identify the secondary institution. Another option is "emailDomain". For example:
+#
+#    '<ID of the primary institution B>': {
+#        'criteria': 'emailDomain',
+#        'institutions': {
+#            '<the email domain for identifying institution B1>': '<ID of secondary institution B1',
+#            '<the email domain for identifying institution B2>': '<ID of secondary institution B2',
+#            ...
+#        }
+#        ...
+#    }
+#
+INSTITUTION_SHARED_SSO_MAP = {
+    'brown': {
+        'criteria': 'attribute',
+        'attribute': 'isMemberOf',
+        'institutions': {
+            'thepolicylab': 'thepolicylab',
+        },
+    },
+}
+
 
 class InstitutionAuthentication(BaseAuthentication):
     """A dedicated authentication class for view ``InstitutionAuth``.
@@ -85,6 +122,49 @@ class InstitutionAuthentication(BaseAuthentication):
         middle_names = provider['user'].get('middleNames')
         suffix = provider['user'].get('suffix')
         department = provider['user'].get('department')
+
+        # Check secondary institutions which uses the SSO of primary ones
+        secondary_institution = None
+        if provider['id'] in INSTITUTION_SHARED_SSO_MAP:
+            switch_map = INSTITUTION_SHARED_SSO_MAP[provider['id']]
+            criteria_type = switch_map.get('criteria')
+            if criteria_type == 'attribute':
+                attribute_name = switch_map.get('attribute')
+                attribute_value = provider['user'].get(attribute_name)
+                if attribute_value:
+                    secondary_institution_id = switch_map.get(
+                        'institutions',
+                        {},
+                    ).get(attribute_value)
+                    logger.info(
+                        'Institution SSO: primary=[{}], secondary=[{}], '
+                        'user=[{}]'.format(provider['id'], secondary_institution_id, username),
+                    )
+                    secondary_institution = Institution.load(secondary_institution_id)
+                    if not secondary_institution:
+                        # Log warnings and inform Sentry but do not raise an exception if OSF fails
+                        # to load the secondary institution from database
+                        logger.warning(
+                            'Institution SSO warning: invalid secondary institution '
+                            '[{}]'.format(secondary_institution_id),
+                        )
+                        sentry.log_message(
+                            'Invalid secondary institution: primary=[{}], secondary=[{}], username='
+                            '[{}]'.format(secondary_institution_id, provider['id'], username),
+                        )
+                else:
+                    # SSO from primary institution only
+                    logger.info(
+                        'Institution SSO: primary=[{}], secondary=[None], '
+                        'user=[{}]'.format(provider['id'], username),
+                    )
+            else:
+                logger.warning('Institution SSO warning: criteria type [{}] '
+                               'invalid or not implemented'.format(criteria_type))
+                sentry.log_message(
+                    'Criteria type invalid or not implemented: criteria=[{}], primary=[{}], '
+                    'username=[{}]'.format(criteria_type, provider['id'], username),
+                )
 
         # Use given name and family name to build full name if it is not provided
         if given_name and family_name and not fullname:
@@ -204,9 +284,14 @@ class InstitutionAuthentication(BaseAuthentication):
                 storage_flag_is_active=waffle.flag_is_active(request, features.STORAGE_I18N),
             )
 
-        # Affiliate the user if not previously affiliated
+        # Affiliate the user to the primary institution if not previously affiliated
         if not user.is_affiliated_with_institution(institution):
             user.affiliated_institutions.add(institution)
+            user.save()
+
+        # Affiliate the user to the secondary institution if not previously affiliated
+        if secondary_institution and not user.is_affiliated_with_institution(secondary_institution):
+            user.affiliated_institutions.add(secondary_institution)
             user.save()
 
         return user, None

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from api.base import settings
 from api.base.settings.defaults import API_BASE
+from api.institutions.authentication import INSTITUTION_SHARED_SSO_MAP
 
 from framework.auth import signals, Auth
 from framework.auth.views import send_confirm_email
@@ -28,6 +29,7 @@ def make_payload(
         given_name='',
         family_name='',
         department='',
+        is_member_of='',
 ):
 
     data = {
@@ -40,7 +42,8 @@ def make_payload(
                 'fullname': fullname,
                 'suffix': '',
                 'username': username,
-                'department': department
+                'department': department,
+                'isMemberOf': is_member_of
             }
         }
     }
@@ -58,16 +61,34 @@ def make_payload(
     )
 
 
+@pytest.fixture()
+def institution():
+    return InstitutionFactory()
+
+
+@pytest.fixture()
+def institution_primary():
+    institution = InstitutionFactory()
+    institution._id = 'brown'
+    institution.save()
+    return institution
+
+
+@pytest.fixture()
+def institution_secondary():
+    institution = InstitutionFactory()
+    institution._id = 'thepolicylab'
+    institution.save()
+    return institution
+
+
+@pytest.fixture()
+def url_auth_institution():
+    return '/{0}institutions/auth/'.format(API_BASE)
+
+
 @pytest.mark.django_db
 class TestInstitutionAuth:
-
-    @pytest.fixture()
-    def institution(self):
-        return InstitutionFactory()
-
-    @pytest.fixture()
-    def url_auth_institution(self):
-        return '/{0}institutions/auth/'.format(API_BASE)
 
     def test_invalid_payload(self, app, url_auth_institution):
         res = app.post(url_auth_institution, 'INVALID_PAYLOAD', expect_errors=True)
@@ -373,3 +394,236 @@ class TestInstitutionAuth:
         assert email_verifications == user.email_verifications
         assert accepted_terms_of_service == user.accepted_terms_of_service
         assert not user.has_usable_password()
+
+
+@pytest.mark.django_db
+class TestInstitutionAuthnSharedSSO:
+
+    def test_new_user_primary_only(self, app, url_auth_institution,
+                                        institution_primary, institution_secondary):
+
+        username = 'user_created@osf.edu'
+        assert OSFUser.objects.filter(username=username).count() == 0
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution, make_payload(institution_primary, username))
+        assert res.status_code == 204
+        assert mock_signals.signals_sent() == set([signals.user_confirmed])
+
+        user = OSFUser.objects.filter(username=username).first()
+        assert user
+        assert user.fullname == 'Fake User'
+        assert user.accepted_terms_of_service is not None
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()
+
+    def test_new_user_primary_and_secondary(self, app, url_auth_institution,
+                                                 institution_primary, institution_secondary):
+
+        username = 'user_created@osf.edu'
+        assert OSFUser.objects.filter(username=username).count() == 0
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert mock_signals.signals_sent() == set([signals.user_confirmed])
+
+        user = OSFUser.objects.filter(username=username).first()
+        assert user
+        assert user.fullname == 'Fake User'
+        assert user.accepted_terms_of_service is not None
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary in user.affiliated_institutions.all()
+
+    def test_existing_user_primary_only_not_affiliated(self, app, url_auth_institution,
+                                                       institution_primary, institution_secondary):
+        username = 'user_not_affiliated@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution, make_payload(institution_primary, username))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()
+
+    def test_existing_user_primary_only_affiliated(self, app, url_auth_institution,
+                                                   institution_primary, institution_secondary):
+        username = 'user_affiliated@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution, make_payload(institution_primary, username))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()
+
+    def test_existing_user_both_not_affiliated(self, app, url_auth_institution,
+                                               institution_primary, institution_secondary):
+
+        username = 'user_both_not_affiliated@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations + 2
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary in user.affiliated_institutions.all()
+
+    def test_existing_user_both_affiliated(self, app, url_auth_institution,
+                                           institution_primary, institution_secondary):
+
+        username = 'user_both_affiliated@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.affiliated_institutions.add(institution_secondary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary in user.affiliated_institutions.all()
+
+    def test_existing_user_secondary_not_affiliated(self, app, url_auth_institution,
+                                                    institution_primary, institution_secondary):
+
+        username = 'user_secondary_not@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary in user.affiliated_institutions.all()
+
+    def test_invalid_criteria_type(self, app, url_auth_institution,
+                                   institution_primary, institution_secondary):
+
+        INSTITUTION_SHARED_SSO_MAP.update({
+            'brown': {
+                'criteria': 'emailDomain',
+                'institutions': {
+                    'policylab.io': 'thepolicylab',
+                }
+            },
+        })
+
+        username = 'user_invalid_criteria@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()
+
+    def test_invalid_secondary_institution(self, app, url_auth_institution,
+                                           institution_primary, institution_secondary):
+
+        INSTITUTION_SHARED_SSO_MAP.update({
+            'brown': {
+                'criteria': 'attribute',
+                'attribute': 'isMemberOf',
+                'institutions': {
+                    'thepolicylab': 'brownlab',
+                }
+            },
+        })
+
+        username = 'user_invalid_criteria@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='thepolicylab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()
+
+    def test_empty_secondary_institution(self, app, url_auth_institution,
+                                         institution_primary, institution_secondary):
+
+        INSTITUTION_SHARED_SSO_MAP.update({
+            'brown': {
+                'criteria': 'attribute',
+                'attribute': 'isMemberOf',
+                'institutions': {
+                    'thepolicylab': 'thepolicylab',
+                }
+            },
+        })
+
+        username = 'user_invalid_criteria@primary.edu'
+        user = make_user(username, 'Foo Bar')
+        user.affiliated_institutions.add(institution_primary)
+        user.save()
+        number_of_affiliations = user.affiliated_institutions.count()
+
+        with capture_signals() as mock_signals:
+            res = app.post(url_auth_institution,
+                           make_payload(institution_primary, username, is_member_of='brownlab'))
+        assert res.status_code == 204
+        assert not mock_signals.signals_sent()
+
+        user.reload()
+        assert user.fullname == 'Foo Bar'
+        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert institution_primary in user.affiliated_institutions.all()
+        assert institution_secondary not in user.affiliated_institutions.all()

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -621,6 +621,18 @@ INSTITUTIONS = {
                 'delegation_protocol': 'saml-shib',
             },
             {
+                '_id': 'thepolicylab',
+                'name': 'The Policy Lab at Brown University',
+                'description': 'The Policy Lab at Brown University conducts applied research to improve public policy in Rhode Island and beyond.<br />Learn more at <a href="https://thepolicylab.brown.edu/">thepolicylab.brown.edu</a> and tune into our podcast, <a href="https://thirtythousandleagues.com/">30,000 Leagues</a>.',
+                'banner_name': 'thepolicylab-banner.png',
+                'logo_name': 'thepolicylab-shield.png',
+                'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://sso.brown.edu/idp/shibboleth')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
+                'domains': [],
+                'email_domains': [],
+                'delegation_protocol': 'saml-shib',
+            },
+            {
                 '_id': 'thelabatdc',
                 'name': 'The Lab @ DC',
                 'description': 'The Lab @ DC is an entity of the <a href="https://mayor.dc.gov/">Executive Office of the Mayor of the District of Columbia Government</a>. We work in the <a href="https://oca.dc.gov/">Office of the City Administrator</a> and in partnership with a network of universities and research centers to apply the scientific method into day-to-day governance.',


### PR DESCRIPTION
## Purpose

* Implement a feature that different institutions can share the same SSO
* Add the `thepolicylab` to `prod` using `brown`'s SSO of type `saml-shib`

## Changes

* Use a hard-coded map for identifying secondary institutions, which is an easy solution for now without re-design the institution model.
* As long as `brown` SSO succeeds, the authentication is successful. Errors with secondary institution only prevents the extra affiliation of the secondary one.
* Both institutions will be affiliated for `thepolicylab` users, which is a Product suggestion.
* Added API tests to cover both major and corner cases
* Integration tests with https://github.com/CenterForOpenScience/cas-overlay/pull/189 passed as well

## DevOps Notes

### OSF

Run the script to add `thepolicylab` to `prod` institutions.

```
python3 -m scripts.populate_institutions -e prod -i thepolicylab
```

There is no need to update the `test` server.

### Shibboleth

Add the following line to the file `attribute-map.xml`.

```
<Attribute name="urn:oid:1.3.6.1.4.1.5923.1.5.1.1" id="isMemberOf"/>
```

### CAS

Add the following line to the `brown` block in the `institutions-auth.xsl ` file.

```
<isMemberOf><xsl:value-of select="//attribute[@name='isMemberOf']/@value"/></isMemberOf>
```

## QA Notes

N / A

## Documentation

N / A

## Side Effects

N / A

## Ticket

https://openscience.atlassian.net/browse/ENG-1429