### PR TITLE
Integration Fixes For Schema Responses

### DIFF
--- a/api/schema_responses/serializers.py
+++ b/api/schema_responses/serializers.py
@@ -121,6 +121,16 @@ class RegistrationSchemaResponseSerializer(JSONAPISerializer):
 
     def update(self, schema_response, validated_data):
         revision_responses = validated_data.get('revision_responses')
+        justification = validated_data.get('revision_justification')
+
+        if justification:
+            if schema_response.reviews_state == ApprovalStates.IN_PROGRESS.db_name:
+                schema_response.revision_justification = justification
+            else:
+                raise exceptions.ValidationError(
+                    detail='The `revision_justification` can only be changed when a SchemaResponse object has the'
+                           ' `reviews_state` `in_progress`'
+                )
 
         if revision_responses:
             try:
@@ -128,4 +138,5 @@ class RegistrationSchemaResponseSerializer(JSONAPISerializer):
             except ValueError as exc:
                 raise exceptions.ValidationError(detail=str(exc))
 
+        schema_response.save()
         return schema_response

--- a/api/schema_responses/views.py
+++ b/api/schema_responses/views.py
@@ -11,6 +11,7 @@ from osf.models import SchemaResponse, Registration
 from api.base.filters import ListFilterMixin
 from api.schema_responses.schemas import create_schema_response_payload
 from framework.auth.oauth_scopes import CoreScopes
+from api.base.utils import get_object_or_error
 
 
 class SchemaResponseList(JSONAPIBaseView, ListFilterMixin, generics.ListCreateAPIView):
@@ -64,7 +65,11 @@ class SchemaResponseDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIVie
             raise NotImplementedError()
 
     def get_object(self):
-        return SchemaResponse.objects.get(_id=self.kwargs['schema_response_id'])
+        return get_object_or_error(
+            SchemaResponse,
+            self.kwargs['schema_response_id'],
+            request=self.request,
+        )
 
     def perform_destroy(self, instance):
         ## check state

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -241,12 +241,12 @@ class ComposedScopes(object):
                           CoreScopes.NODE_CITATIONS_READ, CoreScopes.NODE_COMMENTS_READ, CoreScopes.NODE_LOG_READ,
                           CoreScopes.NODE_FORKS_READ, CoreScopes.WIKI_BASE_READ, CoreScopes.LICENSE_READ,
                           CoreScopes.IDENTIFIERS_READ, CoreScopes.NODE_PREPRINTS_READ, CoreScopes.PREPRINT_REQUESTS_READ,
