### PR TITLE
[ENG-2347] Registration Form Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,10 +153,6 @@ install:
 
 # Run Python tests (core and addon) and JS tests
 
-after_script:
-    # This ensures failed tests are removed from the cache so they can be re-tried.
-    - inv remove_failures_from_testmon --db-path=$HOME/.cache/testmon/.testmondata_$TEST_BUILD
-
 script:
     - export COVERAGE=`if [ "$TRAVIS_BRANCH" == "master-w-coverage" ]; then echo "--coverage"; else echo ""; fi`
     # Testmon will run for PRs, but will be disabled when merging into master or develop
@@ -168,6 +164,8 @@ after_success:
     - if [[ "$TRAVIS_BRANCH" == "master-w-coverage" ]]; then coveralls; fi
 
 before_cache:
+  # This ensures failed tests are removed from the cache so they can be re-tried.
+  - inv remove_failures_from_testmon --db-path=$HOME/.cache/testmon/.testmondata_$TEST_BUILD
   - rm -Rf $HOME/.cache/pip/http
   - rm -f $HOME/.cache/pip/log/debug.log
   # exclude python requirements from github repo's

--- a/osf/migrations/0221_add_schemas.py
+++ b/osf/migrations/0221_add_schemas.py
@@ -18,7 +18,7 @@ def add_invisible_schemas(apps, schema_editor):
 
     schema_names = [schema['name'] for schema in schemas]
 
-    RegistrationSchema.objects.filter(name__in=schema_names).update(visible=False, active=False)
+    RegistrationSchema.objects.filter(name__in=schema_names).update(visible=False, active=True)
 
 
 class Migration(migrations.Migration):

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -266,7 +266,7 @@ def find_title_description_help_example(rs, question):
     title = question.get('title', '')
     description = strip_html(question.get('description', ''))
     help = strip_html(question.get('help', ''))
-    example = ''
+    example = strip_html(question.get('example', ''))
 
     schema_name = rs.schema.get('name', '')
     # Descriptions that contain any of these keywords

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -464,7 +464,11 @@ def test(ctx, all=False, lint=False):
 def remove_failures_from_testmon(ctx, db_path=None):
 
     conn = sqlite3.connect(db_path)
-    tests_decached = conn.execute("delete from node where result <> '{}'").rowcount
+    try:
+        tests_decached = conn.execute("delete from node where result <> '{}'").rowcount
+    except Exception:
+        # Typically "sqlite3.OperationalError: no such table: node"
+        tests_decached = 0
     ctx.run('echo {} failures purged from travis cache'.format(tests_decached))
 
 @task

--- a/website/project/metadata/asist-results-registration.json
+++ b/website/project/metadata/asist-results-registration.json
@@ -16,7 +16,7 @@
                "format":"textarea",
                "title":"Results summary",
                "description":"Please provide a brief summary of the results enclosed in your results registration document. This includes results of analyses set forth in the preregistration and results of any post hoc analyses.",
