### PR TITLE
[Replaces #9595] [ENG-2813] newCAS Prod Release Support

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -138,10 +138,8 @@ class InstitutionAuthentication(BaseAuthentication):
                         'institutions',
                         {},
                     ).get(attribute_value)
-                    logger.info(
-                        'Institution SSO: primary=[{}], secondary=[{}], '
-                        'username=[{}]'.format(provider['id'], secondary_institution_id, username)
-                    )
+                    logger.info('Institution SSO: primary=[{}], secondary=[{}], '
+                                'username=[{}]'.format(provider['id'], secondary_institution_id, username))
                     secondary_institution = Institution.load(secondary_institution_id)
                     if not secondary_institution:
                         # Log errors and inform Sentry but do not raise an exception if OSF fails

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -6,7 +6,6 @@ import jwe
 import jwt
 import waffle
 
-from django.utils import timezone
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -264,9 +263,6 @@ class InstitutionAuthentication(BaseAuthentication):
                 user.fullname = fullname
 
             user.update_date_last_login()
-
-            # Relying on front-end validation until `accepted_tos` is added to the JWT payload
-            user.accepted_terms_of_service = timezone.now()
 
             # Register and save user
             password = str(uuid.uuid4()) if new_password_required else None

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -242,9 +242,16 @@ class InstitutionAuthentication(BaseAuthentication):
             logger.info('Institution SSO: new user "{}"'.format(username))
 
         # The `department` field is updated each login when it was changed.
-        if department and user.department != department:
-            user.department = department
-            user.save()
+        user_guid = user.guids.first()._id
+        if department:
+            if user.department != department:
+                user.department = department
+                user.save()
+            logger.info('Institution SSO: user w/ dept: user={}, email={}, inst={} and '
+                        'dept={}'.format(user_guid, username, institution._id, department))
+        else:
+            logger.info('Institution SSO: user w/o dept: user={}, email={} and '
+                        'inst={}'.format(user_guid, username, institution._id))
 
         # Both created and activated accounts need to be updated and registered
         if created or activation_required:

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -113,7 +113,10 @@ class InstitutionAuthentication(BaseAuthentication):
         provider = data['provider']
         institution = Institution.load(provider['id'])
         if not institution:
-            raise AuthenticationFailed('Invalid institution id: "{}"'.format(provider['id']))
+            message = 'Institution SSO Error: invalid institution ID [{}]'.format(provider['id'])
+            logger.error(message)
+            sentry.log_message(message)
+            raise AuthenticationFailed(message)
         username = provider['user'].get('username')
         fullname = provider['user'].get('fullname')
         given_name = provider['user'].get('givenName')
@@ -137,33 +140,25 @@ class InstitutionAuthentication(BaseAuthentication):
                     ).get(attribute_value)
                     logger.info(
                         'Institution SSO: primary=[{}], secondary=[{}], '
-                        'user=[{}]'.format(provider['id'], secondary_institution_id, username),
+                        'username=[{}]'.format(provider['id'], secondary_institution_id, username)
                     )
                     secondary_institution = Institution.load(secondary_institution_id)
                     if not secondary_institution:
-                        # Log warnings and inform Sentry but do not raise an exception if OSF fails
+                        # Log errors and inform Sentry but do not raise an exception if OSF fails
                         # to load the secondary institution from database
-                        logger.warning(
-                            'Institution SSO warning: invalid secondary institution '
-                            '[{}]'.format(secondary_institution_id),
-                        )
-                        sentry.log_message(
-                            'Invalid secondary institution: primary=[{}], secondary=[{}], username='
-                            '[{}]'.format(secondary_institution_id, provider['id'], username),
-                        )
+                        message = 'Institution SSO Error: invalid secondary institution [{}]; ' \
+                                  'primary=[{}], username=[{}]'.format(attribute_value, provider['id'], username)
+                        logger.error(message)
+                        sentry.log_message(message)
                 else:
                     # SSO from primary institution only
-                    logger.info(
-                        'Institution SSO: primary=[{}], secondary=[None], '
-                        'user=[{}]'.format(provider['id'], username),
-                    )
+                    logger.info('Institution SSO: primary=[{}], secondary=[None], '
+                                'username=[{}]'.format(provider['id'], username))
             else:
-                logger.warning('Institution SSO warning: criteria type [{}] '
-                               'invalid or not implemented'.format(criteria_type))
-                sentry.log_message(
-                    'Criteria type invalid or not implemented: criteria=[{}], primary=[{}], '
-                    'username=[{}]'.format(criteria_type, provider['id'], username),
-                )
+                message = 'Institution SSO Error: invalid criteria [{}]; ' \
+                          'primary=[{}], username=[{}]'.format(criteria_type, provider['id'], username)
+                logger.error(message)
+                sentry.log_message(message)
 
         # Use given name and family name to build full name if it is not provided
         if given_name and family_name and not fullname:
