### PR TITLE
Fixing the &amp; in recent activity logs. Adding test [ENG-1350]

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -15,6 +15,7 @@ from api.base.serializers import (
 from osf.models import OSFUser, AbstractNode, Preprint
 from osf.utils.names import impute_names_model
 from osf.utils import permissions as osf_permissions
+from website.util import sanitize
 
 
 class NodeLogIdentifiersSerializer(RestrictedDictSerializer):
@@ -83,7 +84,7 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     previous_institution = NodeLogInstitutionSerializer(read_only=True)
     source = NodeLogFileParamsSerializer(read_only=True)
     study = ser.CharField(read_only=True)
-    tag = ser.CharField(read_only=True)
+    tag = ser.SerializerMethodField(read_only=True)
     tags = ser.CharField(read_only=True)
     target = NodeLogFileParamsSerializer(read_only=True)
     template_node = ser.DictField(read_only=True)
@@ -194,6 +195,15 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
                 provider = preprint.provider
                 return {'url': provider.external_url, 'name': provider.name}
         return None
+
+    def get_tag(self, obj):
+        tag = obj.get('tag', None)
+        if tag:
+            tag = sanitize.escape_html(tag)
+            tag = sanitize.temp_ampersand_fixer(tag)
+            return tag
+        return None
+
 
 class NodeLogSerializer(JSONAPISerializer):
 

--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -93,6 +93,15 @@ class TestNodeLogList:
         assert res.json['data'][API_LATEST]['attributes']['action'] == 'tag_added'
         assert 'Rheisen' == public_project.logs.latest().params['tag']
 
+    def test_escape_ampersand(self, app, user, user_auth, public_project, public_url):
+        public_project.add_tag('cats&amp;dogs', auth=user_auth)
+        assert public_project.logs.latest().action == 'tag_added'
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == public_project.logs.count()
+        assert res.json['data'][API_LATEST]['attributes']['action'] == 'tag_added'
+        assert res.json['data'][API_LATEST]['attributes']['params']['tag'] == 'cats&dogs'
+
     def test_remove_tag(
             self, app, user, user_auth,
             public_project, public_url):


### PR DESCRIPTION


## Purpose

Fixing the special character in recent activity on the proejct page

## Changes

Modifying the node log serializer, adding a test

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify That adding a tag with a special character (like &) doesn't appear as &amp; in recent activity
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised? N/A

## Documentation

N/A

## Side Effects

N/A
## Ticket

https://openscience.atlassian.net/browse/ENG-1350