### PR TITLE
Adding logging when metadata is missing upon registration time [ENG-2438]

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -16,6 +16,7 @@ from dirtyfields import DirtyFieldsMixin
 
 from framework.auth import Auth
 from framework.exceptions import PermissionsError
+from framework.sentry import log_message
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.permissions import ADMIN, READ, WRITE
 from osf.exceptions import NodeStateError, DraftRegistrationStateError
@@ -486,6 +487,9 @@ class Registration(AbstractNode):
 
         self.registered_meta[self.registration_schema._id] = registration_metadata
         self.registration_responses = registration_responses
+
+        if draft.registration_metadata == {}:
+            log_message(f'Issue creating registration: {self._id} no registered metadata. Registration was created anyway...')
 
         if save:
             self.save()


### PR DESCRIPTION


## Purpose

Sometimes metadata goes missing when a draft is registered. Not sure why. Hopefully some logging will help.

## Changes

Adding sentry logging when a registration is created but the draft has no associated metadata

## QA Notes

This can't really be tested because we can't really reproduce it!

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? Registration metadata validation needs a good looking at.

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-2486