### PR TITLE
[Draft] [WIP] [ENG-3098] [ENG-3180] Update/Create models and implement the preparation task

### DIFF
--- a/osf/models/__init__.py
+++ b/osf/models/__init__.py
@@ -53,3 +53,5 @@ from osf.models.blacklisted_email_domain import BlacklistedEmailDomain  # noqa
 from osf.models.brand import Brand  # noqa
 from osf.models.schema_response import SchemaResponse  # noqa
 from osf.models.schema_response_block import SchemaResponseBlock  # noqa
+from osf.models.registration_bulk_upload import RegistrationBulkUpload  # noqa
+from osf.models.bulk_uploaded_registration import BulkUploadedRegistration  # noqa

--- a/osf/models/bulk_uploaded_registration.py
+++ b/osf/models/bulk_uploaded_registration.py
@@ -1,0 +1,41 @@
+import logging
+
+from django.db import models
+
+from osf.models.base import BaseModel
+from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
+
+logger = logging.getLogger(__name__)
+
+
+class BulkUploadedRegistration(BaseModel):
+    """Defines a database table of which each row stores information about one to-be-created registration.
+    """
+
+    # The id that registration provider uses to identify each to-be-created registration in one upload
+    external_id = models.CharField(blank=False, null=False, max_length=255)
+
+    # The bulk upload to which this registration belongs
+    upload = models.ForeignKey('RegistrationBulkUpload', blank=False, null=True, on_delete=models.CASCADE)
+
+    # The draft registration that have been successfully created
+    draft_registration = models.ForeignKey('DraftRegistration', null=True, blank=True, on_delete=models.CASCADE)
+
+    # A flag that indicates whether the draft registration has been created
+    is_completed = models.BooleanField(default=False)
+
+    # A flag that indicates whether the draft registration creation is in progress
+    is_picked_up = models.BooleanField(default=False)
+
+    # The raw text string of a row in the CSV template
+    csv_raw = models.TextField(default='', blank=False, null=False, unique=True)
+
+    # The parsed version of the above raw text string.
+    # TODO: add/update comments here for the expected format of the value
+    csv_parsed = DateTimeAwareJSONField(default=dict, blank=False, null=False)
+
+    @classmethod
+    def create(cls, external_id, upload, csv_raw, csv_parsed):
+        registration_row = cls(external_id=external_id, upload=upload, draft_registration=None,
+                               is_completed=False, is_picked_up=False, csv_raw=csv_raw, csv_parsed=csv_parsed)
+        return registration_row

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -229,6 +229,7 @@ class RegistrationProvider(AbstractProvider):
     # [{'field_name': 'foo'}, {'field_name': 'bar'}]
     additional_metadata_fields = DateTimeAwareJSONField(blank=True)
     default_schema = models.ForeignKey(RegistrationSchema, related_name='default_schema', null=True, blank=True, on_delete=models.SET_NULL)
+    bulk_upload_auto_approval = models.NullBooleanField(default=False)
 
     def __init__(self, *args, **kwargs):
         self._meta.get_field('share_publish_type').default = 'Registration'

