### PR TITLE
[ENG-2927] Send emails to institution users upon deactivation

### DIFF
--- a/admin/institutions/views.py
+++ b/admin/institutions/views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import logging
 
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -17,7 +18,12 @@ from django.views.generic.edit import FormView
 from admin.base import settings
 from admin.base.forms import ImportFileForm
 from admin.institutions.forms import InstitutionForm, InstitutionalMetricsAdminRegisterForm
+from framework import sentry
 from osf.models import Institution, Node, OSFUser
+from website.mails import send_mail, INSTITUTION_DEACTIVATION
+from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
+
+logger = logging.getLogger(__name__)
 
 
 class InstitutionList(PermissionRequiredMixin, ListView):
@@ -204,7 +210,37 @@ class DeactivateInstitution(PermissionRequiredMixin, UpdateView):
         institution = self.get_object()
         institution.deactivated = timezone.now()
         institution.save()
+        # Django mangers aren't used when querying on related models. Thus, we can query
+        # affiliated users and send notification emails after the institution has been deactivated.
+        self._send_deactivation_email(institution)
         return redirect('institutions:detail', institution_id=institution.id)
+
+    @staticmethod
+    def _send_deactivation_email(institution):
+        forgot_password = 'forgotpassword' if DOMAIN.endswith('/') else '/forgotpassword'
+        attempts = 0
+        success = 0
+        # Use iterator to reduce potential memory load when there are a lot of users. The side
+        # effect is that this disables QuerySet caching. This is fine since it isn't used again.
+        for user in OSFUser.objects.filter(affiliated_institutions___id=institution._id).iterator():
+            try:
+                attempts += 1
+                send_mail(
+                    to_addr=user.username,
+                    mail=INSTITUTION_DEACTIVATION,
+                    user=user,
+                    forgot_password_link='{}{}'.format(DOMAIN, forgot_password),
+                    osf_support_email=OSF_SUPPORT_EMAIL
+                )
+            except Exception:
+                logger.error('Failed to send institution deactivation email to '
+                             'user [{}] at [{}]'.format(user._id, institution._id))
+                sentry.log_exception()
+                continue
+            else:
+                success += 1
+        logger.info('Institution deactivation notification email has been sent to '
+                    '[{}/{}] users for [{}]'.format(success, attempts, institution._id))
 
 
 class ReactivateInstitution(PermissionRequiredMixin, UpdateView):
@@ -231,6 +267,7 @@ class CannotDeleteInstitution(TemplateView):
         context = super(CannotDeleteInstitution, self).get_context_data(**kwargs)
         context['institution'] = Institution.objects.get_all_institutions().get(id=self.kwargs['institution_id'])
         return context
+
 
 class InstitutionalMetricsAdminRegister(PermissionRequiredMixin, FormView):
     permission_required = 'osf.change_institution'

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -184,14 +184,13 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
                     osf_support_email=website_settings.OSF_SUPPORT_EMAIL
                 )
             except Exception:
-                logger.error('Failed to send institution deactivation email to '
-                             'user [{}] at [{}]'.format(user._id, self._id))
+                logger.error(f'Failed to send institution deactivation email to user [{user._id}] at [{self._id}]')
                 sentry.log_exception()
                 continue
             else:
                 success += 1
-        logger.info('Institution deactivation notification email has been sent to '
-                    '[{}/{}] users for [{}]'.format(success, attempts, self._id))
+        logger.info(f'Institution deactivation notification email has been '
+                    f'sent to [{success}/{attempts}] users for [{self._id}]')
 
     def deactivate(self):
         """Deactivate an active institution, update OSF search and send emails to all affiliated users.
@@ -203,8 +202,9 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
             # affiliated users and send notification emails after the institution has been deactivated.
             self._send_deactivation_email()
         else:
-            logger.warning('Action rejected - deactivating an inactive institution [{}].'.format(self._id))
-            sentry.log_message('Action rejected - deactivating an inactive institution [{}]'.format(self._id))
+            message = f'Action rejected - deactivating an inactive institution [{self._id}].'
+            logger.warning(message)
+            sentry.log_message(message)
 
     def reactivate(self):
         """Reactivate an inactive institution and update OSF search without sending out emails.
@@ -213,8 +213,9 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
             self.deactivated = None
             self.save()
         else:
-            logger.warning('Action rejected - reactivating an active institution [{}].'.format(self._id))
-            sentry.log_message('Action rejected - reactivating an active institution [{}]'.format(self._id))
+            message = f'Action rejected - reactivating an active institution [{self._id}].'
+            logger.warning(message)
+            sentry.log_message(message)
 
 
 @receiver(post_save, sender=Institution)

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -16,8 +16,8 @@ from osf.utils.fields import NonNaiveDateTimeField
 from osf.models import base
 from osf.models.contributor import InstitutionalContributor
 from osf.models.mixins import Loggable, GuardianMixin
