### PR TITLE
Remove embargo_termination_approval objects when they are no longer

### DIFF
--- a/osf_tests/management_commands/test_correct_registration_moderation_states.py
+++ b/osf_tests/management_commands/test_correct_registration_moderation_states.py
@@ -61,13 +61,14 @@ class TestCorrectRegistrationModerationState(OsfTestCase):
     def test_correct_registration_moderation_states_only_collects_initial_registrations(self):
         # Implicitly invoke update_moderation_state.
         # We should not attempt to update state on these Registrations.
+        # Also should not attempt to update self.registration_approval, which should be in initial
         self.embargo.to_COMPLETED()
         self.retraction.to_APPROVED()
 
         with mock.patch.object(Registration, 'update_moderation_state') as mock_update:
             correct_registration_moderation_states()
 
-        assert mock_update.call_count == 2
+        assert mock_update.call_count == 1
 
     def test_correct_registration_moderation_states_ignores_deleted_registrations(self):
         deleted_registration = self.registration_approval.target_registration
@@ -77,7 +78,9 @@ class TestCorrectRegistrationModerationState(OsfTestCase):
         with mock.patch.object(Registration, 'update_moderation_state') as mock_update:
             correct_registration_moderation_states()
 
-        assert mock_update.call_count == 3
+        # Shouldn't attempt to update self.registration_approval (deleted)
+        # or self.embargo (correctly in 'initial')
+        assert mock_update.call_count == 2
 
     def test_correct_registration_moderation_states_only_reports_updated_registrations(self):
         # INITIAL is the correct state for a Registration with an

--- a/scripts/approve_embargo_terminations.py
+++ b/scripts/approve_embargo_terminations.py
@@ -47,17 +47,23 @@ def main():
             )
             continue
         if not registration.is_embargoed:
+            # Embargo previously completed
             logger.warning('Registration {0} associated with this embargo termination request ({0}) is not embargoed.'.format(
                 registration._id,
                 request._id
             ))
+            registration.embargo_termination_approval = None
+            registration.save()
             continue
         embargo = registration.embargo
         if not embargo:
+            # Embargo was otherwise disappeared
             logger.warning('No Embargo associated with this embargo termination request ({0}) on Node: {1}'.format(
                 request._id,
                 registration._id
             ))
+            registration.embargo_termination_approval = None
+            registration.save()
             continue
         else:
             count += 1

--- a/scripts/tests/test_approve_embargo_terminations.py
+++ b/scripts/tests/test_approve_embargo_terminations.py
@@ -68,3 +68,16 @@ class TestApproveEmbargoTerminations(OsfTestCase):
             assert_true(node.is_public)
             assert_equal(node.embargo_termination_approval.state, Sanction.APPROVED)
             assert_false(node.is_embargoed)
+
+    def test_main_removes_embargo_termination_approvals_for_completed_embargos(self):
+        self.registration2.embargo.mark_as_completed()
+        main()
+        self.registration2.refresh_from_db()
+        assert self.registration2.embargo_termination_approval is None
+
+    def test_main_removes_embargo_termination_approvals_For_removed_embargos(self):
+        self.registration2.embargo = None
+        self.registration2.save()
+        main()
+        self.registration2.refresh_from_db()
+        assert self.registration2.embargo_termination_approval is None


### PR DESCRIPTION
valid. Fix tests for corret_registration_moderation_states

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make sure we don't leave dangling `embargo_termination_approval` objects when an embargo expires before the termination is approved.

These historically have just been ignored, but now they mess with `moderation_state`, which is no good.

## Changes
Following the pattern for `EmbargoTerminationApproval._on_reject`, set registration.embargo_termination_approval to None when it is no longer valid.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
