### PR TITLE
[ENG-2464] Add admin app node license editor

### DIFF
--- a/osf/admin.py
+++ b/osf/admin.py
@@ -3,7 +3,7 @@ from django_extensions.admin import ForeignKeyAutocompleteAdmin
 from django.contrib.auth.models import Group
 from django.db.models import Q
 
-from osf.models import OSFUser, Node, BlacklistedEmailDomain
+from osf.models import OSFUser, Node, BlacklistedEmailDomain, NodeLicense
 
 
 def list_displayable_fields(cls):
@@ -34,6 +34,11 @@ class OSFUserAdmin(admin.ModelAdmin):
             for group in groups_to_preserve:
                 form.instance.groups.add(group)
 
+
+class LicenseAdmin(admin.ModelAdmin):
+    fields = list_displayable_fields(NodeLicense)
+
+
 class BlacklistedEmailDomainAdmin(admin.ModelAdmin):
     fields = list_displayable_fields(BlacklistedEmailDomain)
     ordering = ('domain', )
@@ -41,3 +46,4 @@ class BlacklistedEmailDomainAdmin(admin.ModelAdmin):
 admin.site.register(OSFUser, OSFUserAdmin)
 admin.site.register(Node, NodeAdmin)
 admin.site.register(BlacklistedEmailDomain, BlacklistedEmailDomainAdmin)
+admin.site.register(NodeLicense, LicenseAdmin)

--- a/osf/models/licenses.py
+++ b/osf/models/licenses.py
@@ -36,16 +36,39 @@ class NodeLicenseManager(models.Manager):
 
 
 class NodeLicense(ObjectIDMixin, BaseModel):
-    license_id = models.CharField(max_length=128, null=False, unique=True)
-    name = models.CharField(max_length=256, null=False, unique=True)
-    text = models.TextField(null=False)
-    url = models.URLField(blank=True)
-    properties = ArrayField(models.CharField(max_length=128), default=list, blank=True)
+    license_id = models.CharField(
+        max_length=128,
+        null=False,
+        unique=True,
+        help_text='A unique id for the license. for example'
+    )
+    name = models.CharField(
+        max_length=256,
+        null=False,
+        unique=True,
+        help_text='The name of the license'
+    )
+    text = models.TextField(
+        null=False,
+        help_text='The text of the license with custom properties surround by curly brackets, for example: '
+                  '<i>Copyright (c) {{year}}, {{copyrightHolders}} All rights reserved.</i>'
+    )
+    url = models.URLField(
+        blank=True,
+        help_text='The license\'s url for example: <i>http://opensource.org/licenses/BSD-3-Clause</i>'
+    )
+    properties = ArrayField(
+        models.CharField(max_length=128),
+        default=list,
+        blank=True,
+        help_text='The custom elements in a license\'s text surrounded with curly brackets for example: '
+                  '<i>{year,copyrightHolders}</i>'
+    )
 
     objects = NodeLicenseManager()
 
-    def __unicode__(self):
-        return '(license_id={}, name={})'.format(self.license_id, self.name)
+    def __str__(self):
+        return f'{self.name} ({self.license_id})'
 
     class Meta:
         unique_together = ['_id', 'license_id']


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow admins to add Node Licenses to adminadmin app

## Changes

- register admin app models and add help text

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify you can create license and add them to a provider


## Documentation

add help text, no addtional docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2464