### PR TITLE
[ENG-2543][ENG-2642] clean up how metadata is pushed to SHARE

### DIFF
--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -290,7 +290,9 @@ class TestNodeReindex(AdminTestCase):
                     view.delete(self.request)
                     data = json.loads(rsps.calls[-1].request.body.decode())
 
-                    assert data['data']['attributes']['data']['@graph'][0]['creative_work']['@type'] == 'project'
+                    share_graph = data['data']['attributes']['data']['@graph']
+                    identifier_node = next(n for n in share_graph if n['@type'] == 'workidentifier')
+                    assert identifier_node['creative_work']['@type'] == 'project'
                     nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
     def test_reindex_registration_share(self):

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -127,6 +127,7 @@ class GraphNode(object):
 def format_user(user):
     person = GraphNode(
         'person', **{
+            'name': user.fullname,
             'suffix': user.suffix,
             'given_name': user.given_name,
             'family_name': user.family_name,

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -249,8 +249,9 @@ def serialize_preprint(preprint, old_subjects=None):
         GraphNode('workidentifier', creative_work=preprint_graph, uri=urljoin(settings.DOMAIN, preprint._id + '/')),
     ]
 
-    if preprint.get_identifier('doi'):
-        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri='https://doi.org/{}'.format(preprint.get_identifier('doi').value)))
+    doi = preprint.get_identifier_value('doi')
+    if doi:
+        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri=f'{settings.DOI_URL_PREFIX}{doi}'))
 
     if preprint.provider.domain_redirect_enabled:
         to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri=preprint.absolute_url))
@@ -259,7 +260,7 @@ def serialize_preprint(preprint, old_subjects=None):
         # Article DOI refers to a clone of this preprint on another system and therefore does not qualify as an identifier for this preprint
         related_work = GraphNode('creativework')
         to_visit.append(GraphNode('workrelation', subject=preprint_graph, related=related_work))
-        to_visit.append(GraphNode('workidentifier', creative_work=related_work, uri='https://doi.org/{}'.format(preprint.article_doi)))
+        to_visit.append(GraphNode('workidentifier', creative_work=related_work, uri=f'{settings.DOI_URL_PREFIX}{preprint.article_doi}'))
 
     preprint_graph.attrs['tags'] = [
         GraphNode('throughtags', creative_work=preprint_graph, tag=GraphNode('tag', name=tag))
@@ -328,6 +329,10 @@ def serialize_osf_node(osf_node, additional_attrs=None):
         graph_node,
         GraphNode('workidentifier', creative_work=graph_node, uri=urljoin(settings.DOMAIN, osf_node.url)),
     ]
