### PR TITLE
Fix embedding of schema_responses and make revision_state filterable

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -155,12 +155,12 @@ def default_node_permission_queryset(user, model_cls):
     assert model_cls in {Node, Registration}
     return model_cls.objects.get_nodes_for_user(user, include_public=True)
 
-def default_node_list_permission_queryset(user, model_cls):
+def default_node_list_permission_queryset(user, model_cls, **annotations):
     # **DO NOT** change the order of the querysets below.
     # If get_roots() is called on default_node_list_qs & default_node_permission_qs,
     # Django's alaising will break and the resulting QS will be empty and you will be sad.
     qs = default_node_permission_queryset(user, model_cls) & default_node_list_queryset(model_cls)
-    return qs.annotate(region=F('addons_osfstorage_node_settings__region___id'))
+    return qs.annotate(region=F('addons_osfstorage_node_settings__region___id'), **annotations)
 
 def extend_querystring_params(url, params):
     scheme, netloc, path, query, _ = urlsplit(url)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -118,6 +118,7 @@ from api.nodes.serializers import (
 from api.nodes.utils import NodeOptimizationMixin, enforce_no_children
 from api.osf_groups.views import OSFGroupMixin
 from api.preprints.serializers import PreprintSerializer
+from api.registrations import annotations as registration_annotations
 from api.registrations.serializers import (
     RegistrationSerializer,
     RegistrationCreateSerializer,
@@ -705,7 +706,9 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
     # overrides ListCreateAPIView
     # TODO: Filter out withdrawals by default
     def get_queryset(self):
-        nodes = self.get_node().registrations_all
+        nodes = self.get_node().registrations_all.annotate(
+            revision_state=registration_annotations.REVISION_STATE,
+        )
         auth = get_user_auth(self.request)
         registrations = [node for node in nodes if node.can_view(auth)]
         return registrations

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -17,8 +17,6 @@ from api.base.utils import get_object_or_error, get_user_auth, is_truthy
 from api.licenses.views import LicenseList
 from api.collections.permissions import CanSubmitToCollectionOrPublic
 from api.collections.serializers import CollectionSubmissionSerializer, CollectionSubmissionCreateSerializer
-from api.registrations.serializers import RegistrationSerializer
-from api.requests.serializers import PreprintRequestSerializer, RegistrationRequestSerializer
 from api.preprints.permissions import PreprintPublishedOrAdmin
 from api.preprints.serializers import PreprintSerializer
 from api.providers.permissions import CanAddModerator, CanDeleteModerator, CanUpdateModerator, CanSetUpProvider, MustBeModerator
@@ -29,6 +27,9 @@ from api.providers.serializers import (
     RegistrationProviderSerializer,
     RegistrationModeratorSerializer,
 )
+from api.registrations import annotations as registration_annotations
+from api.registrations.serializers import RegistrationSerializer
+from api.requests.serializers import PreprintRequestSerializer, RegistrationRequestSerializer
 from api.schemas.serializers import RegistrationSchemaSerializer
 from api.subjects.views import SubjectList
 from api.subjects.serializers import SubjectSerializer
@@ -723,6 +724,8 @@ class RegistrationProviderRegistrationList(JSONAPIBaseView, generics.ListAPIView
 
         return Registration.objects.filter(
             provider=provider,
+        ).annotate(
+            revision_state=registration_annotations.REVISION_STATE,
         )
 
     # overrides ListAPIView

--- a/api/registrations/annotations.py
+++ b/api/registrations/annotations.py
@@ -1,0 +1,9 @@
+from django.db.models import CharField, OuterRef, Subquery
+from osf.models import SchemaResponse
+
+REVISION_STATE = Subquery(
+    SchemaResponse.objects.filter(
+        nodes__id=OuterRef('id'),
+    ).order_by('-created').values('reviews_state')[:1],
+    output_field=CharField(),
+)

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -366,7 +366,7 @@ class RegistrationSerializer(NodeSerializer):
         related_view_kwargs={'node_id': '<_id>'},
     ))
 
-    revision_state = HideIfWithdrawal(ser.CharField())
+    revision_state = HideIfWithdrawal(ser.CharField(allow_null=True, default=None))
 
     @property
     def subjects_related_view(self):

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -70,6 +70,13 @@ class RegistrationSerializer(NodeSerializer):
         'withdrawn',
     ]
 
+    # Fields not on the model that should be usable for filtering
+    # must be added here
+    filterable_fields = frozenset([
+        'reviews_state',
+        'revision_state',
+    ])
+
     ia_url = ser.URLField(read_only=True)
     reviews_state = ser.CharField(source='moderation_state', read_only=True)
     title = ser.CharField(read_only=True)
@@ -358,6 +365,8 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:schema-responses-list',
         related_view_kwargs={'node_id': '<_id>'},
     ))
+
+    revision_state = HideIfWithdrawal(ser.CharField())
 
     @property
     def subjects_related_view(self):

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -434,12 +434,6 @@ class RegistrationSerializer(NodeSerializer):
     def get_files_count(self, obj):
         return obj.files_count or 0
 
