### PR TITLE
[ENG-2596] fix issue of source pulling from node object and causing validation e…

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1210,7 +1210,7 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
     Overrides NodeContributorsSerializer to add email, full_name, send_email, and non-required index and users field.
     """
 
-    id = IDField(source='_id', required=False, allow_null=True)
+    id = IDField(source='user._id', required=False, allow_null=True)
     full_name = ser.CharField(required=False)
     email = ser.EmailField(required=False, source='user.email', write_only=True)
     index = ser.IntegerField(required=False, source='_order')


### PR DESCRIPTION

## Purpose

When POSTing to `v2/nodes/<node_id>/contributors` to create an unregistered contributor, the API responds with 400 and an error message that reads "Do not provide an email when providing this user_id". 


## Changes

- Changes source argument to be specific for user, before it was pulling from the node

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that adding a contributor with the ticketed payload works.

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-2596