-               "help":"Hypothesis #1 was confirmed: Navigation skill determines search strategy (p = 0.023). Hypothesis was not confirmed: H2 was not confirmed: Triage is more efficient before anticipated death of high value victims than after (p = .273).",
+               "example":"Hypothesis #1 was confirmed: Navigation skill determines search strategy (p = 0.023). Hypothesis was not confirmed: H2 was not confirmed: Triage is more efficient before anticipated death of high value victims than after (p = .273).",
                "required":true
             },
             {
@@ -41,7 +41,7 @@
                "format":"text",
                "title":"Testbed used",
                "description":"Please provide the name of and link to the latest testbed version used in gathering the data for the preregistered experiment.",
-               "help":"Last version of the testbed used: 1.0.n https://gitlab.asist.aptima.com/XXXX",
+               "example":"Last version of the testbed used: 1.0.n https://gitlab.asist.aptima.com/XXXX",
                "required":true
             },
             {
@@ -50,7 +50,7 @@
                "format":"text",
                "title":"Dataset used",
                "description":"Please link to the datasets used in running your the preregistered plans/analyses.",
-               "help":"The following datasets were used in running our preregistered analyses: https://console.cloud.google.com/XXXX",
+               "example":"The following datasets were used in running our preregistered analyses: https://console.cloud.google.com/XXXX",
                "required":true
             },
             {

--- a/website/project/metadata/qualitative-research.json
+++ b/website/project/metadata/qualitative-research.json
@@ -34,7 +34,7 @@
                "format":"textarea",
                "title":"Research question(s)",
                "description":"Please specify your research question or questions as they are guiding your research now. If relevant, you may also specify here any hypotheses to be assessed. The research questions may break down your aim into smaller, distinct inquiries. If relevant, you may distinguish between primary and secondary research questions or hypotheses.",
-               "help":"For example, if it is your aim to explore the attitudes of caregivers towards Alzheimer patients in a local ward, your research questions could specify precisely what you plan to study; for instance, how ward staff tries to treat the patients with dignity or how the relationship between the patient and their family members or loved ones evolved since that patient was admitted to the ward.",
+               "example":"For example, if it is your aim to explore the attitudes of caregivers towards Alzheimer patients in a local ward, your research questions could specify precisely what you plan to study; for instance, how ward staff tries to treat the patients with dignity or how the relationship between the patient and their family members or loved ones evolved since that patient was admitted to the ward.",
                "required":true
             },
             {
@@ -103,7 +103,7 @@
                "format":"textarea",
                "title":"Stopping criteria",
                "description":"Please describe the criteria or rationale behind when you will stop data generation or collection. Possible criteria include (but are not restricted to): data saturation*, when inclusion criteria are satisfied, resource constraints (e.g. time/funding), or when the analysis has produced an enriching answer to the research question(s).",
-               "help":"* We follow Fusch & Ness (2005) and interpret saturation to be reached when there is enough information to replicate the study, the ability to obtain new information has been attained, and further coding is no longer feasible.",
+               "example":"* We follow Fusch & Ness (2005) and interpret saturation to be reached when there is enough information to replicate the study, the ability to obtain new information has been attained, and further coding is no longer feasible.",
                "required":true
             }
          ]
@@ -118,7 +118,7 @@
                "format":"textarea",
                "title":"Data analysis approach",
                "description":"Please specify the type and details of your data analysis approach. Examples of approaches include (but are not limited to): narrative analysis, phenomenological analysis, thematic analysis, content analysis, psychoanalytic analysis, grounded theory, process tracing, comparative analysis, or discourse analysis. If multiple interpretations of your approach exist, please specify the version you will be using. Please provide a rationale for why your selected data analytic approach is appropriate given your study’s aim(s).",
-               "help":"For example, if you indicated ‘phenomenological analysis’, you may want to specify the theorist whose approach you are following, e.g. “We use a phenomenological approach as explained by Colaizzi (1978)”; or if you indicated ‘content analysis’, a specification could be: “We apply inductive content analysis as described in Elo & Kyngäs (2008)”.",
+               "example":"For example, if you indicated ‘phenomenological analysis’, you may want to specify the theorist whose approach you are following, e.g. “We use a phenomenological approach as explained by Colaizzi (1978)”; or if you indicated ‘content analysis’, a specification could be: “We apply inductive content analysis as described in Elo & Kyngäs (2008)”.",
                "required":true
             },
             {
@@ -176,7 +176,7 @@
                "format":"textarea",
                "title":"Reflection on your positionality (optional)",
                "description":"Feel free to reflect on your relation to * or association with the studied phenomenon and your position in the research setting/field, including your academic/personal standpoints, assumptions and values. In addition, if there is a potential conflict of interest that can arise, you may want to report that here.* whether you have a previous relationship with the studied phenomenon, and if you consider that there are previous positions or assumptions that may influence the present study.",
-               "help":"For example, if you study the lives of detained immigrants, you might want to talk about your political viewpoints, experience working with detained immigrants, relevant policy work, or perhaps your own experience as a detained immigrant.",
+               "example":"For example, if you study the lives of detained immigrants, you might want to talk about your political viewpoints, experience working with detained immigrants, relevant policy work, or perhaps your own experience as a detained immigrant.",
                "required":false
             }
          ]

