### PR TITLE
[ENG-2594] Contributor Management on Draft Registrations

### DIFF
--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -2,7 +2,6 @@ from rest_framework import permissions
 
 from api.base.utils import get_user_auth, assert_resource_type
 from osf.models import (
-    Node,
     DraftRegistration,
     AbstractNode,
     DraftRegistrationContributor,
@@ -26,9 +25,6 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
         if not auth:
             return False
 
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
-
         if request.method in permissions.SAFE_METHODS:
             return obj.is_contributor(auth.user)
         else:
@@ -49,9 +45,6 @@ class IsAdminContributor(permissions.BasePermission):
         auth = get_user_auth(request)
         if not auth.user:
             return False
-
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
 
         if request.method in permissions.SAFE_METHODS:
             return obj.is_contributor(auth.user)

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -76,6 +76,11 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
+    current_user_permissions = ser.SerializerMethodField(
+        help_text='List of strings representing the permissions '
+        'for the current user on this draft registratione.',
+    )
+
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -76,11 +76,6 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
-    current_user_permissions = ser.SerializerMethodField(
-        help_text='List of strings representing the permissions '
-        'for the current user on this draft registratione.',
-    )
-
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -73,7 +73,7 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
 
 class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixin):
     permission_classes = (
-        IsContributorOrAdminContributor,
+        ContributorOrPublic,
         AdminDeletePermissions,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -35,9 +35,6 @@ class ContributorOrPublic(permissions.BasePermission):
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
 
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
-
         if request.method in permissions.SAFE_METHODS:
             return obj.is_public or obj.can_view(auth)
         else:

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -139,6 +139,17 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(url_draft_registrations, auth=draft_admin.auth)
         assert res.status_code == 200
 
+    # Overwrites TestDraftRegistrationDetail
+    def test_can_view_after_added(
+            self, app, schema, draft_registration, url_draft_registrations):
+        # Draft Registration permissions are no longer based on the branched from project
+
+        user = AuthUserFactory()
+        project = draft_registration.branched_from
+        project.add_contributor(user, ADMIN)
+        res = app.get(url_draft_registrations, auth=user.auth, expect_errors=True)
+        assert res.status_code == 403
+
     # Overrides TestDraftRegistrationDetail
     def test_reviewer_can_see_draft_registration(
             self, app, schema, draft_registration, url_draft_registrations):

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -43,14 +43,14 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth,
-            expect_errors=True)
+            expect_errors=False)
         assert res.status_code == 200
 
         #   test_read_write_contributor_can_view_draft
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth,
-            expect_errors=True)
+            expect_errors=False)
         assert res.status_code == 200
 
     def test_cannot_view_draft(
@@ -128,26 +128,15 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         project_public.add_contributor(node_admin, ADMIN)
         assert project_public.has_permission(node_admin, ADMIN) is True
         assert draft_registration.has_permission(node_admin, ADMIN) is False
-        res = app.get(url_draft_registrations, auth=node_admin.auth)
-        assert res.status_code == 200
+        res = app.get(url_draft_registrations, auth=node_admin.auth, expect_errors=True)
+        assert res.status_code == 403
 
         # Admin on draft but not node
         draft_admin = AuthUserFactory()
         draft_registration.add_contributor(draft_admin, ADMIN)
         assert project_public.has_permission(draft_admin, ADMIN) is False
         assert draft_registration.has_permission(draft_admin, ADMIN) is True
-        res = app.get(url_draft_registrations, auth=draft_admin.auth, expect_errors=True)
-        assert res.status_code == 403
-
-    # Overwrites TestDraftRegistrationDetail
-    def test_can_view_after_added(
-            self, app, schema, draft_registration, url_draft_registrations):
-        # Draft Registration permissions are based on the branched from node
-
-        user = AuthUserFactory()
-        project = draft_registration.branched_from
-        project.add_contributor(user, ADMIN)
-        res = app.get(url_draft_registrations, auth=user.auth)
+        res = app.get(url_draft_registrations, auth=draft_admin.auth)
         assert res.status_code == 200
 
     # Overrides TestDraftRegistrationDetail

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -39,18 +39,16 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
         # test_read_only_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
-            auth=user_read_contrib.auth,
-            expect_errors=True)
+            auth=user_read_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
-            auth=user_write_contrib.auth,
-            expect_errors=True)
+            auth=user_write_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_logged_in_non_contributor_can_view_draft_list
         res = app.get(

--- a/api_tests/users/views/test_user_draft_registration_list.py
+++ b/api_tests/users/views/test_user_draft_registration_list.py
@@ -70,13 +70,13 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth)
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_logged_in_non_contributor_cannot_view_draft_list
         res = app.get(

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1071,7 +1071,6 @@ class TaxonomizableMixin(models.Model):
         Preprint = apps.get_model('osf.Preprint')
         CollectionSubmission = apps.get_model('osf.CollectionSubmission')
         DraftRegistration = apps.get_model('osf.DraftRegistration')
-        Node = apps.get_model('osf.Node')
 
         if isinstance(self, AbstractNode):
             if not self.has_permission(auth.user, ADMIN):
@@ -1079,9 +1078,6 @@ class TaxonomizableMixin(models.Model):
         elif isinstance(self, Preprint):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have admin or write permissions to change a preprint\'s subjects.')
