### PR TITLE
[ENG-2247] Creates a Node quota_status v1 endpoint for WB to enforce storage limits

### DIFF
--- a/addons/osfstorage/routes.py
+++ b/addons/osfstorage/routes.py
@@ -23,6 +23,15 @@ api_routes = {
 
         Rule(
             [
+                '/<guid>/osfstorage/quota_status/',
+            ],
+            'get',
+            views.osfstorage_get_storage_quota_status,
+            json_renderer
+        ),
+
+        Rule(
+            [
                 '/<guid>/osfstorage/<fid>/',
             ],
             'delete',

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -316,6 +316,15 @@ class ReadOnlyIfRegistration(permissions.BasePermission):
         return True
 
 
+class WriteAdmin(permissions.BasePermission):
+
+    acceptable_models = (AbstractNode,)
+
+    def has_object_permission(self, request, view, obj):
+        auth = get_user_auth(request)
+        return obj.can_edit(auth)
+
+
 class ShowIfVersion(permissions.BasePermission):
 
     def __init__(self, min_version, max_version, deprecated_message):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -280,6 +280,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'registration',
         'root',
         'settings',
+        'storage',
         'subjects',
         'tags',
         'template_from',
@@ -524,6 +525,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view='nodes:node-preprints',
         related_view_kwargs={'node_id': '<_id>'},
     ))
