### PR TITLE
[ENG-2373] Fix Registration.is_pending_{approval/embargo/retraction} for FE

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -94,17 +94,17 @@ class Sanction(ObjectIDMixin, BaseModel, SanctionStateMachine):
 
     @property
     def is_pending_approval(self):
-        pending_states = [
-            SanctionStates.PENDING_ADMIN_APPROVAL, SanctionStates.PENDING_MODERATOR_APPROVAL
-        ]
-        return self.approval_stage in pending_states or self.state == Sanction.UNAPPROVED
+        '''The sanction is awaiting admin approval.'''
+        return self.approval_stage is SanctionStates.PENDING_ADMIN_APPROVAL
 
     @property
     def is_approved(self):
+        '''The sanction has received all required admin and moderator approvals.'''
         return self.approval_stage is SanctionStates.ACCEPTED or self.state == Sanction.APPROVED
 
     @property
     def is_rejected(self):
+        '''The sanction has been rejected by either an admin or a moderator.'''
         rejected_states = [
             SanctionStates.ADMIN_REJECTED, SanctionStates.MODERATOR_REJECTED
         ]


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
As part of ENG-2182, the `is_pending_approval`, `is_pending_embargo`, and 'is_pending_retraction` properties were updated to return True until the underlying sanction had both admin and moderator approval. FE uses these properties to alert registration contributors when a sanction requires admin attention, so they should return False once all admin approvals are granted, even if the sanction is still pending moderation.

## Changes

Update `Sanction.is_pending_approval` to only check whether the current `approval_stage` is `PENDING_ADMIN_APPROVAL`, this resolves all of the registration properties.

Note that `is_approved`, `is_embargoed`, and `is_retracted` will all continue to return False until moderator approval is also granted (if required).

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-2373