-                          CoreScopes.REGISTRATION_REQUESTS_READ)
+                          CoreScopes.REGISTRATION_REQUESTS_READ, CoreScopes.READ_SCHEMA_RESPONSES)
     NODE_METADATA_WRITE = NODE_METADATA_READ + \
                     (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE, CoreScopes.IDENTIFIERS_WRITE,
                      CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE,
                      CoreScopes.NODE_PREPRINTS_WRITE, CoreScopes.PREPRINT_REQUESTS_WRITE, CoreScopes.WIKI_BASE_WRITE,
-                     CoreScopes.REGISTRATION_REQUESTS_WRITE)
+                     CoreScopes.REGISTRATION_REQUESTS_WRITE, CoreScopes.WRITE_SCHEMA_RESPONSES)
 
     # Preprints collection
     # TODO: Move Metrics scopes to their own restricted composed scope once the Admin app can manage scopes on tokens/apps

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -208,7 +208,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         '''
         if self.state is not ApprovalStates.IN_PROGRESS:
             raise SchemaResponseStateError(
-                f'SchemaResponse with id [{self.id}]  has state {self.reviews_state}. '
+                f'SchemaResponse with id [{self._id}]  has state {self.reviews_state}. '
                 'Must have state "in_progress" to update responses'
             )
 
@@ -228,7 +228,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         if updated_responses:
             raise ValueError(
                 'Encountered unexpected keys while trying to update responses for '
-                f'SchemaResponse with id {self._id}: {", ".join(updated_responses.keys())}'
+                f'SchemaResponse with id [{self._id}]: {", ".join(updated_responses.keys())}'
             )
 
     def _response_reverted(self, current_block, latest_response):
@@ -268,8 +268,8 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
     def delete(self, *args, **kwargs):
         if self.state is not ApprovalStates.IN_PROGRESS:
             raise SchemaResponseStateError(
-                'Cannot delete SchemaResponse with id [{self.id}]. In order to delete, '
-                'state must be "in_progress", but is "{self.reviews_state}" instead.'
+                f'Cannot delete SchemaResponse with id [{self._id}]. In order to delete, '
+                f'state must be "in_progress", but is "{self.reviews_state}" instead.'
             )
         super().delete(*args, **kwargs)
 
@@ -289,7 +289,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         if user is None and not (trigger == 'accept' and self.state is ApprovalStates.UNAPPROVED):
             raise ValueError(
                 f'Trigger {trigger} from state {self.state} for '
-                f'SchemaResponse with id [{self.id}] must be called with a user.'
+                f'SchemaResponse with id [{self._id}] must be called with a user.'
             )
 
         trigger_specific_validator = getattr(self, f'_validate_{trigger}_trigger')
@@ -306,7 +306,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         if not self.parent.is_admin_contributor(user):
             raise PermissionsError(
                 f'User {user} is not an admin contributor on parent resource {self.parent} '
-                f'and does not have permission to "submit" SchemaResponse with id [{self.id}]'
+                f'and does not have permission to "submit" SchemaResponse with id [{self._id}]'
             )
 
     def _validate_approve_trigger(self, user):
@@ -319,7 +319,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         """
         if user not in self.pending_approvers.all():
             raise PermissionsError(
-                f'User {user} is not a pending approver for SchemaResponse with id [{self.id}]'
+                f'User {user} is not a pending approver for SchemaResponse with id [{self._id}]'
             )
 
     def _validate_accept_trigger(self, user):
@@ -346,13 +346,13 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
                 return
             raise ValueError(
                 'Invalid usage of "accept" trigger from UNAPPROVED state '
-                f'against SchemaResponse with id [{self.id}]'
+                f'against SchemaResponse with id [{self._id}]'
             )
 
         if not user.has_perm('accept_submissions', self.parent.provider):
             raise PermissionsError(
                 f'User {user} is not a modrator on {self.parent.provider} and does not '
-                f'have permission to "accept" SchemaResponse with id [{self.id}]'
+                f'have permission to "accept" SchemaResponse with id [{self._id}]'
             )
 
     def _validate_reject_trigger(self, user):
@@ -366,14 +366,14 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         if self.state is ApprovalStates.UNAPPROVED:
             if user not in self.pending_approvers.all():
                 raise PermissionsError(
-                    f'User {user} is not a pending approver for SchemaResponse with id [{self.id}]'
+                    f'User {user} is not a pending approver for SchemaResponse with id [{self._id}]'
                 )
             return
 
         if not user.has_perm('reject_submissions', self.parent.provider):
             raise PermissionsError(
                 f'User {user} is not a modrator on {self.parent.provider} and does not '
-                f'have permission to "reject" SchemaResponse with id [{self.id}]'
+                f'have permission to "reject" SchemaResponse with id [{self._id}]'
             )
 
     def _on_submit(self, event_data):
@@ -381,7 +381,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         approvers = event_data.kwargs.get('required_approvers', None)
         if not approvers:
             raise ValueError(
-                f'Cannot submit SchemaResponses with id [{self.id}] '
+                f'Cannot submit SchemaResponses with id [{self._id}] '
                 'for review with no required approvers'
             )
         self.pending_approvers.set(approvers)

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -215,6 +215,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         # make a local copy of the responses so we can pop with impunity
         # no need for deepcopy, since we aren't mutating dictionary values
         updated_responses = dict(updated_responses)
+
         for block in self.response_blocks.all():
             # Remove values from updated_responses to help detect unsupported keys
             latest_response = updated_responses.pop(block.schema_key, None)
@@ -234,6 +235,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         '''Handle the case where an answer is reverted over the course of editing a Response.'''
         if not self.previous_response:
             return False
+
         previous_response_block = self.previous_response.response_blocks.get(
             schema_key=current_block.schema_key
         )

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -215,7 +215,6 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         # make a local copy of the responses so we can pop with impunity
         # no need for deepcopy, since we aren't mutating dictionary values
         updated_responses = dict(updated_responses)
-
         for block in self.response_blocks.all():
             # Remove values from updated_responses to help detect unsupported keys
             latest_response = updated_responses.pop(block.schema_key, None)
@@ -228,14 +227,13 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         if updated_responses:
             raise ValueError(
                 'Encountered unexpected keys while trying to update responses for '
-                f'SchemaResponse with id [{self.id}]: {", ".join(updated_responses.keys())}'
+                f'SchemaResponse with id {self._id}: {", ".join(updated_responses.keys())}'
             )
 
     def _response_reverted(self, current_block, latest_response):
         '''Handle the case where an answer is reverted over the course of editing a Response.'''
         if not self.previous_response:
             return False
-
         previous_response_block = self.previous_response.response_blocks.get(
             schema_key=current_block.schema_key
         )


### PR DESCRIPTION
## Purpose

During initial integration testing I encountered three minor bugs. This PR fixes them.

## Changes

- `registration_schema` serialization was wrong and just outside of test ranges, simple fix
- If you PATCHed without a `revisions_response` dict it would 500 instead of no-oping
- We didn't add `SCHEMA_RESPONSE_READ/WRITE` to the scope config properly, so token auth didn't work. 
- `get_object` for the schema detail endpoint 500ed instread of 404ing for bad ids.
- We forgot to allow PATCHing for `revision_justifications`!

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify SchemaResponses are creatable and updatable via the API.
- Verify you can use the Bearer auth properly.

## Side Effects

None that I know of.

## Ticket

None.