### PR TITLE
Hotfix/remove unused migration part

### DIFF
--- a/osf/migrations/0224_population_registration_subscription_notifications.py
+++ b/osf/migrations/0224_population_registration_subscription_notifications.py
@@ -30,6 +30,5 @@ class Migration(migrations.Migration):
             model_name='notificationsubscription',
             name='event_name',
             field=models.CharField(max_length=100),
-        ),
-        migrations.RunPython(populate_subscriptions, revert)
+        )
     ]


### PR DESCRIPTION
## Purpose

We ended up not running the management commands during the migration, so we want to remove the call to that to reflect how it ended up being on the server.

## Changes

Removed call to function that called the management commands.

## Ticket

N/A