### PR TITLE
Replace abstract in elastic index

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -889,8 +889,9 @@ def create_index(index=None):
                     'programArea': NOT_ANALYZED_PROPERTY,
                     'provider': NOT_ANALYZED_PROPERTY,
                     'title': ENGLISH_ANALYZER_PROPERTY,
+                    'abstract': ENGLISH_ANALYZER_PROPERTY,
                     'schoolType': NOT_ANALYZED_PROPERTY,
-                    'studyDesign': NOT_ANALYZED_PROPERTY
+                    'studyDesign': NOT_ANALYZED_PROPERTY,
                 }
             }
         else:


### PR DESCRIPTION
## Purpose

We accidentally removed abstract from the elastic index recently; this puts it back.

## Changes

1. Add `abstract` back to elastic index
2. Add a trailing comma to the last item in the dict

## Side Effects

Shouldn't be.

## Ticket

N/A