--- a/website/project/metadata/real-world-evidence.json
+++ b/website/project/metadata/real-world-evidence.json
@@ -16,7 +16,7 @@
                "format":"textarea",
                "title":"Research question",
                "description":"The research question is essential to guide the research project and should pinpoint exactly what you are attempting to test. For hypothesis evaluating treatment effect or comparative effectiveness research the question should include the population of interest, exposure, comparator and outcome(s) to be evaluated.",
-               "help":"Does in-hospital zxxxxxnib improve pulmonary function compared to yxxxxxnib in patients treated with high-dose corticosteroids for moderate to severe SARS-CoV-2 pneumonia? What are the comparative risks for stroke or major bleeding in patients with non-valvular atrial fibrillation who initiate anticoagulant X versus anticoagulant Y?",
+               "example":"Does in-hospital zxxxxxnib improve pulmonary function compared to yxxxxxnib in patients treated with high-dose corticosteroids for moderate to severe SARS-CoV-2 pneumonia? What are the comparative risks for stroke or major bleeding in patients with non-valvular atrial fibrillation who initiate anticoagulant X versus anticoagulant Y?",
                "required":true
             },
             {
@@ -25,7 +25,7 @@
                "format":"text",
                "title":"Funding source(s)",
                "description":"Please include grant numbers and funding source, or company name",
-               "help":"Grant number: XYZ9999 source: PCORI, OR company: AbbPfir BioPharmaceutical",
+               "example":"Grant number: XYZ9999 source: PCORI, OR company: AbbPfir BioPharmaceutical",
                "required":true
             },
             {
@@ -34,7 +34,7 @@
                "format":"text",
                "title":"Data source(s)",
                "description":"Please list the databases or other source of data for this secondary data use study",
-               "help":"IBM Marketscan Claims and Encounters Database; Clinical Practice Research Datalink (CPRD)",
+               "example":"IBM Marketscan Claims and Encounters Database; Clinical Practice Research Datalink (CPRD)",
                "required":true
             },
             {
@@ -43,7 +43,7 @@
                "format":"text",
                "title":"Extraction date",
                "description":"This refers to either the extraction version number or the date of the final analytic dataset of extraction for the RWD database that will be used to implement the study protocol.",
-               "help":"09/10/2020 or v 7.1.0",
+               "example":"09/10/2020 or v 7.1.0",
                "required":true
             },
             {
@@ -52,7 +52,7 @@
                "format":"text",
                "title":"Study period(s)",
                "description":"The calendar time boundaries for data used to create the analyzed study data set, including exposures, inclusion and exclusion criteria, covariates, outcome, and follow-up. This is the full window of data observation – from the date of the earliest data point to the date of the last data point, across all subjects.",
-               "help":"01/15/2010 to 09/22/2019 (can include a future date as well)",
+               "example":"01/15/2010 to 09/22/2019 (can include a future date as well)",
                "required":true
             }
          ]
@@ -74,7 +74,7 @@
                   "Cross-sectional",
                   "Other (describe in text box below)"
                ],
