### PR TITLE
[ENG-2597] Serializer Current User Permissions on Draft Registrations

### DIFF
--- a/api/draft_registrations/permissions.py
+++ b/api/draft_registrations/permissions.py
@@ -2,7 +2,6 @@ from rest_framework import permissions
 
 from api.base.utils import get_user_auth, assert_resource_type
 from osf.models import (
-    Node,
     DraftRegistration,
     AbstractNode,
     DraftRegistrationContributor,
@@ -26,9 +25,6 @@ class IsContributorOrAdminContributor(permissions.BasePermission):
         if not auth:
             return False
 
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
-
         if request.method in permissions.SAFE_METHODS:
             return obj.is_contributor(auth.user)
         else:
@@ -49,9 +45,6 @@ class IsAdminContributor(permissions.BasePermission):
         auth = get_user_auth(request)
         if not auth.user:
             return False
-
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
 
         if request.method in permissions.SAFE_METHODS:
             return obj.is_contributor(auth.user)

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -76,6 +76,11 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
+    current_user_permissions = ser.SerializerMethodField(
+        help_text='List of strings representing the permissions '
+        'for the current user on this draft registratione.',
+    )
+
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -10,6 +10,7 @@ from api.nodes.serializers import (
     DraftRegistrationDetailLegacySerializer,
     update_institutions,
     get_license_details,
+    NodeSerializer,
     NodeLicenseSerializer,
     NodeLicenseRelationshipField,
     NodeContributorsSerializer,
@@ -76,6 +77,11 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
+    current_user_permissions = ser.SerializerMethodField(
+        help_text='List of strings representing the permissions '
+        'for the current user on this draft registratione.',
+    )
+
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},
@@ -116,6 +122,9 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
     def get_node(self, validated_data):
         # Node comes from branched_from relationship rather than from URL
         return validated_data.pop('branched_from', None)
+
+    def get_current_user_permissions(self, obj):
+        return NodeSerializer.get_current_user_permissions(self, obj)
 
     def expect_subjects_as_relationships(self, request):
         """Determines whether subjects should be serialized as a relationship.

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -76,11 +76,6 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         related_view_kwargs={'draft_id': '<_id>'},
     )
 
-    current_user_permissions = ser.SerializerMethodField(
-        help_text='List of strings representing the permissions '
-        'for the current user on this draft registratione.',
-    )
-
     license = NodeLicenseRelationshipField(
         related_view='licenses:license-detail',
         related_view_kwargs={'license_id': '<license.node_license._id>'},

--- a/api/draft_registrations/views.py
+++ b/api/draft_registrations/views.py
@@ -73,7 +73,7 @@ class DraftRegistrationList(NodeDraftRegistrationsList):
 
 class DraftRegistrationDetail(NodeDraftRegistrationDetail, DraftRegistrationMixin):
     permission_classes = (
-        IsContributorOrAdminContributor,
+        ContributorOrPublic,
         AdminDeletePermissions,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -35,9 +35,6 @@ class ContributorOrPublic(permissions.BasePermission):
         assert_resource_type(obj, self.acceptable_models)
         auth = get_user_auth(request)
 
-        if isinstance(obj, DraftRegistration) and isinstance(obj.branched_from, Node):
-            obj = obj.branched_from
-
         if request.method in permissions.SAFE_METHODS:
             return obj.is_public or obj.can_view(auth)
         else:

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -139,6 +139,17 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(url_draft_registrations, auth=draft_admin.auth)
         assert res.status_code == 200
 
+    # Overwrites TestDraftRegistrationDetail
+    def test_can_view_after_added(
+            self, app, schema, draft_registration, url_draft_registrations):
+        # Draft Registration permissions are no longer based on the branched from project
+
+        user = AuthUserFactory()
+        project = draft_registration.branched_from
+        project.add_contributor(user, ADMIN)
+        res = app.get(url_draft_registrations, auth=user.auth, expect_errors=True)
+        assert res.status_code == 403
+
     # Overrides TestDraftRegistrationDetail
     def test_reviewer_can_see_draft_registration(
             self, app, schema, draft_registration, url_draft_registrations):

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -162,6 +162,17 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         # New workflows aren't accommodating old prereg challenge
         assert res.status_code == 403
 
+    def test_current_permissions_field(self, app, user_read_contrib,
+            user_write_contrib, user, draft_registration, url_draft_registrations):
+        res = app.get(url_draft_registrations, auth=user_read_contrib.auth, expect_errors=False)
+        assert res.json['data']['attributes']['current_user_permissions'] == [READ]
+
+        res = app.get(url_draft_registrations, auth=user_write_contrib.auth, expect_errors=False)
+        assert res.json['data']['attributes']['current_user_permissions'] == [WRITE, READ]
+
+        res = app.get(url_draft_registrations, auth=user.auth, expect_errors=False)
+        assert res.json['data']['attributes']['current_user_permissions'] == [ADMIN, WRITE, READ]
+
 
 class TestUpdateEditableFieldsTestCase:
     @pytest.fixture()

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -43,14 +43,14 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth,
-            expect_errors=True)
+            expect_errors=False)
         assert res.status_code == 200
 
         #   test_read_write_contributor_can_view_draft
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth,
-            expect_errors=True)
+            expect_errors=False)
         assert res.status_code == 200
 
     def test_cannot_view_draft(
@@ -128,26 +128,15 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         project_public.add_contributor(node_admin, ADMIN)
         assert project_public.has_permission(node_admin, ADMIN) is True
         assert draft_registration.has_permission(node_admin, ADMIN) is False
-        res = app.get(url_draft_registrations, auth=node_admin.auth)
-        assert res.status_code == 200
+        res = app.get(url_draft_registrations, auth=node_admin.auth, expect_errors=True)
+        assert res.status_code == 403
 
         # Admin on draft but not node
         draft_admin = AuthUserFactory()
         draft_registration.add_contributor(draft_admin, ADMIN)
         assert project_public.has_permission(draft_admin, ADMIN) is False
         assert draft_registration.has_permission(draft_admin, ADMIN) is True
-        res = app.get(url_draft_registrations, auth=draft_admin.auth, expect_errors=True)
-        assert res.status_code == 403
-
-    # Overwrites TestDraftRegistrationDetail
-    def test_can_view_after_added(
-            self, app, schema, draft_registration, url_draft_registrations):
-        # Draft Registration permissions are based on the branched from node
-
-        user = AuthUserFactory()
-        project = draft_registration.branched_from
-        project.add_contributor(user, ADMIN)
-        res = app.get(url_draft_registrations, auth=user.auth)
+        res = app.get(url_draft_registrations, auth=draft_admin.auth)
         assert res.status_code == 200
 
     # Overrides TestDraftRegistrationDetail

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -39,18 +39,16 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
         # test_read_only_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
-            auth=user_read_contrib.auth,
-            expect_errors=True)
+            auth=user_read_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
-            auth=user_write_contrib.auth,
-            expect_errors=True)
+            auth=user_write_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_logged_in_non_contributor_can_view_draft_list
         res = app.get(

--- a/api_tests/users/views/test_user_draft_registration_list.py
+++ b/api_tests/users/views/test_user_draft_registration_list.py
@@ -70,13 +70,13 @@ class TestDraftRegistrationList(DraftRegistrationTestCase):
         res = app.get(
             url_draft_registrations,
             auth=user_read_contrib.auth)
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_read_write_contributor_can_view_draft_list
         res = app.get(
             url_draft_registrations,
             auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 0
+        assert len(res.json['data']) == 1
 
         #   test_logged_in_non_contributor_cannot_view_draft_list
         res = app.get(

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1071,7 +1071,6 @@ class TaxonomizableMixin(models.Model):
         Preprint = apps.get_model('osf.Preprint')
         CollectionSubmission = apps.get_model('osf.CollectionSubmission')
         DraftRegistration = apps.get_model('osf.DraftRegistration')
-        Node = apps.get_model('osf.Node')
 
         if isinstance(self, AbstractNode):
             if not self.has_permission(auth.user, ADMIN):
@@ -1079,9 +1078,6 @@ class TaxonomizableMixin(models.Model):
         elif isinstance(self, Preprint):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have admin or write permissions to change a preprint\'s subjects.')
-        if isinstance(self, DraftRegistration) and isinstance(self.branched_from, Node):
-            if not self.branched_from.has_permission(auth.user, WRITE):
-                raise PermissionsError('Must have admin on parent node to update draft registration\'s subjects.')
         elif isinstance(self, DraftRegistration):
             if not self.has_permission(auth.user, WRITE):
                 raise PermissionsError('Must have write permissions to change a draft registration\'s subjects.')

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2229,7 +2229,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         else:
             return []
 
-    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True, contributors=True):
+    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, save=True):
         """
         Copy various editable fields from the 'resource' object to the current object.
         Includes, title, description, category, contributors, node_license, tags, subjects, and affiliated_institutions
@@ -2245,8 +2245,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
 
         # Contributors will always come from "resource", as contributor constraints
         # will require contributors to be present on the resource
-        if contributors:
-            self.copy_contributors_from(resource)
+        self.copy_contributors_from(resource)
         # Copy unclaimed records for unregistered users
         self.copy_unclaimed_records(resource)
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1473,7 +1473,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=True)
+        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1473,9 +1473,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
-        registered.copy_contributors_from(draft_registration)
-        registered.copy_unclaimed_records(draft_registration)
+        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=True)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1474,8 +1474,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             alternative_resource = None
 
         registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource, contributors=False)
