### PR TITLE
Require explicit "write" perms to link BB repo [ENG-2329]

### DIFF
--- a/addons/bitbucket/api.py
+++ b/addons/bitbucket/api.py
@@ -78,6 +78,7 @@ class BitbucketClient(BaseClient):
         :return: list of repository objects
         """
         query_params = {
+            'role': 'contributor',
             'pagelen': 100,
             'fields': 'values.full_name'
         }
@@ -106,7 +107,7 @@ class BitbucketClient(BaseClient):
         """
 
         query_params = {
-            'role': 'member',
+            'role': 'contributor',
             'pagelen': 100,
             'fields': 'values.links.repositories.href'
         }


### PR DESCRIPTION
## Purpose

Normalize BitBucket repo permissions for consistency.

## Changes

- Perm level required to link personal repos lowered from "owner" to "contributor"
- Perm level required to link team repos raised from "member" to "contributor"

## QA Notes

Affects what repositories may show up when selecting a repo to link to a node on `osf.io/<node_id>/addons`.
Expected that, for both "personal" and "team", repos where the authorizing user has either the "contributor", "admin", or "owner" permission level will display, whereas "member" will not.

## Side Effects

If any exist, previously-connected "team" repos where the user was only a "member" and not "contributor" will no longer be displayed or connectable from the addon settings page, but will continue to render in the files widget unless disconnected.

## Ticket
https://openscience.atlassian.net/browse/ENG-2329
