### PR TITLE
Avoids files throttling for ember app

### DIFF
--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -127,5 +127,5 @@ class BurstRateThrottle(UserRateThrottle):
 class FilesRateThrottle(UserRateThrottle):
     scope = 'files'
 
-class FilesBurstRateThrottle(UserRateThrottle):
+class FilesBurstRateThrottle(NonCookieAuthThrottle, UserRateThrottle):
     scope = 'files-burst'


### PR DESCRIPTION
## Purpose
The ember app was being throttled when retrieving files. This allows the ember app to circumvent the throttling while still throttling other users. 

## Changes
* Made `NonCookieAuthThrottle` a super class of `FilesBurstRateThrottle`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify all files are retrieved and detailed as expected

What are the areas of risk?
n/a

Any concerns/considerations/questions that development raised?
n/a

## Documentation
n/a

## Side Effects
n/a

## Ticket
pre-release fix