+
+    doi = osf_node.get_identifier_value('doi')
+    if doi:
+        to_visit.append(GraphNode('workidentifier', creative_work=graph_node, uri=f'{settings.DOI_URL_PREFIX}{doi}'))
 
     graph_node.attrs['tags'] = [
         GraphNode('throughtags', creative_work=graph_node, tag=GraphNode('tag', name=tag._id))

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -238,7 +238,7 @@ def serialize_preprint(preprint, old_subjects=None):
             'description': preprint.description or '',
             'is_deleted': (
                 (not preprint.verified_publishable and not preprint.is_retracted)
-                or preprint.is_spammy
+                or preprint.is_spam
                 or is_qa_resource(preprint)
             ),
             'date_updated': preprint.modified.isoformat(),
@@ -319,7 +319,7 @@ def serialize_osf_node(osf_node, additional_attrs=None):
             'is_deleted': (
                 not osf_node.is_public
                 or osf_node.is_deleted
-                or osf_node.is_spammy
+                or osf_node.is_spam
                 or is_qa_resource(osf_node)
             ),
             **(additional_attrs or {}),

--- a/osf/management/commands/recatalog_metadata.py
+++ b/osf/management/commands/recatalog_metadata.py
@@ -1,0 +1,116 @@
+"""Resend metadata for all (or some) public objects (registrations, preprints...) to SHARE/Trove
+"""
+import logging
+
+from django.core.management.base import BaseCommand
+from osf.models import AbstractProvider, Registration, Preprint, Node
+from api.share.utils import update_share
+
+logger = logging.getLogger(__name__)
+
+
+def recatalog_chunk(provided_model, providers, start_id, chunk_size):
+    items = provided_model.objects.filter(
+        id__gte=start_id,
+    ).order_by('id')
+
+    if providers is not None:
+        items = items.filter(provider__in=providers)
+
+    item_chunk = list(items[:chunk_size])
+    last_id = None
+    if item_chunk:
+        first_id = item_chunk[0].id
+        last_id = item_chunk[-1].id
+
+        for item in item_chunk:
+            update_share(item)
+
+        logger.info(f'Recatalogued metadata for {len(item_chunk)} {provided_model.__name__}ses (ids in range [{first_id},{last_id}])')
+    else:
+        logger.info(f'Done recataloguing metadata for {provided_model.__name__}ses!')
+
+    return last_id
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        provider_group = parser.add_mutually_exclusive_group(required=True)
+        provider_group.add_argument(
+            '--providers',
+            type=str,
+            nargs='+',
+            help='recatalog metadata for items from specific providers (by `_id`)',
+        )
+        provider_group.add_argument(
+            '--all-providers',
+            '-a',
+            action='store_true',
+            help='recatalog metadata for items from all providers',
+        )
+
+        type_group = parser.add_mutually_exclusive_group(required=True)
+        type_group.add_argument(
+            '--preprints',
+            action='store_true',
+            help='recatalog metadata for preprints',
+        )
+        type_group.add_argument(
+            '--registrations',
+            action='store_true',
+            help='recatalog metadata for registrations (and registration components)',
+        )
+        type_group.add_argument(
+            '--projects',
+            action='store_true',
+            help='recatalog metadata for non-registration projects (and components)',
+        )
+
+        parser.add_argument(
+            '--start-id',
+            type=int,
+            default=0,
+            help='id to start from, if resuming a previous run (default 0)',
+        )
+        parser.add_argument(
+            '--chunk-size',
+            type=int,
+            default=500,
+            help='maximum number of items to query at one time',
+        )
+        parser.add_argument(
+            '--chunk-count',
+            type=int,
+            default=int(9e9),
+            help='maximum number of chunks (default all/enough/lots)',
+        )
+
+    def handle(self, *args, **options):
+        pls_all_providers = options['all_providers']
+        pls_recatalog_preprints = options['preprints']
+        pls_recatalog_registrations = options['registrations']
+        pls_recatalog_projects = options['projects']
+        start_id = options['start_id']
+        chunk_size = options['chunk_size']
+        chunk_count = options['chunk_count']
+
+        if pls_all_providers:
+            providers = None  # `None` means "don't filter by provider"
+        else:
+            provider_ids = options['providers']
+            providers = AbstractProvider.objects.filter(_id__in=provider_ids)
+
+        provided_model = None
+        if pls_recatalog_preprints:
+            provided_model = Preprint
+        if pls_recatalog_registrations:
+            provided_model = Registration
+        if pls_recatalog_projects:
+            provided_model = Node
+
+        for _ in range(chunk_count):
+            last_id = recatalog_chunk(provided_model, providers, start_id, chunk_size)
+            if last_id is None:
+                logger.info('All done!')
+                return
+            start_id = last_id + 1

--- a/osf_tests/management_commands/test_recatalog_metadata.py
+++ b/osf_tests/management_commands/test_recatalog_metadata.py
@@ -1,0 +1,135 @@
+import pytest
+from unittest import mock
+from operator import attrgetter
+
+from django.core.management import call_command
+
+from osf_tests.factories import (
+    PreprintProviderFactory,
+    PreprintFactory,
+    ProjectFactory,
+    RegistrationProviderFactory,
+    RegistrationFactory,
+)
+
+
+def sorted_by_id(things_with_ids):
+    return sorted(
+        things_with_ids,
+        key=attrgetter('id')
+    )
+
+
+@pytest.mark.django_db
+class TestRecatalogMetadata:
+
+    @pytest.fixture
+    def preprint_provider(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture
+    def preprints(self, preprint_provider):
+        return sorted_by_id([
+            PreprintFactory(provider=preprint_provider)
+            for _ in range(7)
+        ])
+
+    @pytest.fixture
+    def registration_provider(self):
+        return RegistrationProviderFactory()
+
+    @pytest.fixture
+    def registrations(self, registration_provider):
+        return sorted_by_id([
+            RegistrationFactory(provider=registration_provider)
+            for _ in range(7)
+        ])
+
+    @pytest.fixture
+    def projects(self, registrations):
+        return sorted_by_id([
+            ProjectFactory()
+            for _ in range(7)
+        ] + [
+            registration.registered_from
+            for registration in registrations
+        ])
+
+    @mock.patch('api.share.utils.update_share')
+    def test_recatalog_metadata(self, mock_update_share, preprint_provider, preprints, registration_provider, registrations, projects):
+
+        # test preprints
+        call_command(
+            'recatalog_metadata',
+            '--preprints',
+            '--providers',
+            preprint_provider._id,
+        )
+        expected_update_share_calls = [
+            mock.call(preprint)
+            for preprint in preprints
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # test registrations
+        call_command(
+            'recatalog_metadata',
+            '--registrations',
+            '--providers',
+            registration_provider._id,
+        )
+        expected_update_share_calls = [
+            mock.call(registration)
+            for registration in registrations
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # test projects
+        call_command(
+            'recatalog_metadata',
+            '--projects',
+            '--all-providers',
+        )
+        expected_update_share_calls = [
+            mock.call(project)
+            for project in projects  # already ordered by id
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # test chunking
+        call_command(
+            'recatalog_metadata',
+            '--registrations',
+            '--all-providers',
+            f'--start-id={registrations[1].id}',
+            '--chunk-size=3',
+            '--chunk-count=1',
+        )
+        expected_update_share_calls = [
+            mock.call(registration)
+            for registration in registrations[1:4]
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # slightly different chunking
+        expected_update_share_calls = [
+            mock.call(registration)
+            for registration in registrations[2:6]  # already ordered by id
+        ]
+        call_command(
+            'recatalog_metadata',
+            '--registrations',
+            '--all-providers',
+            f'--start-id={registrations[2].id}',
+            '--chunk-size=2',
+            '--chunk-count=2',
+        )
+        assert mock_update_share.mock_calls == expected_update_share_calls

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -1995,10 +1995,12 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         people = sorted([nodes.pop(k) for k, v in list(nodes.items()) if v['@type'] == 'person'], key=lambda x: x['given_name'])
         expected_people = sorted([{
             '@type': 'person',
-            'given_name': u'BoJack',
-            'family_name': u'Horseman',
+            'name': 'BoJack Horseman',
+            'given_name': 'BoJack',
+            'family_name': 'Horseman',
         }, {
             '@type': 'person',
+            'name': self.preprint.creator.fullname,
             'given_name': self.preprint.creator.given_name,
             'family_name': self.preprint.creator.family_name,
         }], key=lambda x: x['given_name'])
@@ -2086,10 +2088,12 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         people = sorted([nodes.pop(k) for k, v in list(nodes.items()) if v['@type'] == 'person'], key=lambda x: x['given_name'])
         expected_people = sorted([{
             '@type': 'person',
-            'given_name': u'BoJack',
-            'family_name': u'Horseman',
+            'name': 'BoJack Horseman',
+            'given_name': 'BoJack',
+            'family_name': 'Horseman',
         }, {
             '@type': 'person',
+            'name': self.preprint.creator.fullname,
             'given_name': self.preprint.creator.given_name,
             'family_name': self.preprint.creator.family_name,
         }], key=lambda x: x['given_name'])

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -15,7 +15,7 @@ import itsdangerous
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 
-from api.share.utils import format_preprint, format_user
+from api.share.utils import serialize_preprint, format_user
 from website import settings, mails
 from website.preprints.tasks import on_preprint_updated, update_or_create_preprint_identifiers, update_or_enqueue_on_preprint_updated
 from website.identifiers.clients import CrossRefClient, ECSArXivCrossRefClient, crossref
@@ -1960,13 +1960,14 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         assert 'contributors' in  updated_task.kwargs['saved_fields']
         assert set(first_subjects + second_subjects).issubset(updated_task.kwargs['old_subjects'])
 
-    def test_format_preprint(self):
-        res = format_preprint(self.preprint)
+    def test_serialize_preprint(self):
+        res = serialize_preprint(self.preprint)
 
-        assert set(gn['@type'] for gn in res) == {'creator', 'contributor', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'preprint', 'workrelation', 'creativework'}
+        assert set(gn['@type'] for gn in res['@graph']) == {'creator', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'preprint', 'workrelation', 'creativework'}
 
-        nodes = dict(enumerate(res))
+        nodes = dict(enumerate(res['@graph']))
         preprint = nodes.pop(next(k for k, v in iter(nodes.items()) if v['@type'] == 'preprint'))
+        assert res['central_node_id'] == preprint['@id']
         assert preprint['title'] == self.preprint.title
         assert preprint['description'] == self.preprint.description
         assert preprint['is_deleted'] == (not self.preprint.is_published or not self.preprint.is_public or self.preprint.is_preprint_orphan)
@@ -1998,10 +1999,6 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             'family_name': u'Horseman',
         }, {
             '@type': 'person',
-            'given_name': self.user.given_name,
-            'family_name': self.user.family_name,
-        }, {
-            '@type': 'person',
             'given_name': self.preprint.creator.given_name,
             'family_name': self.preprint.creator.family_name,
         }], key=lambda x: x['given_name'])
@@ -2027,22 +2024,8 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             'creative_work': {'@id': preprint['@id'], '@type': preprint['@type']},
         }]
 
-        contributors = [nodes.pop(k) for k, v in list(nodes.items()) if v['@type'] == 'contributor']
-        assert contributors == [{
-            '@id': contributors[0]['@id'],
-            '@type': 'contributor',
-            'cited_as': u'{}'.format(self.user.fullname),
-            'agent': {'@id': [p['@id'] for p in people if p['given_name'] == self.user.given_name][0], '@type': 'person'},
-            'creative_work': {'@id': preprint['@id'], '@type': preprint['@type']},
-        }]
-
         agentidentifiers = {nodes.pop(k)['uri'] for k, v in list(nodes.items()) if v['@type'] == 'agentidentifier'}
-        assert agentidentifiers == set([
-            'mailto:' + self.user.username,
-            'mailto:' + self.preprint.creator.username,
-            self.user.profile_image_url(),
-            self.preprint.creator.profile_image_url(),
-        ]) | set(user.absolute_url for user in self.preprint.contributors)
+        assert agentidentifiers == set(user.absolute_url for user in self.preprint.visible_contributors)
 
         related_work = next(nodes.pop(k) for k, v in nodes.items() if v['@type'] == 'creativework')
         assert set(related_work.keys()) == {'@id', '@type'}  # Empty except @id and @type
@@ -2062,35 +2045,38 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         assert nodes == {}
 
     def test_format_thesis(self):
-        res = format_preprint(self.thesis)
+        res = serialize_preprint(self.thesis)
 
-        assert set(gn['@type'] for gn in res) == {'creator', 'contributor', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'thesis', 'workrelation', 'creativework'}
+        assert set(gn['@type'] for gn in res['@graph']) == {'creator', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'thesis', 'workrelation', 'creativework'}
 
-        nodes = dict(enumerate(res))
+        nodes = dict(enumerate(res['@graph']))
         thesis = nodes.pop(next(k for k, v in nodes.items() if v['@type'] == 'thesis'))
+        assert res['central_node_id'] == thesis['@id']
         assert thesis['title'] == self.thesis.title
         assert thesis['description'] == self.thesis.description
 
-    def test_format_preprint_date_modified_node_updated(self):
+    def test_serialize_preprint_date_modified_node_updated(self):
         self.preprint.save()
-        res = format_preprint(self.preprint)
-        nodes = dict(enumerate(res))
+        res = serialize_preprint(self.preprint)
+        nodes = dict(enumerate(res['@graph']))
         preprint = nodes.pop(next(k for k, v in nodes.items() if v['@type'] == 'preprint'))
+        assert res['central_node_id'] == preprint['@id']
         assert preprint['date_updated'] == self.preprint.modified.isoformat()
 
-    def test_format_preprint_nones(self):
+    def test_serialize_preprint_nones(self):
         self.preprint.tags.clear()
         self.preprint.date_published = None
         self.preprint.article_doi = None
         self.preprint.set_subjects([], auth=Auth(self.preprint.creator))
 
-        res = format_preprint(self.preprint)
+        res = serialize_preprint(self.preprint)
 
         assert self.preprint.provider != 'osf'
-        assert set(gn['@type'] for gn in res) == {'creator', 'contributor', 'workidentifier', 'agentidentifier', 'person', 'preprint'}
+        assert set(gn['@type'] for gn in res['@graph']) == {'creator', 'workidentifier', 'agentidentifier', 'person', 'preprint'}
 
-        nodes = dict(enumerate(res))
+        nodes = dict(enumerate(res['@graph']))
         preprint = nodes.pop(next(k for k, v in nodes.items() if v['@type'] == 'preprint'))
+        assert res['central_node_id'] == preprint['@id']
         assert preprint['title'] == self.preprint.title
         assert preprint['description'] == self.preprint.description
         assert preprint['is_deleted'] == (not self.preprint.is_published or not self.preprint.is_public or self.preprint.is_preprint_orphan or (self.preprint.deleted or False))
@@ -2102,10 +2088,6 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             '@type': 'person',
             'given_name': u'BoJack',
             'family_name': u'Horseman',
-        }, {
-            '@type': 'person',
-            'given_name': self.user.given_name,
-            'family_name': self.user.family_name,
         }, {
             '@type': 'person',
             'given_name': self.preprint.creator.given_name,
@@ -2133,22 +2115,8 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             'creative_work': {'@id': preprint['@id'], '@type': preprint['@type']},
         }]
 