+
+    storage = RelationshipField(
+        related_view='nodes:node-storage',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
 
     @property
     def subjects_related_view(self):
@@ -1353,6 +1359,28 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     def update(self, instance, validated_data):
         pass
+
+
+class NodeStorageSerializer(JSONAPISerializer):
+    id = IDField(source='_id', required=True)
+    storage_limit_status = ser.CharField(source='storage_limit_status.name', read_only=True, allow_null=True)
+    storage_usage = ser.CharField(source='formatted_storage_usage', read_only=True, allow_null=True)
+
+    class Meta:
+        type_ = 'node-storage'
+
+    links = LinksField({
+        'self': 'get_absolute_url',
+    })
+
+    def get_absolute_url(self, obj):
+        return absolute_reverse(
+            'nodes:node-storage',
+            kwargs={
+                'node_id': obj._id,
+                'version': self.context['request'].parser_context['kwargs']['version'],
+            },
+        )
 
 
 class NodeStorageProviderSerializer(JSONAPISerializer):

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -48,6 +48,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/relationships/subjects/$', views.NodeSubjectsRelationship.as_view(), name=views.NodeSubjectsRelationship.view_name),
     url(r'^(?P<node_id>\w+)/requests/$', views.NodeRequestListCreate.as_view(), name=views.NodeRequestListCreate.view_name),
     url(r'^(?P<node_id>\w+)/settings/$', views.NodeSettings.as_view(), name=views.NodeSettings.view_name),
+    url(r'^(?P<node_id>\w+)/storage/$', views.NodeStorage.as_view(), name=views.NodeStorage.view_name),
     url(r'^(?P<node_id>\w+)/subjects/$', views.NodeSubjectsList.as_view(), name=views.NodeSubjectsList.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/$', views.NodeViewOnlyLinksList.as_view(), name=views.NodeViewOnlyLinksList.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/(?P<link_id>\w+)/$', views.NodeViewOnlyLinkDetail.as_view(), name=views.NodeViewOnlyLinkDetail.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -8,7 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import PermissionDenied, ValidationError, NotFound, MethodNotAllowed, NotAuthenticated
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT
 
 from addons.base.exceptions import InvalidAuthError
 from addons.osfstorage.models import OsfStorageFolder
@@ -73,6 +73,7 @@ from api.nodes.permissions import (
     IsAdminContributor,
     IsPublic,
     AdminOrPublic,
+    WriteAdmin,
     ContributorOrPublic,
     AdminContributorOrPublic,
     RegistrationAndPermissionCheckForPointers,
@@ -104,6 +105,7 @@ from api.nodes.serializers import (
     NodeViewOnlyLinkUpdateSerializer,
     NodeSettingsSerializer,
     NodeSettingsUpdateSerializer,
+    NodeStorageSerializer,
     NodeCitationSerializer,
     NodeCitationStyleSerializer,
     NodeGroupsSerializer,
@@ -1723,6 +1725,35 @@ class NodeInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestr
         except RelationshipPostMakesNoChanges:
             return Response(status=HTTP_204_NO_CONTENT)
         return ret
+
+
+class NodeStorage(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin):
+    """The documentation for this endpoint should be found [here](https://developer.osf.io/#operation/node_storage)
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        WriteAdmin,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_WRITE]
+    required_write_scopes = [CoreScopes.NULL]
+
+    view_category = 'nodes'
+    view_name = 'node-storage'
+
+    serializer_class = NodeStorageSerializer
+
+    def get_object(self):
+        return self.get_node()
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        if instance.storage_usage is None:
+            return Response(serializer.data, status=HTTP_202_ACCEPTED)
+        else:
+            return Response(serializer.data)
 
 
 class NodeSubjectsList(BaseResourceSubjectsList, NodeMixin):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -196,7 +196,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             'subjects',
             'wiki_enabled']
         # fields that do not appear on registrations
-        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'children', 'groups']
+        non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'storage', 'children', 'groups']
 
         for field in NodeSerializer._declared_fields:
             assert_in(field, RegistrationSerializer._declared_fields)

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -155,6 +155,7 @@ class TestNodeRegistrationSerializer:
             'registration_schema',
             'region',
             'provider',
+            'storage',
             'groups',
         ]
 

--- a/api_tests/nodes/views/test_node_storage.py
+++ b/api_tests/nodes/views/test_node_storage.py
@@ -1,0 +1,106 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api.caching import settings as cache_settings
+from api.caching.utils import storage_usage_cache
+from osf_tests.factories import (
+    ProjectFactory,
+    AuthUserFactory
+)
+from osf.utils.permissions import READ, WRITE
+from website import settings
+from website.project.utils import sizeof_fmt
+
+
+@pytest.mark.django_db
+@pytest.mark.enable_quickfiles_creation
+class TestNodeStorage:
+    @pytest.fixture()
+    def admin_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def write_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def read_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def project(self, admin_contributor, write_contributor, read_contributor):
+        project = ProjectFactory(
+            creator=admin_contributor
+        )
+        project.add_contributor(write_contributor, WRITE, visible=False)
+        project.add_contributor(read_contributor, READ)
+        project.save()
+        return project
+
+    @pytest.fixture()
+    def url(self, project):
+        return '/{}nodes/{}/storage/'.format(API_BASE, project._id)
+
+    @pytest.fixture()
+    def embed_url(self, project):
+        return '/{}nodes/{}/?embed=storage'.format(API_BASE, project._id)
+
+    def test_node_storage_permissions(self, app, url, project,
+            write_contributor, read_contributor, non_contributor):
+
+        # Test GET unauthenticated
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 401
+
+        # Test GET non_contributor
+        res = app.get(url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Test GET read contrib
+        res = app.get(url, auth=read_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # Tests Node Storage fo Nodes without Storage Usage
+        res = app.get(url, auth=write_contributor.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['attributes']['storage_limit_status'] == 'DEFAULT'
+        assert data['attributes']['storage_usage'] == '0.0B'
+
+    def test_node_storage_request_type(self, app, url, project, write_contributor):
+
+        # Test POST not allowed
+        res = app.post_json_api(url, auth=write_contributor.auth, expect_errors=True)
+        assert res.status_code == 405
+
+    def test_node_storage_with_storage_usage(self, app, url, project, admin_contributor):
+
+        # Test Node Storage with OSFStorage Usage
+        storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
+        formatted_storage_usage = sizeof_fmt(storage_usage)
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
+        storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+
+        res = app.get(url, auth=admin_contributor.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
+        assert data['attributes']['storage_usage'] == formatted_storage_usage
+
+    def test_node_storage_embed(self, app, embed_url, project, admin_contributor):
+
+        # Tests Node Storage Embed
+        storage_usage = (settings.STORAGE_LIMIT_PRIVATE + 1) * settings.GBs
+        formatted_storage_usage = sizeof_fmt(storage_usage)
+        key = cache_settings.STORAGE_USAGE_KEY.format(target_id=project._id)
+        storage_usage_cache.set(key, storage_usage, settings.STORAGE_USAGE_CACHE_TIMEOUT)
+
+        res = app.get(embed_url, auth=admin_contributor.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert data['embeds']['storage']['data']['attributes']['storage_limit_status'] == 'OVER_PRIVATE'
+        assert data['embeds']['storage']['data']['attributes']['storage_usage'] == formatted_storage_usage

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -63,6 +63,7 @@ from website.citations.utils import datetime_to_csl
 from website.project import signals as project_signals
 from website.project import tasks as node_tasks
 from website.project.model import NodeUpdateError
+from website.project.utils import sizeof_fmt
 from website.identifiers.tasks import update_doi_metadata_on_change
 from website.identifiers.clients import DataCiteClient
 from osf.utils.permissions import (
@@ -398,12 +399,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def storage_limit_status(self):
         """ This should indicate if a node is at or over a certain storage threshold indicating a status. If nodes have
         a custom limit this should indicate that."""
-
-        return settings.StorageLimits.from_node_usage(
-            self.storage_usage,
-            self.custom_storage_usage_limit_private,
-            self.custom_storage_usage_limit_public
-        )
+        if self.storage_usage is not None:
+            return settings.StorageLimits.from_node_usage(
+                self.storage_usage,
+                self.custom_storage_usage_limit_private,
+                self.custom_storage_usage_limit_public
+            )
 
     @property
     def nodes(self):
@@ -1229,9 +1230,15 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         elif permissions == 'private' and self.is_public:
             if self.is_registration and not self.is_pending_embargo:
                 raise NodeStateError('Public registrations must be withdrawn, not made private.')
-            else:
-                self.is_public = False
-                self.keenio_read_key = ''
+
+            if auth:
+                if self.storage_limit_status is None:
+                    raise NodeStateError('This project\'s node storage usage could not be calculated. Please try again.')
+                elif self.storage_limit_status.value >= settings.StorageLimits.OVER_PRIVATE:
+                    raise NodeStateError('This project exceeds private project storage limits and thus cannot be converted into a private project.')
+
+            self.is_public = False
+            self.keenio_read_key = ''
         else:
             return False
 
@@ -2381,11 +2388,17 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=self._id)
 
         storage_usage_total = storage_usage_cache.get(key)
-        if storage_usage_total:
+        if storage_usage_total is not None:
             return storage_usage_total
         else:
             update_storage_usage(self)  # sets cache
             return storage_usage_cache.get(key) or 0
+
+    @property
+    def formatted_storage_usage(self):
+        if self.storage_usage is not None:
+            return sizeof_fmt(self.storage_usage)
+        return None
 
     # Overrides ContributorMixin
     # TODO: Deprecate this when we emberize contributors management for nodes

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1967,6 +1967,8 @@ STORAGE_WARNING_THRESHOLD = .9  # percent of maximum storage used before users g
 STORAGE_LIMIT_PUBLIC = 50
 STORAGE_LIMIT_PRIVATE = 5
 
+GBs = 10 ** 9
+
 
 #  Needs to be here so the enum can be used in the admin template
 def forDjango(cls):
@@ -1982,8 +1984,9 @@ class StorageLimits(enum.IntEnum):
     DEFAULT = 0
     APPROACHING_PRIVATE = 1
     OVER_PRIVATE = 2
-    OVER_PUBLIC = 3
-    APPROACHING_PUBLIC = 4
+    APPROACHING_PUBLIC = 3
+    OVER_PUBLIC = 4
+
 
     @classmethod
     def from_node_usage(cls,  usage_bytes, private_limit=None, public_limit=None):


### PR DESCRIPTION
## Purpose
Provides Waterbutler with an endpoint to check if a node has exceeded storage limits prior to conducting file operations

## Changes
* Adds an endpoint (`api/v1/<guid>/osfstorage/quota_status/`) for WB to check the `over_quota` status of a node
* Adds tests for the new endpoint

## QA Notes
Dev Tested (Endpoint can only be accessed by WB)

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2247)