-               "help":"Cohort designs - A study design where one or more samples (called cohorts) are identified and patients categorized by treatment or exposure groups and followed for a defined period of time with subsequent status evaluations of the outcome(s) of interest. Cohort studies are conducted to determine the magnitude of treatment associations with the outcome. As the study is conducted, outcomes from participants in each cohort are measured and relationships with specific characteristics are determined. Within cohorts, one can apply sampling designs that oversample patient according to certain study parameters to increase study efficiency: Case-control sampling identifies patients according to their outcome status; case-cohort sampling identifies patients according to exposure status and pre-exposure patient characteristics; and two-stage sampling which does both. The efficiency gain with cohort sampling approaches is most relevant if some information critical to the study is difficult or costly to acquire. The family of self-controlled designs use an individual’s experience at different times as their own control. We differentiate self-controlled designs by how patients are selected into the study, or the indexing event: the case-crossover design is indexed by the study outcome, while the self-controlled case series is typically exposure-indexed.\nQuasi-experimental: research that resembles experimental research but is not true experimental research. Often but not always a cohort design, it also involves a condition or analytical technique that proxies randomization of treatment assignment to some degree but is not true randomization.",
+               "example":"Cohort designs - A study design where one or more samples (called cohorts) are identified and patients categorized by treatment or exposure groups and followed for a defined period of time with subsequent status evaluations of the outcome(s) of interest. Cohort studies are conducted to determine the magnitude of treatment associations with the outcome. As the study is conducted, outcomes from participants in each cohort are measured and relationships with specific characteristics are determined. Within cohorts, one can apply sampling designs that oversample patient according to certain study parameters to increase study efficiency: Case-control sampling identifies patients according to their outcome status; case-cohort sampling identifies patients according to exposure status and pre-exposure patient characteristics; and two-stage sampling which does both. The efficiency gain with cohort sampling approaches is most relevant if some information critical to the study is difficult or costly to acquire. The family of self-controlled designs use an individual’s experience at different times as their own control. We differentiate self-controlled designs by how patients are selected into the study, or the indexing event: the case-crossover design is indexed by the study outcome, while the self-controlled case series is typically exposure-indexed.\nQuasi-experimental: research that resembles experimental research but is not true experimental research. Often but not always a cohort design, it also involves a condition or analytical technique that proxies randomization of treatment assignment to some degree but is not true randomization.",
                "required":true
             },
             {
@@ -90,7 +90,7 @@
                "format":"textarea",
                "title":"Study population",
                "description":"Please choose one the population under evaluation in the study",
-               "help":"The population under evaluation in the study",
+               "example":"The population under evaluation in the study",
                "required":true
             },
             {
@@ -99,7 +99,7 @@
                "format":"text",
                "title":"Cohort entry (index) date",
                "description":"The cohort entry date could also be referred to as the ‘index’ date. This is the date from which the cohorts will be followed forward in time in the data set. This could be the first date of drug initiation or first prescription fill date, or the date of diagnosis of the disease of interest or perhaps the date of disease progression.",
-               "help":" The cohort entry date was defined by new initiation of SLEEPINATOR – XR (intervention) or melatonin (comparator).",
+               "example":" The cohort entry date was defined by new initiation of SLEEPINATOR – XR (intervention) or melatonin (comparator).",
                "required":true
             },
             {
@@ -108,7 +108,7 @@
                "format":"textarea",
                "title":"Specific Inclusion criteria",
                "description":"A description of how exactly patients enter the study",
-               "help":"A prior diagnosis of condition X.",
+               "example":"A prior diagnosis of condition X.",
                "required":true
             },
             {
@@ -117,7 +117,7 @@
                "format":"textarea",
                "title":"Specific Exclusion criteria",
                "description":"The population that you want to leave OUT of the study",
-               "help":"Adults with previous sleep disordered breathing-related surgery; Patients under 18 years of age",
+               "example":"Adults with previous sleep disordered breathing-related surgery; Patients under 18 years of age",
                "required":true
             },
             {
@@ -126,7 +126,7 @@
                "format":"textarea",
                "title":"Intervention",
                "description":"The intervention or approach you are evaluating",
-               "help":"SLEEPINATOR – XR (oral formulation)",
+               "example":"SLEEPINATOR – XR (oral formulation)",
                "required":true
             },
             {
@@ -135,7 +135,7 @@
                "format":"textarea",
                "title":"Comparator",
                "description":"The approach you’re comparing the intervention to. The comparator could be a placebo or a control group, but often it is a different type of medical treatment or the usual form of care",
-               "help":"Melatonin",
+               "example":"Melatonin",
                "required":true
             },
             {
@@ -144,7 +144,7 @@
                "format":"textarea",
                "title":"Outcome(s)",
                "description":"Variables that are monitored during a study to document the impact that a given intervention has on the health of a given population.",
-               "help":"Hospitalization for injury based on a fall, acceptance of CPAP treatment, adherence to CPAP treatment, change in functional status or quality of life. Adverse effects or complications related to the use of SLEEPINATOR – XR and Melatonin.",
+               "example":"Hospitalization for injury based on a fall, acceptance of CPAP treatment, adherence to CPAP treatment, change in functional status or quality of life. Adverse effects or complications related to the use of SLEEPINATOR – XR and Melatonin.",
                "required":true
             },
             {
@@ -153,7 +153,7 @@
                "format":"textarea",
                "title":"Patient Characteristics to be used in the analysis",
                "description":"For HETE studies, to reduce confounding in the absence of baseline randomization one may want to identify pre-exposure patient characteristics that are associated/correlated with the study outcome.",
-               "help":"Age, sex, pre-existing dementia, BMI, Hb A1c measurement, …..",
+               "example":"Age, sex, pre-existing dementia, BMI, Hb A1c measurement, …..",
                "required":true
             },
             {
@@ -162,7 +162,7 @@
                "format":"textarea",
                "title":"Patient subgroups",
                "description":"A subset of subjects from the overall study population defined by a variable (age or a certain co-morbidity) based on a reasonable supposition that one group or another might have a different response or outcome.",
-               "help":"Age >65; patients with low density lipoproteins (LDL) > 200 mg/dl",
+               "example":"Age >65; patients with low density lipoproteins (LDL) > 200 mg/dl",
                "required":true
             }
          ]
