### PR TITLE
Creating a redirect when a draft has been registered [ENG-2471]

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -306,3 +306,11 @@ class NonDescendantNodeError(APIException):
         if not detail:
             detail = self.default_detail.format(node_id)
         super(NonDescendantNodeError, self).__init__(detail=detail)
+
+
+class PermanentlyMovedError(APIException):
+    status_code = 301
+    location = ''
+
+    def __init__(self, detail=None):
+        super(PermanentlyMovedError, self).__init__(detail=detail)

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -310,7 +310,4 @@ class NonDescendantNodeError(APIException):
 
 class PermanentlyMovedError(APIException):
     status_code = 301
-    location = ''
-
-    def __init__(self, detail=None):
-        super(PermanentlyMovedError, self).__init__(detail=detail)
+    default_detail = _('This object has permanently moved.')

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -23,6 +23,7 @@ from api.base.exceptions import (
     RelationshipPostMakesNoChanges,
     EndpointNotImplementedError,
     InvalidQueryStringError,
+    PermanentlyMovedError,
 )
 from api.base.filters import ListFilterMixin, PreprintFilterMixin
 from api.base.pagination import CommentPagination, NodeContributorPagination, MaxSizePagination
@@ -218,7 +219,9 @@ class DraftMixin(object):
                 raise PermissionDenied('This draft has already been approved and cannot be modified.')
         else:
             if draft.registered_node and not draft.registered_node.is_deleted:
-                raise Gone(detail='This draft has already been registered.')
+                redirect_url = draft.registered_node.absolute_api_v2_url
+                self.headers['location'] = redirect_url
+                raise PermanentlyMovedError(detail='Draft has already been registered')
 
         if check_object_permissions:
             self.check_resource_permissions(draft)


### PR DESCRIPTION


## Purpose

Currently when a draft has been registered, it shows a 410 (Gone). Front end would like a 301 (Permanently moved).

## Changes

Adding the redirect

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify After a draft is registered, the API properly redirects.
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

Shouldn't be.
## Ticket

https://openscience.atlassian.net/browse/ENG-2471