### PR TITLE
Adds logic to check_access so waterbutler file operations effectively…

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -41,7 +41,7 @@ from addons.base import signals as file_signals
 from addons.base.utils import format_last_known_metadata, get_mfr_url
 from osf import features
 from osf.models import (BaseFileNode, TrashedFileNode, BaseFileVersionsThrough,
-                        OSFUser, AbstractNode, Preprint,
+                        OSFUser, AbstractNode, DraftNode, Preprint,
                         NodeLog, DraftRegistration,
                         Guid, FileVersionUserMetadata, FileVersion)
 from osf.metrics import PreprintView, PreprintDownload
@@ -174,6 +174,10 @@ def check_access(node, auth, action, cas_resp):
     permission = permission_map.get(action, None)
     if permission is None:
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST)
+
+    # Permissions for DraftNode should be based upon the draft registration
+    if isinstance(node, DraftNode):
+        node = node.registered_draft.first()
 
     if cas_resp:
         if permission == permissions.READ:

--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -124,7 +124,7 @@ class SendEmailDeactivationThrottle(SendEmailThrottle):
 class BurstRateThrottle(UserRateThrottle):
     scope = 'burst'
 
-class FilesRateThrottle(UserRateThrottle):
+class FilesRateThrottle(NonCookieAuthThrottle, UserRateThrottle):
     scope = 'files'
 
 class FilesBurstRateThrottle(NonCookieAuthThrottle, UserRateThrottle):


### PR DESCRIPTION
## Purpose
Modifies `check_access` used by waterbutler to verify permission to check permissions on the draft registration rather than draft node.

## Changes
* Adds `if` block to change subject of permissions to draft registration if the file operation is on a draft node

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify file operations on no-project draft registrations work as expected

What are the areas of risk?
permissions

Any concerns/considerations/questions that development raised?

## Documentation
n/a

## Side Effects
n/a

## Ticket
pre-release fix