### PR TITLE
[ENG-2691] No-Project email fixes

### DIFF
--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from framework.auth.core import Auth
@@ -17,9 +18,7 @@ from osf_tests.factories import (
 )
 from osf.utils.permissions import READ, WRITE, ADMIN
 
-from tests.base import capture_signals
-from website import settings
-from website.project.signals import contributor_added
+from website import mails, settings
 
 @pytest.mark.django_db
 class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
@@ -241,21 +240,25 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
             expect_errors=True)
         assert res.status_code == 403
 
+    def test_create_project_based_draft_does_not_email_initiator(
+            self, app, user, url_draft_registrations, payload):
+        post_url = url_draft_registrations + 'embed=branched_from&embed=initiator'
+        with mock.patch.object(mails, 'send_mail') as mock_send_mail:
+            app.post_json_api(post_url, payload, auth=user.auth)
+
+        assert not mock_send_mail.called
 
 class TestDraftRegistrationCreateWithoutNode(TestDraftRegistrationCreate):
     @pytest.fixture()
-    def url_draft_registrations(self, project_public):
+    def url_draft_registrations(self):
         return '/{}draft_registrations/?'.format(API_BASE)
 
     # Overrides TestDraftRegistrationList
     def test_admin_can_create_draft(
-            self, app, user, project_public, url_draft_registrations,
+            self, app, user, url_draft_registrations,
             payload, metaschema_open_ended):
         url = '{}embed=branched_from&embed=initiator'.format(url_draft_registrations)
-        with capture_signals() as mock_signals:
-            res = app.post_json_api(url, payload, auth=user.auth)
-
-        assert contributor_added in mock_signals.signals_sent()
+        res = app.post_json_api(url, payload, auth=user.auth)
 
         assert res.status_code == 201
         data = res.json['data']
@@ -271,8 +274,24 @@ class TestDraftRegistrationCreateWithoutNode(TestDraftRegistrationCreate):
         assert draft.creator == user
         assert draft.has_permission(user, ADMIN) is True
 
-    def test_create_draft_with_provider(self, app, user, url_draft_registrations, non_default_provider, payload_with_non_default_provider):
+    def test_create_no_project_draft_emails_initiator(
+            self, app, user, url_draft_registrations, payload):
+        post_url = url_draft_registrations + 'embed=branched_from&embed=initiator'
 
+        # Intercepting the send_mail call from website.project.views.contributor.notify_added_contributor
+        with mock.patch.object(mails, 'send_mail') as mock_send_mail:
+            resp = app.post_json_api(post_url, payload, auth=user.auth)
+        assert mock_send_mail.called
+
+        # Python 3.6 does not support mock.call_args.args/kwargs
+        # Instead, mock.call_args[0] is positional args, mock.call_args[1] is kwargs
+        # (note, this is compatible with later versions)
+        mock_send_kwargs = mock_send_mail.call_args[1]
+        assert mock_send_kwargs['mail'] == mails.CONTRIBUTOR_ADDED_DRAFT_REGISTRATION
+        assert mock_send_kwargs['user'] == user
+        assert mock_send_kwargs['node'] == DraftRegistration.load(resp.json['data']['id'])
+
+    def test_create_draft_with_provider(self, app, user, url_draft_registrations, non_default_provider, payload_with_non_default_provider):
         res = app.post_json_api(url_draft_registrations, payload_with_non_default_provider, auth=user.auth)
         assert res.status_code == 201
         data = res.json['data']

