### PR TITLE
[ENG-2422] RegistrationReviewAction Descending Ordering in API

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -800,6 +800,7 @@ class RegistrationActionList(JSONAPIBaseView, ListFilterMixin, generics.ListCrea
     view_name = 'registration-actions-list'
 
     serializer_class = RegistrationActionSerializer
+    ordering = ('-created',)
     node_lookup_url_kwarg = 'node_id'
 
     def get_registration(self):


### PR DESCRIPTION
## Purpose
API results from the RegistrationReviewAction endpoint should be in descending order by `created` timestamp

## Changes
* Adds an explicit ordering to the RegistrationReviewAction view

## QA Notes
- Verify that API results from `/v2/registrations/<registration_id>/actions` are ordered such that the most recent review actions are earlier in the results.

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2422)
