### PR TITLE
[ENG-2400] Remove comments_anonymous from admin app Registries Moderation setup 

### DIFF
--- a/admin/registration_providers/forms.py
+++ b/admin/registration_providers/forms.py
@@ -30,7 +30,8 @@ class RegistrationProviderForm(forms.ModelForm):
             'domain_redirect_enabled',
             'collected_type_choices',
             'status_choices',
-            'reviews_comments_private'
+            'reviews_comments_private',
+            'reviews_comments_anonymous',
         ]
 
         widgets = {

--- a/admin/registration_providers/views.py
+++ b/admin/registration_providers/views.py
@@ -145,6 +145,9 @@ class RegistrationProviderDisplay(PermissionRequiredMixin, DetailView):
         # set api key for tinymce
         kwargs['tinymce_apikey'] = settings.TINYMCE_APIKEY
 
+        # this doesn't apply to reg providers so delete it and exclude from form
+        del kwargs['registration_provider']['reviews_comments_anonymous']
+
         return kwargs
 
 


### PR DESCRIPTION
…d info page

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently we show info and options for changing the `reviews_comments_anonymous` attribute on the provider model, but the registration type of provider doesn't have the option for non-anon comments, this is confusing, so we're removing the option from the admin app.

## Changes

- simple config changes to the views.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify `reviews_comments_anonymous` no longer appears anywhere on the registration provider admin app page.
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2400