### PR TITLE
[Hotfix] Fix API Disabled Wiki Behavior for Registrations

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -258,6 +258,18 @@ class HideIfWikiDisabled(ConditionalField):
         has_wiki_addon = instance.has_wiki_addon if hasattr(instance, 'has_wiki_addon') else instance.has_addon('wiki')
         return not utils.is_deprecated(request.version, min_version='2.8') and not has_wiki_addon
 
+class HideIfWithdrawalOrWikiDisabled(ConditionalField):
+    """
+    If wiki is disabled or registration is withdrawn, don't show relationship field, only available after 2.7
+    """
+
+    def should_hide(self, instance):
+        request = self.context.get('request')
+        has_wiki_addon = instance.has_wiki_addon if hasattr(instance, 'has_wiki_addon') else instance.has_addon('wiki')
+        return instance.is_retracted or (not utils.is_deprecated(request.version, min_version='2.8') and not has_wiki_addon)
+
+    def should_be_none(self, instance):
+        return not isinstance(self.field, RelationshipField)
 
 class HideIfNotNodePointerLog(ConditionalField):
     """

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1826,7 +1826,7 @@ class NodeWikiList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ListF
 
     def get_default_queryset(self):
         node = self.get_node()
-        if node.addons_wiki_node_settings.deleted:
+        if not node.has_addon('wiki') or node.addons_wiki_node_settings.deleted:
             raise NotFound(detail='The wiki for this node has been disabled.')
         return node.wikis.filter(deleted__isnull=True)
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -28,6 +28,7 @@ from api.base.serializers import (
     IDField, RelationshipField, LinksField, HideIfWithdrawal,
     FileRelationshipField, NodeFileHyperLinkField, HideIfRegistration,
     ShowIfVersion, VersionedDateTimeField, ValuesListField,
+    HideIfWithdrawalOrWikiDisabled,
 )
 from framework.auth.core import Auth
 from osf.exceptions import ValidationValueError, NodeStateError
@@ -191,7 +192,7 @@ class RegistrationSerializer(NodeSerializer):
         related_meta={'count': 'get_files_count'},
     ))
 
-    wikis = HideIfWithdrawal(RelationshipField(
+    wikis = HideIfWithdrawalOrWikiDisabled(RelationshipField(
         related_view='registrations:registration-wikis',
         related_view_kwargs={'node_id': '<_id>'},
         related_meta={'count': 'get_wiki_page_count'},

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -205,6 +205,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             if field not in visible_on_withdrawals and field not in non_registration_fields:
                 assert_true(
                     isinstance(reg_field, base_serializers.HideIfWithdrawal) or
+                    isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or
                     isinstance(reg_field, base_serializers.ShowIfVersion) or
                     isinstance(reg_field, base_serializers.ShowIfAdminScopeOrAnonymous)
                 )


### PR DESCRIPTION
## Purpose

Fix API Disabled Wiki Behavior for Registrations

## Changes
- Prevent 502 when hitting relationship url
- Create and Apply `HideIfWithdrawalOrWikiDisabled` to relationship

## Side Effects
None expected

## Ticket
None
