### PR TITLE
[ENG-3100] Bulk Upload: Monitor Upload and Create Draft Registration

### DIFF
--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -222,7 +222,6 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
             error = 'Duplicate subjects found: [text={}]'.format(text)
             raise RegistrationBulkCreationRowError(row.upload.id, row.id, row_title, row_external_id, error=error)
         subject_ids.append(subject_list.first()._id)
-    logger.error(subject_ids)
 
     # Prepare node licences
     license_name = metadata.get('license').get('name')

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -83,6 +83,7 @@ def prepare_for_registration_bulk_creation(payload_hash, initiator_id, provider_
         logger.info('Bulk creating [{}] registration bulk upload rows ...'.format(len(bulk_upload_rows)))
         created_objects = RegistrationBulkUploadRow.objects.bulk_create(bulk_upload_rows)
     except (ValueError, IntegrityError) as e:
+        upload.delete()
         message = 'Bulk insertion failed: [error={}, cause={}]'.format(type(e), e.__cause__)
         return handle_error(initiator, inform_product=True, error_message=message)
     logger.info('[{}] rows successfully inserted.'.format(len(created_objects)))

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -192,13 +192,13 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
     """
 
     metadata = row.csv_parsed.get('metadata', {})
-    row_external_id = metadata.get('external id', 'N/A')
-    row_title = metadata.get('title', 'N/A')
+    row_external_id = metadata.get('External Id', 'N/A')
+    row_title = metadata.get('Title', '')
     responses = row.csv_parsed.get('registration_responses', {})
     auth = Auth(user=initiator)
 
     # Check node
-    node_id = metadata.get('project guid', '')
+    node_id = metadata.get('Project GUID', '')
     node = None
     if node_id:
         try:
@@ -211,7 +211,7 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
             raise RegistrationBulkCreationRowError(row.upload.id, row.id, row_title, row_external_id, error=error)
 
     # Prepare subjects
-    subject_texts = metadata.get('subjects', [])
+    subject_texts = metadata.get('Subjects', [])
     subject_ids = []
     for text in subject_texts:
         subject_list = provider.all_subjects.filter(text=text)
@@ -224,9 +224,9 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
         subject_ids.append(subject_list.first()._id)
 
     # Prepare node licences
-    license_name = metadata.get('license').get('name')
-    year = metadata.get('license').get('required_fields', {}).get('year', None),
-    copyright_holders = metadata.get('license').get('required_fields', {}).get('copyright_holders', None),
+    license_name = metadata.get('License').get('name')
+    year = metadata.get('License').get('required_fields', {}).get('year', None),
+    copyright_holders = metadata.get('License').get('required_fields', {}).get('copyright_holders', None),
     try:
         node_license = NodeLicense.objects.get(name=license_name)
     except NodeLicense.DoesNotExist:
@@ -244,14 +244,14 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
     # Prepare editable fields
     data = {
         'title': row_title,
-        'category': metadata.get('category').lower(),
-        'description': metadata.get('description'),
+        'category': metadata.get('Category'),
+        'description': metadata.get('Description'),
         'node_license': node_license,
     }
 
     # Prepare institutions
     affiliated_institutions = []
-    institution_names = metadata.get('affiliated institutions')
+    institution_names = metadata.get('Affiliated Institutions', [])
     for name in institution_names:
         try:
             institution = Institution.objects.get(name=name, is_delete=False)
@@ -261,22 +261,22 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
         affiliated_institutions.append(institution)
 
     # Prepare tags
-    tags = metadata.get('tags')
+    tags = metadata.get('Tags')
 
     # Prepare contributors
-    admin_list = metadata.get('admin contributors', [])
+    admin_list = metadata.get('Admin Contributors', [])
     if not admin_list:
         admin_list = []
     admin_set = {contributor.get('email') for contributor in admin_list}
-    read_only_list = metadata.get('read-only contributors', [])
+    read_only_list = metadata.get('Read-Only Contributors', [])
     if not read_only_list:
         read_only_list = []
     read_only_set = {contributor.get('email') for contributor in read_only_list}
-    read_write_list = metadata.get('read-write contributors', [])
+    read_write_list = metadata.get('Read-Write Contributors', [])
     if not read_write_list:
         read_write_list = []
     read_write_set = {contributor.get('email') for contributor in read_write_list}
-    author_list = metadata.get('bibliographic contributors', [])
+    author_list = metadata.get('Bibliographic Contributors', [])
     if not author_list:
         author_list = []
     author_set = {contributor.get('email') for contributor in author_list}

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -874,5 +874,5 @@ class RegistrationBulkCreate(APIView):
                 content_type='application/vnd.api+json; application/json',
             )
         parsed = upload.get_parsed()
-        enqueue_task(prepare_for_registration_bulk_creation.s(file_md5, user_id, provider_id, parsed, dry_run=True))
+        enqueue_task(prepare_for_registration_bulk_creation.s(file_md5, user_id, provider_id, parsed, dry_run=False))
         return Response(status=204)

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -199,6 +199,7 @@ def serialize_share_data(resource, old_subjects=None):
     """
     from osf.models import (
         Node,
+        DraftNode,
         Preprint,
         Registration,
     )
@@ -211,6 +212,8 @@ def serialize_share_data(resource, old_subjects=None):
         serializer = serialize_osf_node
     elif isinstance(resource, Registration):
         serializer = serialize_registration
+    elif isinstance(resource, DraftNode):
+        return {}
     else:
         raise NotImplementedError()
 

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -173,3 +173,15 @@ class PreviousSchemaResponseError(SchemaResponseError):
     already has a SchemaResponse in an unsupported state
     """
     pass
+
+
+class RegistrationBulkCreationRowError(OSFError):
+    """Raised if a draft registration failed creation during bulk upload"""
+
+    def __init__(self, upload_id, row_id, title, external_id, draft_id=None, error=None, approval_failure=False):
+        self.short_message = 'Title: {}, External ID: {}'.format(title, external_id)
+        self.long_message = 'Draft registration creation failed: [upload_id={}, row_id={}, ' \
+                            'title={}, external_id={}]'.format(upload_id, row_id, title, external_id)
+        self.draft_id = draft_id
+        self.error = error if error else 'Draft registration creation error'
+        self.approval_failure = approval_failure

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1284,7 +1284,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         )
         draft.save()
         draft.copy_editable_fields(node, Auth(user), save=True)
-        draft.update(data)
+        draft.update(data, auth=Auth(user))
 
         if node.type == 'osf.draftnode':
             initiator_permissions = draft.contributor_set.get(user=user).permission

--- a/website/registrations/utils.py
+++ b/website/registrations/utils.py
@@ -25,7 +25,7 @@ METADATA_FIELDS = {'Title': {'format': 'string', 'required': True, 'error_type':
                    'License': {'format': 'object', 'required': True, 'error_type': {'missing': 'missingLicenseName', 'invalid': 'invalidLicenseName'}},
                    'Subjects': {'format': 'list', 'required': True, 'error_type': {'missing': 'missingSubjectName', 'invalid': 'invalidSubjectName'}},
                    'Tags': {'format': 'list'},
-                   'Project GUID': {'format': 'string', 'error_type': { 'invalid': 'invalidProjectId'}},
+                   'Project GUID': {'format': 'string', 'error_type': {'invalid': 'invalidProjectId'}},
                    'External ID': {'format': 'string'}}
 CONTRIBUTOR_METADATA_FIELDS = ['Admin Contributors',
                                'Read-Write Contributors',
@@ -150,8 +150,6 @@ class BulkRegistrationUpload():
             'header': kwargs['header'],
             'column_index': get_excel_column_name(kwargs['column_index']),
             'row_index': kwargs['row_index'],
-            'missing': kwargs.get('missing', False),
-            'invalid': kwargs.get('invalid', False),
             'external_id': kwargs.get('external_id', ''),
             'type': kwargs.get('type', '')
         })
@@ -205,11 +203,13 @@ class Row():
                 'registration_responses': self.get_registration_responses()}
 
     def get_raw_value(self):
-        raw_value = io.StringIO()
+        raw_value_buffer = io.StringIO()
+        csv_writer = csv.writer(raw_value_buffer)
         cell_values = [cell.value for cell in self.cells]
-        csv_writer = csv.writer(raw_value)
         csv_writer.writerow(cell_values)
-        return raw_value.getvalue()
+        raw_value = raw_value_buffer.getvalue()
+        raw_value_buffer.close()
+        return raw_value
 
     def validate(self):
         for cell in self.cells:

--- a/website/registrations/utils.py
+++ b/website/registrations/utils.py
@@ -14,18 +14,18 @@ from osf.models import AbstractNode, RegistrationProvider, RegistrationSchema, I
 from website import settings
 
 
-METADATA_FIELDS = {'Title': {'format': 'string', 'required': True},
-                   'Description': {'format': 'string', 'required': True},
-                   'Admin Contributors': {'format': 'list', 'required': True},
-                   'Read-Write Contributors': {'format': 'list'},
-                   'Read-Only Contributors': {'format': 'list'},
-                   'Bibliographic Contributors': {'format': 'list'},
-                   'Category': {'format': 'string'},
-                   'Affiliated Institutions': {'format': 'list'},
-                   'License': {'format': 'object', 'required': True},
-                   'Subjects': {'format': 'list', 'required': True},
+METADATA_FIELDS = {'Title': {'format': 'string', 'required': True, 'error_type': {'missing': 'missingTitle'}},
+                   'Description': {'format': 'string', 'required': True, 'error_type': {'missing': 'missingDescription'}},
+                   'Admin Contributors': {'format': 'list', 'required': True, 'error_type': {'missing': 'missingContributors', 'invalid': 'invalidContributors'}},
+                   'Read-Write Contributors': {'format': 'list', 'error_type': {'invalid': 'invalidContributors'}},
+                   'Read-Only Contributors': {'format': 'list', 'error_type': {'invalid': 'invalidContributors'}},
+                   'Bibliographic Contributors': {'format': 'list', 'error_type': {'invalid': 'invalidContributors'}},
+                   'Category': {'format': 'string', 'error_type': {'invalid': 'invalidCategoryName'}},
+                   'Affiliated Institutions': {'format': 'list', 'error_type': {'invalid': 'invalidInstitutionName'}},
+                   'License': {'format': 'object', 'required': True, 'error_type': {'missing': 'missingLicenseName', 'invalid': 'invalidLicenseName'}},
+                   'Subjects': {'format': 'list', 'required': True, 'error_type': {'missing': 'missingSubjectName', 'invalid': 'invalidSubjectName'}},
                    'Tags': {'format': 'list'},
-                   'Project GUID': {'format': 'string'},
+                   'Project GUID': {'format': 'string', 'error_type': { 'invalid': 'invalidProjectId'}},
                    'External ID': {'format': 'string'}}
 CONTRIBUTOR_METADATA_FIELDS = ['Admin Contributors',
                                'Read-Write Contributors',
@@ -295,7 +295,7 @@ class RegistrationResponseField(UploadField):
     def _validate(self):
         parsed_value = None
         if self.required and not bool(self.value):
-            self.log_error(missing=True)
+            self.log_error()
         else:
             if not self.value:
                 return
@@ -304,7 +304,7 @@ class RegistrationResponseField(UploadField):
             elif self.type == 'choose' and self.format in ['singleselect', 'multiselect']:
                 if self.format == 'singleselect':
                     if self.value not in self.options:
-                        self.log_error(invalid=True)
+                        self.log_error()
                     else:
                         parsed_value = self.value
                 else:
@@ -312,7 +312,7 @@ class RegistrationResponseField(UploadField):
                     choices = [val.strip() for val in self.value.split(';')]
                     for choice in choices:
                         if choice not in self.options:
-                            self.log_error(invalid=True)
+                            self.log_error()
                         else:
                             parsed_value.append(choice)
             self._parsed_value = parsed_value
@@ -324,6 +324,7 @@ class MetadataField(UploadField):
         self.required = validations.get('required', False)
         self.value = value.strip()
         self.log_error = log_error
+        self.error_type = validations.get('error_type')
 
     def get_field_type(self):
         return self.format
@@ -331,7 +332,7 @@ class MetadataField(UploadField):
     def _validate(self):
         parsed_value = None
         if self.required and not bool(self.value):
-            self.log_error(missing=True)
+            self.log_error(type=self.error_type['missing'])
         else:
             if self.format == 'string':
                 parsed_value = self.value
@@ -345,7 +346,7 @@ class ContributorField(MetadataField):
     def _validate(self):
         parsed_value = None
         if self.required and not bool(self.value):
-            self.log_error(missing=True, type='invalidContributors')
+            self.log_error(type=self.error_type['missing'])
         else:
             if not self.value:
                 return
@@ -358,22 +359,22 @@ class ContributorField(MetadataField):
                         full_name = match.group('full_name')
                         email = match.group('email')
                     except AttributeError:
-                        self.log_error(invalid=True, type='invalidContributors')
+                        self.log_error(type=self.error_type['invalid'])
                     else:
                         parsed_value.append({'full_name': full_name.strip(), 'email': email.strip()})
                 else:
-                    self.log_error(invalid=True, type='invalidContributors')
+                    self.log_error(type=self.error_type['invalid'])
             self._parsed_value = parsed_value
 
 class LicenseField(MetadataField):
     # format: license_name;year;copyright_holder_one,copyright_holder_two,...
     with_required_fields_regex = re.compile(r'(?P<name>[\w\W]+);\s*?(?P<year>[1-3][0-9]{3});(?P<copyright_holders>[\w\W]+)')
-    no_required_fields_regex = re.compile(r'(?P<name>[\w\W]+)')
+    no_required_fields_regex = re.compile(r'(?P<name>[\w\W][^;]+)')
 
     def _validate(self):
         parsed_value = None
         if self.required and not bool(self.value):
-            self.log_error(missing=True, type='invalidLicenseName')
+            self.log_error(type=self.error_type['missing'])
         else:
             if not self.value:
                 return
@@ -386,7 +387,7 @@ class LicenseField(MetadataField):
                 try:
                     node_license = STORE.licenses.get(name__iexact=node_license_name)
                 except NodeLicense.DoesNotExist:
-                    self.log_error(invalid=True, type='invalidLicenseName')
+                    self.log_error(type=self.error_type['invalid'])
                 else:
                     has_required_fields = bool(node_license.properties)
                     if has_required_fields:
@@ -402,14 +403,14 @@ class LicenseField(MetadataField):
                         parsed_value = {'name': node_license.name}
                     self._parsed_value = parsed_value
             else:
-                self.log_error(invalid=True, type='invalidLicenseName')
+                self.log_error(type=self.error_type['invalid'])
 
 class CategoryField(MetadataField):
     def _validate(self):
         try:
             self._parsed_value = CATEGORY_REVERSE_LOOKUP[self.value if self.value else 'Uncategorized']
         except KeyError:
-            self.log_error(invalid=True, type='invalidCategoryName')
+            self.log_error(type=self.error_type['invalid'])
 
 class SubjectsField(MetadataField):
     def _validate(self):
@@ -419,7 +420,7 @@ class SubjectsField(MetadataField):
         valid_subjects = list(STORE.subjects.filter(text__in=subjects).values_list('text', flat=True))
         invalid_subjects = list(set(subjects) - set(valid_subjects))
         if len(invalid_subjects):
-            self.log_error(invalid=True, type='invalidSubjectName')
+            self.log_error(type=self.error_type['invalid'])
         else:
             self._parsed_value = valid_subjects
 
@@ -434,7 +435,7 @@ class InstitutionsField(MetadataField):
         valid_institutions = list(STORE.institutions.filter(name__in=institutions).values_list('name', flat=True))
         invalid_institutions = list(set(institutions) - set(valid_institutions))
         if len(invalid_institutions):
-            self.log_error(invalid=True, type='invalidInstitutionName')
+            self.log_error(type=self.error_type['invalid'])
         else:
             self._parsed_value = valid_institutions
 
@@ -445,6 +446,6 @@ class ProjectIDField(MetadataField):
         try:
             AbstractNode.objects.get(guids___id=self.value, is_deleted=False, type='osf.node')
         except AbstractNode.DoesNotExist:
-            self.log_error(invalid=True, type='invalidProjectId')
+            self.log_error(type=self.error_type['invalid'])
         else:
             self._parsed_value = self.value

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -671,6 +671,11 @@ class CeleryConfig:
                     'batch_size_stuck': 10
                 }
             },
+            'monitor_registration_bulk_upload_jobs': {
+                'task': 'api.providers.tasks.monitor_registration_bulk_upload_jobs',
+                'schedule': crontab(minute=0, hour=7),  # Daily 03:00 a.m. EDT
+                'kwargs': {'dry_run': False}
+            },
         }
 
         # Tasks that need metrics and release requirements

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -673,7 +673,8 @@ class CeleryConfig:
             },
             'monitor_registration_bulk_upload_jobs': {
                 'task': 'api.providers.tasks.monitor_registration_bulk_upload_jobs',
-                'schedule': crontab(hour='*/3'),  # Every 3 hours
+                # 'schedule': crontab(hour='*/3'),  # Every 3 hours
+                'schedule': crontab(minute='*/5'),  # Every 5 minutes for staging server QA test
                 'kwargs': {'dry_run': False}
             },
         }

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -673,7 +673,7 @@ class CeleryConfig:
             },
             'monitor_registration_bulk_upload_jobs': {
                 'task': 'api.providers.tasks.monitor_registration_bulk_upload_jobs',
-                'schedule': crontab(minute=0, hour=7),  # Daily 03:00 a.m. EDT
+                'schedule': crontab(hour='*/3'),  # Every 3 hours
                 'kwargs': {'dry_run': False}
             },
         }


### PR DESCRIPTION
## Purpose

* Fix the preparation task
* Create two tasks to monitor registration bulk upload jobs and to create draft registrations

## Changes

* Delete bulk upload job if registration rows fail creation
* Create a cron job that monitors uploads and kicks off reg. creation
* Fully implemented draft registration creation task without sending emails of errors
* Reschedule the monitor task to run every 3 hours

## Side Effects

* Fixed Share failure on DraftNode creation
* Fixed missing auth when updating draft registration data
* Applied fixes form https://github.com/CenterForOpenScience/osf.io/pull/9776

## TODO

- [x] Set up pre-commit hooks and fix linting
- [x] Update tasks due to recent schema and parser updates
- [x] Add sentry message and extra logging
- [ ] Send emails
- [ ] Add unit tests for tasks

## QA Notes / Dev Notes / DevOps Notes

N / A

## Ticket

https://openscience.atlassian.net/browse/ENG-3100

