### PR TITLE
Adding post endpoints for registries moderation [ENG-2130]

### DIFF
--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 from rest_framework import generics
 from rest_framework import serializers as ser
 from rest_framework import status as http_status
+from rest_framework.exceptions import PermissionDenied
 
-from framework.exceptions import HTTPError
+from framework.exceptions import HTTPError, PermissionsError
 
 from api.base import utils
 from api.base.exceptions import Conflict
@@ -291,7 +292,6 @@ class RegistrationActionSerializer(BaseActionSerializer):
                 retraction = target.retract_registration(
                     user=user, justification=comment,
                 )
-                retraction.accept(user=None)
                 retraction.accept(user)
             else:
                 raise JSONAPIAttributeException(attribute='trigger', detail='Invalid trigger.')
@@ -303,5 +303,7 @@ class RegistrationActionSerializer(BaseActionSerializer):
                 http_status.HTTP_400_BAD_REQUEST,
                 data={'message_short': short_message, 'message_long': long_message},
             )
+        except PermissionsError:
+            raise PermissionDenied('You do not have permission to perform this trigger at this time')
 
         return target.actions.last()

--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -256,7 +256,7 @@ class RegistrationActionSerializer(BaseActionSerializer):
 
     permissions = ser.ChoiceField(choices=permissions.API_CONTRIBUTOR_PERMISSIONS, required=False)
     visible = ser.BooleanField(default=True, required=False)
