### PR TITLE
remove logs endpoint link and fix withdraw behavior

### DIFF
--- a/admin/templates/internet_archive/internet_archive.html
+++ b/admin/templates/internet_archive/internet_archive.html
@@ -105,16 +105,6 @@
                         >{{ osf_pigeon_url }}</b>
                     </li>
                     <li>
-                        Pigeon Logs:
-                        <a
-                                data-toggle="tooltip"
-                                data-placement="bottom"
-                                title="The url to download the most recent Pigeon logs, this may not be able if you are
-                                on a production server."
-                                href="{{ osf_pigeon_url }}logs"
-                        >Logs</a>
-                    </li>
-                    <li>
                         <a href="https://archive.org/advancedsearch.php?q=collection%3A({{ ia_collection }})">
                             Use this Search page to find synced data in our collection
                         </a>

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -199,7 +199,7 @@ def has_pigeon_scope(request):
     if token is None or not isinstance(token, CasResponse):
         return False
 
-    if token['accessToken'] == website_settings.PIGEON_CALLBACK_BEARER_TOKEN:
+    if token.attributes['accessToken'] == website_settings.PIGEON_CALLBACK_BEARER_TOKEN:
         return True
     else:
         return False

--- a/conftest.py
+++ b/conftest.py
@@ -234,7 +234,7 @@ def mock_pigeon():
 
     with mock.patch.object(website_settings, 'IA_ARCHIVE_ENABLED', True):
         with mock.patch.object(website_settings, 'OSF_PIGEON_URL', 'http://test.pigeon.osf.io/'):
