### PR TITLE
[hotfix] Update requirements for requests library to be compatible with zotero

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ sendgrid==1.5.13
 # https://github.com/jaraco/keyring/blob/9.1/setup.py
 keyring==9.1
 
-requests>=2.20.0
+requests>=2.21.0
 urllib3==1.22
 oauthlib==2.0.6
 requests-oauthlib==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ sendgrid==1.5.13
 # https://github.com/jaraco/keyring/blob/9.1/setup.py
 keyring==9.1
 
-requests==2.20.0
+requests<=2.20.0
 urllib3==1.22
 oauthlib==2.0.6
 requests-oauthlib==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ sendgrid==1.5.13
 # https://github.com/jaraco/keyring/blob/9.1/setup.py
 keyring==9.1
 
-requests<=2.20.0
+requests>=2.20.0
 urllib3==1.22
 oauthlib==2.0.6
 requests-oauthlib==0.8.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -7,7 +7,7 @@ pytz==2014.9
 python-dateutil==2.5.0
 html5lib==0.999999999
 bleach==2.1.3
-requests==2.20.0
+requests>=2.20.0
 urllib3==1.22
 requests-oauthlib==0.5.0
 oauthlib==1.1.2  # Mendeley pins to a much lower version but OSF overrides

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -544,7 +544,10 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, pty=True):
             if os.path.isdir(path):
                 req_file = os.path.join(path, 'requirements.txt')
                 if os.path.exists(req_file):
-                    cmd = 'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
+                    cmd = (
+                        'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {} '
+                        '--use-deprecated=legacy-resolver'
+                    ).format(
                         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
                     )
                     ctx.run(cmd, pty=pty)
@@ -554,7 +557,10 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, pty=True):
         req_file = os.path.join(HERE, 'requirements', 'dev.txt')
     else:
         req_file = os.path.join(HERE, 'requirements.txt')
-    cmd = 'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
+    cmd = (
+        'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {} '
+        '--use-deprecated=legacy-resolver'
+    ).format(
         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
     )
     ctx.run(cmd, pty=pty)

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -545,8 +545,8 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, pty=True):
                 req_file = os.path.join(path, 'requirements.txt')
                 if os.path.exists(req_file):
                     cmd = (
-                        'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {} '
-                        '--use-deprecated=legacy-resolver'
+                        'pip3 wheel --use-deprecated=legacy-resolver '
+                        '--find-links={} -r {} --wheel-dir={} -c {} '
                     ).format(
                         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
                     )
@@ -558,8 +558,8 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, pty=True):
     else:
         req_file = os.path.join(HERE, 'requirements.txt')
     cmd = (
-        'pip3 wheel --find-links={} -r {} --wheel-dir={} -c {} '
-        '--use-deprecated=legacy-resolver'
+        'pip3 wheel --use-deprecated=legacy-resolver '
+        '--find-links={} -r {} --wheel-dir={} -c {} '
     ).format(
         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
     )

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -20,7 +20,7 @@ def pip_install(req_file, constraints_file=None):
     Return the proper 'pip install' command for installing the dependencies
     defined in ``req_file``. Optionally obey a file of constraints in case of version conflicts
     """
-    cmd = bin_prefix('pip3 install --exists-action w --upgrade -r {} '.format(req_file))
+    cmd = bin_prefix('pip3 install --use-deprecated=legacy-resolver --exists-action w --upgrade -r {} '.format(req_file))
     if constraints_file:  # Support added in pip 7.1
         cmd += ' -c {}'.format(constraints_file)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
There have been breaking changes to the pip dependency resolver, leading to our build breaking due to our requirement for the `requests` library (`==2.20.0`) being incompatible with zotero's (`>=2.21.0`).

UPDATE: mendeley also has a competing `requests` requirement, and who knows how many other of these we may find.

## Changes
Allow for newer versions of `requests` in our requirements. Use `--use-deprecated=legacy-resolver` argument in all pip3 commands.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