--- a/osf/migrations/0228_abstractnode_branched_from_node.py
+++ b/osf/migrations/0228_abstractnode_branched_from_node.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('osf', '0226_auto_20210224_1610'),
+        ('osf', '0227_add_secondary_data'),
     ]
 
     operations = [

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1113,11 +1113,9 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         else:
             provider.validate_schema(schema)
 
-        add_initiator = False
         if not node:
             # If no node provided, a DraftNode is created for you
             node = DraftNode.objects.create(creator=user, title='Untitled')
-            add_initiator = True
 
         if not (isinstance(node, Node) or isinstance(node, DraftNode)):
             raise DraftRegistrationStateError()
@@ -1133,7 +1131,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         draft.copy_editable_fields(node, Auth(user), save=True)
         draft.update(data)
 
-        if add_initiator:
+        if node.type == 'osf.draftnode':
             initiator_permissions = draft.contributor_set.get(user=user).permission
             signals.contributor_added.send(
                 draft,

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -890,7 +890,6 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
     @property
     def url(self):
         return self.URL_TEMPLATE.format(
-            node_id=self.branched_from._id,
             draft_id=self._id
         )
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -760,7 +760,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         'node_license',
     ]
 
-    URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/drafts/{draft_id}'
+    URL_TEMPLATE = settings.DOMAIN + 'registries/drafts/{draft_id}'
 
     # Overrides EditableFieldsMixin to make title not required
     title = models.TextField(validators=[validate_title], blank=True, default='')
@@ -1135,7 +1135,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
 
         if add_initiator:
             initiator_permissions = draft.contributor_set.get(user=user).permission
-            signals.add_contributor.send(
+            signals.contributor_added.send(
                 draft,
                 contributor=user,
                 auth=None,

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -255,7 +255,7 @@ class TestDraftRegistrations:
         project = factories.ProjectFactory()
         draft = factories.DraftRegistrationFactory(branched_from=project)
 
-        assert draft.url == settings.DOMAIN + 'project/{}/drafts/{}'.format(project._id, draft._id)
+        assert draft.url == settings.DOMAIN + 'registries/drafts/{}'.format(draft._id)
 
     def test_create_from_node_existing(self, user):
         node = factories.ProjectFactory(creator=user)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2063,8 +2063,8 @@ class TestAddingContributorViews(OsfTestCase):
         project.save()
         assert_true(send_mail.called)
         send_mail.assert_called_with(
-            contributor.username,
-            mails.CONTRIBUTOR_ADDED_DEFAULT,
+            to_addr=contributor.username,
+            mail=mails.CONTRIBUTOR_ADDED_DEFAULT,
             user=contributor,
             node=project,
             referrer_name=self.auth.user.fullname,

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -576,8 +576,8 @@ def notify_added_contributor(node, contributor, auth=None, email_template='defau
             email_template = mails.CONTRIBUTOR_ADDED_DEFAULT
 
         mails.send_mail(
-            contributor.username,
-            email_template,
+            to_addr=contributor.username,
+            mail=email_template,
             user=contributor,
             node=node,
             referrer_name=auth.user.fullname if auth else '',

--- a/website/templates/emails/contributor_added_draft_registration.html.mako
+++ b/website/templates/emails/contributor_added_draft_registration.html.mako
@@ -13,7 +13,7 @@
         % if node.title == 'Untitled':
             <a href="${node.absolute_url}">a new registration draft</a>
         % else:
-            a new registration draft titled <a href="${node.absolute_url}"> + ${node.title} </a>
+            a new registration draft titled <a href="${node.absolute_url}"> ${node.title} </a>
         % endif
     </p>
     <p>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make sure initiators of a "No-Project" Draft Registration receive an email with the link to the registration.

Draft Registrations that are not associated with a Project currently have no means of discovery beyond the email link sent to contributors. Historically, contributors

## Changes
* Call the `contributor_added` signal in `DraftRegistration.create_from_node` when creating a DraftRegistration without a backing project.
* Update the `send_mail` call when notifying new contributors to pass all args as kwargs to improve hygiene
* Update the `URL_TEMPLATE` for DraftRegistrations to match the correct, updated format
* Minor fix to email text for new Draft Registration contributors
* Tests to confirm new behavior

## QA Notes
New tests verify that email is sent to the initiator iff the draft node is created without a `branched_from` node.

QA/Product should verify email text

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-2691
