### PR TITLE
Ensure withdrawal justification is saved as comment for withdrawal action [ENG-2453]

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -624,8 +624,8 @@ class Registration(AbstractNode):
 
         initiated_by = initiated_by or self.sanction.initiated_by
 
-        if trigger is RegistrationModerationTriggers.REQUEST_WITHDRAWAL:
-            comment = self.withdrawal_justification
+        if not comment and trigger is RegistrationModerationTriggers.REQUEST_WITHDRAWAL:
+            comment = self.withdrawal_justification or ''  # Withdrawal justification is null by default
 
         action = RegistrationAction.objects.create(
             target=self,

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -624,7 +624,7 @@ class Registration(AbstractNode):
 
         initiated_by = initiated_by or self.sanction.initiated_by
 
-        if trigger is RegistrationModerationTriggers.REQUEST_WITHDRAWAL.value:
+        if trigger is RegistrationModerationTriggers.REQUEST_WITHDRAWAL:
             comment = self.withdrawal_justification
 
         action = RegistrationAction.objects.create(

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -624,6 +624,9 @@ class Registration(AbstractNode):
 
         initiated_by = initiated_by or self.sanction.initiated_by
 
+        if trigger is RegistrationModerationTriggers.REQUEST_WITHDRAWAL.value:
+            comment = self.withdrawal_justification
+
         action = RegistrationAction.objects.create(
             target=self,
             creator=initiated_by,

--- a/tests/test_registrations/test_review_flows.py
+++ b/tests/test_registrations/test_review_flows.py
@@ -678,7 +678,7 @@ class TestModerationActions:
 
     @pytest.fixture
     def retraction(self, provider):
-        sanction = RetractionFactory()
+        sanction = RetractionFactory(justification='bird')
         registration = sanction.target_registration
         registration.provider = provider
         registration.update_moderation_state()
@@ -708,6 +708,7 @@ class TestModerationActions:
         registration.refresh_from_db()
         latest_action = registration.actions.last()
         assert latest_action.trigger == RegistrationModerationTriggers.ACCEPT_SUBMISSION.db_name
+        assert latest_action.comment == 'bird'
 
     @pytest.mark.parametrize('sanction_fixture', [registration_approval, embargo])
     def test_moderator_reject_submission_writes_accept_submission_action(

--- a/tests/test_registrations/test_review_flows.py
+++ b/tests/test_registrations/test_review_flows.py
@@ -708,7 +708,6 @@ class TestModerationActions:
         registration.refresh_from_db()
         latest_action = registration.actions.last()
         assert latest_action.trigger == RegistrationModerationTriggers.ACCEPT_SUBMISSION.db_name
-        assert latest_action.comment == 'bird'
 
     @pytest.mark.parametrize('sanction_fixture', [registration_approval, embargo])
     def test_moderator_reject_submission_writes_accept_submission_action(
@@ -731,6 +730,7 @@ class TestModerationActions:
         registration.refresh_from_db()
         latest_action = registration.actions.last()
         assert latest_action.trigger == RegistrationModerationTriggers.REQUEST_WITHDRAWAL.db_name
+        assert latest_action.comment == 'bird'
 
 
     def test_moderator_accept_retraction_writes_accept_withdrawal_action(


### PR DESCRIPTION


## Purpose

The API needs to return the withdrawal justification as the comment in the withdrawal action. Its not doing this right now

## Changes

Ensure the registration model saves the withdrawal justification as the action comment.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the API returns the withdrawal justification made by the registration admin in the API
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

N/A
## Ticket

https://openscience.atlassian.net/browse/ENG-2453