### PR TITLE
[Hotfix] Cache node.osfstorage_region

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -974,7 +974,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         """For v1 compat."""
         return self.registrations.all()
 
-    @property
+    @cached_property
     def osfstorage_region(self):
         from addons.osfstorage.models import Region
         osfs_settings = self._settings_model('osfstorage')

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -83,6 +83,7 @@ def test_file_update_respects_region(project, user, create_test_file):
     node_settings.region = new_region
     node_settings.save()
     test_file.save()
+    test_file.reload()
 
     new_version = test_file.create_version(
         user, {


### PR DESCRIPTION
## Purpose
We make far too many queries on `osfstorage_region` in certain API endpoints. We should make only one.

## Changes
- Make `node.osfstorage_region` a `cached_property`

## Side Effects
None expected, waiting for TCI

## Ticket
None