@@ -171,8 +166,9 @@ class InstitutionAuthentication(BaseAuthentication):
 
         # Non-empty full name is required. Fail the auth and inform sentry if not provided.
         if not fullname:
-            message = 'Institution login failed: fullname required for ' \
-                      'user "{}" from institution "{}"'.format(username, provider['id'])
+            message = 'Institution SSO Error: missing fullname ' \
+                      'for user [{}] from institution [{}]'.format(username, provider['id'])
+            logger.error(message)
             sentry.log_message(message)
             raise AuthenticationFailed(message)
 
@@ -188,7 +184,7 @@ class InstitutionAuthentication(BaseAuthentication):
         if not created:
             try:
                 drf.check_user(user)
-                logger.info('Institution SSO: active user "{}"'.format(username))
+                logger.info('Institution SSO: active user [{}]'.format(username))
             except exceptions.UnclaimedAccountError:
                 # Unclaimed user (i.e. a user that has been added as an unregistered contributor)
                 user.unclaimed_records = {}
@@ -196,7 +192,7 @@ class InstitutionAuthentication(BaseAuthentication):
                 # Unclaimed users have an unusable password when being added as an unregistered
                 # contributor. Thus a random usable password must be assigned during activation.
                 new_password_required = True
-                logger.info('Institution SSO: unclaimed contributor "{}"'.format(username))
+                logger.warning('Institution SSO: unclaimed contributor [{}]'.format(username))
             except exceptions.UnconfirmedAccountError:
                 if user.has_usable_password():
                     # Unconfirmed user from default username / password signup
@@ -206,26 +202,24 @@ class InstitutionAuthentication(BaseAuthentication):
                     # sign-up. However, it must be overwritten by a new random one so the creator
                     # (if he is not the real person) can not access the account after activation.
                     new_password_required = True
-                    logger.info('Institution SSO: unconfirmed user "{}"'.format(username))
+                    logger.warning('Institution SSO: unconfirmed user [{}]'.format(username))
                 else:
                     # Login take-over has not been implemented for unconfirmed user created via
                     # external IdP login (ORCiD).
-                    message = 'Institution SSO is not eligible for an unconfirmed account ' \
-                              'created via external IdP login: username = "{}"'.format(username)
+                    message = 'Institution SSO Error: SSO is not eligible for an unconfirmed account [{}] ' \
+                              'created via IdP login'.format(username)
                     sentry.log_message(message)
                     logger.error(message)
                     return None, None
             except exceptions.DeactivatedAccountError:
                 # Deactivated user: login is not allowed for deactivated users
-                message = 'Institution SSO is not eligible for a deactivated account: ' \
-                          'username = "{}"'.format(username)
+                message = 'Institution SSO Error: SSO is not eligible for a deactivated account: [{}]'.format(username)
                 sentry.log_message(message)
                 logger.error(message)
                 return None, None
             except exceptions.MergedAccountError:
                 # Merged user: this shouldn't happen since merged users do not have an email
-                message = 'Institution SSO is not eligible for a merged account: ' \
-                          'username = "{}"'.format(username)
+                message = 'Institution SSO Error: SSO is not eligible for a merged account: [{}]'.format(username)
                 sentry.log_message(message)
                 logger.error(message)
                 return None, None
@@ -233,13 +227,13 @@ class InstitutionAuthentication(BaseAuthentication):
                 # Other invalid status: this shouldn't happen unless the user happens to be in a
                 # temporary state. Such state requires more updates before the user can be saved
                 # to the database. (e.g. `get_or_create_user()` creates a temporary-state user.)
-                message = 'Institution SSO is not eligible for an inactive account with ' \
-                          'an unknown or invalid status: username = "{}"'.format(username)
+                message = 'Institution SSO Error: SSO is not eligible for an inactive account [{}] ' \
+                          'with an unknown or invalid status'.format(username)
                 sentry.log_message(message)
                 logger.error(message)
                 return None, None
         else:
-            logger.info('Institution SSO: new user "{}"'.format(username))
+            logger.info('Institution SSO: new user [{}]'.format(username))
 
         # The `department` field is updated each login when it was changed.
         user_guid = user.guids.first()._id
@@ -247,11 +241,11 @@ class InstitutionAuthentication(BaseAuthentication):
             if user.department != department:
                 user.department = department
                 user.save()
