### PR TITLE
[ENG-2626] Add management command to copy contributors from projects to draft registrations

### DIFF
--- a/osf/management/commands/project_to_draft_registration_contributor_sync.py
+++ b/osf/management/commands/project_to_draft_registration_contributor_sync.py
@@ -1,0 +1,26 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count, Q
+
+
+from osf.models import DraftRegistration
+
+logger = logging.getLogger(__name__)
+
+
+def project_to_draft_registration_contributor_sync():
+    # Retrieve all active draft registrations
+    active_draft_registrations = DraftRegistration.objects.filter(Q(deleted__isnull=True) & (Q(registered_node=None) | Q(registered_node__is_deleted=True)))
+    # Retrieve active draft registrations with only 1 contributor (the initiator)
+    active_unsynced_draft_regs = active_draft_registrations.annotate(num_contributor=Count('_contributors')).filter(num_contributor=1)
+    logger.debug(f'A total of {active_unsynced_draft_regs.count()} draft registrations will be synced with the contributors from their projects.')
+
+    for draft_reg in active_unsynced_draft_regs:
+        draft_reg.copy_contributors_from(draft_reg.branched_from)
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        project_to_draft_registration_contributor_sync()

--- a/osf/management/commands/project_to_draft_registration_contributor_sync.py
+++ b/osf/management/commands/project_to_draft_registration_contributor_sync.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 def retrieve_draft_registrations_to_sync():
     # Retrieve all active draft registrations
     active_draft_registrations = DraftRegistration.objects.filter(Q(deleted__isnull=True) & (Q(registered_node=None) | Q(registered_node__is_deleted=True)))
-    # Retrieve active draft registrations with only 1 contributor (the initiator)
-    active_unsynced_draft_regs = active_draft_registrations.annotate(num_contributor=Count('_contributors')).filter(num_contributor=1)
+    # Retrieve the subset of all active draft registrations that branched from a Node
+    active_draft_registrations_node = active_draft_registrations.filter(branched_from__type='osf.node')
+    # Retrieve the subset with only 1 contributor (the initiator)
+    active_unsynced_draft_regs = active_draft_registrations_node.annotate(num_contributor=Count('_contributors')).filter(num_contributor__lte=1)
     return active_unsynced_draft_regs
 
 def project_to_draft_registration_contributor_sync(dry_run=False):

--- a/osf/management/commands/project_to_draft_registration_contributor_sync.py
+++ b/osf/management/commands/project_to_draft_registration_contributor_sync.py
@@ -16,15 +16,25 @@ def retrieve_draft_registrations_to_sync():
     active_unsynced_draft_regs = active_draft_registrations.annotate(num_contributor=Count('_contributors')).filter(num_contributor=1)
     return active_unsynced_draft_regs
 
-def project_to_draft_registration_contributor_sync():
+def project_to_draft_registration_contributor_sync(dry_run=False):
     active_unsynced_draft_regs = retrieve_draft_registrations_to_sync()
     logger.debug(f'A total of {active_unsynced_draft_regs.count()} draft registrations will be synced with the contributors from their projects.')
 
     for draft_reg in active_unsynced_draft_regs:
+        if dry_run:
+            logger.info(f'{draft_reg._id} will copy contributors from the {draft_reg.branched_from._id} project.')
+            continue
         draft_reg.copy_contributors_from(draft_reg.branched_from)
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry_run',
+            action='store_true',
+            help='Iterate through draft registrations but don\'t copy contributors',
+        )
 
     def handle(self, *args, **options):
-        project_to_draft_registration_contributor_sync()
+        dry_run = options['dry_run']
+        project_to_draft_registration_contributor_sync(dry_run=dry_run)

--- a/osf/management/commands/project_to_draft_registration_contributor_sync.py
+++ b/osf/management/commands/project_to_draft_registration_contributor_sync.py
@@ -9,11 +9,15 @@ from osf.models import DraftRegistration
 logger = logging.getLogger(__name__)
 
 
-def project_to_draft_registration_contributor_sync():
+def retrieve_draft_registrations_to_sync():
     # Retrieve all active draft registrations
     active_draft_registrations = DraftRegistration.objects.filter(Q(deleted__isnull=True) & (Q(registered_node=None) | Q(registered_node__is_deleted=True)))
     # Retrieve active draft registrations with only 1 contributor (the initiator)
     active_unsynced_draft_regs = active_draft_registrations.annotate(num_contributor=Count('_contributors')).filter(num_contributor=1)
+    return active_unsynced_draft_regs
+
+def project_to_draft_registration_contributor_sync():
+    active_unsynced_draft_regs = retrieve_draft_registrations_to_sync()
     logger.debug(f'A total of {active_unsynced_draft_regs.count()} draft registrations will be synced with the contributors from their projects.')
 
     for draft_reg in active_unsynced_draft_regs:

--- a/osf_tests/test_management_commands.py
+++ b/osf_tests/test_management_commands.py
@@ -436,13 +436,18 @@ class TestProjectDraftRegContributorSync:
         draft_reg.add_contributor(draft_reg_contributor, WRITE)
         return draft_reg
 
+    @pytest.fixture()
+    def no_project_draft_registration(self, initiator):
+        return DraftRegistrationFactory()
+
     def test_draft_reg_to_sync_retrieval(
-            self, app, active_draft_registration, inactive_draft_registration, active_draft_registration_multiple_contributor):
-        # Tests if the function used to retriev draft registrations to copy project contributors
+            self, app, active_draft_registration, inactive_draft_registration, active_draft_registration_multiple_contributor, no_project_draft_registration):
+        # Tests if the function used to retrieve draft registrations to copy project contributors
         # to is limited to those without registrations
         active_unsynced_draft_regs = retrieve_draft_registrations_to_sync()
         assert active_draft_registration in active_unsynced_draft_regs
         assert inactive_draft_registration not in active_unsynced_draft_regs
+        assert no_project_draft_registration not in active_unsynced_draft_regs
         assert active_draft_registration_multiple_contributor not in active_unsynced_draft_regs
 
     def test_project_draft_reg_contributor_sync(


### PR DESCRIPTION
## Purpose
We are modifying draft registrations to copy contributors from the branched project upon creation. This means that post-release all new draft registrations will have contributors from the branched project. Pre-release draft registrations will not have contributors from the branched project. This management command ensures that existing draft registrations contributor permissions are in line with what users expect after contributor management shifts to be on the draft registration. 

## Changes
- Creates a management command to copy contributors from projects to active draft registrations
- Creates a test for the management command

## QA Notes
This should be dev tested on a staging environment

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2626)