### PR TITLE
[ENG-2424] Too many results from notification subscription queryset

### DIFF
--- a/api/subscriptions/views.py
+++ b/api/subscriptions/views.py
@@ -28,7 +28,13 @@ class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     def get_default_queryset(self):
         user = self.request.user
-        return NotificationSubscription.objects.filter(Q(none=user) | Q(email_digest=user) | Q(email_transactional=user))
+        return NotificationSubscription.objects.filter(
+            Q(none=user) |
+            Q(email_digest=user) |
+            Q(
+                email_transactional=user,
+            ),
+        ).distinct()
 
     def get_queryset(self):
         return self.get_queryset_from_request()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently our filters for notifications return too many duplicates of the same thing.

## Changes

- add distinct to query so notifications aren't repeated.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that Futa's notifications aren't repeated.

## Documentation


🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2424