### PR TITLE
Adding auth groups creation to provider creation [ENG-2387]

### DIFF
--- a/admin/registration_providers/views.py
+++ b/admin/registration_providers/views.py
@@ -32,6 +32,7 @@ class CreateRegistrationProvider(PermissionRequiredMixin, CreateView):
         self.object = form.save(commit=False)
         self.object._creator = self.request.user
         self.object.save()
+        self.object.update_group_permissions()  # Creating moderator groups
         return super(CreateRegistrationProvider, self).form_valid(form)
 
     def get_context_data(self, *args, **kwargs):


### PR DESCRIPTION


## Purpose

Moderator groups aren't being created when the provider is created in the admin app. They need to be.

## Changes

Creating the auth groups at create time for the provider

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify You can add moderators and admins right after you create the provider in the admin app
- Verify

What are the areas of risk? None

Any concerns/considerations/questions that development raised? None

## Documentation

N/A

## Side Effects

Shouldn't be.
## Ticket

https://openscience.atlassian.net/browse/ENG-2387