### PR TITLE
[ENG-2334] Make DOIs mint on project/draft registration 

### DIFF
--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 
 from future.moves.urllib.parse import urlparse
@@ -27,11 +26,6 @@ from website import settings
 @pytest.fixture()
 def user():
     return AuthUserFactory()
-
-
-@pytest.fixture()
-def all_identifiers():
-    return Identifier.objects.all()
 
 
 @pytest.mark.django_db
@@ -73,11 +67,10 @@ class TestRegistrationIdentifierList:
     def test_identifier_list_returns_correct_number_and_referent(
             self, registration, identifier_registration,
             data_registration_identifiers, res_registration_identifiers,
-            all_identifiers
     ):
         # test_identifier_list_returns_correct_number
         total = res_registration_identifiers.json['links']['meta']['total']
-        assert total == all_identifiers.count()
+        assert total == Identifier.objects.filter(object_id=registration.id).count()
 
         # test_identifier_list_returns_correct_referent
         paths = [
@@ -88,16 +81,15 @@ class TestRegistrationIdentifierList:
         assert '/{}registrations/{}/'.format(API_BASE,
                                              registration._id) in paths
 
-    def test_identifier_list_returns_correct_categories_and_values(
-            self, all_identifiers, data_registration_identifiers):
+    def test_identifier_list_returns_correct_categories_and_values(self, data_registration_identifiers):
         # test_identifier_list_returns_correct_categories
-        categories = [identifier.category for identifier in all_identifiers]
+        categories = [identifier.category for identifier in Identifier.objects.all()]
         categories_in_response = [identifier['attributes']['category']
                                   for identifier in data_registration_identifiers]
         assert_equals(categories_in_response, categories)
 
         # test_identifier_list_returns_correct_values
-        values = [identifier.value for identifier in all_identifiers]
+        values = [identifier.value for identifier in Identifier.objects.all()]
         values_in_response = [identifier['attributes']['value']
                               for identifier in data_registration_identifiers]
         assert_equals(values_in_response, values)
@@ -189,11 +181,11 @@ class TestNodeIdentifierList:
 
     def test_identifier_list_returns_correct_number_and_referent(
             self, node, identifier_node, res_node_identifiers,
-            data_node_identifiers, all_identifiers
+            data_node_identifiers
     ):
         # test_identifier_list_returns_correct_number
         total = res_node_identifiers.json['links']['meta']['total']
-        assert total == all_identifiers.count()
+        assert total == Identifier.objects.all().count()
 
         # test_identifier_list_returns_correct_referent
         paths = [
@@ -204,15 +196,15 @@ class TestNodeIdentifierList:
         assert '/{}nodes/{}/'.format(API_BASE, node._id) in paths
 
     def test_identifier_list_returns_correct_categories_and_values(
-            self, all_identifiers, data_node_identifiers):
+            self, data_node_identifiers):
         # test_identifier_list_returns_correct_categories
-        categories = [identifier.category for identifier in all_identifiers]
+        categories = [identifier.category for identifier in Identifier.objects.all()]
         categories_in_response = [
             identifier['attributes']['category'] for identifier in data_node_identifiers]
         assert_equals(categories_in_response, categories)
 
         # test_identifier_list_returns_correct_values
-        values = [identifier.value for identifier in all_identifiers]
+        values = [identifier.value for identifier in Identifier.objects.all()]
         values_in_response = [
             identifier['attributes']['value'] for identifier in data_node_identifiers
         ]
@@ -306,21 +298,21 @@ class TestPreprintIdentifierList:
         assert '/{}preprints/{}/'.format(API_BASE, preprint._id) in paths
 
     def test_identifier_list_returns_correct_categories_and_values(
-            self, all_identifiers, data_preprint_identifier):
+            self, data_preprint_identifier):
         # test_identifier_list_returns_correct_categories
-        categories = all_identifiers.values_list('category', flat=True)
+        categories = Identifier.objects.all().values_list('category', flat=True)
         categories_in_response = [identifier['attributes']['category']
                                   for identifier in data_preprint_identifier]
         assert_equals(categories_in_response, list(categories))
 
         # test_identifier_list_returns_correct_values
