### PR TITLE
[ENG-2386] Remove check for deleted registrations on registrations action list

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -81,7 +81,7 @@ def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     return url
 
 
-def get_object_or_error(model_or_qs, query_or_pk=None, request=None, display_name=None):
+def get_object_or_error(model_or_qs, query_or_pk=None, request=None, display_name=None, check_deleted=True):
     if not request:
         # for backwards compat with existing get_object_or_error usages
         raise TypeError('request is a required argument')
@@ -136,7 +136,7 @@ def get_object_or_error(model_or_qs, query_or_pk=None, request=None, display_nam
     # disabled.
     if model_cls is OSFUser and obj.is_disabled:
         raise UserGone(user=obj)
-    elif model_cls is not OSFUser and not getattr(obj, 'is_active', True) or getattr(obj, 'is_deleted', False) or getattr(obj, 'deleted', False):
+    if check_deleted and (model_cls is not OSFUser and not getattr(obj, 'is_active', True) or getattr(obj, 'is_deleted', False) or getattr(obj, 'deleted', False)):
         if display_name is None:
             raise Gone
         else:

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -783,7 +783,7 @@ class RegistrationIdentifierList(RegistrationMixin, NodeIdentifierList):
     serializer_class = RegistrationIdentifierSerializer
 
 
-class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCreateAPIView, RegistrationMixin, ProviderMixin):
+class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCreateAPIView, ProviderMixin):
     provider_class = RegistrationProvider
 
     permission_classes = (
@@ -800,22 +800,21 @@ class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCrea
     view_name = 'registration-actions-list'
 
     serializer_class = RegistrationActionSerializer
+    node_lookup_url_kwarg = 'node_id'
 
-    def get_node(self, check_object_permissions=True):
-        node = get_object_or_error(
+    def get_registration(self):
+        registration = get_object_or_error(
             Registration,
             self.kwargs[self.node_lookup_url_kwarg],
             self.request,
-            check_deleted=False
+            check_deleted=False,
         )
-
         # May raise a permission denied
-        if check_object_permissions:
-            self.check_object_permissions(self.request, node)
-        return node
+        self.check_object_permissions(self.request, registration)
+        return registration
 
     def get_default_queryset(self):
-        return self.get_node().actions.all()
+        return self.get_registration().actions.all()
 
     def get_queryset(self):
         return self.get_queryset_from_request()

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -801,6 +801,19 @@ class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCrea
 
     serializer_class = RegistrationActionSerializer
 
+    def get_node(self, check_object_permissions=True):
+        node = get_object_or_error(
+            Registration,
+            self.kwargs[self.node_lookup_url_kwarg],
+            self.request,
+            check_deleted=False
+        )
+
+        # May raise a permission denied
+        if check_object_permissions:
+            self.check_object_permissions(self.request, node)
+        return node
+
     def get_default_queryset(self):
         return self.get_node().actions.all()
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently when a registration is deleted it's moderation actions become inaccessible, this fixes that.

## Changes

- add simple conditional overriding is_deleted check and overrides function.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify actions are still accessible for deleted registrations

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2386