-        contributors = [nodes.pop(k) for k, v in list(nodes.items()) if v['@type'] == 'contributor']
-        assert contributors == [{
-            '@id': contributors[0]['@id'],
-            '@type': 'contributor',
-            'cited_as': self.user.fullname,
-            'agent': {'@id': [p['@id'] for p in people if p['given_name'] == self.user.given_name][0], '@type': 'person'},
-            'creative_work': {'@id': preprint['@id'], '@type': preprint['@type']},
-        }]
-
         agentidentifiers = {nodes.pop(k)['uri'] for k, v in list(nodes.items()) if v['@type'] == 'agentidentifier'}
-        assert agentidentifiers == set([
-            'mailto:' + self.user.username,
-            'mailto:' + self.preprint.creator.username,
-            self.user.profile_image_url(),
-            self.preprint.creator.profile_image_url(),
-        ]) | set(user.absolute_url for user in self.preprint.contributors)
+        assert agentidentifiers == set(user.absolute_url for user in self.preprint.visible_contributors)
 
         workidentifiers = {nodes.pop(k)['uri'] for k, v in list(nodes.items()) if v['@type'] == 'workidentifier'}
         # URLs should *always* be osf.io/guid/
@@ -2156,7 +2124,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
 
         assert nodes == {}
 
