### PR TITLE
[ENG-1696] Make it so write users ‘license’ edits do persist

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -40,8 +40,6 @@ class RegistrationSerializer(NodeSerializer):
         'custom_citation',
         'is_pending_retraction',
         'is_public',
-        'license',
-        'license_type',
         'withdrawal_justification',
     ]
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -2275,12 +2275,10 @@ class TestNodeUpdateLicense:
         assert node.node_license.copyright_holders == [
             'Mr. Monument', 'Princess OSF']
 
-    def test_cannot_update(
+    def test_update(
             self, user_write_contrib, user_read_contrib,
             user_non_contrib, node, make_payload,
             make_request, license_cc0, url_node):
-
-        # def test_rw_contributor_cannot_update_license(self):
         data = make_payload(
             node_id=node._id,
             license_id=license_cc0._id
@@ -2290,8 +2288,8 @@ class TestNodeUpdateLicense:
             url_node, data,
             auth=user_write_contrib.auth,
             expect_errors=True)
-        assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == exceptions.PermissionDenied.default_detail
+        assert res.status_code == 200
+        assert res.json['data']['id'] == node._id
 
     # def test_read_contributor_cannot_update_license(self):
         data = make_payload(

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -26,12 +26,8 @@ def set_license(node, license_detail, auth, node_type='node'):
     ):
         return {}, False
 
-    if node_type == 'preprint':
-        if not node.has_permission(auth.user, permissions.WRITE):
-            raise framework_exceptions.PermissionsError('You need admin or write permissions to change a {}\'s license'.format(node_type))
-    else:
-        if not node.has_permission(auth.user, permissions.ADMIN):
-            raise framework_exceptions.PermissionsError('Only admins can change a {}\'s license'.format(node_type))
+    if not node.has_permission(auth.user, permissions.WRITE):
+        raise framework_exceptions.PermissionsError('You need admin or write permissions to change a {}\'s license'.format(node_type))
 
     try:
         node_license = NodeLicense.objects.get(license_id=license_id)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently when a user with write permissions edits a DraftRegistration the permission scheme doesn't allow those edits, this fix gives the user the permission to do that.

## Changes

- simple logic change to `set_license` 
- simple change to registration views

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that license changes persist after a write user edits thier license.

## Documentation

🐞  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-1696