### PR TITLE
Prohibit file upload for read only token [ENG-2221]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -254,20 +254,19 @@ def get_metric_class_for_action(action, from_mfr):
 @collect_auth
 def get_auth(auth, **kwargs):
     cas_resp = None
-    if not auth.user:
-        # Central Authentication Server OAuth Bearer Token
-        authorization = request.headers.get('Authorization')
-        if authorization and authorization.startswith('Bearer '):
-            client = cas.get_client()
-            try:
-                access_token = cas.parse_auth_header(authorization)
-                cas_resp = client.profile(access_token)
-            except cas.CasError as err:
-                sentry.log_exception()
-                # NOTE: We assume that the request is an AJAX request
-                return json_renderer(err)
-            if cas_resp.authenticated:
-                auth.user = OSFUser.load(cas_resp.user)
+    # Central Authentication Server OAuth Bearer Token
+    authorization = request.headers.get('Authorization')
+    if authorization and authorization.startswith('Bearer '):
+        client = cas.get_client()
+        try:
+            access_token = cas.parse_auth_header(authorization)
+            cas_resp = client.profile(access_token)
+        except cas.CasError as err:
+            sentry.log_exception()
+            # NOTE: We assume that the request is an AJAX request
+            return json_renderer(err)
+        if cas_resp.authenticated and not getattr(auth, 'user'):
+            auth.user = OSFUser.load(cas_resp.user)
 
     try:
         data = jwt.decode(


### PR DESCRIPTION


## Purpose

Personal access tokens with only a read only scope should not be able to upload files. Currently they can. Thats not good

## Changes

Ensuring tokens are checked for all authentication operations, even if user.auth is present

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Make a personal access token with full read scope. Create a project, and use the command found in the ticket to ensure it gives you an error

What are the areas of risk?

Shouldn't be any.

Any concerns/considerations/questions that development raised?

N/A

## Documentation

N/A

## Side Effects

Shouldn't be

## Ticket

https://openscience.atlassian.net/browse/ENG-2221