@@ -177,7 +177,7 @@
                "format":"textarea",
                "title":"Duration of treatment",
                "description":"The text definition of how long you will follow a therapy for both the intervention and comparator, include any information about if or how - gaps in therapy will be calculated or accommodated, dose adjustments may influence the calculation if applicable, and define your date of censoring (end of therapy) criteria.",
-               "help":"Subjects’ duration of therapy will be counted from Day 1 (fill date) to the calculated end of first prescription (day 1 + days supplied). Any dose-adjusted prescriptions that occur prior to the calculated end of treatment based on first prescription will be added to the original treatment duration by adding day supplied from prescription 1 and 2 and subtracting overlapping days. The last day of that last prescription will be the end date of therapy.",
+               "example":"Subjects’ duration of therapy will be counted from Day 1 (fill date) to the calculated end of first prescription (day 1 + days supplied). Any dose-adjusted prescriptions that occur prior to the calculated end of treatment based on first prescription will be added to the original treatment duration by adding day supplied from prescription 1 and 2 and subtracting overlapping days. The last day of that last prescription will be the end date of therapy.",
                "required":true
             },
             {
@@ -186,7 +186,7 @@
                "format":"textarea",
                "title":"Treatment effect of interest and follow-up model",
                "description":"The text definition of the full follow-up window inclusive of treatment for both intervention and comparator.",
-               "help":"Day 1 (fill date) through 100 days, the last day of the study period, death, or disenrollment.",
+               "example":"Day 1 (fill date) through 100 days, the last day of the study period, death, or disenrollment.",
                "required":true
             }
          ]
@@ -210,7 +210,7 @@
                   "Statistical comparisons completed"
                ],
                "description":"Please choose the one best short description that best reflects the amount of data handling that you have had up until the date of registration for this study.",
-               "help":"If you have looked at the data to determine whether there are enough adults with sleep disordered breathing to at least satisfy requirements for your sample size, you should choose option 3 –conducted feasibility counts.",
+               "example":"If you have looked at the data to determine whether there are enough adults with sleep disordered breathing to at least satisfy requirements for your sample size, you should choose option 3 –conducted feasibility counts.",
                "required":true
             }
          ]


### PR DESCRIPTION
## Purpose
Updates the new registration forms

## Changes
* Replaces 'help' keys with 'example' keys in the new registration schemas
* Updates migration utils function to ensure 'example' is retrieved and saved into schemas blocks from schemas
* Updates migration 0221 to ensure new registration forms are not visible but are active

## QA Notes
- Verify example text in the registration form shows up as expected
- Verify new schemas are not visible but are active and can be added to a branded registry in the admin app
(Both have been verified locally)

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2347)