### PR TITLE
[ENG-2191] OSF confirmation link doesn't resolve

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -620,7 +620,7 @@ def confirm_email_get(token, auth=None, **kwargs):
     if log_out:
         return auth_email_logout(token, user)
 
-    if auth and auth.user and user.merged_by and (auth.user._id == user._id or auth.user._id == user.merged_by._id):
+    if auth and auth.user and (auth.user._id == user._id or auth.user._id == getattr(user.merged_by, '_id', False)):
         if not is_merge:
             # determine if the user registered through a campaign
             campaign = campaigns.campaign_for_user(user)

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -620,7 +620,7 @@ def confirm_email_get(token, auth=None, **kwargs):
     if log_out:
         return auth_email_logout(token, user)
 
-    if auth and auth.user and (auth.user._id == user._id or auth.user._id == user.merged_by._id):
+    if auth and auth.user and user.merged_by and (auth.user._id == user._id or auth.user._id == user.merged_by._id):
         if not is_merge:
             # determine if the user registered through a campaign
             campaign = campaigns.campaign_for_user(user)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For a while we've had a mysterious issue where confirmation links would fail, initially we didn't know what caused it and why it was effecting certain users. It turns out according to Sentry reports the link was failing because the user already had a logged in session causing a simple logic error.

## Changes

- add extra conditional addressing non-merging users who have a `auth.user` object already.

## QA Notes

To recreate this bug:

1: Create an unconfirmed account and save the email link (but don't click it)
2: Log in to any pre-exsisting account
3: Click the link

- Verify can do the above steps without causing an error.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2191