### PR TITLE
[ENG-2566] Add bibliographic contributor relationship to draft registrations

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -71,6 +71,11 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
+    bibliographic_contributors = RelationshipField(
+        related_view='draft_registrations:draft-registration-bibliographic-contributor-detail',
+        related_view_kwargs={'draft_id': '<_id>'},
+    )
+
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},

--- a/api/draft_registrations/urls.py
+++ b/api/draft_registrations/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^(?P<draft_id>\w+)/$', views.DraftRegistrationDetail.as_view(), name=views.DraftRegistrationDetail.view_name),
     url(r'^(?P<draft_id>\w+)/contributors/$', views.DraftContributorsList.as_view(), name=views.DraftContributorsList.view_name),
     url(r'^(?P<draft_id>\w+)/contributors/(?P<user_id>\w+)/$', views.DraftContributorDetail.as_view(), name=views.DraftContributorDetail.view_name),
+    url(r'^(?P<draft_id>\w+)/bibliographic_contributors/$', views.DraftBibliographicContributorsList.as_view(), name=views.DraftBibliographicContributorsList.view_name),
     url(r'^(?P<draft_id>\w+)/institutions/$', views.DraftInstitutionsList.as_view(), name=views.DraftInstitutionsList.view_name),
     url(r'^(?P<draft_id>\w+)/relationships/institutions/$', views.DraftInstitutionsRelationship.as_view(), name=views.DraftInstitutionsRelationship.view_name),
     url(r'^(?P<draft_id>\w+)/relationships/subjects/$', views.DraftSubjectsRelationship.as_view(), name=views.DraftSubjectsRelationship.view_name),

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -230,3 +230,17 @@ class DraftContributorDetail(NodeContributorDetail, DraftRegistrationMixin):
         context['resource'] = self.get_draft()
         context['default_email'] = 'draft'
         return context
+
+
+class DraftBibliographicContributorsList(DraftContributorsList):
+
+    view_name = 'draft-registration-bibliographic-contributor-detail'
+
+    def get_default_queryset(self):
+        # Overrides NodeContributorsList
+        draft = self.get_draft()
+        return draft.draftregistrationcontributor_set.filter(visible=True).include('user__guids')
+
+    # Read-only
+    def get_serializer_class(self):
+        return DraftRegistrationContributorDetailSerializer

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -241,6 +241,6 @@ class DraftBibliographicContributorsList(DraftContributorsList):
         draft = self.get_draft()
         return draft.draftregistrationcontributor_set.filter(visible=True).include('user__guids')
 
-    # Read-only
+    # Override to prevent use DraftRegistrationContributorsCreateSerializer, this endpoint is read-only
     def get_serializer_class(self):
         return DraftRegistrationContributorDetailSerializer


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To an bibliographic endpoint the draft registration endpoint.

## Changes

- add bibliographic contributor relationship to view


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify view the bibliographic contributor endpoint from DraftRegistration


## Documentation

Remember to change API docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2566