### PR TITLE
[ENG-2333] Update fangorn safari error for storage limits

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1018,6 +1018,7 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
          if ($osf.isSafari()) {
              msgText += 'Could not upload file. Possible reasons: <br>';
              msgText += '1. Cannot upload folders. <br>2. ';
+             msgText += 'Your project/component is over its storage limit. <br>3. ';
          }
          msgText += 'Unable to reach the provider, please try again later. ';
          msgText += 'If the problem persists, please contact ' + $osf.osfSupportEmail() + '.';


### PR DESCRIPTION
## Purpose

The error message for fangorn upload fails in Safari doesn't cover storage limits, this makes sure it does.

## Changes

- simple textual change 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the new growlbox message is displayed in Safari ⚠️  MAKE SURE CACHE IS REFRESHED ⚠️ 


## Documentation

simple task, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2333