### PR TITLE
Changing primary email address should change email in mailchimp [ENG-2381]

### DIFF
--- a/osf/management/commands/update_mailchimp_email.py
+++ b/osf/management/commands/update_mailchimp_email.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def update_mailchimp_email():
     users_updated = 0
-    for user in OSFUser.objects.filter(deleted=None):
+    for user in OSFUser.objects.filter(deleted__isnull=True):
         for list_name, subscription in user.mailchimp_mailing_lists.items():
             if subscription:
                 mailchimp_utils.subscribe_mailchimp(list_name, user._id)

--- a/osf/management/commands/update_mailchimp_email.py
+++ b/osf/management/commands/update_mailchimp_email.py
@@ -1,0 +1,35 @@
+import logging
+import datetime
+
+from django.core.management.base import BaseCommand
+from osf.models import OSFUser
+from website import mailchimp_utils
+
+logger = logging.getLogger(__name__)
+
+
+def update_mailchimp_email():
+    users_updated = 0
+    for user in OSFUser.objects.filter(deleted=None):
+        for list_name, subscription in user.mailchimp_mailing_lists.items():
+            if subscription:
+                mailchimp_utils.subscribe_mailchimp(list_name, user._id)
+        users_updated += 1
+
+    return users_updated
+
+
+class Command(BaseCommand):
+    help = '''Backfills users that might have updated their email and not had it updated in mailchimp'''
+
+    def handle(self, *args, **options):
+        script_start_time = datetime.datetime.now()
+        logger.info(f'Script started time: {script_start_time}')
+
+        users_updated = update_mailchimp_email()
+
+        script_finish_time = datetime.datetime.now()
+        logger.info(f'Script finished time: {script_finish_time}')
+        script_runtime = script_finish_time - script_start_time
+        logger.info(f'Run time {script_runtime}')
+        logger.info(f'{users_updated} Users updated in mailchimp')

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -143,7 +143,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     # Overrides DirtyFieldsMixin, Foreign Keys checked by '<attribute_name>_id' rather than typical name.
     FIELDS_TO_CHECK = SEARCH_UPDATE_FIELDS.copy()
-    FIELDS_TO_CHECK.update({'password', 'last_login', 'merged_by_id'})
+    FIELDS_TO_CHECK.update({'password', 'last_login', 'merged_by_id', 'username'})
 
     # TODO: Add SEARCH_UPDATE_NODE_FIELDS, for fields that should trigger a
     #   search update for all nodes to which the user is a contributor.
@@ -1032,6 +1032,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     # Overrides BaseModel
     def save(self, *args, **kwargs):
+        from website import mailchimp_utils
+
         self.update_is_active()
         self.username = self.username.lower().strip() if self.username else None
         dirty_fields = set(self.get_dirty_fields(check_relationship=True))
@@ -1046,6 +1048,10 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             if quickfiles:
                 quickfiles.title = get_quickfiles_project_title(self)
                 quickfiles.save()
+        if 'username' in dirty_fields:
+            for list_name, subscription in self.mailchimp_mailing_lists.items():
+                if subscription:
+                    mailchimp_utils.subscribe_mailchimp(list_name, self._id)
         return ret
 
     # Legacy methods

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1495,8 +1495,9 @@ class TestMergingUsers:
             assert mock_signals.signals_sent() == set([user_merged])
 
     @pytest.mark.enable_enqueue_task
+    @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     @mock.patch('website.mailchimp_utils.unsubscribe_mailchimp_async')
-    def test_merged_user_unsubscribed_from_mailing_lists(self, mock_unsubscribe, dupe, merge_dupe, email_subscriptions_enabled):
+    def test_merged_user_unsubscribed_from_mailing_lists(self, mock_mailchimp_api, mock_unsubscribe, dupe, merge_dupe, email_subscriptions_enabled):
         list_name = 'foo'
         dupe.mailchimp_mailing_lists[list_name] = True
         dupe.save()

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -215,12 +215,6 @@ def update_user(auth):
 
     user.save()
 
-    # Update subscribed mailing lists with new primary email
-    # TODO: move to user.save()
-    for list_name, subscription in user.mailchimp_mailing_lists.items():
-        if subscription:
-            mailchimp_utils.subscribe_mailchimp(list_name, user._id)
-
     return _profile_view(user, is_profile=True)
 
 


### PR DESCRIPTION


## Purpose

Currently, when a user changes their primary email address, their email address in mailchimp isn't updated. 

## Changes

Removing the mailchimp updating from website/profile/views.py and moving it to the user.save() method, anytime the username is updated, it will update mailchimp.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify Mailchimp gets the new email address
- Verify the backfill updates all email addresses

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

Shouldn't be. This is a better solution than before.
## Ticket

https://openscience.atlassian.net/browse/ENG-2381