-        if isinstance(self, DraftRegistration) and isinstance(self.branched_from, Node):
-            if not self.branched_from.has_permission(auth.user, WRITE):
-                raise PermissionsError('Must have admin on parent node to update draft registration\'s subjects.')
         elif isinstance(self, DraftRegistration):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have write permissions to change a draft registration\'s subjects.')

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2229,7 +2229,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         else:
             return []
 
-    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True, contributors=True):
+    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True):
         """
         Copy various editable fields from the 'resource' object to the current object.
         Includes, title, description, category, contributors, node_license, tags, subjects, and affiliated_institutions
@@ -2245,8 +2245,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
 
         # Contributors will always come from "resource", as contributor constraints
         # will require contributors to be present on the resource
-        if contributors:
-            self.copy_contributors_from(resource)
+        self.copy_contributors_from(resource)
         # Copy unclaimed records for unregistered users
         self.copy_unclaimed_records(resource)
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1473,7 +1473,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=True)
+        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1473,9 +1473,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
-        registered.copy_contributors_from(draft_registration)
-        registered.copy_unclaimed_records(draft_registration)
+        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=True)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1474,8 +1474,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             alternative_resource = None
 
         registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
-        registered.copy_contributors_from(self)
-        registered.copy_unclaimed_records(self)
+        registered.copy_contributors_from(draft_registration)
+        registered.copy_unclaimed_records(draft_registration)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1126,7 +1126,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True, contributors=True)
+        draft.copy_editable_fields(node, Auth(user), save=True)
         draft.update(data)
         return draft
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1126,7 +1126,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True, contributors=False)
+        draft.copy_editable_fields(node, Auth(user), save=True, contributors=True)
         draft.update(data)
         return draft
 
@@ -1231,8 +1231,6 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         )
         self.registered_node = registration
         self.add_status_log(auth.user, DraftRegistrationLog.REGISTERED)
-
-        self.copy_contributors_from(node)
 
         if save:
             self.save()

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -308,12 +308,12 @@ class TestDraftRegistrations:
         assert draft.description == description
         assert draft.category == category
         assert user in draft.contributors.all()
-        assert write_contrib not in draft.contributors.all()
+        assert write_contrib in draft.contributors.all()
         assert member not in draft.contributors.all()
         assert not draft.has_permission(member, 'read')
 
         assert draft.get_permissions(user) == [READ, WRITE, ADMIN]
-        assert draft.get_permissions(write_contrib) == []
+        assert draft.get_permissions(write_contrib) == [READ, WRITE]
 
         assert draft.node_license.license_id == GPL3.license_id
         assert draft.node_license.name == GPL3.name


### PR DESCRIPTION
## Purpose
Currently, there are two approaches we take to contributor management for Draft Registrations. We want to align these two approaches such that contributors are always managed on the draft registration, contributors on the draft registration may diverge from a potential branched from project, and the resulting registration’s contributors are based upon the draft registration’s contributors.

This largely reverses changes made in a [previous PR here](https://github.com/CenterForOpenScience/osf.io/commit/8091dae1df0eec2fc8b9617c51ec6c463d285dd7)

## Changes
* Modify `DraftRegistration.create_from_node` to copy contributors from project, upon creation of the Draft Registration
	* Modify tests checking for contributor permissions upon draft registration creation
* Modify `Node.register_node` to copy contributors from the draft registration rather than `self`
	* Add test checking for contributor permissions upon registration creation
* Modify `DraftRegistration.register` to not copy contributors from the project upon registration
	* Modify tests checking for contributor sync between the project and draft registration upon registration
* Remove subject modification permissions check on Node
* Modify DraftRegistration API permissions to be based upon DraftRegistration
	* Modify DraftRegistration API Tests related to permissions
		* `test_draft_registration_perms_checked_on_draft_not_node`
		* `test_can_view_after_added`
		* `test_current_permissions_field`

## QA Notes
Please make verification statements inspired by your code and what your code touches.
* Verify that a newly created draft registration has copied contributors from the branched project
* Verify that registrations copy contributors from the draft registration contributor set rather than the original project contributor set
* Verify that permissions to read, write, and administrate a draft registration through the API are based upon contributorship on the draft registration

What are the areas of risk?
Ensuring that permissions are accurate and access to draft registrations for different types of contributors is appropriate.

Any concerns/considerations/questions that development raised?
Testing this will only be possible on new draft registrations until a management command adjusts contributors for existing draft registrations ([see ticket here](https://openscience.atlassian.net/browse/ENG-2626))

## Documentation
N/A

## Side Effects
Divergence of where and how contributors should be managed for new and existing draft registrations but that is addressed by [ENG-2626](https://openscience.atlassian.net/browse/ENG-2626)

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2594)