--- a/osf/models/registration_bulk_upload.py
+++ b/osf/models/registration_bulk_upload.py
@@ -1,0 +1,44 @@
+import logging
+
+from django.db import models
+
+from osf.models.base import BaseModel
+from osf.utils.fields import NonNaiveDateTimeField
+
+logger = logging.getLogger(__name__)
+
+
+class RegistrationBulkUpload(BaseModel):
+    """Defines a database table of which each row stores information about one registration bulk upload.
+    """
+
+    # The hash of the CSV template payload
+    payload_hash = models.CharField(blank=False, null=False, unique=True, max_length=255)
+
+    # The status/state of the bulk upload
+    state = models.CharField(choices=[
+        ('pending', 'Database preparation in progress'),
+        ('initialized', 'Database preparation done'),
+        ('picked_up', 'Registration creation in progress'),
+        ('done_full', 'Successful'),
+        ('done_partial', 'Partial'),
+        ('done_error', 'Failed'),
+    ], max_length=255)
+
+    # The user / admin who started this bulk upload
+    initiator = models.ForeignKey('OSFUser', null=True, on_delete=models.CASCADE)
+
+    # The registration provider this bulk upload targets
+    provider = models.ForeignKey('RegistrationProvider', null=True, on_delete=models.CASCADE)
+
+    # The registration template this bulk upload uses
+    schema = models.ForeignKey('RegistrationSchema', blank=False, null=True, on_delete=models.CASCADE)
+
+    # The date when success / failure emails are sent after the creation of registrations in this upload has been done
+    email_sent = NonNaiveDateTimeField(null=True, blank=True)
+
+    @classmethod
+    def create(cls, payload_hash, initiator, provider, schema):
+        upload = cls(payload_hash=payload_hash, state='pending',
+                     initiator=initiator, provider=provider, schema=schema, email_sent=None)
+        return upload