-    def test_format_preprint_is_deleted(self):
+    def test_serialize_preprint_is_deleted(self):
         self.file = OsfStorageFile.create(
             target=self.preprint,
             path='/panda.txt',
@@ -2182,22 +2150,23 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             orig_val = getattr(target, key.split('.')[-1])
             setattr(target, key.split('.')[-1], value)
 
-            res = format_preprint(self.preprint)
+            res = serialize_preprint(self.preprint)
 
-            preprint = next(v for v in res if v['@type'] == 'preprint')
+            preprint = next(v for v in res['@graph'] if v['@type'] == 'preprint')
+            assert res['central_node_id'] == preprint['@id']
             assert preprint['is_deleted'] is is_deleted
 
             setattr(target, key.split('.')[-1], orig_val)
 
-    def test_format_preprint_is_deleted_true_if_qatest_tag_is_added(self):
-        res = format_preprint(self.preprint)
-        preprint = next(v for v in res if v['@type'] == 'preprint')
+    def test_serialize_preprint_is_deleted_true_if_qatest_tag_is_added(self):
+        res = serialize_preprint(self.preprint)
+        preprint = next(v for v in res['@graph'] if v['@type'] == 'preprint')
         assert preprint['is_deleted'] is False
 
         self.preprint.add_tag('qatest', auth=self.auth, save=True)
 
-        res = format_preprint(self.preprint)
-        preprint = next(v for v in res if v['@type'] == 'preprint')
+        res = serialize_preprint(self.preprint)
+        preprint = next(v for v in res['@graph'] if v['@type'] == 'preprint')
         assert preprint['is_deleted'] is True
 
     def test_unregistered_users_guids(self):
@@ -2213,7 +2182,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         user.save()
 
         node = format_user(user)
-        assert {x.attrs['uri'] for x in node.get_related()} == {'fake-orcid', user.absolute_url, user.profile_image_url()}
+        assert {x.attrs['uri'] for x in node.get_related()} == {'fake-orcid', user.absolute_url}
 
     def test_unverified_orcid(self):
         user = UserFactory.build(is_registered=True)
@@ -2221,7 +2190,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         user.save()
 
         node = format_user(user)
-        assert {x.attrs['uri'] for x in node.get_related()} == {user.absolute_url, user.profile_image_url()}
+        assert {x.attrs['uri'] for x in node.get_related()} == {user.absolute_url}
 
 
 class TestPreprintConfirmationEmails(OsfTestCase):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
SHARE will be changing soon, and will not be merging data from different
sources together -- let's stop relying on that behavior
<!-- Describe the purpose of your changes -->

## Changes
- update the metadata record sent to share:
  - include the full node lineage (parent, grandparent, etc. up to the
  root) for registrations and projects, including metadata (title and
  guid-url identifier) for each – building the lineage for search
  results previously depended on merging multiple records together

  - include full metadata for non-registration nodes – previously
  only marked a project deleted, relying on merging with harvested
  data to fill in the rest

  - don’t include emails or "profile image url" as identifiers

  - don't include non-bibliographic contributors

  - add `suid` and `central_node_id` to the pushed payload – makes it
  unambiguous what object the metadata record describes, so SHARE
  doesn’t have to guess
  - use `is_spam` instead of `is_spammy` -- only delete from share if *confirmed* spam
- add `recatalog_metadata` management command, with chunking and resumability
  - e.g. `python3 manage.py recatalog_metadata --preprints --all-providers`
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify updates to projects, preprints, and registrations are correctly reflected in SHARE-based search results
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-2543]
[ENG-2642]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-2543]: https://openscience.atlassian.net/browse/ENG-2543