### PR TITLE
[ENG-2106] Add management command to copy custom taxonomies to allow hightlighting

### DIFF
--- a/osf/management/commands/make_taxonomy_custom.py
+++ b/osf/management/commands/make_taxonomy_custom.py
@@ -13,6 +13,9 @@ logger = logging.getLogger(__name__)
 
 def main(provider_id):
     provider = AbstractProvider.objects.get(_id=provider_id)
+
+    assert provider.subjects.count() == 0, 'This provider already has a custom taxonomy'
+
     # Flat taxonomy is stored locally, read in here
     with open(os.path.join(settings.APP_PATH, 'website', 'static', 'bepress_taxonomy.json')) as fp:
         taxonomy = json.load(fp)

--- a/osf/management/commands/make_taxonomy_custom.py
+++ b/osf/management/commands/make_taxonomy_custom.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+import os
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+
+from website import settings
+from osf.models import AbstractProvider, Subject
+
+logger = logging.getLogger(__name__)
+
+
+def main(provider_id):
+    provider = AbstractProvider.objects.get(_id=provider_id)
+    # Flat taxonomy is stored locally, read in here
+    with open(os.path.join(settings.APP_PATH, 'website', 'static', 'bepress_taxonomy.json')) as fp:
+        taxonomy = json.load(fp)
+
+    for subject_path in taxonomy.get('data'):
+        subjects = subject_path.split('_')
+        text = subjects[-1]
+
+        parent = None
+        if len(subjects) > 1:
+            parent, _ = Subject.objects.get_or_create(text=subjects[-2], provider=provider)
+        subject, _ = Subject.objects.get_or_create(text=text, provider=provider)
+        if parent and not subject.parent:
+            subject.parent = parent
+            subject.save()
+
+
+class Command(BaseCommand):
+    """Ensure all features and switches are updated with the switch and flag files
+    """
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            '-id',
+            type=str,
+            help='The id of the provider who\'s taxonomy you want to make custom'
+        )
+
+    def handle(self, *args, **options):
+        provider_id = options.get('id', False)
+        main(provider_id)

--- a/osf/models/subject.py
+++ b/osf/models/subject.py
@@ -9,7 +9,7 @@ from include import IncludeQuerySet
 from website.util import api_v2_url
 
 from osf.models.base import BaseModel, ObjectIDMixin
-from osf.models.validators import validate_subject_hierarchy_length, validate_subject_provider_mapping, validate_subject_highlighted_count
+from osf.models.validators import validate_subject_hierarchy_length, validate_subject_highlighted_count
 
 class SubjectQuerySet(IncludeQuerySet):
     def include_children(self):
@@ -78,7 +78,6 @@ class Subject(ObjectIDMixin, BaseModel, DirtyFieldsMixin):
 
     def save(self, *args, **kwargs):
         saved_fields = self.get_dirty_fields() or []
-        validate_subject_provider_mapping(self.provider, self.bepress_subject)
         validate_subject_highlighted_count(self.provider, bool('highlighted' in saved_fields and self.highlighted))
         if 'text' in saved_fields and self.pk and (self.preprints.exists() or self.abstractnodes.exists()):
             raise ValidationError('Cannot edit a used Subject')

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -115,10 +115,6 @@ def validate_subject_hierarchy_length(parent):
     if parent and len(parent.hierarchy) >= 3:
         raise DjangoValidationError('Invalid hierarchy')
 
-def validate_subject_provider_mapping(provider, mapping):
-    if not mapping and provider._id != 'osf':
-        raise DjangoValidationError('Invalid PreprintProvider / Subject alias mapping.')
-
 def validate_subjects(subject_list):
     """
     Asserts all subjects in subject_list are valid subjects

--- a/osf_tests/management_commands/test_make_taxonomy_custom.py
+++ b/osf_tests/management_commands/test_make_taxonomy_custom.py
@@ -1,0 +1,19 @@
+import pytest
+
+from django.core.management import call_command
+
+from osf_tests.factories import PreprintProviderFactory
+
+@pytest.mark.django_db
+class TestMakeTaxonomyCustom:
+
+    @pytest.fixture()
+    def provider(self):
+        return PreprintProviderFactory()
+
+    def test_make_custom_taxonomy(self, provider):
+        assert provider.subjects.count() == 0
+
+        call_command('make_taxonomy_custom', f'-id={provider._id}')
+
+        assert provider.subjects.count() == 1217

--- a/osf_tests/management_commands/test_make_taxonomy_custom.py
+++ b/osf_tests/management_commands/test_make_taxonomy_custom.py
@@ -15,5 +15,9 @@ class TestMakeTaxonomyCustom:
         assert provider.subjects.count() == 0
 
         call_command('make_taxonomy_custom', f'-id={provider._id}')
-
         assert provider.subjects.count() == 1217
+
+        with pytest.raises(AssertionError) as e:
+            call_command('make_taxonomy_custom', f'-id={provider._id}')
+
+        assert str(e.value) == 'This provider already has a custom taxonomy'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To allow providers with the standard bepress taxonomy to highlight certain subjects, we need to copy that providers taxonomy into postgres. This adds a management command to copy over the standard taxonomy.

## Changes

- adds management command that copies taxonomy with tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that "OSF Subjects" in the admin app lists all the subjects for the provider and that highlighted status can be changed.


## Documentation

new management command, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2106