### PR TITLE
[ENG-2371] Add registrations and links fields to RegistrationProviderSerializer

### DIFF
--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -148,14 +148,6 @@ class RegistrationProviderSerializer(ProviderSerializer):
         'external_url': 'get_external_url',
     })
 
-    def get_registrations_url(self, obj):
-        return absolute_reverse(
-            'providers:registration-providers:registrations-list', kwargs={
-                'provider_id': obj._id,
-                'version': self.context['request'].parser_context['kwargs']['version'],
-            },
-        )
-
 
 class PreprintProviderSerializer(MetricsSerializerMixin, ProviderSerializer):
 

--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -145,7 +145,6 @@ class RegistrationProviderSerializer(ProviderSerializer):
 
     links = LinksField({
         'self': 'get_absolute_url',
-        'preprints': 'get_registrations_url',
         'external_url': 'get_external_url',
     })
 

--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -138,6 +138,26 @@ class RegistrationProviderSerializer(ProviderSerializer):
         'name',
     ])
 
+    registrations = ReviewableCountsRelationshipField(
+        related_view='providers:registration-providers:registrations-list',
+        related_view_kwargs={'provider_id': '<_id>'},
+    )
+
+    links = LinksField({
+        'self': 'get_absolute_url',
+        'preprints': 'get_registrations_url',
+        'external_url': 'get_external_url',
+    })
+
+    def get_registrations_url(self, obj):
+        return absolute_reverse(
+            'providers:registration-providers:registrations-list', kwargs={
+                'provider_id': obj._id,
+                'version': self.context['request'].parser_context['kwargs']['version'],
+            },
+        )
+
+
 class PreprintProviderSerializer(MetricsSerializerMixin, ProviderSerializer):
 
     class Meta:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Add a `registrations` relationship to the RegistrationProviderSerializer

## Changes

Adapted the `preprints` and `links` fields from the PreprintProviderSerializer to the RegistrationProviderSerializer.

## QA Notes

Confirmed the presence of the field the local api.


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-2371