### PR TITLE
[ENG-2360][Hotfix] Fix schema ordering for travis

### DIFF
--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -272,7 +272,7 @@ def delete_draft_registration(auth, node, draft, *args, **kwargs):
     return None, http_status.HTTP_204_NO_CONTENT
 
 
-def sort_schemas(schema):
+def order_schemas(schema):
     """ Schemas not specified in METASCHEMA_ORDERING get sent to the bottom of the list."""
     try:
         return METASCHEMA_ORDERING.index(schema.name)
@@ -294,7 +294,7 @@ def get_metaschemas(*args, **kwargs):
     if include == 'latest':
         meta_schemas = RegistrationSchema.objects.get_latest_versions()
 
-    meta_schemas = sorted(meta_schemas, key=lambda x: sort_schemas(x))
+    meta_schemas = sorted(meta_schemas, key=order_schemas)
 
     return {
         'meta_schemas': [

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -271,6 +271,15 @@ def delete_draft_registration(auth, node, draft, *args, **kwargs):
     draft.save(update_fields=['deleted'])
     return None, http_status.HTTP_204_NO_CONTENT
 
+
+def sort_schemas(schema):
+    """ Schemas not specified in METASCHEMA_ORDERING get sent to the bottom of the list."""
+    try:
+        return METASCHEMA_ORDERING.index(schema.name)
+    except ValueError:
+        return len(METASCHEMA_ORDERING)
+
+
 def get_metaschemas(*args, **kwargs):
     """
     List metaschemas with which a draft registration may be created. Only fetch the newest version for each schema.
@@ -285,7 +294,7 @@ def get_metaschemas(*args, **kwargs):
     if include == 'latest':
         meta_schemas = RegistrationSchema.objects.get_latest_versions()
 
-    meta_schemas = sorted(meta_schemas, key=lambda x: METASCHEMA_ORDERING.index(x.name))
+    meta_schemas = sorted(meta_schemas, key=lambda x: sort_schemas(x))
 
     return {
         'meta_schemas': [


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Everytime we add a schema now, we forget to change the ding-dang schema ordering list, causing Travis to fail, this makes it more inclusive pushing unordered schemas to the bottom of the list.

## Changes

- adds new method for sorting schemas

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify travis passes

## Documentation

🐞 fix, no docs

## Side Effects

none that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2360