-        values = all_identifiers.values_list('value', flat=True)
+        values = Identifier.objects.all().values_list('value', flat=True)
         values_in_response = [identifier['attributes']['value']
                               for identifier in data_preprint_identifier]
         assert_equals(values_in_response, list(values))
 
     def test_preprint_identifier_list_permissions_unpublished(
-            self, app, all_identifiers, user, data_preprint_identifier, preprint, url_preprint_identifier):
+            self, app, user, data_preprint_identifier, preprint, url_preprint_identifier):
         preprint.is_published = False
         preprint.save()
 
@@ -350,7 +342,7 @@ class TestPreprintIdentifierList:
         assert res.status_code == 200
 
     def test_preprint_identifier_list_permissions_private(
-            self, app, all_identifiers, user, data_preprint_identifier, preprint, url_preprint_identifier):
+            self, app, user, data_preprint_identifier, preprint, url_preprint_identifier):
         preprint.is_public = False
         preprint.save()
 
@@ -380,7 +372,7 @@ class TestPreprintIdentifierList:
         assert res.status_code == 200
 
     def test_preprint_identifier_list_permissions_deleted(
-            self, app, all_identifiers, user, data_preprint_identifier, preprint, url_preprint_identifier):
+            self, app, user, data_preprint_identifier, preprint, url_preprint_identifier):
         preprint.deleted = timezone.now()
         preprint.save()
 
@@ -408,7 +400,7 @@ class TestPreprintIdentifierList:
         assert res.status_code == 404
 
     def test_preprint_identifier_list_permissions_abandoned(
-            self, app, all_identifiers, user, data_preprint_identifier, preprint, url_preprint_identifier):
+            self, app, user, data_preprint_identifier, preprint, url_preprint_identifier):
         preprint.machine_state = DefaultStates.INITIAL.value
         preprint.save()
 
@@ -489,7 +481,7 @@ class TestNodeIdentifierCreate:
         responses.add(
             responses.Response(
                 responses.POST,
-                client.base_url + '/metadata',
+                client.base_url + f'/metadata/{client.build_doi(resource)}',
                 body='OK (10.70102/FK2osf.io/dp438)',
                 status=201,
             )
@@ -508,16 +500,7 @@ class TestNodeIdentifierCreate:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'You can only mint a DOI, not a different type of identifier.'
 
-        # Cannot connect to DOI service
         res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
-        assert res.status_code == 503
-        assert res.json['errors'][0]['detail'] == 'Service is unavailable at this time.'
-
-        with mock.patch('osf.models.AbstractNode.get_doi_client') as mock_get_doi:
-            mock_get_doi.return_value = client
-            res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth)
-
-        resource.reload()
         assert res.status_code == 201
         assert res.json['data']['attributes']['category'] == 'doi'
         assert res.json['data']['attributes']['value'] == resource.get_identifier_value('doi')
@@ -526,6 +509,13 @@ class TestNodeIdentifierCreate:
         assert resource.logs.first().action == 'external_ids_added'
         assert resource.identifiers.count() == 1
 
+        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
+
+        resource.reload()
+        # cannot request a DOI when one already exists
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'A DOI already exists for this resource.'
+
         # write contributor cannot create identifier
         res = app.post_json_api(identifier_url, identifier_payload, auth=write_contributor.auth, expect_errors=True)
         assert res.status_code == 403
@@ -533,11 +523,6 @@ class TestNodeIdentifierCreate:
         # read contributor cannot create identifier
         res = app.post_json_api(identifier_url, identifier_payload, auth=read_contributor.auth, expect_errors=True)
         assert res.status_code == 403
