### PR TITLE
Removing History js [ENG-2749]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "font-awesome-webpack": "0.0.5-beta.2",
     "gsap": "1.18.0",
     "highlight.js": "~8.4.0",
-    "historyjs": "^1.8.0-b2",
     "html-loader": "^0.2.3",
     "imports-loader": "^0.6.3",
     "js-cookie": "2.1.2",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -143,7 +143,6 @@ var resolve = {
         'jquery-qrcode': staticPath('vendor/bower_components/jquery-qrcode/jquery.qrcode.min.js'),
         'jquery-tagsinput': staticPath('vendor/bower_components/jquery.tagsinput/jquery.tagsinput.js'),
         'clipboard': staticPath('vendor/bower_components/clipboard/dist/clipboard.js'),
-        'history': nodePath('historyjs/scripts/bundled/html4+html5/jquery.history.js'),
         // Needed for knockout-sortable
         'jquery.ui.sortable': staticPath('vendor/bower_components/jquery-ui/ui/widgets/sortable.js'),
         'truncate': staticPath('vendor/bower_components/truncate/jquery.truncate.js'),

--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -7,7 +7,6 @@
 
 var $ = require('jquery');
 var bootbox = require('bootbox');
-var historyjs = require('exports-loader?History!history');
 
 var ko = require('knockout');
 require('knockout.validation');
@@ -334,7 +333,7 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
 
             this.changeMessage(language.apiOauth2Application.creationSuccess, 'text-success', 5000);
             this.apiDetailUrl(dataObj.apiDetailUrl); // Toggle ViewModel --> act like a display view now.
-            historyjs.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page
+            history.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page
         }.bind(this));
 
         request.fail(function (xhr, status, error) {
@@ -376,7 +375,7 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
                     request.done(function () {
                         this.allowExit(true);
                         // Don't let user go back to a deleted application page
-                        historyjs.replaceState({}, '', this.webListUrl);
+                        history.replaceState({}, '', this.webListUrl);
                         this.visitList();
                     }.bind(this));
                     request.fail(function () {

--- a/website/static/js/apiPersonalToken.js
+++ b/website/static/js/apiPersonalToken.js
@@ -7,7 +7,6 @@
 
 var $ = require('jquery');
 var bootbox = require('bootbox');
-var historyjs = require('exports-loader?History!history');
 
 var ko = require('knockout');
 require('knockout.validation');
@@ -326,7 +325,7 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
             this.showToken(true);
             this.changeMessage(language.apiOauth2Token.creationSuccess, 'text-success');
             this.apiDetailUrl(dataObj.apiDetailUrl); // Toggle ViewModel --> act like a display view now.
-            historyjs.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page
+            history.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page
         }.bind(this));
 
         request.fail(function (xhr, status, error) {
@@ -368,7 +367,7 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
                     request.done(function () {
                         this.allowExit(true);
                         // Don't let user go back to a deleted token page
-                        historyjs.replaceState({}, '', this.webListUrl);
+                        history.replaceState({}, '', this.webListUrl);
                         this.visitList();
                     }.bind(this));
                     request.fail(function () {

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -13,7 +13,6 @@ var FileRevisionsTable = require('./revisions.js');
 var storageAddons = require('json-loader!storageAddons.json');
 var CommentModel = require('js/comment');
 
-var History = require('exports-loader?History!history');
 var SocialShare = require('js/components/socialshare');
 
 // Sanity
@@ -395,7 +394,7 @@ var FileViewPage = {
             var state = {
                 scrollTop: $(window).scrollTop(),
             };
-            History.pushState(state, 'OSF | ' + window.contextVars.file.name, url);
+            history.pushState(state, 'OSF | ' + window.contextVars.file.name, url);
         }
 
         function changeVersionHeader(){
@@ -475,7 +474,7 @@ var FileViewPage = {
                             state = {
                                 scrollTop: $(window).scrollTop(),
                             };
-                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, url);
+                            history.pushState(state, 'OSF | ' + window.contextVars.file.name, url);
                         }
                     }
                 }, ctrl.editor.title);
@@ -523,11 +522,11 @@ var FileViewPage = {
                         if (!ctrl.mfrIframeParent.is(':visible') || panelsShown > 1) {
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = false;
-                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
+                            history.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
                         } else if (ctrl.mfrIframeParent.is(':visible') && !ctrl.editor){
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = true;
-                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
+                            history.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
                         }
                     }
                 }, 'View'), editButton())
