### PR TITLE
[ENG-2280] Adds storage limit status messaging to file notifications

### DIFF
--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -107,7 +107,11 @@ def store_emails(recipient_ids, notification_type, event, user, node, timestamp,
             continue
         context['localized_timestamp'] = localize_timestamp(timestamp, recipient)
         context['recipient'] = recipient
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info(context)
         message = mails.render_message(template, **context)
+        logger.info(message)
         digest = NotificationDigest(
             timestamp=timestamp,
             send_type=notification_type,

--- a/website/templates/emails/file_updated.html.mako
+++ b/website/templates/emails/file_updated.html.mako
@@ -6,6 +6,23 @@
             <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">
                 <span class="person" style="font-weight: bold;">${user.fullname} </span>
                 ${message}
+                % if storage_limit_context:
+                    % if storage_limit_context['public']:
+                        This public project is ${storage_limit_context['storage_limit_status']} the 50GB OSF Storage limit and requires your attention. In order to avoid disruption of your workflow, please take action through one of the following options:<br>
+                        <ul>
+                            <li>Connect an <a href="https://help.osf.io/hc/en-us/sections/360003623833-Storage-add-ons">OSF Storage add-on</a> to continue managing your research efficiently from OSF. OSF add-ons are an easy way to extend your storage space while also streamlining your data management workflow.</li>
+                            <li><a href="https://help.osf.io/hc/en-us/articles/360019737614-Create-Components">Organize your project with components</a> to take advantage of the flexible structure and maximize storage options.</li>
+                        </ul>
+                    % else:
+                        This private project is ${storage_limit_context['storage_limit_status']} the 5GB OSF Storage limit and requires your attention. In order to avoid disruption of your workflow, please take action through one of the following options:<br>
+                        <ul>
+                            <li>Connect an <a href="https://help.osf.io/hc/en-us/sections/360003623833-Storage-add-ons">OSF Storage add-on</a> to continue managing your research efficiently from OSF. OSF add-ons are an easy way to extend your storage space while also streamlining your data management workflow.</li>
+                            <li>Free up space by making one or more of your components public. <a href="https://help.osf.io/hc/en-us/articles/360019737614-Create-Components">Organize your project with components</a> to take advantage of the flexible structure and maximize storage options.</li>
+                            <li><a href="https://help.osf.io/hc/en-us/articles/360018981414-Control-Your-Privacy-Settings#Make-your-project-or-components-public">Make your project public</a> to increase storage capacity to 50 GB for files stored in OSF Storage.</li>
+                        </ul>
+                    % endif
+                    Learn more about OSF Storage capacity limits <a href="https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps">here</a>.
+                % endif
             </span>
         </td>
         <td width="25" style="text-align:center;border-collapse: collapse;font-size: 24px;border-left: 1px solid #ddd;">


### PR DESCRIPTION
## Purpose
Notifies admins on a given project if the project is approaching or over OSF Storage limits. This is necessary because admin contributors may not see initially see or be notified if the project is approaching OSF Storage limits. 

## Changes
* Adds storage_limit_context as a part of the context sent to `file_updated.html.mako`
* Updates `file_updated.html.mako` to use storage_limit_context to selectively show storage usage messaging

## QA Notes
* Verify that upon file actions, the file notification provides the appropriate storage usage messaging:
  * approaching storage caps vs over storage caps
  * messaging for public vs private projects

What are the areas of risk?
* Because of the way in which storage usage is calculated and cached, we may see instances of the storage usage messaging either being relevant to the state of the project prior to the file change but no longer being accurate or instances of no storage usage messaging because the storage usage has not been calculated before the code that stores these emails runs.

Any concerns/considerations/questions that development raised?
* I added messaging for when the project is over the storage limit as well as approaching (approaching is what the ticket requested); there is conversation in the product-consults flow around the desirability of this addition.

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2280)