-
-        # cannot request a DOI when one already exists
-        res = app.post_json_api(identifier_url, identifier_payload, auth=user.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'A DOI already exists for this resource.'
 
         # cannot request a DOI for a private resource
         resource.is_public = False

--- a/api_tests/registries_moderation/test_submissions.py
+++ b/api_tests/registries_moderation/test_submissions.py
@@ -327,6 +327,8 @@ class TestRegistriesModerationSubmissions:
         assert resp.status_code == 201
         assert resp.json['data']['attributes']['trigger'] == RegistrationModerationTriggers.ACCEPT_SUBMISSION.db_name
         registration.refresh_from_db()
+        assert registration.identifiers.all().count() == 1
+
         assert registration.moderation_state == RegistrationModerationStates.ACCEPTED.db_name
 
     @pytest.mark.enable_quickfiles_creation

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2321,10 +2321,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         return oauth_scopes.CoreScopes.NODE_FILE_WRITE
 
     def get_doi_client(self):
-        if settings.DATACITE_URL and settings.DATACITE_PREFIX:
-            return DataCiteClient(base_url=settings.DATACITE_URL, prefix=settings.DATACITE_PREFIX)
-        else:
-            return None
+        return DataCiteClient(base_url=settings.DATACITE_URL, prefix=settings.DATACITE_PREFIX)
 
     def update_custom_citation(self, custom_citation, auth):
         if not self.has_permission(auth.user, ADMIN):

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -875,18 +875,18 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
             user = event_data.args[0]
         NodeLog = apps.get_model('osf.NodeLog')
 
-        register = self._get_registration()
-        if register.is_spammy:
+        registration = self._get_registration()
+        if registration.is_spammy:
             raise NodeStateError('Cannot approve a spammy registration')
 
         super()._on_complete(event_data)
         self.save()
-        registered_from = register.registered_from
+        registered_from = registration.registered_from
         # Pass auth=None because the registration initiator may not be
         # an admin on components (component admins had the opportunity
         # to disapprove the registration by this point)
-        register.set_privacy('public', auth=None, log=False)
-        for child in register.get_descendants_recursive(primary_only=True):
+        registration.set_privacy('public', auth=None, log=False)
+        for child in registration.get_descendants_recursive(primary_only=True):
             child.set_privacy('public', auth=None, log=False)
         # Accounts for system actions where no `User` performs the final approval
         auth = Auth(user) if user else None
@@ -894,16 +894,19 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
             action=NodeLog.REGISTRATION_APPROVAL_APPROVED,
             params={
                 'node': registered_from._id,
-                'registration': register._id,
+                'registration': registration._id,
                 'registration_approval_id': self._id,
             },
             auth=auth,
         )
-        for node in register.root.node_and_primary_descendants():
+        for node in registration.root.node_and_primary_descendants():
             self._add_success_logs(node, user)
             node.update_search()  # update search if public
 
         self.save()
+
+        doi = registration.request_identifier('doi')
+        registration.set_identifier_value('doi', doi)
 
     def _on_reject(self, event_data):
         user = event_data.kwargs.get('user')
@@ -976,6 +979,9 @@ class DraftRegistrationApproval(Sanction):
         else:
             raise ValueError("'registration_choice' must be either 'embargo' or 'immediate'")
         sanction(notify_initiator_on_complete=True)
+
+        doi = registration.request_identifier('doi')
+        registration.set_identifier_value('doi', doi)
 
     def _on_reject(self, user, *args, **kwargs):
         DraftRegistration = apps.get_model('osf.DraftRegistration')

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -25,6 +25,8 @@ FIXTURES = os.path.join(HERE, 'fixtures')
 @pytest.fixture(autouse=True)
 def override_doi_settings():
     settings.DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
+    settings.DATACITE_PASSWORD = 'swordfish'
+    settings.DATACITE_USERNAME = 'Doc Sportello'
 
 @pytest.fixture()
 def datacite_client(registration):
@@ -39,7 +41,7 @@ def datacite_client(registration):
         metadata_delete = mock.Mock(return_value='OK heeeeeeey')
 
     return DataCiteClient(
-        base_url = 'https://mds.fake.datacite.org',
+        base_url='https://mds.fake.datacite.org',
         prefix=settings.DATACITE_PREFIX,
         client=MockDataciteClient()
     )
@@ -57,25 +59,36 @@ def datacite_metadata_response():
 @pytest.mark.django_db
 class TestDataCiteClient:
 
+    @responses.activate
     def test_datacite_create_identifiers(self, registration, datacite_client):