--- a/scripts/prepare_for_registration_bulk_creation.py
+++ b/scripts/prepare_for_registration_bulk_creation.py
@@ -1,0 +1,155 @@
+import logging
+
+from django.core.exceptions import ValidationError
+
+from framework.celery_tasks import app as celery_app
+from website.app import setup_django
+setup_django()
+
+from osf.models import OSFUser, RegistrationProvider, RegistrationBulkUpload, \
+                       BulkUploadedRegistration, RegistrationSchema
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@celery_app.task(name='scripts.prepare_for_registration_bulk_creation')
+def prepare_for_registration_bulk_creation(parsing_output, dry_run=False):
+
+    if not parsing_output:
+        logger.error('Missing CSV input')
+        return handle_internal_error()
+        # The following are temporarily hard-coded and used for local implementation/testing only. The format of
+        # the `csv_input` has mostly been determined, except for the `csv_parsed` which needs collaboration with
+        # the parser piece. The value of `csv_parsed` is expected to be a serializable object that can be pickled
+        # and un-pickled by celery automatically.
+        # parsing_output = {
+        #     'payload_hash': '07eef7ee-fc69-4e3a-9047-8d0e0a4cb909',
+        #     'provider_id': 'osf',
+        #     'schema_id': '60f74311ed3441000141b265',
+        #     'initiator_id': 't47ka',
+        #     'registrations': [
+        #         {
+        #             'external_id': '27093472',
+        #             'csv_raw': '1997,Ford,F250,Black',
+        #             'csv_parsed': {
+        #                 'year': 1997,
+        #                 'make': 'Ford',
+        #                 'model': 'F250',
+        #                 'color': 'Black',
+        #             },
+        #         },
+        #         {
+        #             'external_id': '98709987',
+        #             'csv_raw': '2000,Volkswagen,Golf,White',  # here goes the raw string of one row
+        #             'csv_parsed': {
+        #                 'year': 2000,
+        #                 'make': 'Volkswagen',
+        #                 'model': 'Golf',
+        #                 'color': 'White',
+        #             },
+        #         },
+        #         {
+        #             'external_id': '64510752',
+        #             'csv_raw': '2011,Subaru,WRX,Blue',  # here goes the raw string of
+        #             'csv_parsed': {
+        #                 'year': 2011,
+        #                 'make': 'Subaru',
+        #                 'model': 'WRX',
+        #                 'color': 'Blue',
+        #             },
+        #         },
+        #     ],
+        # }
+
+    logger.info('Preparing OSF database for registration bulk creation ...')
+    initiator_id = parsing_output.get('initiator_id', None)
+    if not initiator_id:
+        logger.error('Missing initiator id')  # internal error
+        return handle_internal_error()
+    initiator = OSFUser.load(initiator_id)
+    if not initiator:
+        logger.error('Initiator not found: [id={}]'.format(initiator_id))  # internal error
+        return handle_internal_error()
+
+    provider_id = parsing_output.get('provider_id', None)
+    if not provider_id:
+        logger.error('Missing provider id')  # internal error
+        return handle_internal_error()
+    provider = RegistrationProvider.objects.filter(_id=provider_id).first()
+    if not provider:
+        logger.error('Provider not found: [id={}] '.format(provider_id))  # internal error
+        return handle_internal_error()
+
+    schema_id = parsing_output.get('schema_id', None)
+    if not schema_id:
+        logger.error('Missing schema id')  # internal error
+        return handle_internal_error()
+    schema = RegistrationSchema.objects.filter(_id=schema_id).first()
+    if not schema:
+        logger.error('Schema not found: [id={}] '.format(provider_id))  # internal error
+        return handle_internal_error()
+
+    upload = RegistrationBulkUpload.create(parsing_output.get('payload_hash', ''), initiator, provider, schema)
+    logger.info('Inserting the bulk upload [hash={}] into the table RegistrationBulkUpload ...'.format(upload.payload_hash))
+    if not dry_run:
+        try:
+            upload.save()
+        except ValidationError as e:
+            logger.error('Insertion failed: [error={}, message={}]'.format(e.__class__.__name__, e.messages))
+            return handle_internal_error()
+
+        upload.reload()
+        logger.info('Bulk upload [pk={}, hash={}] inserted'.format(upload.id, upload.payload_hash))
+    else:
+        logger.info('Dry run: insertion into RegistrationBulkUpload not saved')
+
+    registrations = parsing_output.get('registrations', [])
+    if not registrations:
+        logger.error('Missing registration rows')  # internal error
+        return handle_internal_error()
+    for reg_row in registrations:
+        registration_row = BulkUploadedRegistration.create(
+            reg_row.get('external_id', ''), upload, reg_row.get('csv_raw', ''), reg_row.get('csv_parsed', {})
+        )
+        logger.info('Inserting the registration row [external_id={}] '
+                    'into the table BulkUploadedRegistration ...'.format(registration_row.external_id))
+        if not dry_run:
+            try:
+                registration_row.save()
+            except ValidationError as e:
+                logger.error('Insertion failed: [error={}, message={}]'.format(e.__class__.__name__, e.messages))
+                return handle_internal_error()
+            upload.reload()
+            logger.info('Registration row inserted: [pk={}, external_id={}, '
+                        'upload_id={}]'.format(registration_row.id, registration_row.external_id, upload.id))
+        else:
+            logger.info('Dry run: insertion into BulkUploadedRegistration not saved')
+
+    if not dry_run:
+        logger.info('Database successfully populated for bulk upload: [upload_id={}, provider_id={}, schema_id={}, '
+                    'initiator_id={}]'.format(upload.id, upload.provider._id, upload.schema._id, upload.initiator._id))
+        upload.state = 'initialized'
+        upload.save()
+        return
+    else:
+        logger.info("Dry run: complete")
+        return
+
+
+def handle_internal_error():
+    """Handle internal errors that are not caused by CSV template.
+    0. Roll back
+    1. Send an email to OSF Product team about the failure.
+    2. Send an email to the upload initiator and ask them to try again only after they have heard back from us.
+    """
+    pass
+
+
+def handle_external_error():
+    """Handle external errors that are caused by CSV template.
+    0. Roll back
+    1. Send an email to OSF Product team about the failure.
+    2. Send an email to the initiator and ask them to fix the CSV template.
+    """
+    pass


### PR DESCRIPTION
## Purpose