@@ -544,14 +543,14 @@ var FileViewPage = {
                             ctrl.editor.selected = false;
                         }
                         ctrl.revisions.selected = true;
-                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
+                        history.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
                     } else {
                         ctrl.mfrIframeParent.toggle();
                         if (ctrl.editor) {
                             ctrl.editor.selected = false;
                         }
                         ctrl.revisions.selected = false;
-                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
+                        history.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
                     }
                 }}, 'Revisions')
             ])

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -12,7 +12,6 @@ var moment = require('moment');
 var lodashHas = require('lodash.has');
 var lodashSet = require('lodash.set');
 var lodashIncludes = require('lodash.includes');
-var History = require('exports-loader?History!history');
 
 require('js/koHelpers');
 
@@ -810,7 +809,7 @@ var RegistrationEditor = function(urls, editorId, preview) {
             page.active(false);
         });
         currentPage.active(true);
-        History.replaceState({page: self.pages().indexOf(currentPage)});
+        history.replaceState({page: self.pages().indexOf(currentPage)});
     });
 
     self.onLastPage = ko.computed(function() {
@@ -954,7 +953,7 @@ RegistrationEditor.prototype.init = function(draft) {
 
     // Set currentPage to the first page
     var pages = self.draft().pages();
-    var index = History.getState().data.page || 0;
+    var index = history.getState().data.page || 0;
     if (index > pages.length) {
         index = 0;
     }

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -953,7 +953,7 @@ RegistrationEditor.prototype.init = function(draft) {
 
     // Set currentPage to the first page
     var pages = self.draft().pages();
-    var index = history.getState().data.page || 0;
+    var index = history.state.page || 0;
     if (index > pages.length) {
         index = 0;
     }

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -4,7 +4,6 @@ var ko = require('knockout');
 var $ = require('jquery');
 var bootbox = require('bootbox');
 require('bootstrap.growl');
-var History = require('exports-loader?History!history');
 
 var siteLicenses = require('js/licenses');
 var licenses = siteLicenses.list;
@@ -504,11 +503,6 @@ var ViewModel = function(params) {
 
     //History JS callback
     self.pageChange = function() {
-        if (self.stateJustPushed) {
-            self.stateJustPushed = false;
-            return;
-        }
-
         self.loadState();
 
         self.search(true);
@@ -537,7 +531,7 @@ var ViewModel = function(params) {
 
     //Load state from History JS
     self.loadState = function() {
-        var state = History.getState().data;
+        var state = history.state;
         self.currentPage(state.page || 1);
         self.setCategory(state.filter);
         self.query(state.query || '');
@@ -564,7 +558,7 @@ var ViewModel = function(params) {
         //Indicate that we've just pushed a state so the
         //Call back does not process this push as a state change
         self.stateJustPushed = true;
-        History.pushState(state, 'OSF | Search', url);
+        history.pushState(state, 'OSF | Search', url);
     };
 
     self.setCategory = function(cat) {
@@ -582,7 +576,8 @@ function Search(selector, url, appURL) {
     var self = this;
 
     self.viewModel = new ViewModel({'url': url, 'appURL': appURL});
-    History.Adapter.bind(window, 'statechange', self.viewModel.pageChange);
+    // History.Adapter.bind(window, 'statechange', self.viewModel.pageChange);
+    window.addEventListener('popstate', self.viewModel.pageChange);
 
     var data = {
         query: $osf.urlParams().q,
@@ -591,7 +586,7 @@ function Search(selector, url, appURL) {
         filter: $osf.urlParams().filter
     };
     //Ensure our state keeps its URL paramaters
-    History.replaceState(data, 'OSF | Search', location.search);
+    history.replaceState(data, 'OSF | Search', location.search);
     //Set out observables from the newly replaced state
     self.viewModel.loadState();
     //Preform search from url params


### PR DESCRIPTION


## Purpose

History JS is no longer supported. Worse, it has legacy dependency issues. 
## Changes

Getting rid of History js. Modifying the search page (the only place Histroy js was being used) to utilize the HTML5 History API instead.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the search page works as intended without history js 
- Verify

What are the areas of risk? N/A

Any concerns/considerations/questions that development raised?
We have single use dependencies everywhere.

## Documentation

N/A

## Side Effects

Shouldn't be.

## Ticket

https://openscience.atlassian.net/browse/ENG-2749
