### PR TITLE
[ENG-2466][warmfix] retracted preprints may actually be spam

### DIFF
--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -154,8 +154,9 @@ def format_preprint(preprint, old_subjects=None):
             'title': preprint.title,
             'description': preprint.description or '',
             'is_deleted': (
-                (not preprint.verified_publishable and not preprint.is_retracted) or
-                preprint.tags.filter(name='qatest').exists()
+                (not preprint.verified_publishable and not preprint.is_retracted)
+                or preprint.is_spammy
+                or is_qa_resource(preprint)
             ),
             'date_updated': preprint.modified.isoformat(),
             'date_published': preprint.date_published.isoformat() if preprint.date_published else None,

--- a/conftest.py
+++ b/conftest.py
@@ -152,7 +152,7 @@ def mock_share():
     with mock.patch('api.share.utils.settings.SHARE_ENABLED', True):
         with mock.patch('api.share.utils.settings.SHARE_API_TOKEN', 'mock-api-token'):
             with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
-                rsps.add(responses.POST, 'https://share.osf.io/api/v2/normalizeddata/', status=200)
+                rsps.add(responses.POST, f'{website_settings.SHARE_URL}api/v2/normalizeddata/', status=200)
                 yield rsps
 
 


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
make sure spam preprints don't show up in search results
<!-- Describe the purpose of your changes -->

## Changes
close a loophole wherethrough spam preprints are surfaced in SHARE if
they have ever been retracted.

may apply retroactively by calling `api.share.utils.update_share` on
each of:
```py
Preprint.objects.filter(
    date_withdrawn__isnull=False,
    spam_status__in=[SpamStatus.FLAGGED, SpamStatus.SPAM],  # or whatever is most appropriate
)
```
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that if a preprint is both retracted/withdrawn AND marked spam, it remains hidden

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/ENG-2466