-    trigger = ser.ChoiceField(choices=RegistrationModerationTriggers.char_choices())
+    trigger = ser.ChoiceField(choices=RegistrationModerationTriggers.char_field_choices())
 
     target = TargetRelationshipField(
         target_class=Registration,

--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -304,10 +304,9 @@ class RegistrationActionSerializer(BaseActionSerializer):
             raise PermissionDenied('You do not have permission to perform this trigger at this time')
 
         target.refresh_from_db()
-        determined_trigger = RegistrationModerationTriggers.from_db_name(target.actions.last().trigger)
-        request_trigger = RegistrationModerationTriggers.from_db_name(trigger)
+        determined_trigger = target.actions.last().trigger
 
-        if determined_trigger != request_trigger:
+        if determined_trigger != trigger:
             short_message = 'Operation not allowed at this time'
             long_message = f'This {trigger} is invalid for the current state of the registration.'
             raise HTTPError(

--- a/api/actions/serializers.py
+++ b/api/actions/serializers.py
@@ -289,10 +289,9 @@ class RegistrationActionSerializer(BaseActionSerializer):
             elif trigger == RegistrationModerationTriggers.REJECT_WITHDRAWAL.db_name:
                 sanction.reject(user)
             elif trigger == RegistrationModerationTriggers.FORCE_WITHDRAW.db_name:
-                retraction = target.retract_registration(
-                    user=user, justification=comment,
+                target.retract_registration(
+                    user=user, justification=comment, moderator_initiated=True,
                 )
-                retraction.accept(user)
             else:
                 raise JSONAPIAttributeException(attribute='trigger', detail='Invalid trigger.')
         except InvalidTriggerError:

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -275,7 +275,7 @@ class FilterMixin(object):
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id']:
+                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id', 'moderation_state']:
                         query.get(key).update({
                             field_name: {
                                 'op': 'in',

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -41,10 +41,10 @@ class ContributorOrPublic(permissions.BasePermission):
 
         if isinstance(obj, Registration) and obj.provider:
             if obj.provider.get_group('moderator').user_set.filter(id=request.user.id).exists():
-                return True
+                is_moderator = True
 
         if request.method in permissions.SAFE_METHODS:
-            return obj.is_public or obj.can_view(auth)
+            return obj.is_public or obj.can_view(auth) or is_moderator
         else:
             return obj.can_edit(auth)
 

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -39,6 +39,7 @@ class ContributorOrPublic(permissions.BasePermission):
         if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
             obj = obj.branched_from
 
+        is_moderator = False
         if isinstance(obj, Registration) and obj.provider:
             if obj.provider.get_group('moderator').user_set.filter(id=request.user.id).exists():
                 is_moderator = True

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -240,7 +240,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         'contributors',
         'preprint',
         'subjects',
-        'machine_state',
+        'reviews_state',
     ])
 
     # If you add a field to this serializer, be sure to add to this

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -729,6 +729,9 @@ class RegistrationProviderRequestList(JSONAPIBaseView, generics.ListAPIView, Lis
 class RegistrationProviderActionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, ProviderMixin):
     provider_class = RegistrationProvider
 
+    required_read_scopes = [CoreScopes.ACTIONS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
     permission_classes = (
         drf_permissions.IsAuthenticated,
         base_permissions.TokenHasScope,
@@ -738,7 +741,7 @@ class RegistrationProviderActionList(JSONAPIBaseView, generics.ListAPIView, List
     view_name = 'registration-provider-action-list'
 
     required_read_scopes = [CoreScopes.ACTIONS_READ]
-    required_write_scopes = [CoreScopes.NULL]
+    required_write_scopes = [CoreScopes.ACTIONS_WRITE]
 
     serializer_class = RegistrationActionSerializer
 

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -729,9 +729,6 @@ class RegistrationProviderRequestList(JSONAPIBaseView, generics.ListAPIView, Lis
 class RegistrationProviderActionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, ProviderMixin):
     provider_class = RegistrationProvider
 
-    required_read_scopes = [CoreScopes.ACTIONS_READ]
-    required_write_scopes = [CoreScopes.NULL]
-
     permission_classes = (
         drf_permissions.IsAuthenticated,
         base_permissions.TokenHasScope,

--- a/api/registrations/permissions.py
+++ b/api/registrations/permissions.py
@@ -8,6 +8,7 @@ class ContributorOrModerator(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         auth = get_user_auth(request)
 
+        is_moderator = False
         if obj.provider.get_group('moderator').user_set.filter(id=request.user.id).exists():
                 is_moderator = True
 

--- a/api/registrations/permissions.py
+++ b/api/registrations/permissions.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from rest_framework import permissions
+
+from api.base.utils import get_user_auth
+
+class ContributorOrModerator(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        auth = get_user_auth(request)
+
+        if obj.provider.get_group('moderator').user_set.filter(id=request.user.id).exists():
+                is_moderator = True
+
+        return obj.is_admin_contributor(auth.user) or is_moderator

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -69,7 +69,7 @@ class RegistrationSerializer(NodeSerializer):
         'withdrawn',
     ]
 
-    machine_state = ser.CharField(read_only=True)
+    reviews_state = ser.CharField(source='moderation_state', read_only=True)
     title = ser.CharField(read_only=True)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True)
     category_choices = NodeSerializer.category_choices

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -786,9 +786,6 @@ class RegistrationIdentifierList(RegistrationMixin, NodeIdentifierList):
 class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCreateAPIView, RegistrationMixin, ProviderMixin):
     provider_class = RegistrationProvider
 
-    required_read_scopes = [CoreScopes.ACTIONS_READ]
-    required_write_scopes = [CoreScopes.NULL]
-
     permission_classes = (
         drf_permissions.IsAuthenticated,
         base_permissions.TokenHasScope,
@@ -831,9 +828,6 @@ class RegistrationRequestList(JSONAPIBaseView, ListFilterMixin, generics.ListCre
         base_permissions.TokenHasScope,
         MustBeModerator,
     )
-
-    required_read_scopes = [CoreScopes.REGISTRATION_REQUESTS_READ]
-    required_write_scopes = [CoreScopes.REGISTRATION_REQUESTS_WRITE]
 
     view_category = 'registrations'
     view_name = 'registration-requests-list'

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -68,7 +68,7 @@ from api.wikis.serializers import RegistrationWikiSerializer
 
 from api.base.utils import get_object_or_error
 from api.actions.serializers import RegistrationActionSerializer
-from api.requests.serializers import RegistrationRequestSerializer, RegistrationRequestCreateSerializer
+from api.requests.serializers import RegistrationRequestSerializer
 from framework.sentry import log_exception
 from osf.utils.permissions import ADMIN
 from api.providers.permissions import MustBeModerator
@@ -839,12 +839,6 @@ class RegistrationRequestList(JSONAPIBaseView, ListFilterMixin, generics.ListCre
     view_name = 'registration-requests-list'
 
     serializer_class = RegistrationRequestSerializer
-
-    def get_serializer_class(self):
-        if self.request.method == 'POST':
-            return RegistrationRequestCreateSerializer
-        else:
-            return RegistrationRequestSerializer
 
     def get_default_queryset(self):
         return self.get_node().requests.all()

--- a/api/requests/serializers.py
+++ b/api/requests/serializers.py
@@ -89,6 +89,40 @@ class RegistrationRequestSerializer(RequestSerializer):
             },
         )
 
+class RegistrationRequestCreateSerializer(RegistrationRequestSerializer):
+    request_type = ser.ChoiceField(required=True, choices=RequestTypes.choices())
+
+    def create(self, validated_data):
+        auth = get_user_auth(self.context['request'])
+        if not auth.user:
+            raise exceptions.PermissionDenied
+
+        registration = self.context['view'].get_target()
+
+        if not registration.has_permission(auth.user, osf_permissions.ADMIN):
+            raise exceptions.PermissionDenied
+
+        comment = validated_data.pop('comment', '')
+        request_type = validated_data('request_type', None)
+
+        if NodeRequest.objects.filter(target_id=registration.id, creator_id=auth.user.id, request_type=request_type).exists():
+            raise Conflict(f'Users may not have more than one {request_type} request per registration.')
+
+        if request_type != RequestTypes.WITHDRAWAL.value:
+            raise exceptions.ValidationError('You must specify a valid request_type')
+
+        node_request = NodeRequest.objects.create(
+            target=registration,
+            creator=auth.user,
+            comment=comment,
+            machine_state=DefaultStates.INITIAL.value,
+            request_type=request_type,
+        )
+
+        node_request.save()
+        node_request.run_submit(auth.user)
+        return node_request
+
 class NodeRequestCreateSerializer(NodeRequestSerializer):
     request_type = ser.ChoiceField(required=True, choices=RequestTypes.choices())
 

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -149,6 +149,7 @@ class CoreScopes(object):
     PREPRINT_REQUESTS_WRITE = 'preprint_requests_write'
 
     REGISTRATION_REQUESTS_READ = 'registration_request_read'
+    REGISTRATION_REQUESTS_WRITE = 'registration_request_write'
 
     PROVIDERS_WRITE = 'providers_write'
 
@@ -236,11 +237,13 @@ class ComposedScopes(object):
     NODE_METADATA_READ = (CoreScopes.NODE_BASE_READ, CoreScopes.NODE_CHILDREN_READ, CoreScopes.NODE_LINKS_READ,
                           CoreScopes.NODE_CITATIONS_READ, CoreScopes.NODE_COMMENTS_READ, CoreScopes.NODE_LOG_READ,
                           CoreScopes.NODE_FORKS_READ, CoreScopes.WIKI_BASE_READ, CoreScopes.LICENSE_READ,
-                          CoreScopes.IDENTIFIERS_READ, CoreScopes.NODE_PREPRINTS_READ, CoreScopes.PREPRINT_REQUESTS_READ)
+                          CoreScopes.IDENTIFIERS_READ, CoreScopes.NODE_PREPRINTS_READ, CoreScopes.PREPRINT_REQUESTS_READ,
+                          CoreScopes.REGISTRATION_REQUESTS_READ)
     NODE_METADATA_WRITE = NODE_METADATA_READ + \
                     (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE, CoreScopes.IDENTIFIERS_WRITE,
                      CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE,
-                     CoreScopes.NODE_PREPRINTS_WRITE, CoreScopes.PREPRINT_REQUESTS_WRITE, CoreScopes.WIKI_BASE_WRITE)
+                     CoreScopes.NODE_PREPRINTS_WRITE, CoreScopes.PREPRINT_REQUESTS_WRITE, CoreScopes.WIKI_BASE_WRITE,
+                     CoreScopes.REGISTRATION_REQUESTS_WRITE)
 
     # Preprints collection
     # TODO: Move Metrics scopes to their own restricted composed scope once the Admin app can manage scopes on tokens/apps

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -350,7 +350,7 @@ class Registration(AbstractNode):
         :raises: PermissionsError if user is not an admin for the Node
         :raises: ValidationError if end_date is not within time constraints
         """
-        if not self.is_admin_contributor(user):
+        if not self.is_admin_contributor(user) and not self.provider.get_group('moderator').user_set.filter(id=user.id).exists():
             raise PermissionsError('Only admins may embargo a registration')
         if not self._is_embargo_date_valid(end_date):
             if (end_date - timezone.now()) >= settings.EMBARGO_END_DATE_MIN:


### PR DESCRIPTION


## Purpose

Adding POST/PATCH endpoints for registries moderation
## Changes

Adding serializers. Modifying views.
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify you can perform actions against the endpoint. Verify it doesn't allow you to make actions out of order
- Verify you can make requests. Verify you can update the comment

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

I don't think moderation docs are public

## Side Effects

N/A
## Ticket

https://openscience.atlassian.net/browse/ENG-2130