### PR TITLE
[ENG-2408] Add permissions to ProviderSerializer

### DIFF
--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -38,6 +38,7 @@ class ProviderSerializer(JSONAPISerializer):
 
     share_source = ser.CharField(read_only=True)
     share_publish_type = ser.CharField(read_only=True)
+    permissions = ser.SerializerMethodField()
 
     links = LinksField({
         'self': 'get_absolute_url',
@@ -93,6 +94,12 @@ class ProviderSerializer(JSONAPISerializer):
     def get_assets(self, obj):
         return {asset.name: asset.file.url for asset in obj.asset_files.all()} or None
 
+    def get_permissions(self, obj):
+        auth = get_user_auth(self.context['request'])
+        if not auth.user:
+            return []
+        return get_perms(auth.user, obj)
+
 
 class CollectionProviderSerializer(ProviderSerializer):
     class Meta:
@@ -144,6 +151,7 @@ class RegistrationProviderSerializer(ProviderSerializer):
         'id',
         'name',
         'reviews_workflow',
+        'permissions',
     ])
 
     reviews_workflow = ser.ChoiceField(choices=Workflows.choices(), read_only=True)
@@ -184,7 +192,6 @@ class PreprintProviderSerializer(MetricsSerializerMixin, ProviderSerializer):
 
     preprint_word = ser.CharField(read_only=True, allow_null=True)
     additional_providers = ser.ListField(read_only=True, child=ser.CharField())
-    permissions = ser.SerializerMethodField()
 
     # Reviews settings are the only writable fields
     reviews_workflow = ser.ChoiceField(choices=Workflows.choices())
@@ -214,12 +221,6 @@ class PreprintProviderSerializer(MetricsSerializerMixin, ProviderSerializer):
                 'version': self.context['request'].parser_context['kwargs']['version'],
             },
         )
-
-    def get_permissions(self, obj):
-        auth = get_user_auth(self.context['request'])
-        if not auth.user:
-            return []
-        return get_perms(auth.user, obj)
 
     def validate(self, data):
         required_fields = ('reviews_workflow', 'reviews_comments_private', 'reviews_comments_anonymous')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

We want to display a user's permissions with a provider via the API, for RegistrationProviders as well as PreprintProviders

## Changes

- add serializer field to ProviderMixin

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify your permissions are accurately represented on the registration providers list and details.

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2408