### PR TITLE
Adding ability to add and remove moderators cleanly in the admin app. [ENG-2372]

### DIFF
--- a/admin/registration_providers/urls.py
+++ b/admin/registration_providers/urls.py
@@ -15,6 +15,6 @@ urlpatterns = [
     url(r'^(?P<registration_provider_id>[a-z0-9]+)/schemas/$', views.ChangeSchema.as_view(), name='schemas'),
     url(r'^(?P<registration_provider_id>[a-z0-9]+)/cannot_delete/$', views.CannotDeleteProvider.as_view(), name='cannot_delete'),
     url(r'^(?P<registration_provider_id>[a-z0-9]+)/share_source/$', views.ShareSourceRegistrationProvider.as_view(), name='share_source'),
-    url(r'^(?P<registration_provider_id>[a-z0-9]+)/remove_moderators/$', views.RemoveModerators.as_view(), name='remove_moderators'),
-    url(r'^(?P<registration_provider_id>[a-z0-9]+)/add_moderators/$', views.AddModerators.as_view(), name='add_moderators'),
+    url(r'^(?P<registration_provider_id>[a-z0-9]+)/remove_admins_and_moderators/$', views.RemoveAdminsAndModerators.as_view(), name='remove_admins_and_moderators'),
+    url(r'^(?P<registration_provider_id>[a-z0-9]+)/add_admin_or_moderator/$', views.AddAdminOrModerator.as_view(), name='add_admin_or_moderator'),
 ]

--- a/admin/registration_providers/views.py
+++ b/admin/registration_providers/views.py
@@ -412,7 +412,7 @@ class ChangeSchema(TemplateView):
         return redirect('registration_providers:detail', registration_provider_id=registration_provider.id)
 
 
-class AddModerators(TemplateView):
+class AddAdminOrModerator(TemplateView):
     permission_required = 'osf.change_registrationprovider'
     template_name = 'registration_providers/edit_moderators.html'
 
@@ -423,6 +423,7 @@ class AddModerators(TemplateView):
         context = super().get_context_data(**kwargs)
         context['registration_provider'] = registration_provider
         context['moderators'] = registration_provider.get_group('moderator').user_set.all()
+        context['admins'] = registration_provider.get_group('admin').user_set.all()
         return context
 
     def post(self, request, *args, **kwargs):
@@ -430,19 +431,24 @@ class AddModerators(TemplateView):
         data = dict(request.POST)
         del data['csrfmiddlewaretoken']  # just to remove the key from the form dict
 
-        moderator = OSFUser.load(data['add-moderators-form'][0])
-        if moderator is None:
+        target_user = OSFUser.load(data['add-moderators-form'][0])
+        if target_user is None:
             messages.error(request, f'User for guid: {data["add-moderators-form"][0]} could not be found')
-            return redirect('registration_providers:add_moderators', registration_provider_id=registration_provider.id)
+            return redirect('registration_providers:add_admin_or_moderator', registration_provider_id=registration_provider.id)
 
-        registration_provider.add_to_group(moderator, 'moderator')
+        if 'admin' in data:
+            registration_provider.add_to_group(target_user, 'admin')
+            target_type = 'admin'
+        else:
+            registration_provider.add_to_group(target_user, 'moderator')
+            target_type = 'moderator'
 
-        messages.success(request, f'The following moderator was successfully added: {moderator.fullname} ({moderator.username})')
+        messages.success(request, f'The following {target_type} was successfully added: {target_user.fullname} ({target_user.username})')
 
-        return redirect('registration_providers:add_moderators', registration_provider_id=registration_provider.id)
+        return redirect('registration_providers:add_admin_or_moderator', registration_provider_id=registration_provider.id)
 
 
-class RemoveModerators(TemplateView):
+class RemoveAdminsAndModerators(TemplateView):
     permission_required = 'osf.change_registrationprovider'
     template_name = 'registration_providers/edit_moderators.html'
 
@@ -453,6 +459,7 @@ class RemoveModerators(TemplateView):
         context = super().get_context_data(**kwargs)
         context['registration_provider'] = registration_provider
         context['moderators'] = registration_provider.get_group('moderator').user_set.all()
+        context['admins'] = registration_provider.get_group('admin').user_set.all()
         return context
 
     def post(self, request, *args, **kwargs):
@@ -460,10 +467,20 @@ class RemoveModerators(TemplateView):
         data = dict(request.POST)
         del data['csrfmiddlewaretoken']  # just to remove the key from the form dict
 
-        moderators = OSFUser.objects.filter(id__in=list(data.keys()))
+        to_be_removed = list(data.keys())
+        removed_admins = [admin.replace('Admin-', '') for admin in to_be_removed if 'Admin-' in admin]
+        removed_moderators = [moderator.replace('Moderator-', '') for moderator in to_be_removed if 'Moderator-' in moderator]
+        moderators = OSFUser.objects.filter(id__in=removed_moderators)
+        admins = OSFUser.objects.filter(id__in=removed_admins)
         registration_provider.get_group('moderator').user_set.remove(*moderators)
+        registration_provider.get_group('admin').user_set.remove(*admins)
 
-        moderator_names = ' ,'.join(moderators.values_list('fullname', flat=True))
-        messages.success(request, f'The following moderators were successfully removed: {moderator_names}')
+        if moderators:
+            moderator_names = ' ,'.join(moderators.values_list('fullname', flat=True))
+            messages.success(request, f'The following moderators were successfully removed: {moderator_names}')
 
