### PR TITLE
[Hotfix] Storage Exceeded Announcement Email and Script [ENG-2296][ENG-2289]

### DIFF
--- a/osf/management/commands/collect_user_nodes_exceeding_storage_limits.py
+++ b/osf/management/commands/collect_user_nodes_exceeding_storage_limits.py
@@ -1,0 +1,82 @@
+from django.core.management.base import BaseCommand
+import json
+import logging
+
+from api.caching.tasks import update_storage_usage_cache
+from osf.models import Node
+from website.settings import StorageLimits
+
+logger = logging.getLogger(__name__)
+
+
+def get_write_admin_contributors(node):
+    write_admin_contributor_set = set()
+    for contributor in node.contributor_set.all():
+        if contributor.permission in ['write', 'admin']:
+            write_admin_contributor_set.add(contributor.user._id)
+    return write_admin_contributor_set
+
+
+def retrieve_user_nodes_exceeding_storage_limits():
+    exceeded_user_node_dict = dict()
+
+    for node in Node.objects.filter(type='osf.node'):
+        # if node.storage_limit_status is StorageLimits.NOT_CALCULATED:
+        storage_usage = node.storage_usage
+        if storage_usage is None:
+            logger.info(f'{node._id}\'s storage is uncalculated. Calculating storage now.')
+            update_storage_usage_cache(node.id, node._id)
+
+        if node.is_public:
+            if node.storage_limit_status >= StorageLimits.OVER_PUBLIC:
+                contributors = get_write_admin_contributors(node)
+                for user_id in contributors:
+                    if user_id in exceeded_user_node_dict:
+                        user_public_nodes_exceeding = exceeded_user_node_dict[user_id]['public'].append(node._id)
+                        user_private_nodes_exceeding = exceeded_user_node_dict[user_id]['private']
+                    else:
+                        user_public_nodes_exceeding = [node._id]
+                        user_private_nodes_exceeding = []
+                    exceeded_user_node_dict.update({
+                        user_id: {
+                            'public': user_public_nodes_exceeding,
+                            'private': user_private_nodes_exceeding
+                        }
+                    })
+        else:
+            if node.storage_limit_status >= StorageLimits.OVER_PRIVATE:
+                contributors = get_write_admin_contributors(node)
+                for user_id in contributors:
+                    if user_id in exceeded_user_node_dict:
+                        user_public_nodes_exceeding = exceeded_user_node_dict[user_id]['public']
+                        user_private_nodes_exceeding = exceeded_user_node_dict[user_id]['private'].append(node._id)
+                    else:
+                        user_public_nodes_exceeding = []
+                        user_private_nodes_exceeding = [node._id]
+
+                    exceeded_user_node_dict.update({
+                        user_id: {
+                            'public': user_public_nodes_exceeding,
+                            'private': user_private_nodes_exceeding
+                        }
+                    })
+    return exceeded_user_node_dict
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--path',
+            dest='path',
+            help='Path for the json output',
+        )
+
+    def handle(self, *args, **options):
+        path = options.get('path', None)
+        data = retrieve_user_nodes_exceeding_storage_limits()
+        if path:
+            with open(path, 'w') as f:
+                json.dump(data, f)
+        else:
+            print(json.dumps(data))

--- a/osf/management/commands/send_storage_exceeded_announcement.py
+++ b/osf/management/commands/send_storage_exceeded_announcement.py
@@ -36,7 +36,6 @@ def main(json_file, dry=False):
     targets = json.load(json_file)
     errors = []
     p_bar = tqdm(total=len(targets))
-    i = 1
     for user, public_nodes, private_nodes in obj_gen(targets):
         if public_nodes or private_nodes:
             if not dry:
@@ -53,8 +52,7 @@ def main(json_file, dry=False):
                     errors.append(user._id)
             else:
                 logger.info(f'[Dry] Would mail {user._id}')
-        p_bar.update(i)
-        i += 1
+        p_bar.update()
     p_bar.close()
     logger.info(f'Complete. Errors mailing: {errors}')
 

