### PR TITLE
[ENG-2655] Adds a log message for projects created from no-project draft registrations upon registration

### DIFF
--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -1,5 +1,6 @@
 {
     "project_created":  "${user} created ${node}",
+    "project_created_from_draft_reg": "${node} was created from a draft registration",
     "project_registered": "${user} registered ${node}",
     "project_registered_no_user": "${node} registered",
     "prereg_registration_initiated": "${user} submitted for review to the Preregistration Challenge a registration of ${node}",


### PR DESCRIPTION
## Purpose
Resolves `Unable to retrieve log details` message on newly created projects from no-project draft registrations.

## Changes
* Adds a log message mapped to `project_created_from_draft_reg` to logActionsList.json

## QA Notes
Please make verification statements inspired by your code and what your code touches.
- Verify a newly created project based upon a no-project draft registration has an appropriate log message

What are the areas of risk?
N/A

Any concerns/considerations/questions that development raised?
N/A

## Documentation
N/A

## Side Effects
N/A

## Ticket
[JIRA Ticket](https://openscience.atlassian.net/browse/ENG-2655)