+from website import mails
 from website import settings as website_settings
-from website.mails import send_mail, INSTITUTION_DEACTIVATION
 
 logger = logging.getLogger(__name__)
 
@@ -176,9 +176,9 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
         for user in self.osfuser_set.all():
             try:
                 attempts += 1
-                send_mail(
+                mails.send_mail(
                     to_addr=user.username,
-                    mail=INSTITUTION_DEACTIVATION,
+                    mail=mails.INSTITUTION_DEACTIVATION,
                     user=user,
                     forgot_password_link='{}{}'.format(website_settings.DOMAIN, forgot_password),
                     osf_support_email=website_settings.OSF_SUPPORT_EMAIL

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -1,9 +1,12 @@
+import mock
+import pytest
+
 from django.utils import timezone
 from past.builtins import basestring
-from osf.models import Institution
 
-from .factories import InstitutionFactory, AuthUserFactory
-import pytest
+from osf.models import Institution
+from osf_tests.factories import InstitutionFactory, AuthUserFactory, UserFactory
+from website import mails, settings
 
 
 @pytest.mark.django_db
@@ -103,3 +106,65 @@ class TestInstitutionManager:
         institution.deactivated = timezone.now()
         institution.save()
         assert institution in Institution.objects.get_all_institutions()
+
+    def test_deactivate_institution(self):
+        institution = InstitutionFactory()
+        with mock.patch.object(
+                institution,
+                '_send_deactivation_email',
+                return_value=None
+        ) as mock__send_deactivation_email:
+            institution.deactivate()
+            assert institution.deactivated is not None
+            assert mock__send_deactivation_email.called
+
+    def test_reactivate_institution(self):
+        institution = InstitutionFactory()
+        institution.deactivated = timezone.now()
+        institution.save()
+        institution.reactivate()
+        assert institution.deactivated is None
+
+    @mock.patch('website.mails.send_mail', return_value=None, side_effect=mails.send_mail)
+    def test_send_deactivation_email_call_count(self, mock_send_mail):
+        institution = InstitutionFactory()
+        user_1 = UserFactory()
+        user_1.affiliated_institutions.add(institution)
+        user_1.save()
+        user_2 = UserFactory()
+        user_2.affiliated_institutions.add(institution)
+        user_2.save()
+        institution._send_deactivation_email()
+        assert mock_send_mail.call_count == 2
+
+    def test_send_deactivation_email_call_args(self):
+        institution = InstitutionFactory()
+        user = UserFactory()
+        user.affiliated_institutions.add(institution)
+        user.save()
+        with mock.patch.object(mails, 'send_mail', return_value=None, side_effect=mails.send_mail) as mock_send_mail:
+            institution._send_deactivation_email()
+            forgot_password = 'forgotpassword' if settings.DOMAIN.endswith('/') else '/forgotpassword'
+            mock_send_mail.assert_called_with(
+                to_addr=user.username,
+                mail=mails.INSTITUTION_DEACTIVATION,
+                user=user,
+                forgot_password_link='{}{}'.format(settings.DOMAIN, forgot_password),
+                osf_support_email=settings.OSF_SUPPORT_EMAIL
+            )
+
+    def test_deactivate_inactive_institution_noop(self):
+        institution = InstitutionFactory()
+        institution.deactivated = timezone.now()
+        institution.save()
+        with mock.patch.object(institution, 'save', return_value=None) as mock_save:
+            institution.deactivate()
+            assert not mock_save.called
+
+    def test_reactivate_active_institution_noop(self):
+        institution = InstitutionFactory()
+        institution.deactivated = None
+        institution.save()
+        with mock.patch.object(institution, 'save', return_value=None) as mock_save:
+            institution.reactivate()
+            assert not mock_save.called

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -475,3 +475,8 @@ STORAGE_CAP_EXCEEDED_ANNOUNCEMENT = Mail(
     'storage_cap_exceeded_announcement',
     subject='Action Required to avoid disruption to your OSF project',
 )
+
+INSTITUTION_DEACTIVATION = Mail(
+    'institution_deactivation',
+    subject='Your OSF login methods are changing'
+)

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -478,5 +478,5 @@ STORAGE_CAP_EXCEEDED_ANNOUNCEMENT = Mail(
 
 INSTITUTION_DEACTIVATION = Mail(
     'institution_deactivation',
-    subject='Your OSF login methods are changing'
+    subject='Your OSF login has changed - here\'s what you need to know!'
 )

--- a/website/templates/emails/institution_deactivation.html.mako
+++ b/website/templates/emails/institution_deactivation.html.mako
@@ -1,0 +1,27 @@
+<%inherit file="notify_base.mako" />
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <h3 class="text-center" style="padding: 0;margin: 0;border: none;list-style: none;font-weight: 300;text-align: center;">Your OSF login methods are changing</h3>
+  </td>
+</tr>
+<tr>
+  <td style="border-collapse: collapse;">
+    Hello, ${user.fullname},<br>
+    <br>
+    Beginning today, login through your institution will no longer grant access to OSF.  <b>However, you will not lose access to your account or any of your OSF content.</b><br>
+    <br>
+    You can still access your account with an OSF password or with ORCID login.  Enabling multiple login methods will ensure that you maintain access to your OSF account even if you change your email address or other details.<br>
+    <br>
+    If you have already set an OSF password you are ready to log back into the OSF.  If you need to set an OSF password or if you are not sure if you have set one before, set a password here:<br>
+    <br>
+    <a href="${forgot_password_link}">${forgot_password_link}</a>,<br>
+    <br>
+    If you have issues setting a password for OSF, have issues logging in, or need help with your account, contact <a href="mailto:${osf_support_email}">${osf_support_email}</a>.<br>
+    <br>
+    Sincerely,<br>
+    <br>
+    The OSF Team<br>
+  </td>
+</tr>
+</%def>

--- a/website/templates/emails/institution_deactivation.html.mako
+++ b/website/templates/emails/institution_deactivation.html.mako
@@ -2,22 +2,23 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-    <h3 class="text-center" style="padding: 0;margin: 0;border: none;list-style: none;font-weight: 300;text-align: center;">Your OSF login methods are changing</h3>
+    <h3 class="text-center" style="padding: 0;margin: 0;border: none;list-style: none;font-weight: 300;text-align: center;">Your OSF login has changed - here's what you need to know!</h3>
   </td>
 </tr>
 <tr>
   <td style="border-collapse: collapse;">
     Hello, ${user.fullname},<br>
     <br>
-    Beginning today, login through your institution will no longer grant access to OSF.  <b>However, you will not lose access to your account or any of your OSF content.</b><br>
+    Starting today, you can no longer sign into OSF using your institution's SSO. However, you will not lose access to your account or your OSF content.<br>
     <br>
-    You can still access your account with an OSF password or with ORCID login.  Enabling multiple login methods will ensure that you maintain access to your OSF account even if you change your email address or other details.<br>
+    You can still access your OSF account using your institutional email by adding a password, or using your ORCID credentials (if your institutional email address is associated with your ORCID record).
+      We also recommend having multiple ways to access your account by <a href="https://help.osf.io/hc/en-us/articles/360019737194-Sign-in-to-OSF#Sign-in-through-ORCID--">connecting your ORCID</a>
+      or <a href="https://help.osf.io/hc/en-us/articles/360019738034-Add-a-New-Email-Address-to-Your-Account">alternate email addresses</a> with your account.<br>
     <br>
-    If you have already set an OSF password you are ready to log back into the OSF.  If you need to set an OSF password or if you are not sure if you have set one before, set a password here:<br>
+    Click <a href="${forgot_password_link}">here</a> to set a password<br>
     <br>
-    <a href="${forgot_password_link}">${forgot_password_link}</a>,<br>
-    <br>
-    If you have issues setting a password for OSF, have issues logging in, or need help with your account, contact <a href="mailto:${osf_support_email}">${osf_support_email}</a>.<br>
+    If you have any issues, questions or need our help, contact <a href="mailto:${osf_support_email}">${osf_support_email}</a> and we will be happy to assist.
+      You may find this <a href="https://help.osf.io/hc/en-us/articles/4403227058327-I-can-t-find-my-institution">help guide</a> useful.<br>
     <br>
     Sincerely,<br>
     <br>


### PR DESCRIPTION
## Purpose

Send emails to institution users upon deactivation

## Changes

* Send the following email to all users affiliated with the deactivated institution.

<img width="838" alt="Screen Shot 2021-06-28 at 3 49 26 PM" src="https://user-images.githubusercontent.com/3750414/123695417-8533fb80-d828-11eb-8581-c4a8108a037c.png">

* Django mangers aren't used when querying on related models. Thus, we can query affiliated users and send notification emails after the institution has been deactivated.

* Failure in sending emails will be logged and sent to sentry.

* Success # and attempts # are logged

```
[admin.institutions.views]  INFO: Institution deactivation notification email has been sent to [5/5] users for [cord]
```

* Attempts to deactivate an inactive institution and reactivate an active institution are rejected and logged.

```
admin_1             | [osf.models.institution]  WARNING: Action rejected - deactivating an inactive institution [cord].
admin_1             | [framework.sentry]  WARNING: Sentry called to log message, but is not active: Action rejected - deactivating an inactive institution [cord]
```

* Expanded

## QA Notes

* Verify users receive the email after deactivation within a reasonable time.
* Verify the links in the email works as expected.
* Try institutions with lots of users on staging servers. COS is a good one to test.

## Documentation

N / A

## Side Effects

N / A

## Ticket

https://openscience.atlassian.net/browse/ENG-2927
