### PR TITLE
[ENG-2327] Specifies the MAX_ENTRIES option for the storage usage cache

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -319,6 +319,7 @@ ELASTICSEARCH_METRICS_DATE_FORMAT = '%Y'
 
 WAFFLE_CACHE_NAME = 'waffle_cache'
 STORAGE_USAGE_CACHE_NAME = 'storage_usage'
+STORAGE_USAGE_MAX_ENTRIES = 10000000
 
 
 CACHES = {
@@ -328,6 +329,9 @@ CACHES = {
     STORAGE_USAGE_CACHE_NAME: {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
         'LOCATION': 'osf_cache_table',
+        'OPTIONS': {
+            'MAX_ENTRIES': STORAGE_USAGE_MAX_ENTRIES,
+        },
     },
     WAFFLE_CACHE_NAME: {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',


### PR DESCRIPTION
## Purpose
The Storage Usage cache defaults to 300 max_entries. This PR specifies a MAX_ENTRIES parameter with a value of 1,000,000 that can be overwritten in api.settings.local.py

## Changes
* Adds a `MAX_ENTRIES` parameter to the storage_usage_cache's settings 

## QA Notes
N/A (DevOps Test)

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2327)

## Development Notes
The storage_usage_cache's timeout settings should also be overwritten so that there is no timeout for the cache in production, allowing for storage_usage calculations to persist indefinitely improving user experience.
* Set `website.settings.STORAGE_USAGE_CACHE_TIMEOUT` to `None` in `website/settings/local.py`
