### PR TITLE
Ensuring akismet isn't trained when auto banning users [ENG-2879]

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1992,13 +1992,13 @@ class SpamOverrideMixin(SpamMixin):
     def get_spam_fields(self):
         return NotImplementedError()
 
-    def confirm_spam(self, save=True):
+    def confirm_spam(self, save=True, train_akismet=True):
         """
         This should add behavior specific nodes/preprints confirmed to be spam.
         :param save:
         :return:
         """
-        super().confirm_spam(save=save)
+        super().confirm_spam(save=save, train_akismet=train_akismet)
         self.deleted = timezone.now()
         was_public = self.is_public
         self.set_privacy('private', auth=None, log=False, save=False)
@@ -2014,13 +2014,13 @@ class SpamOverrideMixin(SpamMixin):
         if save:
             self.save()
 
-    def confirm_ham(self, save=False):
+    def confirm_ham(self, save=False, train_akismet=True):
         """
         This should add behavior specific nodes/preprints confirmed to be ham.
         :param save:
         :return:
         """
-        super().confirm_ham()
+        super().confirm_ham(save=save, train_akismet=train_akismet)
 
         if self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]):
             spam_log = self.logs.filter(action__in=[self.log_class.FLAG_SPAM, self.log_class.CONFIRM_SPAM]).latest()

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2110,11 +2110,10 @@ class SpamOverrideMixin(SpamMixin):
         ):
             self.suspend_spam_user(user)
 
-    def suspend_spam_user(self, user, set_spam=False):
+    def suspend_spam_user(self, user, train_akismet=True):
         if user.spam_status == SpamStatus.HAM:
             return False
-        if set_spam:
-            self.confirm_spam(save=True)
+        self.confirm_spam(save=True, train_akismet=train_akismet)
         self.set_privacy('private', log=False, save=True)
 
         # Suspend the flagged user for spam.
@@ -2134,15 +2133,13 @@ class SpamOverrideMixin(SpamMixin):
         # Make public nodes private from this contributor
         for node in user.all_nodes:
             if self._id != node._id and len(node.contributors) == 1 and node.is_public and not node.is_quickfiles:
-                if set_spam:
-                    node.confirm_spam(save=True)
+                node.confirm_spam(save=True, train_akismet=train_akismet)
                 node.set_privacy('private', log=False, save=True)
 
         # Make preprints private from this contributor
         for preprint in user.preprints.all():
             if self._id != preprint._id and len(preprint.contributors) == 1 and preprint.is_public:
-                if set_spam:
-                    preprint.confirm_spam(save=True)
+                preprint.confirm_spam(save=True, train_akismet=train_akismet)
                 preprint.set_privacy('private', log=False, save=True)
 
     def flag_spam(self):

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -150,11 +150,12 @@ class SpamMixin(models.Model):
         if save:
             self.save()
 
-    def confirm_ham(self, save=False):
+    def confirm_ham(self, save=False, train_akismet=True):
         # not all mixins will implement check spam pre-req, only submit ham when it was incorrectly flagged
         if (
             settings.SPAM_CHECK_ENABLED and
-            self.spam_data and self.spam_status in [SpamStatus.FLAGGED, SpamStatus.SPAM]
+            self.spam_data and self.spam_status in [SpamStatus.FLAGGED, SpamStatus.SPAM] and
+            train_akismet
         ):
             client = _get_akismet_client()
             client.submit_ham(
@@ -170,11 +171,12 @@ class SpamMixin(models.Model):
         if save:
             self.save()
 
-    def confirm_spam(self, save=False):
+    def confirm_spam(self, save=False, train_akismet=True):
         # not all mixins will implement check spam pre-req, only submit spam when it was incorrectly flagged
         if (
             settings.SPAM_CHECK_ENABLED and
-            self.spam_data and self.spam_status in [SpamStatus.UNKNOWN, SpamStatus.HAM]
+            self.spam_data and self.spam_status in [SpamStatus.UNKNOWN, SpamStatus.HAM] and
+            train_akismet
         ):
             client = _get_akismet_client()
             client.submit_spam(

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -43,6 +43,7 @@ from osf.models.contributor import Contributor, RecentlyAddedContributor
 from osf.models.institution import Institution
 from osf.models.mixins import AddonModelMixin
 from osf.models.nodelog import NodeLog
+from osf.models.preprintlog import PreprintLog
 from osf.models.spam import SpamMixin
 from osf.models.session import Session
 from osf.models.tag import Tag
@@ -1430,12 +1431,16 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
     def confirm_spam(self, save=True):
         super().confirm_spam(save=save)
         for node in self.nodes.filter(is_public=True, is_deleted=False).exclude(type='osf.quickfilesnode'):
-            node.confirm_spam()
+            node.confirm_spam(train_akismet=False)
+        for preprint in self.preprints.filter(is_public=True, is_deleted=False):
+            preprint.confirm_spam(train_akismet=False)
 
     def confirm_ham(self, save=False):
         super().confirm_ham(save=save)
         for node in self.nodes.filter(logs__action=NodeLog.CONFIRM_SPAM).exclude(type='osf.quickfilesnode'):
-            node.confirm_ham(save=save)
+            node.confirm_ham(save=save, train_akismet=False)
+        for preprint in self.preprints.filter(logs__action=PreprintLog.CONFIRM_SPAM):
+            preprint.confirm_ham(save=save, train_akismet=False)
 
     def update_search(self):
         from website.search.search import update_user

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1432,7 +1432,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         super().confirm_spam(save=save)
         for node in self.nodes.filter(is_public=True, is_deleted=False).exclude(type='osf.quickfilesnode'):
             node.confirm_spam(train_akismet=False)
-        for preprint in self.preprints.filter(is_public=True, is_deleted=False):
+        for preprint in self.preprints.filter(is_public=True, deleted__isnull=True):
             preprint.confirm_spam(train_akismet=False)
 
     def confirm_ham(self, save=False):

--- a/scripts/find_spammy_content.py
+++ b/scripts/find_spammy_content.py
@@ -68,5 +68,5 @@ def find_spammy_content(regex, days, model, ban):
             item_data['fullname'] = item.creator.fullname
             data.append(item_data)
             if ban:
-                item.suspend_spam_user(item.creator, set_spam=True)
+                item.suspend_spam_user(item.creator, train_akismet=False)
     return data


### PR DESCRIPTION


## Purpose

Refraining from training akismet when users are auto banned due to throttling.
## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-2879