### PR TITLE
Allow correct_registries_moderation_states to be scheduled [No ticket]

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -501,6 +501,7 @@ class CeleryConfig:
         'osf.management.commands.deactivate_requested_accounts',
         'osf.management.commands.check_crossref_dois',
         'osf.management.commands.update_institution_project_counts',
+        'osf.management.commands.correct_registration_moderation_states',
     )
 
     # Modules that need metrics and release requirements


### PR DESCRIPTION
## Purpose
Allow correct_registries_moderation_states to be scheduled

## Changes
- Update management command, args
- Update beat imports

## Deployment notes
To run, `beat_schedule` should be updated to include something like

```
'correct_registration_moderation_states': {
   'task': 'management.commands.correct_registration_moderation_states',
   'schedule': crontab(minute='*/30'), # Every 30 minutes
   'kwargs': {'page_size': 500}
},
```

## Ticket
None