### PR TITLE
[ENG-2366] Modify Retraction justification on FORCE_WITHDRAW

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -621,6 +621,9 @@ class Registration(AbstractNode):
             return  # Not a moderated event, no need to write an action
 
         initiated_by = initiated_by or self.sanction.initiated_by
+
+        if trigger == RegistrationModerationTriggers.FORCE_WITHDRAW:
+            comment = 'Force withdrawn by moderator: ' + comment
         action = RegistrationAction.objects.create(
             target=self,
             creator=initiated_by,

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -855,7 +855,7 @@ class TestForcedWithdrawal():
 
         action = RegistrationAction.objects.last()
         assert action.trigger == RegistrationModerationTriggers.FORCE_WITHDRAW.db_name
-        assert action.comment == justification
+        assert action.comment == f'Force withdrawn by moderator: {justification}'
         assert action.from_state == RegistrationModerationStates.ACCEPTED.db_name
         assert action.to_state == RegistrationModerationStates.WITHDRAWN.db_name
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

In order to help distinguish between normal withdrawals and forced withdrawals on the moderator app, we should prepend some sort of "Force withdrawn by moderator" message to the withdrawal justification on FORCE_WITHDRAW triggers

## Changes

- prepend comment when writing RegistrationAction

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify Force withdrawals have prepended comment

## Documentation

tech task, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2366