### PR TITLE
[ENG-2518] Removes registries container 

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -343,3 +343,7 @@ wb:
     - wb_tmp_vol:/tmp
   stdin_open: true
 ```
+
+### Running Collections
+
+To run collections, you must uncomment COLLECTIONS_ENABLED=true in docker-compose.yml under ember_osf_web, then recreate your ember and web containers.

--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -122,8 +122,8 @@
   - `$ docker-compose up -d mfr wb fakecas sharejs`
 5. Run migrations and create preprint providers
   - When starting with an empty database you will need to run migrations and populate preprint providers. See the [Running arbitrary commands](#running-arbitrary-commands) section below for instructions.
-6. Start the OSF Web, API Server, Preprints, and Registries (Detached)
-  - `$ docker-compose up -d worker web api admin preprints registries ember_osf_web`
+6. Start the OSF Web, API Server, and Preprints (Detached)
+  - `$ docker-compose up -d worker web api admin preprints ember_osf_web`
 7. View the OSF at [http://localhost:5000](http://localhost:5000).
 
 
@@ -132,7 +132,7 @@
 - Once the requirements have all been installed, you can start the OSF in the background with
 
   ```bash
-  $ docker-compose up -d assets admin_assets mfr wb fakecas sharejs worker web api admin preprints registries ember_osf_web
+  $ docker-compose up -d assets admin_assets mfr wb fakecas sharejs worker web api admin preprints ember_osf_web
   ```
 
 - To view the logs for a given container:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,6 @@ volumes:
     external: false
   preprints_dist_vol:
     external: false
-  registries_dist_vol:
-    external: false
   reviews_dist_vol:
     external: false
   mfr_requirements_vol:
@@ -302,33 +300,6 @@ services:
       - preprints_dist_vol:/code/dist
     stdin_open: true
 
-  ##############
-  # Registries #
-  ##############
-
-  registries:
-    image: quay.io/centerforopenscience/osf-registries:develop-local
-    command:
-      - /bin/bash
-      - -c
-      - yarn --frozen-lockfile &&
-       yarn start --host 0.0.0.0 --port 4202 --live-reload-port 41955
-    restart: unless-stopped
-    depends_on:
-      - api
-      - web
-    environment:
-      - BACKEND=local
-    expose:
-      - 4202
-      - 41955
-    ports:
-      - 4202:4202
-      - 41955:41955
-    volumes:
-      - registries_dist_vol:/code/dist
-    stdin_open: true
-
   ###########
   # Reviews #
   ###########
@@ -527,6 +498,5 @@ services:
       - osf_node_modules_vol:/code/node_modules
       - ember_osf_web_dist_vol:/ember_osf_web
       - preprints_dist_vol:/preprints
-      - registries_dist_vol:/registries
       - reviews_dist_vol:/reviews
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,6 +261,8 @@ services:
       - api
       - web
     environment:
+      # Uncomment below to enable collections on ember
+      # - COLLECTIONS_ENABLED=true
       - BACKEND=local
     expose:
       - 4200


### PR DESCRIPTION
## Purpose
Clear out outdated container and update readme (ran the idea of removing the container from docker-compose by MattF)

## Changes
* Remove registries container (and volumes) from `docker-compose.yml`
* Updates `README-docker-compose.md` to remove references to registries container

## QA Notes
This does not require QA but should be verified by someone on Dev Ops

## Documentation
The README is appropriately updated

## Side Effects
If any developers are still running the registries container and have an outdated `website/settings/local.py` file expects a registries container, they will encounter errors when trying to interact with the `/registries/` path. They should update the `EXTERNAL_EMBER_APPS` dict to match the `EXTERNAL_EMBER_APPS` in `website/settings/local-dist.py`

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2518)
