### PR TITLE
Hotfix/fix preprint contributor emails

### DIFF
--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -215,6 +215,10 @@ INVITE_DEFAULT = Mail(
     'invite_default',
     subject='You have been added as a contributor to an OSF project.'
 )
+INVITE_OSF_PREPRINT = Mail(
+    'invite_preprints_osf',
+    subject='You have been added as a contributor to an OSF preprint.'
+)
 INVITE_PREPRINT = lambda provider: Mail(
     'invite_preprints',
     subject='You have been added as a contributor to {} {} {}.'.format(get_english_article(provider.name), provider.name, provider.preprint_word)
@@ -222,6 +226,10 @@ INVITE_PREPRINT = lambda provider: Mail(
 CONTRIBUTOR_ADDED_DEFAULT = Mail(
     'contributor_added_default',
     subject='You have been added as a contributor to an OSF project.'
+)
+CONTRIBUTOR_ADDED_OSF_PREPRINT = Mail(
+    'contributor_added_preprints_osf',
+    subject='You have been added as a contributor to an OSF preprint.'
 )
 CONTRIBUTOR_ADDED_PREPRINT = lambda provider: Mail(
     'contributor_added_preprints',

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -561,7 +561,9 @@ def notify_added_contributor(node, contributor, auth=None, email_template='defau
     contrib_on_parent_node = isinstance(node, (Preprint, DraftRegistration)) or \
                              (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor)))
     if contrib_on_parent_node:
-        if email_template == 'preprint' and not node.provider.is_default:
+        if email_template == 'preprint':
+            if node.provider.is_default:
+                return
             email_template = mails.CONTRIBUTOR_ADDED_PREPRINT(node.provider)
             logo = node.provider._id
         elif email_template == 'draft_registration':

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -562,10 +562,10 @@ def notify_added_contributor(node, contributor, auth=None, email_template='defau
                              (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor)))
     if contrib_on_parent_node:
         if email_template == 'preprint':
-            if node.provider.is_default:
-                return
             email_template = mails.CONTRIBUTOR_ADDED_PREPRINT(node.provider)
             logo = node.provider._id
+            if node.provider.is_default:
+                logo = settings.OSF_PREPRINTS_LOGO
         elif email_template == 'draft_registration':
             email_template = mails.CONTRIBUTOR_ADDED_DRAFT_REGISTRATION
         elif email_template == 'access_request':

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -462,9 +462,13 @@ def send_claim_email(email, unclaimed_user, node, notify=True, throttle=24 * 360
     logo = None
     if unclaimed_record.get('email') == claimer_email:
         # check email template for branded preprints
-        if email_template == 'preprint' and not node.provider.is_default:
-            mail_tpl = mails.INVITE_PREPRINT(node.provider)
-            logo = node.provider._id
+        if email_template == 'preprint':
+            if node.provider.is_default:
+                mail_tpl = mails.INVITE_OSF_PREPRINT
+                logo = settings.OSF_PREPRINTS_LOGO
+            else:
+                mail_tpl = mails.INVITE_PREPRINT(node.provider)
+                logo = node.provider._id
         else:
             mail_tpl = mails.INVITE_DEFAULT
 
@@ -562,10 +566,12 @@ def notify_added_contributor(node, contributor, auth=None, email_template='defau
                              (not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor)))
     if contrib_on_parent_node:
         if email_template == 'preprint':
-            email_template = mails.CONTRIBUTOR_ADDED_PREPRINT(node.provider)
-            logo = node.provider._id
             if node.provider.is_default:
+                email_template = mails.CONTRIBUTOR_ADDED_OSF_PREPRINT
                 logo = settings.OSF_PREPRINTS_LOGO
+            else:
+                email_template = mails.CONTRIBUTOR_ADDED_PREPRINT(node.provider)
+                logo = node.provider._id
         elif email_template == 'draft_registration':
             email_template = mails.CONTRIBUTOR_ADDED_DRAFT_REGISTRATION
         elif email_template == 'access_request':


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
OSF Preprints users were getting errors when trying to add contributors to their preprints. Additionally, unregistered users being added to OSF Preprints

## Changes
Restore the use of the `contributors_added_preprints_osf` and `invite_preprints_osf` templates for preprints on the default provider (i.e. OSF Preprints)

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that both registered and unregistered contributors can be added to both OSF and Branded preprints

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
