### PR TITLE
[Hotfix] Update BitBucket API calls. [No Ticket]

### DIFF
--- a/addons/bitbucket/api.py
+++ b/addons/bitbucket/api.py
@@ -72,7 +72,7 @@ class BitbucketClient(BaseClient):
 
         API docs::
 
-        * https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D
+        * https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories
 
         :rtype:
         :return: list of repository objects
@@ -84,7 +84,7 @@ class BitbucketClient(BaseClient):
         }
         res = self._make_request(
             'GET',
-            self._build_url(settings.BITBUCKET_V2_API_URL, 'repositories', self.username),
+            self._build_url(settings.BITBUCKET_V2_API_URL, 'repositories'),
             expects=(200, ),
             throws=HTTPError(401),
             params=query_params

--- a/addons/bitbucket/models.py
+++ b/addons/bitbucket/models.py
@@ -223,10 +223,9 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             valid_credentials = True
             try:
                 mine = connection.repos()
-                ours = connection.team_repos()
                 repo_names = [
                     repo['full_name'].replace('/', ' / ')
-                    for repo in mine + ours
+                    for repo in mine
                 ]
             except Exception:
                 repo_names = []


### PR DESCRIPTION
## Purpose
Return all repositories authenticated user has permission for.

## Changes
* Update API call from `BITBUCKET_V2_API_URL/repositories/{username}/` to `BITBUCKET_V2_API_URL/repositories/`
* Remove call to [deprecated `teams` endpoint](https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-teams-deprecation/) 

## QA Notes
API changes tested remotely. BB repos should still display and be connectable.

## Side Effects
Leaves some seemingly-dead code related to `teams` endpoint. Follow-up ticket for [analysis and removal filed](https://openscience.atlassian.net/browse/ENG-2344).

## Ticket
None