### PR TITLE
[ENG-2336] Send all additional DOI data over datacite

### DIFF
--- a/osf/management/commands/sync_datacite_doi_metadata.py
+++ b/osf/management/commands/sync_datacite_doi_metadata.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from django.core.management.base import BaseCommand
+from osf.models import Registration
+
+logger = logging.getLogger(__name__)
+
+
+def sync_datacite_doi_metadata(dry_run=True):
+    for registration in Registration.objects.all():
+        if not dry_run:
+            doi = registration.request_identifier('doi')
+            registration.set_identifier_value('doi', doi)
+
+
+class Command(BaseCommand):
+    """Adds DOIs to all registrations"""
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--dry',
+            action='store_true',
+            dest='dry_run',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run')
+        sync_datacite_doi_metadata(dry_run=dry_run)

--- a/osf/management/commands/sync_datacite_doi_metadata.py
+++ b/osf/management/commands/sync_datacite_doi_metadata.py
@@ -1,25 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import logging
 
 from django.core.management.base import BaseCommand
 from osf.models import Registration
-
-logger = logging.getLogger(__name__)
 
 
 def sync_datacite_doi_metadata(dry_run=True):
     for registration in Registration.objects.all():
         if not dry_run:
-            doi = registration.request_identifier('doi')
+            doi = registration.update_identifier('doi')
             registration.set_identifier_value('doi', doi)
 
 
 class Command(BaseCommand):
     """Adds DOIs to all registrations"""
     def add_arguments(self, parser):
