### PR TITLE
Fixing template for storage usage status on admin app [ENG-2322]

### DIFF
--- a/admin/templates/nodes/storage_status.html
+++ b/admin/templates/nodes/storage_status.html
@@ -1,10 +1,14 @@
-{% if not resource.is_public and resource.storage_limit_status is STORAGE_LIMITS.APPROACHING_PRIVATE.value %}
+{% if resource.storage_limit_status is STORAGE_LIMITS.NOT_CALCULATED.value %}
+    <span class="label label-warning">Storage limit not calculated, refresh or click Recalculate node storage usage button</span>
+{% elif not resource.is_public and resource.storage_limit_status is STORAGE_LIMITS.APPROACHING_PRIVATE.value %}
     <span class="label label-warning">Approaching storage limit for private nodes</span>
 {% elif resource.is_public and resource.storage_limit_status is STORAGE_LIMITS.APPROACHING_PUBLIC.value %}
     <span class="label label-warning">Approaching storage limit for public nodes</span>
 {% elif resource.is_public and resource.storage_limit_status is STORAGE_LIMITS.OVER_PUBLIC.value %}
     <span class="label label-danger">Node is over storage limit for public nodes</span>
 {% elif not resource.is_public and resource.storage_limit_status is STORAGE_LIMITS.OVER_PRIVATE.value %}
+    <span class="label label-danger">Node is over storage limit for private nodes</span>
+{% elif not resource.is_public and not resource.storage_limit_status is STORAGE_LIMITS.DEFAULT.value %}
     <span class="label label-danger">Node is over storage limit for private nodes</span>
 {% else %}
 	<span class="label label-default">No storage concern</span>


### PR DESCRIPTION


## Purpose

Storage limit statuses aren't showing up correctly on the admin app due to a missed case where a private node can be over the public limit. The admin app shows this as no storage concern


## Changes

Adding two cases. One for a private node being over the public limit, and one for a non-calculated storage usage.


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify All cases of storage usage are working.
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

Shouldn't be 
## Ticket

https://openscience.atlassian.net/browse/ENG-2322