### PR TITLE
Ensuring target_file_size is an int to prevent a calculation error [hotfix] [ENG-2385]

### DIFF
--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -158,7 +158,7 @@ def update_storage_usage_with_size(payload):
     provider = metadata.get('provider', 'osfstorage')
 
     target_file_id = metadata['path'].replace('/', '')
-    target_file_size = metadata.get('size', 0)
+    target_file_size = metadata.get('sizeInt', 0)
 
     if target_node.storage_limit_status is settings.StorageLimits.NOT_CALCULATED:
         return update_storage_usage(target_node)


### PR DESCRIPTION


## Purpose

Sometimes a data provider gives us back a string size instead of an int size. We need the int.

## Changes

Ensure the size metadata is an int

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify no errors are caused when moving files between google drive and osf storage. This is where the error occured

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A
## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-2385