### PR TITLE
[ENG-2552] Add has_project property to serializers

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -77,6 +77,11 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         read_only=False,
     )
 
+    has_project = ser.SerializerMethodField()
+
+    def get_has_project(self, obj):
+        return obj.has_project
+
     @property
     def subjects_related_view(self):
         # Overrides TaxonomizableSerializerMixin

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -117,6 +117,7 @@ class RegistrationSerializer(NodeSerializer):
         source='is_retracted', read_only=True,
         help_text='The registration has been withdrawn.',
     )
+    has_project = ser.SerializerMethodField()
 
     date_registered = VersionedDateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
     date_withdrawn = VersionedDateTimeField(read_only=True, help_text='Date time of when this registration was retracted.')
@@ -360,6 +361,9 @@ class RegistrationSerializer(NodeSerializer):
         return 'registrations:registration-relationships-subjects'
 
     links = LinksField({'html': 'get_absolute_html_url'})
+
+    def get_has_project(self, obj):
+        return obj.has_project
 
     def get_absolute_url(self, obj):
         return obj.get_absolute_url()

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -77,6 +77,7 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         assert attributes['title'] == project_public.title
         assert attributes['description'] == project_public.description
         assert attributes['category'] == project_public.category
+        assert attributes['has_project']
 
         res.json['data']['links']['self'] == url_draft_registrations
 
@@ -100,6 +101,7 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         assert attributes['description'] == ''
         assert attributes['category'] == ''
         assert attributes['node_license'] is None
+        assert not attributes['has_project']
 
         res.json['data']['links']['self'] == url
         relationships = res.json['data']['relationships']

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -156,6 +156,7 @@ class TestRegistrationDetail:
         registered_from = urlparse(
             data['relationships']['registered_from']['links']['related']['href']).path
         assert data['attributes']['registration'] is True
+        assert data['attributes']['has_project'] is True
         assert data['attributes']['current_user_is_contributor'] is True
         assert registered_from == '/{}nodes/{}/'.format(
             API_BASE, private_project._id)

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -131,6 +131,10 @@ class Registration(AbstractNode):
         return stuck_regs
 
     @property
+    def has_project(self):
+        return isinstance(self.registered_from, Node)
+
+    @property
     def registration_schema(self):
         # For use in RegistrationResponseMixin
         if self.registered_schema.exists():
@@ -876,6 +880,10 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             return self.branched_from.__class__.__name__
         else:
             raise DraftRegistrationStateError
+
+    @property
+    def has_project(self):
+        return isinstance(self.branched_from, Node)
 
     @property
     def url(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The front-end needs a way to determine if a registration has a project or not.

## Changes

Adds a has_project field to the Registration and DraftRegistration serializers


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that the has_project field is viewable via the api


## Documentation

new feature, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2552