-    def get_revision_state(self, obj):
-        latest_revision = obj.schema_responses.first()
-        if latest_revision:
-            return latest_revision.reviews_state
-        return None
-
     def anonymize_registered_meta(self, obj):
         """
         Looks at every question on every page of the schema, for any titles

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -70,10 +70,9 @@ class RegistrationSerializer(NodeSerializer):
         'withdrawn',
     ]
 
-    # Fields not on the model that should be usable for filtering
-    # must be added here
-    filterable_fields = frozenset([
-        'reviews_state',
+    # Union filterable fields unique to the RegistrationSerializer with
+    # filterable fields from the NodeSerializer
+    filterable_fields = NodeSerializer.filterable_fields ^ frozenset([
         'revision_state',
     ])
 
@@ -366,7 +365,7 @@ class RegistrationSerializer(NodeSerializer):
         related_view_kwargs={'node_id': '<_id>'},
     ))
 
-    revision_state = HideIfWithdrawal(ser.CharField(allow_null=True, default=None))
+    revision_state = HideIfWithdrawal(ser.CharField(read_only=True, required=False))
 
     @property
     def subjects_related_view(self):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -105,7 +105,7 @@ class RegistrationMixin(NodeMixin):
             raise NotFound
 
         if node.deleted:
-            raise Gone
+            raise Gone(detail='The requested registration is no longer available.')
 
         if check_object_permissions:
             self.check_object_permissions(self.request, node)

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -1,14 +1,14 @@
-from django.db.models import Exists, OuterRef
 from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import ValidationError, NotFound, PermissionDenied
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import AbstractNode, Registration, OSFUser, RegistrationProvider, SchemaResponse
+from osf.models import Registration, OSFUser, RegistrationProvider
 from osf.utils.permissions import WRITE_NODE
 from osf.utils.workflows import ApprovalStates
 
 from api.base import permissions as base_permissions
 from api.base import generic_bulk_views as bulk_views
+from api.base.exceptions import Gone
 from api.base.filters import ListFilterMixin
 from api.base.views import (
     JSONAPIBaseView,
@@ -81,7 +81,9 @@ from framework.sentry import log_exception
 from osf.utils.permissions import ADMIN
 from api.providers.permissions import MustBeModerator
 from api.providers.views import ProviderMixin
+from api.registrations import annotations
 
+from api.schema_responses import annotations as schema_response_annotations
 from api.schema_responses.serializers import RegistrationSchemaResponseSerializer
 
 
@@ -93,21 +95,21 @@ class RegistrationMixin(NodeMixin):
     serializer_class = RegistrationSerializer
     node_lookup_url_kwarg = 'node_id'
 
-    def get_node(self, check_object_permissions=True):
-        node = get_object_or_error(
-            AbstractNode,
-            self.kwargs[self.node_lookup_url_kwarg],
-            self.request,
-            display_name='node',
+    def get_node(self, check_object_permissions=True, **annotations):
+        guid = self.kwargs[self.node_lookup_url_kwarg]
+        node = Registration.objects.filter(guids___id=guid).annotate(**annotations)
 
-        )
-        # Nodes that are folders/collections are treated as a separate resource, so if the client
-        # requests a collection through a node endpoint, we return a 404
-        if node.is_collection or not node.is_registration:
+        try:
+            node = node.get()
+        except Registration.DoesNotExist:
             raise NotFound
-        # May raise a permission denied
+
+        if node.deleted:
+            raise Gone
+
         if check_object_permissions:
             self.check_object_permissions(self.request, node)
+
         return node
 
 
@@ -145,7 +147,11 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
 
     # overrides NodesFilterMixin
     def get_default_queryset(self):
-        return default_node_list_permission_queryset(user=self.request.user, model_cls=Registration)
+        return default_node_list_permission_queryset(
+            user=self.request.user,
+            model_cls=Registration,
+            revision_state=annotations.REVISION_STATE,
+        )
 
     def is_blacklisted(self):
         query_params = self.parse_query_params(self.request.query_params)
@@ -232,7 +238,7 @@ class RegistrationDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, Regist
 
     # overrides RetrieveAPIView
     def get_object(self):
-        registration = self.get_node()
+        registration = self.get_node(revision_state=annotations.REVISION_STATE)
         if not registration.is_registration:
             raise ValidationError('This is not a registration.')
         return registration
@@ -873,18 +879,10 @@ class RegistrationSchemaResponseList(JSONAPIBaseView, generics.ListAPIView, List
         ExcludeWithdrawals,
     )
 
-    view_category = 'schema-responses'
+    view_category = 'registrations'
     view_name = 'schema-responses-list'
 
     serializer_class = RegistrationSchemaResponseSerializer
-
-    def _make_is_pending_current_user_approval_subquery(self):
-        user = self.request.user
-        return Exists(
-            SchemaResponse.pending_approvers.through.objects.filter(
-                schemaresponse_id=OuterRef('id'), osfuser_id=user.id,
-            ),
-        )
 
     def get_object(self):
         return self.get_node()
@@ -900,7 +898,9 @@ class RegistrationSchemaResponseList(JSONAPIBaseView, generics.ListAPIView, List
         registration = self.get_node()
 
         all_responses = registration.schema_responses.annotate(
-            is_pending_current_user_approval=self._make_is_pending_current_user_approval_subquery(),
+            is_pending_current_user_approval=(
+                schema_response_annotations.is_pending_current_user_approval(user)
+            ),
         )
 
         is_contributor = registration.has_permission(user, 'read') if user else False

--- a/api/schema_responses/annotations.py
+++ b/api/schema_responses/annotations.py
@@ -1,0 +1,28 @@
+from django.db.models import BooleanField, Exists, OuterRef, Subquery
+from osf.models import Contributor, Registration, SchemaResponse
+from osf.utils.workflows import RegistrationModerationStates
+
+
+# NOTE: Conveniently assigns None for withdrawn/deleted parents
+PARENT_IS_PUBLIC = Subquery(
+    Registration.objects.filter(
+        id=OuterRef('object_id'), deleted__isnull=True,
+    ).exclude(
+        moderation_state=RegistrationModerationStates.WITHDRAWN.db_name,
+    ).values('is_public')[:1],
+    output_field=BooleanField(),
+)
+
+
+def is_pending_current_user_approval(user):
+    '''Construct a subquery to see if a given user is a pending_approver for a SchemaResponse.'''
+    return Exists(
+        SchemaResponse.pending_approvers.through.objects.filter(
+            schemaresponse_id=OuterRef('id'), osfuser_id=user.id,
+        ),
+    )
+
+
+def user_is_contributor(user):
+    '''Construct a subquery to determine if user is a contributor to the parent Registration'''
+    return Exists(Contributor.objects.filter(user__id=user.id, node__id=OuterRef('object_id')))

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -32,6 +32,7 @@ from api.nodes.serializers import DraftRegistrationLegacySerializer
 from api.nodes.utils import NodeOptimizationMixin
 from api.osf_groups.serializers import GroupSerializer
 from api.preprints.serializers import PreprintSerializer
+from api.registrations import annotations as registration_annotations
 from api.registrations.serializers import RegistrationSerializer
 
 from api.users.permissions import (
@@ -476,7 +477,11 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesF
     def get_default_queryset(self):
         user = self.get_user()
         current_user = self.request.user
-        qs = default_node_list_permission_queryset(user=current_user, model_cls=Registration)
+        qs = default_node_list_permission_queryset(
+            user=current_user,
+            model_cls=Registration,
+            revision_state=registration_annotations.REVISION_STATE,
+        )
         # OSF group members not copied to registration.  Only registration contributors need to be checked here.
         return qs.filter(contributor__user__id=user.id)
 

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -137,7 +137,7 @@ class TestRegistrationIdentifierList:
 
     def test_do_not_return_deleted_identifier(
             self, app, registration):
-        registration.is_deleted = True
+        registration.deleted = timezone.now()
         registration.save()
         url = '/{}registrations/{}/identifiers/'.format(API_BASE, registration._id)
         res = app.get(url, expect_errors=True)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -370,7 +370,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     custom_storage_usage_limit_public = models.DecimalField(decimal_places=9, max_digits=100, null=True, blank=True)
     custom_storage_usage_limit_private = models.DecimalField(decimal_places=9, max_digits=100, null=True, blank=True)
 
-    schema_responses = GenericRelation('osf.SchemaResponse')
+    schema_responses = GenericRelation('osf.SchemaResponse', related_query_name='nodes')
 
     class Meta:
         base_manager_name = 'objects'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
1) Requests to the RegistrationDetail endpoint were breaking when embedding `SchemaResponses`.

2) Filterable fields through the API must either exist on the model or be assigned via annotation, so the `SerializerMethodField` being used to set `revision_state` on the serialized Registration was insufficient.

Adding the revision_state directly to the Registration model leads to some not-fun abstraction violations, so needed to come up with a pattern for setting this value via annotation.

## Changes
* Fixed the `view_category` for `RegistrationSchemaResponseList`
* Added the concept of `api/{model}/annotations.py` as a place to store all relevant code to produce annotations for filtering and/or populating serializer fields
  * Added `REVISION_STATE` subquery to `api/registrations/annotations.py` 
  * Moved the `PARENT_IS_PUBLIC` subquery and the methods for generating the `is_pending_current_user_approval` and `user_is_contributor`  subqueries to `api/schema_response/annotations.py`
* Updated `api.base.utils.default_node_list_permission_queryset()` and `api.registrations.views.RegistrationMixin.get_node()` to both accept additional annotations as kwargs to be applied to their querysets
* Updated  `RegistrationDetail`, `RegistrationList`, `NodeRegistrationsList`, `RegistrationProviderRegistrationsList`, and `UserRegistrationList` endpoints to add the `revision_state` annotation.

## QA Notes

All changes were hand-tested.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