+        responses.add(
+            responses.POST,
+            f'{datacite_client.base_url}/metadata/10.70102/FK2osf.io/{registration._id}',
+            body=f'OK (10.70102/FK2osf.io/{registration._id})',
+            status=200
+        )
         identifiers = datacite_client.create_identifier(node=registration, category='doi')
-        datacite_node_metadata = datacite_client.build_metadata(node=registration)
-
         assert identifiers['doi'] == settings.DOI_FORMAT.format(prefix=settings.DATACITE_PREFIX, guid=registration._id)
-        datacite_client._client.metadata_post.assert_called_with(datacite_node_metadata)
 
+    @responses.activate
     def test_datacite_update_doi_public_registration(self, registration, datacite_client):
+        responses.add(
+            responses.POST,
+            f'{datacite_client.base_url}/metadata/10.70102/FK2osf.io/{registration._id}',
+            body=f'OK (10.70102/FK2osf.io/{registration._id})',
+            status=200
+        )
         identifiers = datacite_client.update_identifier(registration, category='doi')
-        datacite_node_metadata = datacite_client.build_metadata(registration)
-
         assert identifiers['doi'] == settings.DOI_FORMAT.format(prefix=settings.DATACITE_PREFIX, guid=registration._id)
-        datacite_client._client.metadata_post.assert_called_with(datacite_node_metadata)
 
     def test_datacite_update_doi_status_unavailable(self, datacite_client):
+        settings.DATACITE_ENABLED = True
         node = ProjectFactory(is_public=False)
         datacite_client.update_identifier(node, category='doi')
 
         assert datacite_client._client.metadata_delete.called
+        settings.DATACITE_ENABLED = False
+
 
     def test_datacite_build_doi(self, registration, datacite_client):
         assert datacite_client.build_doi(registration) == settings.DOI_FORMAT.format(prefix=settings.DATACITE_PREFIX, guid=registration._id)
@@ -147,7 +160,7 @@ class TestDataCiteViews(OsfTestCase):
         responses.add(
             responses.Response(
                 responses.POST,
-                self.client.base_url + '/metadata',
+                self.client.base_url + f'/metadata/{self.client.build_doi(self.node)}',
                 body='OK (10.70102/FK2osf.io/cq695)',
                 status=201,
             )

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -325,13 +325,11 @@ DOI_URL_PREFIX = 'https://doi.org/'
 DOI_FORMAT = '{prefix}/osf.io/{guid}'
 
 # datacite
+DATACITE_ENABLED = True
 DATACITE_USERNAME = None
 DATACITE_PASSWORD = None
 DATACITE_URL = None
 DATACITE_PREFIX = '10.70102'  # Datacite's test DOI prefix -- update in production
-# Minting DOIs only works on Datacite's production server, so
-# disable minting on staging and development environments by default
-DATACITE_MINT_DOIS = not DEV_MODE
 
 # crossref
 CROSSREF_USERNAME = None

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -139,3 +139,4 @@ CHRONOS_FAKE_FILE_URL = 'https://staging2.osf.io/r2t5v/download'
 logging.getLogger('website.mails.mails').setLevel(logging.DEBUG)
 
 SHARE_ENABLED = False
+DATACITE_ENABLED = False

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -105,3 +105,4 @@ logging.getLogger('celery.app.trace').setLevel(logging.FATAL)
 DOI_FORMAT = '{prefix}/FK2osf.io/{guid}'
 
 SHARE_ENABLED = False
+DATACITE_ENABLED = False


### PR DESCRIPTION
## Purpose

This is primarily a ticket for ensuring that DOIs mint of project draft registration, but at some time in the distant past the ability to mint DOIs locally and therefore test this feature was disabled, so I had to make some tweaks in order to restore that behavior.

## Changes

- tweaks client (apparently just flat broken) to allow for minting DOIs and restructure tests to be mocked properly.
- removes old ServiceTemporarilyUnavailable exception
- removes old settings checks that were getting in the way of tests.  

## QA Notes

- Verify at https://doi.test.datacite.org/repositories/demo.cos/dois that DOIs are being minted when a project or draft reg is registered. ⚠️ You will need appropriate credentials to do this. ⚠️ 
- Verify Registration process is timely and error free.

## Documentation

QA: is there any user facing docs about this?

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2334