### PR TITLE
Updating search upon _id change [ENG-2544]

### DIFF
--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -200,10 +200,11 @@ class CollectionProvider(AbstractProvider):
 
     def save(self, *args, **kwargs):
         saved_fields = self.get_dirty_fields() or []
-        ret = super(CollectionProvider, self).save(*args, **kwargs)
+        ret = super().save(*args, **kwargs)
         if '_id' in saved_fields:
             from osf.models.collection import Collection
-            Collection.bulk_update_search(self.primary_collection.collectionsubmission_set.all())
+            if self.primary_collection:
+                Collection.bulk_update_search(self.primary_collection.collectionsubmission_set.all())
         return ret
 
 

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -198,6 +198,14 @@ class CollectionProvider(AbstractProvider):
         path = '/providers/collections/{}/'.format(self._id)
         return api_v2_url(path)
 
+    def save(self, *args, **kwargs):
+        saved_fields = self.get_dirty_fields() or []
+        ret = super(CollectionProvider, self).save(*args, **kwargs)
+        if '_id' in saved_fields:
+            from osf.models.collection import Collection
+            Collection.bulk_update_search(self.primary_collection.collectionsubmission_set.all())
+        return ret
+
 
 class RegistrationProvider(AbstractProvider):
     REVIEWABLE_RELATION_NAME = 'registrations'

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -260,6 +260,18 @@ class TestCollectionsSearch(OsfTestCase):
             self.node_one.collecting_metadata_list[0].collection._id))
         assert_equal(docs[0]['_source']['category'], 'collectionSubmission')
 
+    def test_search_updated_after_id_change(self):
+        self.provider.primary_collection.collect_object(self.node_one, self.node_one.creator)
+        with run_celery_tasks():
+            self.node_one.save()
+        term = f'provider:{self.provider._id}'
+        docs = search.search(build_query(term), index=elastic_search.INDEX, raw=True)
+        assert_equal(len(docs['results']), 1)
+        self.provider._id = 'new_id'
+        self.provider.save()
+        docs = query(f'provider:new_id', raw=True)['results']
+        assert_equal(len(docs), 1)
+
 
 @pytest.mark.enable_search
 @pytest.mark.enable_enqueue_task


### PR DESCRIPTION


## Purpose

Nodes currently aren't updated when collections they have submitted to modified
## Changes

Performing a search update when _id is modified
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify nodes are displayed on collection discovery pages

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? Why is the discover page using the search endpoint?

## Documentation

N/A
## Side Effects

Shouldn't be
## Ticket

https://openscience.atlassian.net/browse/ENG-2544