### PR TITLE
Deindex private nodes from search

### DIFF
--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -5,9 +5,11 @@
 <head>
     <meta charset="utf-8">
     <title>OSF | ${self.title()}</title>
-    % if settings.GOOGLE_SITE_VERIFICATION:
+    % if settings.GOOGLE_SITE_VERIFICATION and node and node['is_public']:
         <meta name="google-site-verification" content="${settings.GOOGLE_SITE_VERIFICATION}" />
-    % endif
+    % else:
+        <meta name="robots" content="noindex">
+    % endif:
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="${self.description()}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
## Purpose

Stop making private node metadata visible in search.

## Changes

- slightly modify base page to remove private node from indexing.


## Documentation

bug fix, no doc.

## Side Effects

None that I know of.