### PR TITLE
[ENG-2291] Adding a script for mass withdrawal for preprints.

### DIFF
--- a/osf/management/commands/withdraw_all_preprints_from_provider.py
+++ b/osf/management/commands/withdraw_all_preprints_from_provider.py
@@ -1,0 +1,98 @@
+import logging
+
+from django.db import transaction
+from django.core.management.base import BaseCommand
+
+from osf.models import PreprintProvider, PreprintRequest, OSFUser
+from osf.utils.workflows import DefaultStates, RequestTypes
+
+PAGE_SIZE = 100
+
+logger = logging.getLogger(__name__)
+
+
+def withdraw_all_preprints(provider_id, page_size, user_guid, comment=None):
+    """ A management command to withdraw all preprints from a specified provider
+        Created to withdraw all EarthRxiv preprints, but can be used for any preprint
+        provider
+    """
+    provider = PreprintProvider.load(provider_id)
+    if not provider:
+        raise RuntimeError('Could not find provider. Check ID and try again')
+
+    user = OSFUser.load(user_guid)
+    if not user:
+        raise RuntimeError('Could not find user. Check GUID and try again')
+
+    if not comment:
+        comment = 'This preprint was moved to the new EartharXiv hosted by CDL. The DOI now resolves to the new location at https://eartharxiv.org/.'
+
+    preprints = provider.preprints.filter(date_withdrawn=None)[:page_size]
+
+    preprints_withdrawn = 0
+
+    for preprint in preprints:
+        preprint_request = PreprintRequest(
+            target=preprint,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value,
+            creator=user
+        )
+        preprint_request.save()
+        preprint_request.run_submit(user)
+        preprint_request.run_accept(user, comment=comment)
+        preprint.reload()
+        assert preprint.is_retracted
+        preprints_withdrawn += 1
+
+        logger.info(f'{preprints_withdrawn} have been withdrawn from provider {provider.name}')
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--provider-id',
+            dest='provider_id',
+            help='ID of the preprint provider to withdraw',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            help='Do not commit, just for testing'
+        )
+        parser.add_argument(
+            '--page-size',
+            dest='page_size',
+            help='How many preprints to withdraw this run.'
+        )
+        parser.add_argument(
+            '--user',
+            dest='user_guid',
+            help='User to use as action creator.'
+        )
+        parser.add_argument(
+            '--comment',
+            dest='comment',
+            help='Comment to withdraw with'
+        )
+
+    def handle(self, *args, **options):
+        provider_id = options.get('provider_id', None)
+        dry_run = options.get('dry_run', False)
+        page_size = int(options.get('page_size', PAGE_SIZE))
+        user_guid = options.get('user_guid', None)
+        comment = options.get('comment', None)
+
+        if not provider_id:
+            raise RuntimeError('Must provide a provider id.')
+
+        if not user_guid:
+            raise RuntimeError('Must provider a user to use as action creator.')
+
+        with transaction.atomic():
+            withdraw_all_preprints(provider_id, page_size, user_guid, comment)
+            if dry_run:
+                raise RuntimeError('Dry run, transaction rolled back.')

--- a/osf/management/commands/withdraw_all_preprints_from_provider.py
+++ b/osf/management/commands/withdraw_all_preprints_from_provider.py
@@ -33,7 +33,7 @@ def withdraw_all_preprints(provider_id, page_size, user_guid, comment=None):
     if not comment and not saved_comment:
         raise RuntimeError('Comment not provided!')
 
-    preprints = provider.preprints.filter(date_withdrawn=None)[:page_size]
+    preprints = provider.preprints.filter(date_withdrawn=None, is_published=True)[:page_size]
 
     preprints_withdrawn = 0
 

--- a/osf/management/commands/withdraw_all_preprints_from_provider.py
+++ b/osf/management/commands/withdraw_all_preprints_from_provider.py
@@ -2,8 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from osf.models import PreprintProvider, PreprintRequest, OSFUser
-from osf.utils.workflows import DefaultStates, RequestTypes
+from osf.models import PreprintProvider, OSFUser
 
 PAGE_SIZE = 100
 
@@ -39,15 +38,7 @@ def withdraw_all_preprints(provider_id, page_size, user_guid, comment=None):
     preprints_withdrawn = 0
 
     for preprint in preprints:
-        preprint_request = PreprintRequest(
-            target=preprint,
-            request_type=RequestTypes.WITHDRAWAL.value,
-            machine_state=DefaultStates.INITIAL.value,
-            creator=user
-        )
-        preprint_request.save()
-        preprint_request.run_submit(user)
-        preprint_request.run_accept(user, comment=comment)
+        preprint.run_withdraw(user, comment)
         preprint.reload()
         assert preprint.is_retracted
         preprints_withdrawn += 1