-        registered.copy_contributors_from(self)
-        registered.copy_unclaimed_records(self)
+        registered.copy_contributors_from(draft_registration)
+        registered.copy_unclaimed_records(draft_registration)
 
         if settings.ENABLE_ARCHIVER:
             registered.refresh_from_db()

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1126,7 +1126,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True, contributors=True)
+        draft.copy_editable_fields(node, Auth(user), save=True)
         draft.update(data)
         return draft
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1126,7 +1126,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True, contributors=False)
+        draft.copy_editable_fields(node, Auth(user), save=True, contributors=True)
         draft.update(data)
         return draft
 
@@ -1231,8 +1231,6 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         )
         self.registered_node = registration
         self.add_status_log(auth.user, DraftRegistrationLog.REGISTERED)
-
-        self.copy_contributors_from(node)
 
         if save:
             self.save()

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -308,12 +308,12 @@ class TestDraftRegistrations:
         assert draft.description == description
         assert draft.category == category
         assert user in draft.contributors.all()
-        assert write_contrib not in draft.contributors.all()
+        assert write_contrib in draft.contributors.all()
         assert member not in draft.contributors.all()
         assert not draft.has_permission(member, 'read')
 
         assert draft.get_permissions(user) == [READ, WRITE, ADMIN]
-        assert draft.get_permissions(write_contrib) == []
+        assert draft.get_permissions(write_contrib) == [READ, WRITE]
 
         assert draft.node_license.license_id == GPL3.license_id
         assert draft.node_license.name == GPL3.name


### PR DESCRIPTION
## Purpose
The current user’s permissions on the draft registration retrieved through the API is not currently an attribute as it is for Nodes and Registrations. This is helpful because it removes the need for a follow-up API call to request the current user’s permissions on the draft registration. 

This PR builds off of https://github.com/CenterForOpenScience/osf.io/pull/9619 to avoid re-writing tests after contributor management is modified.

## Changes
* Add the `current_user_permissions` field to the Draft Registration serializer
* Adds `test_current_permissions_field` to DraftRegistrationDetail tests

## QA Notes
- Verify the presence and accuracy of the `current_user_permissions` field on the DraftRegistrationDetail endpoint
  - Note that permissions should be based off of the user's contributorship on the draft registration as opposed to the branched from node

What are the areas of risk?
N/A

Any concerns/considerations/questions that development raised?
N/A

## Documentation
N/A 

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2597)