### PR TITLE
[ENG-2272] Have open-ended registration form expect files

### DIFF
--- a/website/project/metadata/osf-open-ended-3.json
+++ b/website/project/metadata/osf-open-ended-3.json
@@ -1,6 +1,9 @@
 {
     "name": "Open-Ended Registration",
     "version": 3,
+    "config": {
+    	"hasFiles": true
+    },
     "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length.",
     "pages": [{
         "id": "page1",


### PR DESCRIPTION
## Purpose

Have the Open-Ended Registration form expect files so that any attached files are associated with the registration rather than the node.

## Changes

Add `config.hasFiles=true` to the registration form.

## QA Notes

- Verify that making a registration with the open-ended registration form and a file attached will, when you click on that file's link in the registration, take you to the registration's file.

What are the areas of risk? Low risk. 

Any concerns/considerations/questions that development raised? No

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-2272
