### PR TITLE
[ENG-2348] Removes storage limits messaging on registration pages

### DIFF
--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -121,6 +121,10 @@ def sizeof_fmt(num, suffix='B'):
 
 
 def get_storage_limits_css(node):
+    from osf.models import Node
+
+    if not isinstance(node, Node):
+        return None
     status = node.storage_limit_status
 
     if status is settings.StorageLimits.APPROACHING_PRIVATE:


### PR DESCRIPTION
## Purpose
On the registration files page, storage limits messaging is sometimes displayed. Storage caps does not apply to registrations and messaging related to storage caps should not be displayed on registration pages.

Currently, storage messaging on registration file pages can arise because of this boolean (https://github.com/CenterForOpenScience/osf.io/blob/develop/website/static/js/fangorn.js#L2225). The `storageLimitsStatus` checked in that boolean is based off of the `window.contextVars.node.storageLimitsStatus` which is determined by `website.project.utils.get_storage_limits_css`. Though storage caps don't apply to Registrations, `website.project.utils.get_storage_limits_css` can currently check storage for the Registration and return a dictionary value that should only be returned for Nodes. 

## Changes
* Adds a check on `website.project.utils.get_storage_limits_css` to return `None` if the provided object is not a Node because storage caps don't apply in that case

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that the bug defined [here](https://openscience.atlassian.net/browse/ENG-2348) is no longer occurring

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2348)