-        super(Command, self).add_arguments(parser)
+        super().add_arguments(parser)
         parser.add_argument(
             '--dry',
             action='store_true',

--- a/osf/metadata/serializers.py
+++ b/osf/metadata/serializers.py
@@ -41,7 +41,7 @@ class DataciteMetadataRecordSerializer(MetadataRecordSerializer):
         osfstorage_file = record.file
         target = osfstorage_file.target
         doc = {
-            'creators': utils.datacite_format_contributors(target.visible_contributors),
+            'creators': utils.datacite_format_creators(target.visible_contributors),
             'titles': [
                 {
                     'title': osfstorage_file.name
@@ -74,9 +74,8 @@ class DataciteMetadataRecordSerializer(MetadataRecordSerializer):
             ]
 
         subject_list = []
-        subjects_from_target = target.subjects.all().select_related('bepress_subject')
-        if subjects_from_target.exists():
-            subject_list = utils.datacite_format_subjects(subjects_from_target)
+        if target.subjects.all().exists():
+            subject_list = utils.datacite_format_subjects(target)
         tags_on_file = osfstorage_file.tags.values_list('name', flat=True)
         for tag_name in tags_on_file:
             subject_list.append({'subject': tag_name})

--- a/osf/metadata/utils.py
+++ b/osf/metadata/utils.py
@@ -1,7 +1,7 @@
 from website import settings
 
 
-SUBJECT_SCHEME = 'bepress Digital Commons Three-Tiered Taxonomy'
+BEPRESS_SUBJECT_SCHEME = 'bepress Digital Commons Three-Tiered Taxonomy'
 
 DATACITE_RESOURCE_TYPE_MAP = {
     'Audio/Video': 'Audiovisual',
@@ -23,6 +23,41 @@ DATACITE_RESOURCE_TYPE_MAP = {
 }
 
 
+def datacite_format_creators(creators):
+    """ Format a list of contributors to match the datacite schema
+
+    :param contributors_list: list of OSFUsers to format
+    :return: formatted json for datacite
+    """
+    creators_json = []
+    for creator in creators:
+        name_identifiers = [
+            {
+                'nameIdentifier': f'{creator._id}/',
+                'nameIdentifierScheme': 'OSF',
+                'schemeURI': settings.DOMAIN
+            }
+        ]
+
+        if creator.external_identity.get('ORCID'):
+            verified = list(creator.external_identity['ORCID'].values())[0] == 'VERIFIED'
+            if verified:
+                name_identifiers.append({
+                    'nameIdentifier': list(creator.external_identity['ORCID'].keys())[0],
+                    'nameIdentifierScheme': 'ORCID',
+                    'schemeURI': 'http://orcid.org/'
+                })
+
+        creators_json.append({
+            'nameIdentifiers': name_identifiers,
+            'creatorName': creator.fullname,
+            'familyName': creator.family_name,
+            'givenName': creator.given_name
+        })
+
+    return creators_json
+
+
 def datacite_format_contributors(contributors):
     """ Format a list of contributors to match the datacite schema
 
@@ -33,7 +68,7 @@ def datacite_format_contributors(contributors):
     for contributor in contributors:
         name_identifiers = [
             {
-                'nameIdentifier': contributor.absolute_url,
+                'nameIdentifier': f'{contributor._id}/',
                 'nameIdentifierScheme': 'OSF',
                 'schemeURI': settings.DOMAIN
             }
@@ -49,25 +84,34 @@ def datacite_format_contributors(contributors):
                 })
 
         creators.append({
-            'creatorName': {
-                'creatorName': contributor.fullname,
-                'familyName': contributor.family_name,
-                'givenName': contributor.given_name
-            },
-            'nameIdentifiers': name_identifiers
+            'nameIdentifiers': name_identifiers,
+            'contributorName': contributor.fullname,
+            'contributorType': 'ProjectMember',
+            'familyName': contributor.family_name,
+            'givenName': contributor.given_name
         })
 
     return creators
 
 
-def datacite_format_subjects(subjects):
-    return [
-        {
-            'subject': subject.bepress_subject.text if subject.bepress_subject else subject.text,
-            'subjectScheme': SUBJECT_SCHEME
-        }
-        for subject in subjects
+def datacite_format_subjects(node):
+    datacite_subjects = []
+    subjects = node.subjects.all().select_related('bepress_subject')
+    if subjects.exists():
+        datacite_subjects = [
+            {
+                'subject': subject.bepress_subject.text if subject.bepress_subject else subject.text,
+                'subjectScheme': BEPRESS_SUBJECT_SCHEME
+            }
+            for subject in subjects
+        ]
+    tags = node.tags.filter(system=False)
+    datacite_subjects += [
+        {'subject': tag.name,
+         'subjectScheme': 'OSF tag'
+         } for tag in tags
     ]
+    return datacite_subjects
 
 
 def datacite_format_identifier(target):

--- a/osf/metadata/utils.py
+++ b/osf/metadata/utils.py
@@ -25,6 +25,7 @@ DATACITE_RESOURCE_TYPE_MAP = {
 
 def datacite_format_creators(creators):
     """ Format a list of contributors to match the datacite schema
+    Schema found here: https://schema.datacite.org/meta/kernel-4.3/doc/DataCite-MetadataKernel_v4.3.pdf
 
     :param contributors_list: list of OSFUsers to format
     :return: formatted json for datacite
@@ -60,11 +61,12 @@ def datacite_format_creators(creators):
 
 def datacite_format_contributors(contributors):
     """ Format a list of contributors to match the datacite schema
+    Schema found here: https://schema.datacite.org/meta/kernel-4.3/doc/DataCite-MetadataKernel_v4.3.pdf
 
     :param contributors_list: list of OSFUsers to format
     :return: formatted json for datacite
     """
-    creators = []
+    contributors_json = []
     for contributor in contributors:
         name_identifiers = [
             {
@@ -83,7 +85,7 @@ def datacite_format_contributors(contributors):
                     'schemeURI': 'http://orcid.org/'
                 })
 
-        creators.append({
+        contributors_json.append({
             'nameIdentifiers': name_identifiers,
             'contributorName': contributor.fullname,
             'contributorType': 'ProjectMember',
@@ -91,10 +93,16 @@ def datacite_format_contributors(contributors):
             'givenName': contributor.given_name
         })
 
-    return creators
+    return contributors_json
 
 
 def datacite_format_subjects(node):
+    """ Format a list of subjects to match the datacite schema
+    Schema found here: https://schema.datacite.org/meta/kernel-4.3/doc/DataCite-MetadataKernel_v4.3.pdf
+
+    :param node: a project or registration that should have it's subject formatted for datacite
+    :return: formatted json for datacite
+    """
     datacite_subjects = []
     subjects = node.subjects.all().select_related('bepress_subject')
     if subjects.exists():
@@ -114,16 +122,14 @@ def datacite_format_subjects(node):
     return datacite_subjects
 
 
-def datacite_format_identifier(target):
-    identifier = target.get_identifier('doi')
-    if identifier:
-        return {
-            'identifier': identifier.value,
-            'identifierType': 'DOI'
-        }
-
-
 def datacite_format_rights(license):
+    """ Format the liceses/rights of project/node for a datacite schema
+    Schema found here: https://schema.datacite.org/meta/kernel-4.3/doc/DataCite-MetadataKernel_v4.3.pdf
+
+    :param license: a lincense object for a node that should be formatted for datacite
+    :return: formatted json for datacite
+    """
+
     return {
         'rights': license.name,
         'rightsURI': license.url


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently we are only sending a small portion of our node's metadata to datacite, this fix will send all the available metadata.

## Changes

- modifies formatting for metadata being sent to datacite
- add management command to sync pre-this-PR metadata

## QA Notes

Please make verification statements inspired by your code and what your code touches.
-  Verify at https://doi.test.datacite.org/repositories/demo.cos/dois that DOIs are being minted when a project or draft reg is registered. ⚠️ You will need appropriate credentials to do this. ⚠️
-  Verify Registration process is timely and error free.

## Documentation

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2336