### PR TITLE
Hotfix/fixing mass ham perm issues [hotfix] [ENG-2883]

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -355,7 +355,7 @@ class NodeFlaggedSpamList(NodeSpamList, DeleteView):
 
     def delete(self, request, *args, **kwargs):
         if (('spam_confirm' in list(request.POST.keys()) and not request.user.has_perm('osf.mark_spam')) or
-                ('ham_confirm' in list(request.POST.keys()) and not request.user.has_perm('osf.mark_ham'))):
+                ('ham_confirm' in list(request.POST.keys()) and not request.user.has_perm('osf.mark_spam'))):
             raise PermissionDenied('You do not have permission to update a node flagged as spam.')
         node_ids = [
             nid for nid in list(request.POST.keys())

--- a/admin/templates/nodes/node_list.html
+++ b/admin/templates/nodes/node_list.html
@@ -94,8 +94,6 @@
 </table>
 {% if form_action and perms.osf.mark_spam %}
     {% include 'nodes/ham_spam_modal.html' with target_type="spam" %}
-{% endif %}
-{% if form_action and perms.osf.mark_ham %}
     {% include 'nodes/ham_spam_modal.html' with target_type="ham" %}
 {% endif %}
 {% csrf_token %}

--- a/admin/templates/preprints/preprint_list.html
+++ b/admin/templates/preprints/preprint_list.html
@@ -59,8 +59,6 @@
 </table>
 {% if form_action and perms.osf.mark_spam %}
     {% include 'preprints/ham_spam_modal.html' with target_type="spam" %}
-{% endif %}
-{% if form_action and perms.osf.mark_ham %}
     {% include 'preprints/ham_spam_modal.html' with target_type="ham" %}
 {% endif %}
 {% csrf_token %}

--- a/admin/templates/users/user_list.html
+++ b/admin/templates/users/user_list.html
@@ -57,8 +57,6 @@
 </table>
 {% if form_action and perms.osf.mark_spam %}
     {% include 'users/ham_spam_modal.html' with target_type="spam" %}
-{% endif %}
-{% if form_action and perms.osf.mark_ham %}
     {% include 'users/ham_spam_modal.html' with target_type="ham" %}
 {% endif %}
 {% csrf_token %}


### PR DESCRIPTION

## Purpose

On the mass ham buttons for some reason theres an unimplemented mark_ham permission thats preventing OSF admins from being able to mark mass ham. This hotfix removes that permission in favor of just checking mark spam.
## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/ENG-2883