--- a/osf_tests/management_commands/test_withdraw_all_preprints_from_provider.py
+++ b/osf_tests/management_commands/test_withdraw_all_preprints_from_provider.py
@@ -1,0 +1,36 @@
+import pytest
+
+from osf.management.commands.withdraw_all_preprints_from_provider import withdraw_all_preprints
+from osf_tests.factories import PreprintProviderFactory, PreprintFactory, AuthUserFactory
+
+@pytest.mark.django_db
+class TestWithdrawAllPreprint:
+
+    @pytest.fixture()
+    def preprint_provider(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture()
+    def provider_preprint(self, preprint_provider):
+        return PreprintFactory(provider=preprint_provider)
+
+    @pytest.fixture()
+    def nonprovider_preprint(self):
+        return PreprintFactory()
+
+    @pytest.fixture()
+    def withdrawing_user(self):
+        return AuthUserFactory()
+
+    def test_withdraw_all_preprints(self, preprint_provider, provider_preprint, withdrawing_user):
+        withdraw_all_preprints(preprint_provider._id, 10, withdrawing_user._id, 'test_comment')
+        provider_preprint.reload()
+
+        assert provider_preprint.is_retracted
+        assert provider_preprint.withdrawal_justification == 'test_comment'
+
+    def test_withdraw_no_preprints(self, preprint_provider, nonprovider_preprint, withdrawing_user):
+        withdraw_all_preprints(preprint_provider._id, 10, withdrawing_user._id, 'test_comment')
+        nonprovider_preprint.reload()
+
+        assert not nonprovider_preprint.is_retracted

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -500,7 +500,6 @@ class CeleryConfig:
         'osf.management.commands.check_crossref_dois',
         'osf.management.commands.update_institution_project_counts',
         'osf.management.commands.correct_registration_moderation_states',
-        'osf.management.commands.withdraw_all_preprints_from_provider',
     )
 
     # Modules that need metrics and release requirements

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -426,7 +426,6 @@ class CeleryConfig:
         'website.identifier.tasks',
         'website.preprints.tasks',
         'website.project.tasks',
-        'osf.management.commands.withdraw_all_preprints_from_provider'
     }
 
     high_pri_modules = {
@@ -540,14 +539,6 @@ class CeleryConfig:
                     'mendeley': 14      # http://dev.mendeley.com/reference/topics/authorization_overview.html
                 }},
             },
-            #'withdraw_all_preprints_from_provider': { # Schedule to remove all earthrxiv preprints
-            #    'task': 'osf.management.commands.withdraw_all_preprints_from_provider',
-            #    'schedule': crontab(minute=0, hour=7),  # Daily 2:00 a.m
-            #    'kwargs': {
-            #        'dry_run': False,
-            #        'user': #  Need to put in the user that will be the creator,
-            #    },
-            #},
             'retract_registrations': {
                 'task': 'scripts.retract_registrations',
                 'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -426,6 +426,7 @@ class CeleryConfig:
         'website.identifier.tasks',
         'website.preprints.tasks',
         'website.project.tasks',
+        'osf.management.commands.withdraw_all_preprints_from_provider'
     }
 
     high_pri_modules = {
@@ -500,6 +501,7 @@ class CeleryConfig:
         'osf.management.commands.check_crossref_dois',
         'osf.management.commands.update_institution_project_counts',
         'osf.management.commands.correct_registration_moderation_states',
+        'osf.management.commands.withdraw_all_preprints_from_provider',
     )
 
     # Modules that need metrics and release requirements
@@ -538,6 +540,14 @@ class CeleryConfig:
                     'mendeley': 14      # http://dev.mendeley.com/reference/topics/authorization_overview.html
                 }},
             },
+            #'withdraw_all_preprints_from_provider': { # Schedule to remove all earthrxiv preprints
+            #    'task': 'osf.management.commands.withdraw_all_preprints_from_provider',
+            #    'schedule': crontab(minute=0, hour=7),  # Daily 2:00 a.m
+            #    'kwargs': {
+            #        'dry_run': False,
+            #        'user': #  Need to put in the user that will be the creator,
+            #    },
+            #},
             'retract_registrations': {
                 'task': 'scripts.retract_registrations',
                 'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m

--- a/website/templates/emails/withdrawal_request_granted.html.mako
+++ b/website/templates/emails/withdrawal_request_granted.html.mako
@@ -30,6 +30,9 @@
                 <br>
             % else:
                 ${requester.fullname} has withdrawn your ${document_type} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
+                % if reviewable.withdrawal_justification:
+                    ${requester.fullname} provided the following justification: "${reviewable.withdrawal_justification}"
+                % endif
                 <br>
                 The ${document_type} has been removed from ${reviewable.provider.name}.
                 <br>
@@ -43,12 +46,18 @@
             % elif force_withdrawal:
                 A moderator has withdrawn your ${document_type} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
                 <br>
-                The ${document_type} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${document_type}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
+                The ${document_type} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${document_type}, its contributor list, abstract, tags, and DOI.
+                % if reviewable.withdrawal_justification:
+                    The moderator has provided the following justification: "${reviewable.withdrawal_justification}".
+                    <br>
+                % endif
                 <br>
             % else:
                 ${requester.fullname} has withdrawn your ${document_type} <a href="${reviewable.absolute_url}">"${reviewable.title}"</a> from ${reviewable.provider.name}.
                 <br>
-                The ${document_type} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${document_type}, its contributor list, abstract, tags, DOI, and reason for withdrawal (if provided).
+                The ${document_type} has been removed from ${reviewable.provider.name}, but its metadata is still available: title of the withdrawn ${document_type}, its contributor list, abstract, tags, and DOI.
+                % if reviewable.withdrawal_justification:
+                    ${requester.fullname} provided the following justification: "${reviewable.withdrawal_justification}".
                 <br>
             % endif
         % endif


### PR DESCRIPTION
## Purpose

We need a script to mass withdraw all preprints from one provider

## Changes

Adding the script. Adding tests. Modifying email template to include withdrawal justification.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify Emails are sent correctly
- Verify Preprints are properly withdrawn

What are the areas of risk? Shouldn't be.

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

N/A

## DevOps Notes

DevOps will need to populate the user field in settings/defaults.py before uncommenting it for it to run.

## Ticket

https://openscience.atlassian.net/browse/ENG-2291