### PR TITLE
[ENG-2405] add email template for withdrawal requests

### DIFF
--- a/website/templates/emails/new_pending_withdraw_requests.html.mako
+++ b/website/templates/emails/new_pending_withdraw_requests.html.mako
@@ -1,0 +1,7 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+    There is a new withdrawal request. This is a placeholder email until we get language from Product.
+</tr>
+</%def>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When a withdrawal request was completed an email confirming that was supposed to be sent, but instead because there was no email template the whole transaction would fail, stranding the registration in the old moderation state.

## Changes

- add placeholder template so transaction can complete and moderation state can change.


## QA Notes

- Verify accepting admin withdrawal request causes the moderator to get a registration in the withdrawal request queue.


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2405