### PR TITLE
[ENG-2324] Enables 0 OSFStorage Used to be Displayed in the UI and Admin App

### DIFF
--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -20,7 +20,7 @@ def serialize_node(node):
         'public': node.is_public,
         'parent': node.parent_id,
         'root': node.root._id,
-        'storage_usage': sizeof_fmt(node.storage_usage) if node.storage_usage else 0,
+        'storage_usage': sizeof_fmt(node.storage_usage) if node.storage_usage is not None else None,
         'storage_limit_status': node.storage_limit_status.value,
         'public_storage_cap': round(node.custom_storage_usage_limit_public or STORAGE_LIMIT_PUBLIC, 1),
         'private_storage_cap': round(node.custom_storage_usage_limit_private or STORAGE_LIMIT_PRIVATE, 1),

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -160,6 +160,9 @@ def update_storage_usage_with_size(payload):
     target_file_id = metadata['path'].replace('/', '')
     target_file_size = metadata.get('size', 0)
 
+    if target_node.storage_limit_status is settings.StorageLimits.NOT_CALCULATED:
+        return update_storage_usage(target_node)
+
     current_usage = target_node.storage_usage
     target_file = BaseFileNode.load(target_file_id)
 
@@ -180,6 +183,8 @@ def update_storage_usage_with_size(payload):
         if target_node == source_node and source_provider == provider:
             return  # Its not going anywhere.
         if source_provider == 'osfstorage' and not source_node.is_quickfiles:
+            if source_node.storage_limit_status is settings.StorageLimits.NOT_CALCULATED:
+                return update_storage_usage(source_node)
             source_node_usage = source_node.storage_usage
             source_node_usage = max(source_node_usage - target_file_size, 0)
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2381,11 +2381,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=self._id)
 
         storage_usage_total = storage_usage_cache.get(key)
-        if storage_usage_total:
+        if storage_usage_total is not None:
             return storage_usage_total
         else:
             update_storage_usage(self)  # sets cache
-            return storage_usage_cache.get(key) or 0
+            return storage_usage_cache.get(key)
 
     # Overrides ContributorMixin
     # TODO: Deprecate this when we emberize contributors management for nodes

--- a/osf_tests/test_storage_usage_limits.py
+++ b/osf_tests/test_storage_usage_limits.py
@@ -13,16 +13,19 @@ class TestStorageUsageLimits:
     def node(self):
         return ProjectFactory()
 
-    def test_limit_default(self, node):
-        assert node.storage_usage is 0
+    def test_uncalculated_limit(self, node):
+        assert node.storage_usage is None
+        assert node.storage_limit_status is StorageLimits.NOT_CALCULATED
 
+    def test_limit_default(self, node):
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=node._id)
         storage_usage_cache.set(key, 0)
 
-        assert node.storage_limit_status == StorageLimits.DEFAULT
+        assert node.storage_limit_status is StorageLimits.DEFAULT
 
     def test_storage_limits(self, node):
         GBs = 1024 ** 3.0
+        assert node.storage_limit_status is StorageLimits.NOT_CALCULATED
 
         key = cache_settings.STORAGE_USAGE_KEY.format(target_id=node._id)
         storage_usage_cache.set(key, int(STORAGE_LIMIT_PUBLIC * STORAGE_WARNING_THRESHOLD * GBs))

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -843,7 +843,7 @@ def _view_project(node, auth, primary=False,
     data.update({'storage_flag_is_active': storage_i18n_flag_active()})
     if storage_usage_flag_active():
         storage_usage = node.storage_usage
-        if storage_usage:
+        if storage_usage is not None:
             data['node']['storage_usage'] = sizeof_fmt(storage_usage)
 
     if embed_contributors and not anonymous:

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1979,11 +1979,12 @@ class StorageLimits(enum.IntEnum):
     """
     Values here are in GBs
     """
-    DEFAULT = 0
-    APPROACHING_PRIVATE = 1
-    OVER_PRIVATE = 2
-    OVER_PUBLIC = 3
+    NOT_CALCULATED = 0
+    DEFAULT = 1
+    APPROACHING_PRIVATE = 2
+    OVER_PRIVATE = 3
     APPROACHING_PUBLIC = 4
+    OVER_PUBLIC = 5
 
     @classmethod
     def from_node_usage(cls,  usage_bytes, private_limit=None, public_limit=None):
@@ -1992,6 +1993,8 @@ class StorageLimits(enum.IntEnum):
         public_limit = public_limit or STORAGE_LIMIT_PUBLIC
         private_limit = private_limit or STORAGE_LIMIT_PRIVATE
 
+        if usage_bytes is None:
+            return cls.NOT_CALCULATED
         if usage_bytes >= float(public_limit) * GBs:
             return cls.OVER_PUBLIC
         elif usage_bytes >= float(public_limit) * STORAGE_WARNING_THRESHOLD * GBs:


### PR DESCRIPTION
## Purpose
Checks for storage_usage on a node were structured as `if self.storage_usage`; this leads to issues if there is a calculated 0 value for storage used. 

## Changes
* `osf/models/node.py`: Checks storage_usage against None instead of 0
* `website/settings/defaults.py`: Adds NOT_CALCULATED to the Enum
* `admin/nodes/serializers.py`: Checks storage_usage against None instead of 0
* `website/project/views/node.py`: Checks storage_usage against None instead of 0

## QA Notes
Verify that storage usage for projects with no OSFStorage usage is displayed as 0.0B while other storage usage indication works as anticipated in the UI and in the Admin App.

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2324)