### PR TITLE
[Hotfix] Fix old sanction states

### DIFF
--- a/osf/management/commands/update_old_sanction_states.py
+++ b/osf/management/commands/update_old_sanction_states.py
@@ -1,3 +1,8 @@
+"""
+  Fix bad sanction states introduced by https://github.com/CenterForOpenScience/osf.io/pull/3919
+
+    python3 manage.py update_old_sanction_states
+"""
 from django.core.management.base import BaseCommand
 
 from osf.models import Embargo, Retraction
@@ -13,10 +18,10 @@ def update_old_sanction_states():
     will bring them up-to-date.
     '''
 
-    Embargo.objects.filter(state_iexact='active').update(state=Embargo.APPROVED)
-    Embargo.objects.filter(state_iexact='cancelled').update(state=Embargo.REJECTED)
-    Retraction.objects.filter(state_iexact='retracted').update(state=Retraction.APPROVED)
-    Retraction.objects.filter(state_iexact='cancelled').update(state=Retraction.REJECTED)
+    Embargo.objects.filter(state__iexact='active').update(state=Embargo.APPROVED)
+    Embargo.objects.filter(state__iexact='cancelled').update(state=Embargo.REJECTED)
+    Retraction.objects.filter(state__iexact='retracted').update(state=Retraction.APPROVED)
+    Retraction.objects.filter(state__iexact='cancelled').update(state=Retraction.REJECTED)
 
 
 class Command(BaseCommand):

--- a/osf/management/commands/update_old_sanction_states.py
+++ b/osf/management/commands/update_old_sanction_states.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+
+from osf.models import Embargo, Retraction
+
+
+def update_old_sanction_states():
+    '''Fix out-of-date states for Embargo and Retraction objects.
+
+    https://github.com/CenterForOpenScience/osf.io/pull/3919 homogenized a lot
+    of the code behind the Embargo and Retraction objecs as part of introducing
+    the RegistrationApproval. It abruptly changed the acceptable states for
+    these models without updating existing values for them. This command
+    will bring them up-to-date.
+    '''
+
+    Embargo.objects.filter(state_iexact='active').update(state=Embargo.APPROVED)
+    Embargo.objects.filter(state_iexact='cancelled').update(state=Embargo.REJECTED)
+    Retraction.objects.filter(state_iexact='retracted').update(state=Retraction.APPROVED)
+    Retraction.objects.filter(state_iexact='cancelled').update(state=Retraction.REJECTED)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        update_old_sanction_states()

--- a/osf/management/commands/update_old_sanction_states.py
+++ b/osf/management/commands/update_old_sanction_states.py
@@ -21,6 +21,7 @@ def update_old_sanction_states():
     Embargo.objects.filter(state__iexact='active').update(state=Embargo.APPROVED)
     Embargo.objects.filter(state__iexact='cancelled').update(state=Embargo.REJECTED)
     Retraction.objects.filter(state__iexact='retracted').update(state=Retraction.APPROVED)
+    Retraction.objects.filter(state__iexact='pending').update(state=Retraction.UNAPPROVED)
     Retraction.objects.filter(state__iexact='cancelled').update(state=Retraction.REJECTED)
 
 

--- a/osf_tests/management_commands/test_update_old_sanction_states.py
+++ b/osf_tests/management_commands/test_update_old_sanction_states.py
@@ -23,6 +23,9 @@ class TestUpdateOldSanctionStates:
         old_style_cancelled_retraction = factories.RetractionFactory()
         old_style_cancelled_retraction.state = 'cancelled'
         old_style_cancelled_retraction.save()
+        old_style_pending_retraction = factories.RetractionFactory()
+        old_style_pending_retraction.state = 'pending'
+        old_style_pending_retraction.save()
 
         assert Embargo.objects.filter(state=Embargo.UNAPPROVED).count() == 1
         assert Embargo.objects.filter(state=Embargo.APPROVED).count() == 0
@@ -36,7 +39,7 @@ class TestUpdateOldSanctionStates:
         assert Embargo.objects.filter(state=Embargo.UNAPPROVED).count() == 1
         assert Embargo.objects.filter(state=Embargo.APPROVED).count() == 1
         assert Embargo.objects.filter(state=Embargo.REJECTED).count() == 1
-        assert Retraction.objects.filter(state=Retraction.UNAPPROVED).count() == 1
+        assert Retraction.objects.filter(state=Retraction.UNAPPROVED).count() == 2
         assert Retraction.objects.filter(state=Retraction.APPROVED).count() == 1
         assert Retraction.objects.filter(state=Retraction.REJECTED).count() == 1
 
@@ -48,6 +51,8 @@ class TestUpdateOldSanctionStates:
         assert old_style_embargo.state == Embargo.APPROVED
         old_style_retraction.refresh_from_db()
         assert old_style_retraction.state == Retraction.APPROVED
+        old_style_pending_retraction.refresh_from_db()
+        assert old_style_pending_retraction.state == Retraction.UNAPPROVED
         old_style_cancelled_embargo.refresh_from_db()
         assert old_style_cancelled_embargo.state == Embargo.REJECTED
         old_style_cancelled_retraction.refresh_from_db()

--- a/osf_tests/management_commands/test_update_old_sanction_states.py
+++ b/osf_tests/management_commands/test_update_old_sanction_states.py
@@ -1,0 +1,54 @@
+import pytest
+
+from osf.management.commands.update_old_sanction_states import update_old_sanction_states
+from osf.models import Embargo, Retraction
+from osf_tests import factories
+
+@pytest.mark.django_db
+class TestUpdateOldSanctionStates:
+
+    def test_update_old_sanction_states(self):
+        new_style_embargo = factories.EmbargoFactory()
+        old_style_embargo = factories.EmbargoFactory()
+        old_style_embargo.state = 'active'
+        old_style_embargo.save()
+        old_style_cancelled_embargo = factories.EmbargoFactory()
+        old_style_cancelled_embargo.state = 'cancelled'
+        old_style_cancelled_embargo.save()
+
+        new_style_retraction = factories.RetractionFactory()
+        old_style_retraction = factories.RetractionFactory()
+        old_style_retraction.state = 'retracted'
+        old_style_retraction.save()
+        old_style_cancelled_retraction = factories.RetractionFactory()
+        old_style_cancelled_retraction.state = 'cancelled'
+        old_style_cancelled_retraction.save()
+
+        assert Embargo.objects.filter(state=Embargo.UNAPPROVED).count() == 1
+        assert Embargo.objects.filter(state=Embargo.APPROVED).count() == 0
+        assert Embargo.objects.filter(state=Embargo.REJECTED).count() == 0
+        assert Retraction.objects.filter(state=Retraction.UNAPPROVED).count() == 1
+        assert Retraction.objects.filter(state=Retraction.APPROVED).count() == 0
+        assert Retraction.objects.filter(state=Retraction.REJECTED).count() == 0
+
+        update_old_sanction_states()
+
+        assert Embargo.objects.filter(state=Embargo.UNAPPROVED).count() == 1
+        assert Embargo.objects.filter(state=Embargo.APPROVED).count() == 1
+        assert Embargo.objects.filter(state=Embargo.REJECTED).count() == 1
+        assert Retraction.objects.filter(state=Retraction.UNAPPROVED).count() == 1
+        assert Retraction.objects.filter(state=Retraction.APPROVED).count() == 1
+        assert Retraction.objects.filter(state=Retraction.REJECTED).count() == 1
+
+        new_style_embargo.refresh_from_db()
+        assert new_style_embargo.state == Embargo.UNAPPROVED
+        new_style_retraction.refresh_from_db()
+        assert new_style_retraction.state == Retraction.UNAPPROVED
+        old_style_embargo.refresh_from_db()
+        assert old_style_embargo.state == Embargo.APPROVED
+        old_style_retraction.refresh_from_db()
+        assert old_style_retraction.state == Retraction.APPROVED
+        old_style_cancelled_embargo.refresh_from_db()
+        assert old_style_cancelled_embargo.state == Embargo.REJECTED
+        old_style_cancelled_retraction.refresh_from_db()
+        assert old_style_cancelled_retraction.state == Retraction.REJECTED


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
https://github.com/CenterForOpenScience/osf.io/pull/3919 Introduced the existing Sanction hierarchy and, in the process, changed the states supported by the then-existing Embargo and Retraction models. Some of these old entries are still abandoned in their old states and are breaking the backfill for the new `moderation_state` on Registrations.

## Changes
* convert any `active` states to `approved` for Embargos
* convert any `retracted` states to `approved` for Retractions
* convert any 'pending' states to 'unapproved' for Retractions
* convert any `cancelled` states to `rejected` for both Embargos and Retractions

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