--- a/osf/management/commands/send_storage_exceeded_announcement.py
+++ b/osf/management/commands/send_storage_exceeded_announcement.py
@@ -1,0 +1,80 @@
+import logging
+import json
+from tqdm import tqdm
+
+from website import mails
+from django.core.management.base import BaseCommand
+
+from osf.models import Node, OSFUser
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def obj_gen(targets):
+    for u_id, n_dict in targets.items():
+        try:
+            u = OSFUser.load(u_id)
+            priv = [n for n in [Node.load(n_id) for n_id in n_dict.get('private', [])] if not n.is_public]
+            pub = []
+            for n_id in n_dict.get('public', []):
+                # Add previously-public nodes to private list, as 50>5.
+                # Do not do the reverse.
+                n = Node.load(n_id)
+                if n.is_public:
+                    pub.append(n)
+                else:
+                    priv.append(n)
+            yield u, pub, priv
+        except Exception:
+            logger.error(f'Unknown exception handling {u_id}, skipping')
+
+def main(json_file, dry=False):
+    if not json_file:
+        logger.info('No file detected, exiting.')
+        return
+    targets = json.load(json_file)
+    errors = []
+    p_bar = tqdm(total=len(targets))
+    i = 1
+    for user, public_nodes, private_nodes in obj_gen(targets):
+        if public_nodes or private_nodes:
+            if not dry:
+                try:
+                    mails.send_mail(
+                        to_addr=user.username,
+                        mail=mails.STORAGE_CAP_EXCEEDED_ANNOUNCEMENT,
+                        user=user,
+                        public_nodes=public_nodes,
+                        private_nodes=private_nodes,
+                        can_change_preferences=False,
+                    )
+                except Exception:
+                    errors.append(user._id)
+            else:
+                logger.info(f'[Dry] Would mail {user._id}')
+        p_bar.update(i)
+        i += 1
+    p_bar.close()
+    logger.info(f'Complete. Errors mailing: {errors}')
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--dry',
+            dest='dry',
+            action='store_true',
+            help='Dry run'
+        )
+        parser.add_argument(
+            '--json',
+            dest='json_file',
+            type=open,
+            help='Path of the json input',
+        )
+
+    def handle(self, *args, **options):
+        json_file = options.get('json_file', None)
+        dry = options.get('dry', None)
+        main(json_file, dry)

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -450,3 +450,8 @@ TOU_NOTIF = Mail(
     'tou_notif',
     subject='Updated Terms of Use for COS Websites and Services',
 )
+
+STORAGE_CAP_EXCEEDED_ANNOUNCEMENT = Mail(
+    'storage_cap_exceeded_announcement',
+    subject='Action Required to avoid disruption to your OSF project',
+)

--- a/website/templates/emails/storage_cap_exceeded_announcement.html.mako
+++ b/website/templates/emails/storage_cap_exceeded_announcement.html.mako
@@ -1,0 +1,48 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <%!
+        from website import settings
+    %>
+    Hi ${user.given_name or user.fullname},<br>
+    <br>
+    Thank you for storing your research materials on OSF. We have updated the OSF Storage capacity to 5 GB for private content and 50 GB for public content. None of your current files stored on OSF Storage will be affected, but after November 3, 2020 projects exceeding capacity will no longer accept new file uploads.
+    <br>
+    <br>
+    % if private_nodes:
+    The following private projects and components have exceeded the 5 GB OSF Storage allotment and require your action:
+    <ul>
+      % for node in private_nodes:
+        <li> <a href="${settings.DOMAIN.rstrip('/') + node.url}">${node.title}</a>
+      % endfor
+    </ul>
+    <br>
+    % endif
+    % if public_nodes:
+    The following public projects and components have exceeded the 50 GB OSF Storage allotment and require your action:
+    <ul>
+      % for node in public_nodes:
+        <li> <a href="${settings.DOMAIN.rstrip('/') + node.url}">${node.title}</a>
+      % endfor
+    </ul>
+    <br>
+    % endif
+    <strong>In order to avoid disruption to your workflow, please take action through one of the following options:</strong><br>
+    <ul>
+      <li>Connect an <a href="https://help.osf.io/hc/en-us/sections/360003623833-Storage-add-ons">OSF storage add-on</a> to continue managing your research efficiently from OSF. OSF add-ons are an easy way to extend your storage space while also streamlining your data management workflow.</li>
+      % if private_nodes:
+      <li><a href="https://help.osf.io/hc/en-us/articles/360018981414-Control-Your-Privacy-Settings#Make-your-project-or-components-public">Make your private project public</a> to increase storage capacity to 50 GB for files stored in OSF storage.</li>
+      % endif
+      <li><a href="https://help.osf.io/hc/en-us/articles/360019737614-Create-Components">Organize your project with components</a> to take advantage of the flexible structure and maximize storage options.</li>
+    </ul>
+    <br>
+    Learn more about OSF Storage capacity <a href="https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps">here</a>, or contact <a href="mailto:support@osf.io">support@osf.io</a> with any questions you may have.<br>
+    <br>
+    Thanks,<br>
+    <br>
+    The OSF Team<br>
+    <br>
+</tr>
+</%def>


### PR DESCRIPTION
## Purpose
Add announcement email, script to warn users about exceeding storage capacities. Runs off the output from script ~~in~~ stolen from #9497

## Changes
* Add email
* Add script

## QA Notes
None -- dev QA. Tested locally with a mock input file:
![test_email](https://user-images.githubusercontent.com/5659262/96185876-92ae8d00-0f08-11eb-8035-62e63d90190c.png)


## Side Effects
None expected. Script should be sufficiently verbose and fault-tolerant to alert to errors and allow them to be investigated separately, without worrying about spamming users if multiple runs are necessary.

## Ticket
https://openscience.atlassian.net/browse/ENG-2296
https://openscience.atlassian.net/browse/ENG-2289