### PR TITLE
Add new throttle rates for files in local-dist

### DIFF
--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -40,4 +40,6 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'test-anon': '1/hour',
     'send-email': '2/minute',
     'burst': '10/second',
+    'files': '75/minute',
+    'files-burst': '3/second',
 }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
- Add newly added files-related throttle rates to local-dist.py

## Changes
- Added `files` and `files-burst` to `api/base/settings/local-dist.py`

## QA Notes
- This is updating a settings file for running the OSF locally, and is geared towards developer experience. When running the OSF locally, developers may have overlooked these two throttling rates which can cause unexpected errors when doing file operations. This PR and its changes should have no impact on end-users.

## Documentation
None

## Side Effects
- NA

## Ticket
- NA