### PR TITLE
[Hotfix] Fix link to reauthorize github access token help page

### DIFF
--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -128,7 +128,7 @@
                                         <h4>Don’t see your GitHub organization repositories?</h4>
                                         <p>
                                             You may need to reauthorize your GitHub access token.
-                                            Follow the steps in the <a class="alert-link" href="http://help.osf.io/a/850865-reauthorize-github" target="_black">help guide</a> to resolve the issue. <br>
+                                            Follow the steps in the <a class="alert-link" href="https://help.osf.io/hc/en-us/articles/360054256674-reauthorize-github" target="_black">help guide</a> to resolve the issue. <br>
                                         </p>
                                         <p>
                                             Please contact <a class="alert-link" href="mailto:support@osf.io">support@osf.io</a> if you have questions.


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The old link to the Github access token page was broken, so updating that

## Changes
- Updated target link for the aforementioned help page

## QA Notes
- Please verify that the link in the project add-ons page (osf.io/<project_id>/addons ) goes to the appropriate help page
![image](https://user-images.githubusercontent.com/51409893/94277601-c9037880-ff17-11ea-8cba-d24b97c6a347.png)


## Documentation
`NA`

## Side Effects
`NA`

## Ticket
`NA`
