### PR TITLE
Fixing copyrights in the footers [ENG-2434]

### DIFF
--- a/website/templates/emails/file_operation_failed.html.mako
+++ b/website/templates/emails/file_operation_failed.html.mako
@@ -1,6 +1,7 @@
 <!doctype html>
 <%!
     from website import settings
+    from datetime import datetime
 %>
 <html class="no-js" lang="">
 <head>

--- a/website/templates/emails/file_operation_failed.html.mako
+++ b/website/templates/emails/file_operation_failed.html.mako
@@ -73,7 +73,7 @@
                 <tbody>
                     <tr>
                         <td style="border-collapse: collapse;">
-                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2018 Center For Open Science, All rights reserved. |
+                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; ${datetime.utcnow().year} Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a></p>
                             <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083</p>
                         </td>

--- a/website/templates/emails/file_operation_success.html.mako
+++ b/website/templates/emails/file_operation_success.html.mako
@@ -1,6 +1,7 @@
 <!doctype html>
 <%!
     from website import settings
+    from datetime import datetime
 %>
 <html class="no-js" lang="">
 <head>

--- a/website/templates/emails/file_operation_success.html.mako
+++ b/website/templates/emails/file_operation_success.html.mako
@@ -72,7 +72,7 @@
                 <tbody>
                     <tr>
                         <td style="border-collapse: collapse;">
-                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2018 Center For Open Science, All rights reserved. |
+                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; ${datetime.utcnow().year} Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a></p>
                             <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083</p>
                         </td>

--- a/website/templates/emails/notify_base.mako
+++ b/website/templates/emails/notify_base.mako
@@ -76,7 +76,7 @@
                     <tbody>
                         <tr>
                             <td style="border-collapse: collapse;">
-                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2018 Center For Open Science, All rights reserved. |
+                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; ${datetime.utcnow().year} Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
                                 </p>
                                 <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083</p>

--- a/website/templates/emails/notify_base.mako
+++ b/website/templates/emails/notify_base.mako
@@ -1,5 +1,6 @@
 <%!
     from website import settings
+    from datetime import datetime
 %>
 <!doctype html>
 <html class="no-js" lang="">


### PR DESCRIPTION


## Purpose

In a few of our email templates, the copyright year is hardcoded as 2018 in the footer.

## Changes

Make the emails use dynamic dates

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the email is now 2020 in emails.
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

N/A
## Ticket

https://openscience.atlassian.net/browse/ENG-2434