(Work in progress and don't merge; ~~I was not able create a draft PR~~ I was able to convert it ...)

* This PR covers the following three improvements
  * Update the registration provider model to support per-provider different registration states
  * Create two new models to support bulk upload
  * Create a celery task to prepare the OSF DB for bulk creating registrations

### Dev Notes

* The two new models has been changed to accommodate the task
  * FK `schema` has been removed from `BulkUploadedRegistration` and added to `RegistrationBulkUpload`. Otherwise, each registration row insertion requires query to get the FK object. This change is also consistent with the fact that both `schema` and `provider` are per-upload attributes.
  * Added `external_id` as suggested by @brianjgeiger as a useful reference for both the providers and us. `external_id` is not unique table-wise.

* @adlius In your API endpoint, call `prepare_for_registration_bulk_creation.delay()` to trigger the task.

```python
from scripts.prepare_for_registration_bulk_creation import prepare_for_registration_bulk_creation
...
prepare_for_registration_bulk_creation.delay(parsing_output, dry_run=False)
```

* @fabmiz Here is an example of what my task expects from the parsing outcome (when successful)

```python
parsing_output = {
    'payload_hash': '07eef7ee-fc69-4e3a-9047-8d0e0a4cb909',
    'provider_id': 'osf',
    'schema_id': '60f74311ed3441000141b265',
    'initiator_id': 't47ka',
    'registrations': [
        {
            'external_id': '27093472',
            'csv_raw': '<here goes the raw CSV row as text string>',
            'csv_parsed': csv_parsed,  # a serializable / pickable object 
        },
        ... (more rows) ...
    ],
}
```

* Here are a few local running logs:

```
worker_1            | [2021-08-31 02:58:43,218: INFO/MainProcess] Received task: scripts.prepare_for_registration_bulk_creation[c7027d38-991e-40c8-a914-245ee19524ee]
worker_1            | [2021-08-31 02:58:43,219: DEBUG/MainProcess] TaskPool: Apply <function _fast_trace_task at 0x7f6beede9ae8> (args:('scripts.prepare_for_registration_bulk_creation', 'c7027d38-991e-40c8-a914-245ee19524ee', {'lang': 'py', 'task': 'scripts.prepare_for_registration_bulk_creation', 'id': 'c7027d38-991e-40c8-a914-245ee19524ee', 'eta': None, 'expir
es': None, 'group': None, 'retries': 0, 'timelimit': [None, None], 'root_id': 'c7027d38-991e-40c8-a914-245ee19524ee', 'parent_id': None, 'argsrepr': '(None,)', 'kwargsrepr': "{'dry_run': False}", 'origin': 'gen175@941b62218fac', 'reply_to': 'f0285ec3-6805-30af-9741-edea8c7d040d', 'correlation_id': 'c7027d38-991e-40c8-a914-245ee19524ee', 'delivery_info': {'exchan
ge': '', 'routing_key': 'celery', 'priority': 0, 'redelivered': False}}, '[[null], {"dry_run": false}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]', 'application/json', 'utf-8') kwargs:{})
worker_1            | [2021-08-31 02:58:43,220: INFO/ForkPoolWorker-1] Preparing OSF database for registration bulk creation ...
worker_1            | [2021-08-31 02:58:43,229: DEBUG/MainProcess] Task accepted: scripts.prepare_for_registration_bulk_creation[c7027d38-991e-40c8-a914-245ee19524ee] pid:13
worker_1            | [2021-08-31 02:58:43,288: INFO/ForkPoolWorker-1] Inserting the bulk upload [hash=07eef7ee-fc69-4e3a-9047-8d0e0a4cb909] into the table RegistrationBulkUpload ...
worker_1            | [2021-08-31 02:58:43,328: INFO/ForkPoolWorker-1] The bulk upload [pk=7, hash=07eef7ee-fc69-4e3a-9047-8d0e0a4cb909] inserted
worker_1            | [2021-08-31 02:58:43,334: INFO/ForkPoolWorker-1] Inserting the registration row [external_id=c58ff40b-c15b-4362-ab3f-df2907c4264a] into the table BulkUploadedRegistrationRow ...
worker_1            | [2021-08-31 02:58:43,372: INFO/ForkPoolWorker-1] The registration row inserted: [pk=7, external_id=c58ff40b-c15b-4362-ab3f-df2907c4264a, upload_id=7]
worker_1            | [2021-08-31 02:58:43,378: INFO/ForkPoolWorker-1] Inserting the registration row [external_id=a7ea5da3-5d20-423d-84f2-9b498c98dcd5] into the table BulkUploadedRegistrationRow ...
worker_1            | [2021-08-31 02:58:43,420: INFO/ForkPoolWorker-1] The registration row inserted: [pk=8, external_id=a7ea5da3-5d20-423d-84f2-9b498c98dcd5, upload_id=7]
worker_1            | [2021-08-31 02:58:43,423: INFO/ForkPoolWorker-1] Inserting the registration row [external_id=9bea96ae-7900-4e3c-be5e-a5de6d15493c] into the table BulkUploadedRegistrationRow ...
worker_1            | [2021-08-31 02:58:43,453: INFO/ForkPoolWorker-1] The registration row inserted: [pk=9, external_id=9bea96ae-7900-4e3c-be5e-a5de6d15493c, upload_id=7]
worker_1            | [2021-08-31 02:58:43,455: INFO/ForkPoolWorker-1] Database successfully populated for bulk upload: [upload_id=7, provider_id=osf, schema_id=60f74311ed3441000141b265, initiator_id=t47ka]
worker_1            | [2021-08-31 02:58:43,489: INFO/ForkPoolWorker-1] Task scripts.prepare_for_registration_bulk_creation[c7027d38-991e-40c8-a914-245ee19524ee] succeeded in 0.26878479500010144s: None
```

```
worker_1            | [2021-08-31 02:56:14,823: INFO/MainProcess] Received task: scripts.prepare_for_registration_bulk_creation[14a48dd3-e619-411d-a986-bf44577d8b2a]
worker_1            | [2021-08-31 02:56:14,825: DEBUG/MainProcess] TaskPool: Apply <function _fast_trace_task at 0x7fe208994ae8> (args:('scripts.prepare_for_registration_bulk_creation', '14a48dd3-e619-411d-a986-bf44577d8b2a', {'lang': 'py', 'task': 'scripts.prepare_for_registration_bulk_creation', 'id': '14a48dd3-e619-411d-a986-bf44577d8b2a', 'eta': None, 'expir
es': None, 'group': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '14a48dd3-e619-411d-a986-bf44577d8b2a', 'parent_id': None, 'argsrepr': '(None,)', 'kwargsrepr': "{'dry_run': False}", 'origin': 'gen172@941b62218fac', 'reply_to': '1c59e144-a2c8-3c5b-8808-2a646e5ca6a2', 'correlation_id': '14a48dd3-e619-411d-a986-bf44577d8b2a', 'delivery_info': {'exchan
ge': '', 'routing_key': 'celery', 'priority': 0, 'redelivered': False}}, '[[null], {"dry_run": false}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]', 'application/json', 'utf-8') kwargs:{})
worker_1            | [2021-08-31 02:56:14,827: INFO/ForkPoolWorker-1] Preparing OSF database for registration bulk creation ...
worker_1            | [2021-08-31 02:56:14,837: DEBUG/MainProcess] Task accepted: scripts.prepare_for_registration_bulk_creation[14a48dd3-e619-411d-a986-bf44577d8b2a] pid:13
worker_1            | [2021-08-31 02:56:14,885: INFO/ForkPoolWorker-1] Inserting the bulk upload [hash=07eef7ee-fc69-4e3a-9047-8d0e0a4cb909] into the table RegistrationBulkUpload ...
worker_1            | [2021-08-31 02:56:14,902: ERROR/ForkPoolWorker-1] ['Registration bulk upload with this Payload hash already exists.']
worker_1            | [2021-08-31 02:56:14,904: INFO/ForkPoolWorker-1] Task scripts.prepare_for_registration_bulk_creation[14a48dd3-e619-411d-a986-bf44577d8b2a] succeeded in 0.07791755899961572s: None
```

```
worker_1            | [2021-08-31 02:41:27,940: INFO/MainProcess] Received task: scripts.prepare_for_registration_bulk_creation[33e7a79b-e03e-4fed-b3e7-db878fa03b51]
worker_1            | [2021-08-31 02:41:27,942: DEBUG/MainProcess] TaskPool: Apply <function _fast_trace_task at 0x7f00743e1ae8> (args:('scripts.prepare_for_registration_bulk_creation', '33e7a79b-e03e-4fed-b3e7-db878fa03b51', {'lang': 'py', 'task': 'scripts.prepare_for_registration_bulk_creation', 'id': '33e7a79b-e03e-4fed-b3e7-db878fa03b51', 'eta': None, 'expir
es': None, 'group': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '33e7a79b-e03e-4fed-b3e7-db878fa03b51', 'parent_id': None, 'argsrepr': '(None,)', 'kwargsrepr': "{'dry_run': True}", 'origin': 'gen154@941b62218fac', 'reply_to': '941a66fd-1593-31ed-97db-fa59a76a25ea', 'correlation_id': '33e7a79b-e03e-4fed-b3e7-db878fa03b51', 'delivery_info': {'exchang
e': '', 'routing_key': 'celery', 'priority': 0, 'redelivered': False}}, '[[null], {"dry_run": true}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]', 'application/json', 'utf-8') kwargs:{})
worker_1            | [2021-08-31 02:41:27,945: INFO/ForkPoolWorker-1] Preparing OSF database for registration bulk creation ...
worker_1            | [2021-08-31 02:41:27,961: DEBUG/MainProcess] Task accepted: scripts.prepare_for_registration_bulk_creation[33e7a79b-e03e-4fed-b3e7-db878fa03b51] pid:16
worker_1            | [2021-08-31 02:41:28,034: INFO/ForkPoolWorker-1] Inserting the bulk upload [hash=07eef7ee-fc69-4e3a-9047-8d0e0a4cb909] into the table RegistrationBulkUpload ...
worker_1            | [2021-08-31 02:41:28,038: INFO/ForkPoolWorker-1] Dry run: insertion into RegistrationBulkUpload not saved
worker_1            | [2021-08-31 02:41:28,039: INFO/ForkPoolWorker-1] Inserting the registration row [external_id=1facc8f7-69fb-4639-9f7e-d76d33c59532] into the table BulkUploadedRegistrationRow ...
worker_1            | [2021-08-31 02:41:28,040: INFO/ForkPoolWorker-1] Dry run: insertion into BulkUploadedRegistrationRow not saved
worker_1            | [2021-08-31 02:41:28,040: INFO/ForkPoolWorker-1] Inserting the registration row [external_id=152bb80c-6ee5-4861-9c1d-b77534d060cc] into the table BulkUploadedRegistrationRow ...
worker_1            | [2021-08-31 02:41:28,045: INFO/ForkPoolWorker-1] Dry run: insertion into BulkUploadedRegistrationRow not saved
worker_1            | [2021-08-31 02:41:28,046: INFO/ForkPoolWorker-1] Dry run: complete
worker_1            | [2021-08-31 02:41:28,047: INFO/ForkPoolWorker-1] Task scripts.prepare_for_registration_bulk_creation[33e7a79b-e03e-4fed-b3e7-db878fa03b51] succeeded in 0.10249401799956104s: None
```

### TODOs

- [ ] Use `with transaction.atomic():` to roll-back on exceptions
- [ ] Determine how to handle internal and external errors
- [ ] Bring PR up-to-date and redo migrations when PR is ready for review
- [ ] Finish unit tests and remove temporary local testing fixture

## Changes

TBD

## QA Notes

TBD

## Documentation

TBD

## Side Effects

TBD

## Ticket

https://openscience.atlassian.net/browse/ENG-3098
https://openscience.atlassian.net/browse/ENG-3180
