### PR TITLE
[ENG-2376] Fix registries_moderation tests and add to Travis

### DIFF
--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Case, CharField, Q, Value, When, F
+from django.db.models import Case, CharField, Q, Value, When
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.exceptions import ValidationError
 from rest_framework import generics
@@ -49,7 +49,6 @@ from osf.models import (
     WhitelistedSHAREPreprintProvider,
     NodeRequest,
     Registration,
-    RegistrationApproval,
 )
 from osf.utils.permissions import REVIEW_PERMISSIONS, ADMIN
 from osf.utils.workflows import RequestTypes
@@ -714,8 +713,7 @@ class RegistrationProviderRegistrationList(JSONAPIBaseView, generics.ListAPIView
 
         return Registration.objects.filter(
             provider=provider,
-            registration_approval__state=RegistrationApproval.APPROVED,
-        ).annotate(machine_state=F('moderation_state'))
+        )
 
     # overrides ListAPIView
     def get_queryset(self):

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -345,8 +345,8 @@ API_TESTS1 = [
     'api_tests/schemas',
     'api_tests/providers',
     'api_tests/preprints',
-    'api_tests/registries_moderation',
     'api_tests/registrations',
+    'api_tests/registries_moderation',
     'api_tests/users',
 ]
 API_TESTS2 = [

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -345,6 +345,7 @@ API_TESTS1 = [
     'api_tests/schemas',
     'api_tests/providers',
     'api_tests/preprints',
+    'api_tests/registries_moderation',
     'api_tests/registrations',
     'api_tests/users',
 ]


### PR DESCRIPTION
related tests, add api_tests/registries_moderation/ to Travis

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Our tests for Registries Moderation had some outdated assumptions and were failing on develop, these were not caught because the tests weren't included in the Travis configuration.

## Changes

Update Travis configuration to run api_test/registries_moderation as part of API_TESTS1

Replace outdated references to `machine_state` with the correct `reviews_state`

Update the default_query_set for `RegistrationProviderRegistrationList` to no longer exclude registrations without an `APPROVED` `RegistrationApproval` -- a decision made before Sanctions were turned into the de-facto mode of handling moderated registrations. Remove the `autouse` pytest fixture `unapproved_registration` that was meant to verify that unapproved registrations weren't returned in the query.

Remove the meaningless annotation of the returned registrations in `RegistrationProviderRegistrationList`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
