### PR TITLE
[ENG-2440] edit email templates for new language

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -685,6 +685,7 @@ class Retraction(EmailApprovableSanction):
 
             return {
                 'is_initiator': self.initiated_by == user,
+                'is_moderated': self._get_registration().is_moderated,
                 'initiated_by': self.initiated_by.fullname,
                 'project_name': self.registrations.filter().values_list('title', flat=True).get(),
                 'registration_link': registration_link,
@@ -840,6 +841,7 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
             context.update({
                 'is_initiator': self.initiated_by == user,
                 'initiated_by': self.initiated_by.fullname,
+                'is_moderated': registration.is_moderated,
                 'registration_link': registration_link,
                 'approval_link': approval_link,
                 'disapproval_link': disapproval_link,
@@ -1056,6 +1058,7 @@ class EmbargoTerminationApproval(EmailApprovableSanction):
 
             context.update({
                 'is_initiator': self.initiated_by == user,
+                'is_moderated': registration.is_moderated,
                 'initiated_by': self.initiated_by.fullname,
                 'approval_link': approval_link,
                 'project_name': registration.title,

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -685,7 +685,7 @@ class Retraction(EmailApprovableSanction):
 
             return {
                 'is_initiator': self.initiated_by == user,
-                'is_moderated': self._get_registration().is_moderated,
+                'is_moderated': self.is_moderated,
                 'initiated_by': self.initiated_by.fullname,
                 'project_name': self.registrations.filter().values_list('title', flat=True).get(),
                 'registration_link': registration_link,
@@ -841,7 +841,7 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
             context.update({
                 'is_initiator': self.initiated_by == user,
                 'initiated_by': self.initiated_by.fullname,
-                'is_moderated': registration.is_moderated,
+                'is_moderated': self.is_moderated,
                 'registration_link': registration_link,
                 'approval_link': approval_link,
                 'disapproval_link': disapproval_link,
@@ -1058,7 +1058,7 @@ class EmbargoTerminationApproval(EmailApprovableSanction):
 
             context.update({
                 'is_initiator': self.initiated_by == user,
-                'is_moderated': registration.is_moderated,
+                'is_moderated': self.is_moderated,
                 'initiated_by': self.initiated_by.fullname,
                 'approval_link': approval_link,
                 'project_name': registration.title,

--- a/website/templates/emails/pending_embargo_admin.html.mako
+++ b/website/templates/emails/pending_embargo_admin.html.mako
@@ -6,22 +6,36 @@
     Hello ${user.fullname},<br>
     <br>
     % if is_initiator:
-    You initiated an embargoed registration of ${project_name}. The proposed registration can be viewed here: ${registration_link}.<br>
+    You initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
+     The proposed registration can be viewed here: ${registration_link}.<br>
     % else:
-    ${initiated_by} initiated an embargoed registration of ${project_name}. The proposed registration can be viewed here: ${registration_link}.<br>
+    ${initiated_by} initiated an embargoed registration of ${project_name}  with embargo end date ${embargo_end_date.date()}.
+     The proposed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved, a registration will be created for the project, and it will remain private until it is withdrawn,
-    it is manually made public, or the embargo end date is passed on ${embargo_end_date.date()}.<br>
+    % if is_moderated:
+        If approved, an embargoed registration will be created for the project and sent to ${reviewable.provider.name}
+         moderators for review.
+    % else
+        If approved, a registration will be created for the project, and it will remain private until it is withdrawn,
+         it is manually made public, or the embargo end date is passed on ${embargo_end_date.date()}.
+    % endif
     <br>
-    To approve this embargo, click the following link: ${approval_link}.<br>
+    Approve this embargoed registration: ${approval_link}.<br>
     <br>
-    To cancel this embargo, click the following link: ${disapproval_link}.<br>
+    Cancel this embargoed registration: ${disapproval_link}.<br>
     <br>
-    Note: Clicking the disapproval link will immediately cancel the pending embargo and the
-    registration will remain in draft state. If you neither approve nor disapprove the embargo
-    within ${approval_time_span} hours from midnight tonight (EDT) the registration will remain
-    private and enter into an embargoed state.<br>
+    Note: Clicking the cancel link will immediately cancel the pending embargo and the registration will remain in draft state. This operation is irreversible.
+    <br>
+
+    If you neither approve nor cancel the embargo within ${approval_time_span} hours from midnight tonight (EDT) the registration will
+
+    % if is_moderated:
+        enter into embargo automatically and be sent to ${reviewable.provider.name} moderators for review.
+    % else:
+     remain private and enter into an embargoed state.
+    % endif
+    <br>
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_embargo_admin.html.mako
+++ b/website/templates/emails/pending_embargo_admin.html.mako
@@ -6,11 +6,19 @@
     Hello ${user.fullname},<br>
     <br>
     % if is_initiator:
-    You initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
-     The proposed registration can be viewed here: ${registration_link}.<br>
+        % if is_moderated:
+             You initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
+        % else
+            You initiated an embargoed registration of ${project_name}.
+        % endif
+         The proposed registration can be viewed here: ${registration_link}.<br>
     % else:
-    ${initiated_by} initiated an embargoed registration of ${project_name}  with embargo end date ${embargo_end_date.date()}.
-     The proposed registration can be viewed here: ${registration_link}.<br>
+        % if is_moderated:
+             ${initiated_by} initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
+        % else
+            ${initiated_by} initiated an embargoed registration of ${project_name}.
+        % endif
+         The proposed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
     % if is_moderated:

--- a/website/templates/emails/pending_embargo_admin.html.mako
+++ b/website/templates/emails/pending_embargo_admin.html.mako
@@ -6,20 +6,12 @@
     Hello ${user.fullname},<br>
     <br>
     % if is_initiator:
-        % if is_moderated:
-             You initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
-        % else
-            You initiated an embargoed registration of ${project_name}.
-        % endif
-         The proposed registration can be viewed here: ${registration_link}.<br>
+        You initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
     % else:
-        % if is_moderated:
-             ${initiated_by} initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
-        % else
-            ${initiated_by} initiated an embargoed registration of ${project_name}.
-        % endif
-         The proposed registration can be viewed here: ${registration_link}.<br>
+       ${initiated_by} initiated an embargoed registration of ${project_name} with embargo end date ${embargo_end_date.date()}.
     % endif
+
+    The proposed registration can be viewed here: ${registration_link}.<br>
     <br>
     % if is_moderated:
         If approved, an embargoed registration will be created for the project and sent to ${reviewable.provider.name}

--- a/website/templates/emails/pending_embargo_admin.html.mako
+++ b/website/templates/emails/pending_embargo_admin.html.mako
@@ -21,9 +21,9 @@
          it is manually made public, or the embargo end date is passed on ${embargo_end_date.date()}.
     % endif
     <br>
-    Approve this embargoed registration: ${approval_link}.<br>
+    Approve this embargoed registration: <a href="${approval_link}">Click here</a>.<br>
     <br>
-    Cancel this embargoed registration: ${disapproval_link}.<br>
+    Cancel this embargoed registration: <a href="${disapproval_link}">Click here</a>.<br>
     <br>
     Note: Clicking the cancel link will immediately cancel the pending embargo and the registration will remain in draft state. This operation is irreversible.
     <br>

--- a/website/templates/emails/pending_embargo_non_admin.html.mako
+++ b/website/templates/emails/pending_embargo_non_admin.html.mako
@@ -7,14 +7,12 @@
     <br>
     We just wanted to let you know that ${initiated_by} has initiated an embargoed registration for the following pending registration: ${registration_link}.<br>
     <br>
-    If approved
 
     % if is_moderated:
-       by project admins, an embargoed registration will be created for the project and sent to ${reviewable.provider.name} moderators for review.
+        If approved by project admins, an embargoed registration will be created for the project and sent to ${reviewable.provider.name} moderators for review.
     % else:
-        , a registration will be created for the project, viewable here: ${registration_link}, and it will remain private
-         until it is withdrawn, it is manually made public, or the embargo end date is passed on
-         ${embargo_end_date.date()}.
+       If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain private
+       until it is withdrawn, it is manually made public, or the embargo end date is passed on ${embargo_end_date.date()}.
     % endif
 
     <br>

--- a/website/templates/emails/pending_embargo_non_admin.html.mako
+++ b/website/templates/emails/pending_embargo_non_admin.html.mako
@@ -7,8 +7,17 @@
     <br>
     We just wanted to let you know that ${initiated_by} has initiated an embargoed registration for the following pending registration: ${registration_link}.<br>
     <br>
-    If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain
-    private until it is withdrawn, it is manually made public, or the embargo end date is passed on ${embargo_end_date.date()}.<br>
+    If approved,
+
+    % if is_moderated:
+       by project admins, an embargoed registration will be created for the project and sent to ${reviewable.provider.name} moderators for review.
+    % else:
+        a registration will be created for the project, viewable here: ${registration_link}, and it will remain private
+         until it is withdrawn, it is manually made public, or the embargo end date is passed on
+         ${embargo_end_date.date()}.
+    % endif
+
+    <br>
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_embargo_non_admin.html.mako
+++ b/website/templates/emails/pending_embargo_non_admin.html.mako
@@ -7,12 +7,12 @@
     <br>
     We just wanted to let you know that ${initiated_by} has initiated an embargoed registration for the following pending registration: ${registration_link}.<br>
     <br>
-    If approved,
+    If approved
 
     % if is_moderated:
        by project admins, an embargoed registration will be created for the project and sent to ${reviewable.provider.name} moderators for review.
     % else:
-        a registration will be created for the project, viewable here: ${registration_link}, and it will remain private
+        , a registration will be created for the project, viewable here: ${registration_link}, and it will remain private
          until it is withdrawn, it is manually made public, or the embargo end date is passed on
          ${embargo_end_date.date()}.
     % endif

--- a/website/templates/emails/pending_embargo_termination_admin.html.mako
+++ b/website/templates/emails/pending_embargo_termination_admin.html.mako
@@ -11,11 +11,13 @@
     ${initiated_by} initiated a request to end the embargo for a registration of ${project_name}. The embargoed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    To approve this change and to make this registration public immediately, click the following link: ${approval_link}.<br>
+    Approve this change and make this registration public immediately: ${approval_link}.<br>
     <br>
-    To cancel this change, click the following link: ${disapproval_link}.<br>
+    Cancel this change and keep embargo the same: ${disapproval_link}.<br>
     <br>
-    Note: Clicking the disapproval link will immediately cancel the embargo termination request. If you neither approve nor cancel the request within ${approval_time_span} hours from midnight tonight (EDT) the embargo will be lifted and the registration will be made public. This operation is irreversible.<br>
+    Note: Clicking the disapproval link will immediately cancel the embargo termination request. This operation is irreversible.
+    <br>
+    If you neither approve nor cancel the request within ${approval_time_span} hours from midnight tonight (EDT) the embargo will be lifted and the registration will be made public.
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_embargo_termination_admin.html.mako
+++ b/website/templates/emails/pending_embargo_termination_admin.html.mako
@@ -11,9 +11,9 @@
     ${initiated_by} initiated a request to end the embargo for a registration of ${project_name}. The embargoed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    Approve this change and make this registration public immediately: ${approval_link}.<br>
+    Approve this change and make this registration public immediately:  <a href="${approval_link}">Click here</a>.<br>
     <br>
-    Cancel this change and keep embargo the same: ${disapproval_link}.<br>
+    Cancel this change and keep embargo the same:  <a href="${disapproval_link}">Click here</a><br>
     <br>
     Note: Clicking the disapproval link will immediately cancel the embargo termination request. This operation is irreversible.
     <br>

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -13,7 +13,7 @@
     <br>
 
     % if is_moderated:
-         If approved, a registration will be created for the project and will be made public immediately and sent to ${reviewable.provider.name} moderators for review
+         If approved, a registration will be created for the project and sent to ${reviewable.provider.name} moderators for review
     % else
         If approved, a registration will be created for the project and will be made public immediately.
     % endif
@@ -24,16 +24,13 @@
     To cancel this registration, click the following link: <a href="${disapproval_link}">Click here</a><br>
     <br>
     Note: Clicking the cancel link will immediately cancel the pending registration and the
-    registration will remain in draft state.
+    registration will remain in draft state. This operation is irreversible. <br>
 
     % if is_moderated:
-        <br>
         If you neither approve nor cancel the registration within ${approval_time_span} hours from
         midnight tonight (EDT) the registration will be automatically approved and
          sent to ${reviewable.provider.name} moderators for review.
     % else:
-        This operation is irreversible. <br>
-
         If you neither approve nor cancel the registration within ${approval_time_span} hours from midnight tonight
          (EDT) the registration will be automatically approved and made public.
     % endif

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -14,7 +14,7 @@
 
     % if is_moderated:
          If approved, a registration will be created for the project and sent to ${reviewable.provider.name} moderators for review
-    % else
+    % else:
         If approved, a registration will be created for the project and will be made public immediately.
     % endif
     <br>

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -18,9 +18,9 @@
     .
     <br>
     <br>
-    To approve this registration, click the following link: ${approval_link}<br>
+    To approve this registration, click the following link: <a href="${approval_link}">Click here</a><br>
     <br>
-    To cancel this registration, click the following link: ${disapproval_link}<br>
+    To cancel this registration, click the following link: <a href="${disapproval_link}">Click here</a><br>
     <br>
     % if is_moderated:
         Note: Clicking the cancel link will immediately cancel the pending registration and the

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -11,10 +11,11 @@
     ${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved, a registration will be created for the project and will be made public immediately.
+    If approved, a registration will be created for the project and will be made public immediately
     % if is_moderated:
-         and sent to ${reviewable.provider.name} moderators for review.
+         and sent to ${reviewable.provider.name} moderators for review
     % endif
+    .
     <br>
     <br>
     To approve this registration, click the following link: ${approval_link}<br>

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -11,16 +11,39 @@
     ${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved, a registration will be created for the project and will be made public immediately.<br>
+    If approved, a registration will be created for the project and will be made public immediately.
+    % if is_moderated:
+         and sent to ${reviewable.provider.name} moderators for review.
+    % endif
+    <br>
     <br>
     To approve this registration, click the following link: ${approval_link}<br>
     <br>
     To cancel this registration, click the following link: ${disapproval_link}<br>
     <br>
-    Note: Clicking the disapproval link will immediately cancel the pending registration and the<br>
+    % if is_moderated:
+        Note: Clicking the cancel link will immediately cancel the pending registration and the
+        registration will remain in draft state.
+        If you neither approve nor cancel the registration within ${approval_time_span} hours from
+        midnight tonight (EDT) the registration will be automatically approved and
+         sent to ${reviewable.provider.name} moderators for review.
+    % else:
+        If you neither approve nor cancel the registration within ${approval_time_span} hours from midnight tonight (EDT) the registration will be automatically approved and made public.
+    % endif
+    <br>
+
+
+    Note: Clicking the cancel link will immediately cancel the pending registration and the<br>
     registration will remain in draft state. If you neither approve nor cancel the registration<br>
     within ${approval_time_span} hours from midnight tonight (EDT) the registration will be<br>
-    automatically approved and made public. This operation is irreversible.<br>
+    automatically approved and made public. This operation is irreversible.If you neither approve
+    nor cancel the registration within ${approval_time_span} hours from midnight tonight (EDT)
+     the registration will be automatically approved and made public.
+     % if is_moderated:
+      and sent to ${reviewable.provider.name} moderators for review.
+    % endif
+
+
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -11,11 +11,12 @@
     ${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved, a registration will be created for the project and will be made public immediately
+
     % if is_moderated:
-         and sent to ${reviewable.provider.name} moderators for review
+         If approved, a registration will be created for the project and will be made public immediately and sent to ${reviewable.provider.name} moderators for review
+    % else
+        If approved, a registration will be created for the project and will be made public immediately.
     % endif
-    .
     <br>
     <br>
     To approve this registration, click the following link: <a href="${approval_link}">Click here</a><br>

--- a/website/templates/emails/pending_registration_admin.html.mako
+++ b/website/templates/emails/pending_registration_admin.html.mako
@@ -22,28 +22,21 @@
     <br>
     To cancel this registration, click the following link: <a href="${disapproval_link}">Click here</a><br>
     <br>
+    Note: Clicking the cancel link will immediately cancel the pending registration and the
+    registration will remain in draft state.
+
     % if is_moderated:
-        Note: Clicking the cancel link will immediately cancel the pending registration and the
-        registration will remain in draft state.
+        <br>
         If you neither approve nor cancel the registration within ${approval_time_span} hours from
         midnight tonight (EDT) the registration will be automatically approved and
          sent to ${reviewable.provider.name} moderators for review.
     % else:
-        If you neither approve nor cancel the registration within ${approval_time_span} hours from midnight tonight (EDT) the registration will be automatically approved and made public.
+        This operation is irreversible. <br>
+
+        If you neither approve nor cancel the registration within ${approval_time_span} hours from midnight tonight
+         (EDT) the registration will be automatically approved and made public.
     % endif
     <br>
-
-
-    Note: Clicking the cancel link will immediately cancel the pending registration and the<br>
-    registration will remain in draft state. If you neither approve nor cancel the registration<br>
-    within ${approval_time_span} hours from midnight tonight (EDT) the registration will be<br>
-    automatically approved and made public. This operation is irreversible.If you neither approve
-    nor cancel the registration within ${approval_time_span} hours from midnight tonight (EDT)
-     the registration will be automatically approved and made public.
-     % if is_moderated:
-      and sent to ${reviewable.provider.name} moderators for review.
-    % endif
-
 
     <br>
     Sincerely yours,<br>

--- a/website/templates/emails/pending_registration_non_admin.html.mako
+++ b/website/templates/emails/pending_registration_non_admin.html.mako
@@ -11,7 +11,7 @@
     % if is_moderated:
          by project admins, the registration will be created and sent to ${reviewable.provider.name} moderators for review.
     % else:
-        , a registration will be created for the project, viewable here: ${registration_link}, and it will remain
+        , a registration will be created for the project, viewable here: <a href="${registration_link}">Click here</a>, and it will remain
         public until it is withdrawn.
     % endif
     <br>

--- a/website/templates/emails/pending_registration_non_admin.html.mako
+++ b/website/templates/emails/pending_registration_non_admin.html.mako
@@ -9,6 +9,12 @@
     <br>
     If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain<br>
     public until it is withdrawn.<br>
+    % if is_moderated:
+         by project admins, the registration will be created and sent to ${reviewable.provider.name} moderators for review.
+    % else:
+        a registration will be created for the project, viewable here: ${registration_link}, and it will remain<br>
+        public until it is withdrawn.
+    % endif
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_registration_non_admin.html.mako
+++ b/website/templates/emails/pending_registration_non_admin.html.mako
@@ -7,11 +7,10 @@
     <br>
     We just wanted to let you know that ${initiated_by} has initiated the following pending registration: ${registration_link}.<br>
     <br>
-    If approved
     % if is_moderated:
-         by project admins, the registration will be created and sent to ${reviewable.provider.name} moderators for review.
+        If approved by project admins, the registration will be created and sent to ${reviewable.provider.name} moderators for review.
     % else:
-        , a registration will be created for the project, viewable here: <a href="${registration_link}">Click here</a>, and it will remain
+        If approved, a registration will be created for the project, viewable here: <a href="${registration_link}">Click here</a>, and it will remain
         public until it is withdrawn.
     % endif
     <br>

--- a/website/templates/emails/pending_registration_non_admin.html.mako
+++ b/website/templates/emails/pending_registration_non_admin.html.mako
@@ -7,12 +7,11 @@
     <br>
     We just wanted to let you know that ${initiated_by} has initiated the following pending registration: ${registration_link}.<br>
     <br>
-    If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain<br>
-    public until it is withdrawn.<br>
+    If approved
     % if is_moderated:
          by project admins, the registration will be created and sent to ${reviewable.provider.name} moderators for review.
     % else:
-        a registration will be created for the project, viewable here: ${registration_link}, and it will remain<br>
+        , a registration will be created for the project, viewable here: ${registration_link}, and it will remain
         public until it is withdrawn.
     % endif
     <br>

--- a/website/templates/emails/pending_retraction_admin.html.mako
+++ b/website/templates/emails/pending_retraction_admin.html.mako
@@ -11,13 +11,36 @@
     ${initiated_by} initiated a withdrawal of your registration ${project_name}. The registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved, the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind. The title of a withdrawn registration and its contributor list will remain, as will justification or explanation of the withdrawal, should you wish to provide it.<br>
+    If approved,
+    % if is_moderated:
+        by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
+        <br>
+        If the withdrawal request is accepted by ${reviewable.provider.name} moderators,  the registration will be
+        marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind.
+        The title of a withdrawn registration and its contributor list will remain, as will justification or
+        explanation of the withdrawal, should you wish to provide it.
+    % else:
+        the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
+         metadata behind. The title of a withdrawn registration and its contributor list will remain, as will
+         justification or explanation of the withdrawal, should you wish to provide it.<br>
+    % endif
+
     <br>
     To approve this withdrawal, click the following link: ${approval_link}.<br>
     <br>
     To cancel this withdrawal, click the following link: ${disapproval_link}.<br>
     <br>
-    Note: Clicking the disapproval link will immediately cancel the pending withdrawal. If you neither approve nor disapprove the withdrawal within ${approval_time_span} hours of midnight tonight (EDT) the registration will become withdrawn. This operation is irreversible.<br>
+    Note: Clicking the disapproval link will immediately cancel the pending withdrawal. This operation is irreversible.
+    <br>
+    % if is_moderated:
+        If you neither approve nor cancel the withdrawal within ${approval_time_span} hours of midnight tonight (EDT)
+         the withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
+    % else:
+        If you neither approve nor cancel the withdrawal within ${approval_time_span} hours of midnight tonight (EDT)
+         the registration will become withdrawn.
+    % endif
+
+    <br>
     <br>
     Sincerely yours,<br>
     <br>

--- a/website/templates/emails/pending_retraction_admin.html.mako
+++ b/website/templates/emails/pending_retraction_admin.html.mako
@@ -11,7 +11,7 @@
     ${initiated_by} initiated a withdrawal of your registration ${project_name}. The registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved,
+    If approved
     % if is_moderated:
         by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
         <br>
@@ -20,7 +20,7 @@
         The title of a withdrawn registration and its contributor list will remain, as will justification or
         explanation of the withdrawal, should you wish to provide it.
     % else:
-        the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
+        , the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
          metadata behind. The title of a withdrawn registration and its contributor list will remain, as will
          justification or explanation of the withdrawal, should you wish to provide it.<br>
     % endif

--- a/website/templates/emails/pending_retraction_admin.html.mako
+++ b/website/templates/emails/pending_retraction_admin.html.mako
@@ -11,16 +11,16 @@
     ${initiated_by} initiated a withdrawal of your registration ${project_name}. The registration can be viewed here: ${registration_link}.<br>
     % endif
     <br>
-    If approved
+
     % if is_moderated:
-        by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
+        If approved by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
         <br>
         If the withdrawal request is accepted by ${reviewable.provider.name} moderators,  the registration will be
         marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind.
         The title of a withdrawn registration and its contributor list will remain, as will justification or
         explanation of the withdrawal, should you wish to provide it.
     % else:
-        , the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
+        If approved, the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
          metadata behind. The title of a withdrawn registration and its contributor list will remain, as will
          justification or explanation of the withdrawal, should you wish to provide it.<br>
     % endif

--- a/website/templates/emails/pending_retraction_admin.html.mako
+++ b/website/templates/emails/pending_retraction_admin.html.mako
@@ -26,9 +26,9 @@
     % endif
 
     <br>
-    To approve this withdrawal, click the following link: ${approval_link}.<br>
+    To approve this withdrawal, click the following link: <a href="${approval_link}">Click here</a>.<br>
     <br>
-    To cancel this withdrawal, click the following link: ${disapproval_link}.<br>
+    To cancel this withdrawal, click the following link: <a href="${disapproval_link}">Click here</a>.<br>
     <br>
     Note: Clicking the disapproval link will immediately cancel the pending withdrawal. This operation is irreversible.
     <br>

--- a/website/templates/emails/pending_retraction_non_admin.html.mako
+++ b/website/templates/emails/pending_retraction_non_admin.html.mako
@@ -7,12 +7,11 @@
     <br>
     We just wanted to let you know that ${initiated_by} has requested a withdrawal for the following registration: ${registration_link}.<br>
     <br>
-    If approved
 
     % if is_moderated:
-         by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
+        If approved by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
     % else:
-        , the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
+        If approved, the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
         metadata behind. The title of a withdrawn registration and its contributor list will remain, as will
         justification or explanation of the withdrawal, if provided.<br>
     % endif

--- a/website/templates/emails/pending_retraction_non_admin.html.mako
+++ b/website/templates/emails/pending_retraction_non_admin.html.mako
@@ -7,12 +7,14 @@
     <br>
     We just wanted to let you know that ${initiated_by} has requested a withdrawal for the following registration: ${registration_link}.<br>
     <br>
-    If approved,
+    If approved
 
     % if is_moderated:
          by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
     % else:
-        the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind. The title of a withdrawn registration and its contributor list will remain, as will justification or explanation of the withdrawal, if provided.<br>
+        , the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic
+        metadata behind. The title of a withdrawn registration and its contributor list will remain, as will
+        justification or explanation of the withdrawal, if provided.<br>
     % endif
     <br>
     Sincerely yours,<br>

--- a/website/templates/emails/pending_retraction_non_admin.html.mako
+++ b/website/templates/emails/pending_retraction_non_admin.html.mako
@@ -7,7 +7,13 @@
     <br>
     We just wanted to let you know that ${initiated_by} has requested a withdrawal for the following registration: ${registration_link}.<br>
     <br>
-    If approved, the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind. The title of a withdrawn registration and its contributor list will remain, as will justification or explanation of the withdrawal, if provided.<br>
+    If approved,
+
+    % if is_moderated:
+         by project admins, a withdrawal request will be sent to ${reviewable.provider.name} moderators for review.
+    % else:
+        the registration will be marked as withdrawn. Its content will be removed from the OSF, but leave basic metadata behind. The title of a withdrawn registration and its contributor list will remain, as will justification or explanation of the withdrawal, if provided.<br>
+    % endif
     <br>
     Sincerely yours,<br>
     <br>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This modifies email template language to accommodation registries moderation.

## Changes

Changes text in:
- pending_embargo_admin.html.mako, 
- pending_embargo_non_admin.html.mako
- pending_embargo_termination_admin.html.mako
- pending_registration_admin.html.mako
- pending_registration_non_admin.html.mako
- pending_retraction_admin.html.mako
- pending_retraction_non_admin.html.mako 

and adds `is_moderated` to template context

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify all emails are sent with correct text differing for moderated and moderated registrations 

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

just new language, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2440