### PR TITLE
[ENG-2655] Fixes node:draft-node typing in Files API serialization

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -7,7 +7,7 @@ import pytz
 import jsonschema
 
 from framework.auth.core import Auth
-from osf.models import BaseFileNode, OSFUser, Comment, Preprint, AbstractNode
+from osf.models import BaseFileNode, DraftNode, OSFUser, Comment, Preprint, AbstractNode
 from rest_framework import serializers as ser
 from rest_framework.fields import SkipField
 from website import settings
@@ -190,7 +190,8 @@ class BaseFileSerializer(JSONAPISerializer):
         help_text='The folder in which this file exists',
     )
     files = NodeFileHyperLinkField(
-        related_view='nodes:node-files',
+        related_view=lambda node: 'draft_nodes:node-files' if getattr(node, 'type', False) == 'osf.draftnode' else 'nodes:node-files',
+        view_lambda_argument='target',
         related_view_kwargs={'node_id': '<target._id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder',
     )
@@ -366,6 +367,8 @@ class FileSerializer(BaseFileSerializer):
         target_type = 'node'
         if isinstance(obj, Preprint):
             target_type = 'preprint'
+        if isinstance(obj, DraftNode):
+            target_type = 'draft_node'
         return target_type
 
 


### PR DESCRIPTION
## Purpose
Ensures that the correct node type (node or draft-node) is communicated in the Files API 

## Changes
* Added an `if` branch to `get_target_type` in the FileSerializer to check and return if the target is a draft-node
* Created a `RelatedLambdaRelationshipField`, an extension of RelationshipField which allows for the argument of a lambda view to be specified as an attribute of the serialized object (rather than needing to be the fieldname attribute)
* Modified `NodeFileHyperLinkField` to extend `RelatedLambdaRelationshipField` 
* Added a lambda function for the `files` relationship on the BaseFileSerializer and specified the lambda argument
* Created a test for the link returned by the `files` relationship to ensure points to the `/nodes/` and `/draft_nodes/` endpoints appropriately

## QA Notes
Please make verification statements inspired by your code and what your code touches.
- Verify `v2/files/<file_id>/` (where file_id is a folder) has a `files` relationship that points to the `/nodes/` file list endpoint or the `/draft_nodes/` file list endpoint depending on if the folder is on a draft-node or node
- Verify that the `type` specified on the `target` relationship is accurate based upon if a file is on a draft-node or node

What are the areas of risk?
N/A
Any concerns/considerations/questions that development raised?
N/A

## Documentation
N/A

## Side Effects
N/A

## Ticket
[Jira Ticket](https://openscience.atlassian.net/browse/ENG-2655)

[See this notion document for additional details](https://www.notion.so/cos/No-Project-Integration-Bugs-Issues-Found-64d1ce6cdbe14cddb15d771044b8032e)