### PR TITLE
Storage usage hotfix [ENG-2253] [hotfix]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -519,8 +519,8 @@ def create_waterbutler_log(payload, **kwargs):
 
     metadata = payload.get('metadata') or payload.get('destination')
 
-    node = AbstractNode.load(metadata.get('nid'))
-    if node and not node.is_quickfiles and payload['action'] != 'download_file':
+    target_node = AbstractNode.load(metadata.get('nid'))
+    if target_node and not target_node.is_quickfiles and payload['action'] != 'download_file':
         update_storage_usage_with_size(payload)
 
     with transaction.atomic():

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -518,7 +518,9 @@ def create_waterbutler_log(payload, **kwargs):
             node.create_waterbutler_log(auth, action, payload)
 
     metadata = payload.get('metadata') or payload.get('destination')
-    if metadata.get('nid') and AbstractNode.load(metadata['nid']) and payload['action'] != 'download_file':
+
+    node = AbstractNode.load(metadata.get('nid'))
+    if node and not node.is_quickfiles and payload['action'] != 'download_file':
         update_storage_usage_with_size(payload)
 
     with transaction.atomic():

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -160,7 +160,7 @@ def update_storage_usage_with_size(payload):
     target_file_id = metadata['path'].replace('/', '')
     target_file_size = metadata.get('size', 0)
 
-    current_usage = target_node.storage_usage or 0
+    current_usage = target_node.storage_usage
     target_file = BaseFileNode.load(target_file_id)
 
     if target_file and action in ['copy', 'delete', 'move']:
@@ -180,7 +180,7 @@ def update_storage_usage_with_size(payload):
         if target_node == source_node and source_provider == provider:
             return  # Its not going anywhere.
         if source_provider == 'osfstorage' and not source_node.is_quickfiles:
-            source_node_usage = source_node.storage_usage or 0
+            source_node_usage = source_node.storage_usage
             source_node_usage = max(source_node_usage - target_file_size, 0)
 
             key = cache_settings.STORAGE_USAGE_KEY.format(target_id=source_node._id)

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -180,7 +180,7 @@ def update_storage_usage_with_size(payload):
         if target_node == source_node and source_provider == provider:
             return  # Its not going anywhere.
         if source_provider == 'osfstorage':
-            source_node_usage = source_node.storage_usage
+            source_node_usage = source_node.storage_usage or 0
             source_node_usage = max(source_node_usage - target_file_size, 0)
 
             key = cache_settings.STORAGE_USAGE_KEY.format(target_id=source_node._id)

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -179,7 +179,7 @@ def update_storage_usage_with_size(payload):
         source_provider = payload['source']['provider']
         if target_node == source_node and source_provider == provider:
             return  # Its not going anywhere.
-        if source_provider == 'osfstorage':
+        if source_provider == 'osfstorage' and not source_node.is_quickfiles:
             source_node_usage = source_node.storage_usage or 0
             source_node_usage = max(source_node_usage - target_file_size, 0)
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2385,7 +2385,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             return storage_usage_total
         else:
             update_storage_usage(self)  # sets cache
-            return storage_usage_cache.get(key)
+            return storage_usage_cache.get(key) or 0
 
     # Overrides ContributorMixin
     # TODO: Deprecate this when we emberize contributors management for nodes

--- a/osf_tests/test_storage_usage_limits.py
+++ b/osf_tests/test_storage_usage_limits.py
@@ -14,7 +14,7 @@ class TestStorageUsageLimits:
         return ProjectFactory()
 
     def test_limit_default(self, node):
-        assert node.storage_usage is None
+        assert node.storage_usage is 0
 
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=node._id)
         storage_usage_cache.set(key, 0)


### PR DESCRIPTION


## Purpose

Quickfiles weren't excluded from storage usage calculations.

## Changes

Adding logic to exclude quickfiles. Preventing a nonetype error

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify Quickfiles aren't calculated
-Do a move to a node that has no storage yet.

What are the areas of risk? This catches existing errors, shouldn't add risk.

Any concerns/considerations/questions that development raised?

## Documentation

N/A

## Side Effects

N/A
## Ticket

https://openscience.atlassian.net/browse/ENG-2253