### PR TITLE
[ENG-2375][ENG-2377][Hotfix] Registration Tweaks for RWE and ASIST

### DIFF
--- a/website/project/metadata/asist-hypothesis-capability-registration.json
+++ b/website/project/metadata/asist-hypothesis-capability-registration.json
@@ -1,5 +1,5 @@
 {
-   "name":"ASIST Hypothesis/Capability Registration",
+   "name":"ASIST Hypothesis/Capability Preregistration",
    "version":1,
    "config":{
       "hasFiles":true
@@ -14,16 +14,16 @@
                "qid":"q1",
                "type":"string",
                "format":"text",
-               "title":"Study registration link",
-               "description":"Please provide a link to the study registration this study relies upon.",
+               "title":"Study preregistration link",
+               "description":"Please provide a link to the study preregistration this study relies upon.",
                "required":true
             },
             {
                "qid":"q2",
-               "title":"Hypothesis/Capability Registration",
+               "title":"Hypothesis/Capability preregistration",
                "type":"osf-upload",
                "format":"osf-upload-open",
-               "description":"Please attach the preregistration file containing your hypothesis/capability registration details.",
+               "description":"Please attach the preregistration file containing your hypothesis/capability preregistration details.",
                "required":true
             }
          ]

--- a/website/project/metadata/asist-results-registration.json
+++ b/website/project/metadata/asist-results-registration.json
@@ -23,7 +23,7 @@
                "qid":"q2",
                "type":"string",
                "format":"text",
-               "title":"Study registration link",
+               "title":"Study preregistration link",
                "description":"Please provide a link to the study preregistration this study relies upon.",
                "required":true
             },
@@ -58,7 +58,7 @@
                "title":"Results registration",
                "type":"osf-upload",
                "format":"osf-upload-open",
-               "description":"Please attach the preregistration file containing your hypothesis/capability results registration details.",
+               "description":"Please attach the file containing your hypothesis/capability preregistration and results.",
                "required":true
             }
          ]

--- a/website/project/metadata/real-world-evidence.json
+++ b/website/project/metadata/real-world-evidence.json
@@ -219,7 +219,7 @@
                "type":"string",
                "format":"text",
                "help":"Clarify the description chosen for data handling.",
-               "required":true
+               "required":false
             }
          ]
       },

--- a/website/project/metadata/real-world-evidence.json
+++ b/website/project/metadata/real-world-evidence.json
@@ -1,5 +1,5 @@
 {
-   "name":"Real World Evidence in Health Outcomes Minimum Recommended Form",
+   "name":"Real World Evidence Recommended Minimum Study Registration Template",
    "version":1,
    "config":{
       "hasFiles":true
@@ -42,7 +42,7 @@
                "type":"string",
                "format":"text",
                "title":"Extraction date",
-               "help":"This refers to either the extraction version number or the date of the final analytic dataset of extraction for the RWD database that will be used to implement the study protocol.",
+               "help":"This refers to either the version number for the database that will be used to implement the study protocol or the date that the database was created.",
                "example":"09/10/2020 or v 7.1.0",
                "required":true
             },
@@ -184,7 +184,7 @@
                "qid":"q18",
                "type":"string",
                "format":"textarea",
-               "title":"Treatment effect of interest and follow-up model",
+               "title":"Follow-up definition",
                "help":"The text definition of the full follow-up window inclusive of treatment for both intervention and comparator.",
                "example":"Day 1 (fill date) through 100 days, the last day of the study period, death, or disenrollment.",
                "required":true
@@ -212,6 +212,14 @@
                "help":"Please choose the one best short description that best reflects the amount of data handling that you have had up until the date of registration for this study.",
                "example":"If you have looked at the data to determine whether there are enough adults with sleep disordered breathing to at least satisfy requirements for your sample size, you should choose option 3 –conducted feasibility counts.",
                "required":true
+            },
+            {
+               "qid":"q20",
+               "title":"Data handling",
+               "type":"string",
+               "format":"text",
+               "help":"Clarify the description chosen for data handling.",
+               "required":true
             }
          ]
       },
@@ -220,7 +228,7 @@
          "title":"Protocol Document",
          "questions":[
             {
-               "qid":"q20",
+               "qid":"q21",
                "title":"Upload protocol document",
                "type":"osf-upload",
                "format":"osf-upload-open",


### PR DESCRIPTION
## Purpose
Make some changes to the RWE and ASIST Schemas after they've been further reviewed

## Changes
#### Real World Evidence
1. Change the template name/title to "Real World Evidence Recommended Minimum Study Registration Template", old name was 'Real World Evidence in Health Outcomes Minumum Recommended Form'
2. Change q4 (Extraction date) help text to "This refers to either the version number for the database that will be used to implement the study protocol or the date that the database was created."
3. Change the q18 Question-label to "Follow-up definition"
4. Add another question after q19 for Data handling details in sheet.

(Note: qid incrementation on the schema blocks sheet is off by 1 after q6)

#### ASIST Results Registration
1. Update the question label for q2 from "Study registration link" to “Study preregistration link”
2. Update q6 instructional text to "Please attach the file containing your hypothesis/capability preregistration and results."

#### ASIST Hypothesis Capability Registration
1. Update the Template TITLE updated from "Hypothesis/Capability Registration" to “Hypothesis/Capability Preregistration”
2. Update the question label for q1 from "Study registration link" to “Study preregistration link”
3. Update the help text for q1 also to use preregistration and not registration.
4. Update the question label for q2 from "Hypothesis/Capability Registration" to “Hypothesis/Capability preregistration”


## QA Notes
- Verify 3 registration schemas are in-line with their respective sheet specifications

## Documentation
N/A

## Side Effects
N/A

## Ticket
[ENG-2375](https://openscience.atlassian.net/browse/ENG-2375)
[ENG-2377](https://openscience.atlassian.net/browse/ENG-2377)