-        return redirect('registration_providers:remove_moderators', registration_provider_id=registration_provider.id)
+        if admins:
+            admin_names = ' ,'.join(admins.values_list('fullname', flat=True))
+            messages.success(request, f'The following admins were successfully removed: {admin_names}')
+
+        return redirect('registration_providers:remove_admins_and_moderators', registration_provider_id=registration_provider.id)

--- a/admin/templates/registration_providers/detail.html
+++ b/admin/templates/registration_providers/detail.html
@@ -27,7 +27,7 @@
         </div>
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-primary" href={% url 'registration_providers:add_moderators' registration_provider.id %}>Add/Remove Moderators</a>
+                <a class="btn btn-primary" href={% url 'registration_providers:add_admin_or_moderator' registration_provider.id %}>Manage Admins and Moderators</a>
                 <a class="btn btn-primary" href={% url 'registration_providers:export' registration_provider.id %}>Export registration provider metadata</a>
                 <a class="btn btn-primary" href={% url 'registration_providers:share_source' registration_provider.id %}>Setup Share Source</a>
                 <a class="btn btn-primary" href={% url 'registration_providers:schemas' registration_provider.id %}>Change allowed schemas</a>

--- a/admin/templates/registration_providers/edit_moderators.html
+++ b/admin/templates/registration_providers/edit_moderators.html
@@ -22,30 +22,40 @@
         </div>
         <div class="row">
             <div class="col-md-12">
-                <form id="add-moderators-form" action="{% url 'registration_providers:add_moderators' registration_provider.id %}" method="post">
+                <form id="add-moderators-form" action="{% url 'registration_providers:add_admin_or_moderator' registration_provider.id %}" method="post">
                     {% csrf_token %}
                     <label>Add moderator by guid: </label>
                     <input type="text" name="add-moderators-form">
-                    <input type="submit" value="Add Moderator" class="form-button btn btn-success">
+                    <input type="submit" name="mod" value="Add Moderator" class="form-button btn btn-success">
+                    <input type="submit" name="admin" value="Add Admin" class="form-button btn btn-success">
                 </form>
             </div>
         </div>
         <hr>
         <div class="row">
             <div class="col-md-12">
-                <form id="remove-moderators-form" action="{% url 'registration_providers:remove_moderators' registration_provider.id %}" method="post">
+                <form id="remove-moderators-form" action="{% url 'registration_providers:remove_admins_and_moderators' registration_provider.id %}" method="post">
                     {% csrf_token %}
                     <table class="table table-striped">
                         <th></th>
                         <th>Name</th>
+                        <th>Type</th>
                         {% for moderator in moderators %}
                             <tr>
-                                <td><input type='checkbox' name="{{moderator.id}}"></td>
+                                <td><input type='checkbox' name="Moderator-{{moderator.id}}"></td>
                                 <td>{{ moderator.fullname }} ({{moderator.username}})</td>
+                                <td>Moderator</td>
+                            </tr>
+                        {% endfor %}
+                        {% for admin in admins %}
+                            <tr>
+                                <td><input type='checkbox' name="Admin-{{admin.id}}"></td>
+                                <td>{{ admin.fullname }} ({{admin.username}})</td>
+                                <td>Admin</td>
                             </tr>
                         {% endfor %}
                     </table>
-                    <input class="form-button btn btn-danger" type="submit" value="Remove Moderators" />
+                    <input class="form-button btn btn-danger" type="submit" value="Remove Moderators/Admins" />
                 </form>
             </div>
         </div>

--- a/admin_tests/registration_providers/test_views.py
+++ b/admin_tests/registration_providers/test_views.py
@@ -273,14 +273,14 @@ class TestEditModerators:
 
     @pytest.fixture()
     def remove_moderator_view(self, req, provider):
-        view = views.RemoveModerators()
+        view = views.RemoveAdminsAndModerators()
         view = setup_view(view, req)
         view.kwargs = {'registration_provider_id': provider.id}
         return view
 
     @pytest.fixture()
     def add_moderator_view(self, req, provider):
-        view = views.AddModerators()
+        view = views.AddAdminOrModerator()
         view = setup_view(view, req)
         view.kwargs = {'registration_provider_id': provider.id}
         return view
@@ -293,9 +293,10 @@ class TestEditModerators:
         assert res.status_code == 200
 
     def test_post_remove(self, remove_moderator_view, req, moderator, provider):
+        moderator_id = f'Moderator-{moderator.id}'
         req.POST = {
             'csrfmiddlewaretoken': 'fake csfr',
-            str(moderator.id): ['on']
+            moderator_id: ['on']
         }
 
         # django.contrib.messages has a bug which effects unittests
@@ -311,7 +312,8 @@ class TestEditModerators:
     def test_post_add(self, add_moderator_view, req, user, provider):
         req.POST = {
             'csrfmiddlewaretoken': 'fake csfr',
-            'add-moderators-form': [user._id]
+            'add-moderators-form': [user._id],
+            'moderator': ['Add Moderator']
         }
 
         # django.contrib.messages has a bug which effects unittests


### PR DESCRIPTION


## Purpose

Adding the ability to add admin moderators cleanly to registration providers in the admin app.

## Changes

Modifying templates. Adding code to the views. 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify you can add and remove admins to registration providers
- Verify you can remove a moderator as an admin, but not as a moderator

What are the areas of risk?

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

Shouldn't be.
## Ticket

https://openscience.atlassian.net/browse/ENG-2372