### PR TITLE
Fix contributor filtering error

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -263,6 +263,9 @@ class RegistrationContributorsList(BaseContributorList, RegistrationMixin, UserM
         node = self.get_node(check_object_permissions=False)
         return node.contributor_set.all().include('user__guids')
 
+    def get_resource(self):
+        return self.get_node(check_object_permissions=False)
+
 
 class RegistrationContributorDetail(BaseContributorDetail, RegistrationMixin, UserMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/registrations_contributors_read).


### PR DESCRIPTION
## Purpose

Filtering contributors on permissions raises an internal error due to logical problem with the filtering. This PR fixes the issue by add the expected filtering methods.

## Changes

- adds filtering method to contrib endpoint

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the system no longer 500s


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

🐞 fix, no docs.

## Side Effects

None that I know of.

## Ticket

None