### PR TITLE
[ENG-2545][Hotfix] Handle GitlabAuthenticationError on project landing page

### DIFF
--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -51,7 +51,10 @@ class GitLabClient(object):
         try:
             return self.gitlab.projects.get(repo_id)
         except gitlab.GitlabGetError as exc:
-            raise NotFoundError(exc.error_message)
+            if exc.response_code == 404:
+                raise NotFoundError(exc.error_message)
+            else:
+                raise exc
         except gitlab.GitlabAuthenticationError as exc:
             raise AuthError(exc.error_message)
 

--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -4,6 +4,8 @@ import requests
 import gitlab
 import cachecontrol
 from requests.adapters import HTTPAdapter
+from rest_framework import status as http_status
+from framework.exceptions import HTTPError
 
 from addons.gitlab.exceptions import NotFoundError, AuthError
 from addons.gitlab.settings import DEFAULT_HOSTS
@@ -47,15 +49,20 @@ class GitLabClient(object):
         """
 
         try:
-            return gitlab.Project(self.gitlab, repo_id)
+            return self.gitlab.projects.get(repo_id)
         except gitlab.GitlabGetError as exc:
-            if exc.response_code == 404:
-                raise NotFoundError
-            else:
-                raise exc
+            raise NotFoundError(exc.error_message)
+        except gitlab.GitlabAuthenticationError as exc:
+            raise AuthError(exc.error_message)
 
     def repos(self, all=False):
-        return self.gitlab.projects.list(membership=True, all=all)
+        try:
+            return self.gitlab.projects.list(membership=True, all=all)
+        except gitlab.GitlabAuthenticationError:
+            raise HTTPError(http_status.HTTP_403_FORBIDDEN, data={
+                'message_long': 'Your Gitlab token is deleted or invalid you may disconnect your Gitlab account and '
+                                'reconnect with a valid token <a href="/settings/addons/">here</a>.'
+            })
 
     def branches(self, repo_id, branch=None):
         """List a repo's branches or get a single branch (in a list).
@@ -68,9 +75,9 @@ class GitLabClient(object):
         :return: List of branch dicts
         """
         if branch:
-            return gitlab.Project(self.gitlab, repo_id).branches.get(branch)
+            return gitlab.project.get(self.gitlab, repo_id).branches.get(branch)
 
-        return gitlab.Project(self.gitlab, repo_id).branches.list()
+        return gitlab.project.get(self.gitlab, repo_id).branches.list()
 
     def starball(self, user, repo, repo_id, ref='master'):
         """Get link for archive download.

--- a/addons/gitlab/requirements.txt
+++ b/addons/gitlab/requirements.txt
@@ -1,3 +1,3 @@
 cachecontrol==0.10.2
-python-gitlab==1.4.0
+python-gitlab==2.5.0
 python-magic==0.4.6


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To fix error created by bad gitlab token and drive-by update gitlab client.

## Changes

- catches auth error created by invalid token
- updates python-gitlab client

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify gitlab addon still connects works correct
- Verify that deleting the token from https://gitlab.com/-/profile/personal_access_tokens causes the correct informative error to be thrown.


## Documentation

🐞 fix, no docs

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2545