-            with mock.patch('osf.external.internet_archive.tasks.OSF_PIGEON_URL', 'http://test.pigeon.osf.io/'):
+            with mock.patch('osf.external.internet_archive.tasks.settings.OSF_PIGEON_URL', 'http://test.pigeon.osf.io/'):
                 with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
                     rsps.add_callback(
                         method=responses.POST,

--- a/osf/external/internet_archive/tasks.py
+++ b/osf/external/internet_archive/tasks.py
@@ -3,20 +3,22 @@ from django.apps import apps
 from osf.utils.requests import requests_retry_session
 from framework.celery_tasks import app
 from framework.postcommit_tasks.handlers import get_task_from_postcommit_queue, enqueue_postcommit_task
+from osf.utils.workflows import RegistrationModerationStates
 
-from website.settings import OSF_PIGEON_URL
+from website import settings
 
 
 @app.task(max_retries=5, default_retry_delay=60, ignore_results=False)
 def _archive_to_ia(node_id):
-    requests_retry_session().post(f'{OSF_PIGEON_URL}archive/{node_id}')
+    requests_retry_session().post(f'{settings.OSF_PIGEON_URL}archive/{node_id}')
 
 def archive_to_ia(node):
-    enqueue_postcommit_task(_archive_to_ia, (node._id,), {}, celery=True)
+    if settings.IA_ARCHIVE_ENABLED:
+        enqueue_postcommit_task(_archive_to_ia, (node._id,), {}, celery=True)
 
 @app.task(max_retries=5, default_retry_delay=60, ignore_results=False)
 def _update_ia_metadata(node_id, data):
-    requests_retry_session().post(f'{OSF_PIGEON_URL}metadata/{node_id}', json=data).raise_for_status()
+    requests_retry_session().post(f'{settings.OSF_PIGEON_URL}metadata/{node_id}', json=data).raise_for_status()
 
 def update_ia_metadata(node, data=None):
     """
@@ -25,20 +27,25 @@ def update_ia_metadata(node, data=None):
 
     IA wants us to brand our specific osf metadata with a `osf_` prefix. So we are following IA_MAPPED_NAMES.
     """
-    Registration = apps.get_model('osf.registration')
-    if not data:
-        allowed_metadata = Registration.SYNCED_WITH_IA.intersection(node.get_dirty_fields().keys())
-        data = {key: str(getattr(node, key)) for key in allowed_metadata}
+    if settings.IA_ARCHIVE_ENABLED:
 
-    for key in data.keys():
-        data[Registration.IA_MAPPED_NAMES.get(key, key)] = data.pop(key)
+        Registration = apps.get_model('osf.registration')
+        if not data:
+            allowed_metadata = Registration.SYNCED_WITH_IA.intersection(node.get_dirty_fields().keys())
+            data = {key: str(getattr(node, key)) for key in allowed_metadata}
 
-    if getattr(node, 'ia_url', None) and node.is_public:
-        task = get_task_from_postcommit_queue(
-            'framework.celery_tasks._update_ia_metadata',
-            predicate=lambda task: task.args[0] == node._id and data.keys() == task.args[1].keys()
-        )
-        if task:
-            task.args = (node._id, data, )
-        else:
-            enqueue_postcommit_task(_update_ia_metadata, (node._id, data, ), {}, celery=True)
+        for key in data.keys():
+            data[Registration.IA_MAPPED_NAMES.get(key, key)] = data.pop(key)
+
+        if node.moderation_state == RegistrationModerationStates.WITHDRAWN.db_name:
+            data['withdrawal_justification'] = node.retraction.justification
+
+        if getattr(node, 'ia_url', None) and node.is_public:
+            task = get_task_from_postcommit_queue(
+                'framework.celery_tasks._update_ia_metadata',
+                predicate=lambda task: task.args[0] == node._id and data.keys() == task.args[1].keys()
+            )
+            if task:
+                task.args = (node._id, data, )
+            else:
+                enqueue_postcommit_task(_update_ia_metadata, (node._id, data, ), {}, celery=True)

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -79,7 +79,6 @@ class Registration(AbstractNode):
         'modified',
         'category',
         'article_doi',
-        'moderation_state',
     }
     # IA wants us to brand our specific osf metadata with a `osf_` prefix or as their keyword.
     IA_MAPPED_NAMES = {
@@ -1549,7 +1548,7 @@ def sync_internet_archive_attributes(sender, instance, **kwargs):
     This ensures all our Internet Archive storage buckets are synced with our registrations. Valid fields to update are
      found in SYNCED_WITH_IA, other fields that use foreign keys are updated by other signals.
     """
-    if settings.IA_ARCHIVE_ENABLED and instance.is_public:
+    if instance.is_public:
         if not instance.ia_url:
             archive_to_ia(instance)
         else:
@@ -1558,28 +1557,26 @@ def sync_internet_archive_attributes(sender, instance, **kwargs):
 
 @receiver(post_save, sender=NodeLicenseRecord)
 def sync_internet_archive_license(sender, instance, **kwargs):
-    if settings.IA_ARCHIVE_ENABLED:
+    if instance.nodes.first():
         update_ia_metadata(instance.nodes.first(), {'license': instance.node_license.url})
 
 
 @receiver(models.signals.m2m_changed, sender=Registration.tags.through)
 def sync_internet_archive_tags(sender, instance, action, **kwargs):
-    if settings.IA_ARCHIVE_ENABLED:
-        update_ia_metadata(instance, {'tags': list(instance.tags.all().values_list('name', flat=True))})
+    update_ia_metadata(instance, {'tags': list(instance.tags.all().values_list('name', flat=True))})
 
 
 @receiver(models.signals.m2m_changed, sender=Registration.affiliated_institutions.through)
 def sync_internet_archive_institutions(sender, instance, action, **kwargs):
-    if settings.IA_ARCHIVE_ENABLED:
-        update_ia_metadata(
-            instance, {
-                'affiliated_institutions': list(instance.affiliated_institutions.all().values_list('name', flat=True))
-            }
-        )
+    update_ia_metadata(
+        instance,
+        {
+            'affiliated_institutions': list(instance.affiliated_institutions.all().values_list('name', flat=True))
+        }
+    )
 
 
 @receiver(models.signals.m2m_changed, sender=Registration.subjects.through)
 def sync_internet_archive_subjects(sender, instance, action, **kwargs):
-    if settings.IA_ARCHIVE_ENABLED:
-        subjects = list(instance.subjects.all().values_list('text', flat=True))
-        update_ia_metadata(instance, {'subjects': subjects})
+    subjects = list(instance.subjects.all().values_list('text', flat=True))
+    update_ia_metadata(instance, {'subjects': subjects})


### PR DESCRIPTION
## Purpose

Remove the logs link endpoint and improve withdraw behavior to add justifications, fix pigeon auth token.


## Changes

- Dry-up code by moving `IA_ARCHIVE_ENABLED` conditional
- Fix but getting attributes from token
- Remove pigeon logs link 
- add withdrawal_justification to data

## Side Effects

None that that I know of.


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