-            logger.info('Institution SSO: user w/ dept: user={}, email={}, inst={} and '
-                        'dept={}'.format(user_guid, username, institution._id, department))
+            logger.info('Institution SSO: user w/ dept: user=[{}], email=[{}], inst=[{}], '
+                        'dept=[{}]'.format(user_guid, username, institution._id, department))
         else:
-            logger.info('Institution SSO: user w/o dept: user={}, email={} and '
-                        'inst={}'.format(user_guid, username, institution._id))
+            logger.info('Institution SSO: user w/o dept: user=[{}], email=[{}], '
+                        'inst=[{}]'.format(user_guid, username, institution._id))
 
         # Both created and activated accounts need to be updated and registered
         if created or activation_required:

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -107,7 +107,7 @@ class TestInstitutionAuth:
         user = OSFUser.objects.filter(username=username).first()
         assert user
         assert user.fullname == 'Fake User'
-        assert user.accepted_terms_of_service is not None
+        assert user.accepted_terms_of_service is None
         assert institution in user.affiliated_institutions.all()
 
     def test_existing_user_found_but_not_affiliated(self, app, institution, url_auth_institution):
@@ -413,7 +413,7 @@ class TestInstitutionAuthnSharedSSO:
         user = OSFUser.objects.filter(username=username).first()
         assert user
         assert user.fullname == 'Fake User'
-        assert user.accepted_terms_of_service is not None
+        assert user.accepted_terms_of_service is None
         assert institution_primary in user.affiliated_institutions.all()
         assert institution_secondary not in user.affiliated_institutions.all()
 
@@ -432,7 +432,7 @@ class TestInstitutionAuthnSharedSSO:
         user = OSFUser.objects.filter(username=username).first()
         assert user
         assert user.fullname == 'Fake User'
-        assert user.accepted_terms_of_service is not None
+        assert user.accepted_terms_of_service is None
         assert institution_primary in user.affiliated_institutions.all()
         assert institution_secondary in user.affiliated_institutions.all()
 


### PR DESCRIPTION
## Purpose

Support newCAS `prod` release. This PR replaces https://github.com/CenterForOpenScience/osf.io/pull/9595 due to branch name change (`feature/` -> `hotfix/`)

## DevOps Notes

@mfraezz

* "commit-by-commit" code review is preferred for this PR.
* In addition to OSF and API unit tests, both success and failure scenarios have been fully tested locally with Postman test suite (SAML institutions) and with fakeCAS as an IdP server (CAS institutions).
- [ ] Must be deployed at the same time as newCAS. Either newCAS or OSF can go first since they will not crash each other. The new feature only takes effect when both are up.

## Changes

### OSF

https://github.com/CenterForOpenScience/osf.io/pull/9678/commits/8e09ae5c9ed455035f18cce6ae5d099364c2e206

[ENG-2442](https://openscience.atlassian.net/browse/ENG-2442) with [newCAS-PR-#15](https://github.com/CenterForOpenScience/osf-cas/pull/15) introduces a new feature where `newCAS` is now able to check whether users have agreed to terms of service during login and ask them to check the consent checkbox if not at the final step of login. This information is then released to OSF via authentication attributes.

If users check the TOS consent checkbox via CAS, CAS sets the attribute `termsOfServiceChecked` to `true` and then release it to OSF among other authentication attributes. When OSF receives it, it trusts CAS and updates the user object if this is THE FINAL STEP of the login flow. DON'T update TOS consent status when `external_credential == true` (i.e. w/ `action == 'authenticate'` or `action == 'external_first_login'`) since neither is the final step of a login flow.

### API

https://github.com/CenterForOpenScience/osf.io/pull/9678/commits/6dff2029223bf7541cf82bc2cd777a8e51cb48d3

Removed TOS user consent update in API institution authentication endpoint since 1) the temporary front-end based TOS user consent check has been replaced with a proper back-end solution with newCAS, and 2) the consent update is taken care of during the CAS (protocol) authn process between newCAS and OSF.

### Other

* Added info-level logging to monitor the department attribute during instn SSO: https://github.com/CenterForOpenScience/osf.io/pull/9678/commits/88ad22b66401fe1b0f481e9cd59fb19316657e24
* Improved and normalized institution authentication logs: https://github.com/CenterForOpenScience/osf.io/pull/9678/commits/37825227389b3e00d91dbcb26b3bf7ecdf630a80
* Update existing / add new tests: https://github.com/CenterForOpenScience/osf.io/pull/9678/commits/cc23e792a4bfa6132d010a9e3564b6667e75b7e1

## QA Notes

N / A

## Documentation

N / A

## Side Effects

N / A

## Ticket

https://openscience.atlassian.net/browse/ENG-2813
