### PR TITLE
[ENG-2700][Hotfix] Fixes Registration creation permissions

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -183,12 +183,10 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
         """
         draft_id = self.request.data.get('draft_registration', None) or self.request.data.get('draft_registration_id', None)
         draft = self.get_draft(draft_id)
-        node = draft.branched_from
         user = get_user_auth(self.request).user
 
-        # A user must be an admin contributor on the node (not group member), and have
-        # admin perms on the draft to register
-        if node.is_admin_contributor(user) and draft.has_permission(user, ADMIN):
+        # A user have admin perms on the draft to register
+        if draft.has_permission(user, ADMIN):
             try:
                 serializer.save(draft=draft)
             except ValidationError as e:
@@ -196,7 +194,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
                 raise e
         else:
             raise PermissionDenied(
-                'You must be an admin contributor on both the project and the draft registration to create a registration.',
+                'You must be an admin contributor on the draft registration to create a registration.',
             )
 
     def check_branched_from(self, draft):


### PR DESCRIPTION
## Purpose
The shift to managing draft registration permissions on the draft registration and no-project registrations necessitates removing the permissions check for Registration creation from checking on the project and the draft registration to solely checking on the draft registration.

## Changes
* Remove check for admin permission on project (resulting in a check on only the draft registration) for registration creation
* Modify tests in line with new permissions

## QA Notes
Please make verification statements inspired by your code and what your code touches.
- Verify all admins on draft registration have permission to register (initiator and non-initiator)
- Verify admins on branched projects but not on the draft registration do not have permission to register

What are the areas of risk?
n/a

Any concerns/considerations/questions that development raised?
n/a

## Documentation
n/a

## Side Effects
n/a

## Ticket
[Jira Ticket](https://openscience.atlassian.net/browse/ENG-2700)