### PR TITLE
Support for notifications during registration update flow

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -389,7 +389,7 @@ class RegistrationSerializer(NodeSerializer):
         return None
 
     def get_registration_responses(self, obj):
-        latest_approved_response = obj.root.schema_responses.filter(
+        latest_approved_response = obj.schema_responses.filter(
             reviews_state=ApprovalStates.APPROVED.db_name,
         ).first()
         if latest_approved_response is not None:

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -389,7 +389,7 @@ class RegistrationSerializer(NodeSerializer):
         return None
 
     def get_registration_responses(self, obj):
-        latest_approved_response = obj.schema_responses.filter(
+        latest_approved_response = obj.root.schema_responses.filter(
             reviews_state=ApprovalStates.APPROVED.db_name,
         ).first()
         if latest_approved_response is not None:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1852,12 +1852,12 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         :param bool unique_users: If True, a given admin will only be yielded once
             during iteration.
         """
-        visited_user_ids = []
+        visited_user_ids = set()
         for node in self.node_and_primary_descendants(*args, **kwargs):
             for contrib in node.active_contributors(*args, **kwargs):
                 if unique_users:
                     if contrib._id not in visited_user_ids:
-                        visited_user_ids.append(contrib._id)
+                        visited_user_ids.add(contrib._id)
                         yield (contrib, node)
                 else:
                     yield (contrib, node)
@@ -1870,13 +1870,13 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         :param bool unique_users: If True, a given admin will only be yielded once
             during iteration.
         """
-        visited_user_ids = []
+        visited_user_ids = set()
         for node in self.node_and_primary_descendants(*args, **kwargs):
             for contrib in node.contributors.all():
                 if node.has_permission(contrib, ADMIN) and contrib.is_active:
                     if unique_users:
                         if contrib._id not in visited_user_ids:
-                            visited_user_ids.append(contrib._id)
+                            visited_user_ids.add(contrib._id)
                             yield (contrib, node)
                     else:
                         yield (contrib, node)

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -453,6 +453,8 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             'update_link': self.absolute_url
         }
 
-        for contrib, _ in self.parent.get_active_contributors_recursive(unique_users=True):
-            email_context['user'] = contrib
-            mails.send(contrib.user_name, template, **email_context)
+        for contributor, _ in self.parent.get_active_contributors_recursive(unique_users=True):
+            email_context['user'] = contributor
+            email_context['can_write'] = self.parent.has_permission(contributor, 'write')
+            email_context['is_approver'] = contributor in self.pending_approvers.all()
+            mails.send(to_addr=contributor.user_name, mail=template, **email_context)

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -1,3 +1,5 @@
+from future.moves.urllib.parse import urljoin
+
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -14,9 +16,10 @@ from osf.utils.machines import ApprovalsMachine
 from osf.utils.workflows import ApprovalStates, SchemaResponseTriggers
 
 from website.mails import mails
+from website.settings import DOMAIN
 
 
-EMAIL_TEMPLATES_PER_TRIGGER = {
+EMAIL_TEMPLATES_PER_EVENT = {
     'create': mails.SCHEMA_RESPONSE_INITIATED,
     'submit': mails.SCHEMA_RESPONSE_SUBMITTED,
     'accept': mails.SCHEMA_RESPONSE_APPROVED,
@@ -81,8 +84,11 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             active_state=self.state,
             state_property_name='state'
         )
-        # Add a callback to notify users on every state change
-        self.approvals_state_machine.after_state_change.append('_notify_users')
+
+    @property
+    def absolute_url(self):
+        relative_url_path = f'/{self.parent._id}?revisionId={self._id}'
+        return urljoin(DOMAIN, relative_url_path)
 
     @property
     def all_responses(self):
@@ -195,7 +201,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         )
         new_response.save()
         new_response.response_blocks.add(*previous_response.response_blocks.all())
-        new_response._notify_users(trigger='create')
+        new_response._notify_users(event='create')
         return new_response
 
     def update_responses(self, updated_responses):
@@ -414,7 +420,6 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
     def _on_reject(self, event_data):
         '''Clear out pending_approvers to start fresh on resubmit.'''
         self.pending_approvers.clear()
-        self.notify_users(mails.SchemaResposneRejected(self.parent.title))
 
     def _save_transition(self, event_data):
         '''Save changes here and write the action.'''
@@ -433,28 +438,28 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             creator=event_data.kwargs.get('user', self.initiator),
             comment=event_data.kwargs.get('comment', '')
         )
+        self._notify_users(event=event_data.event.name)
 
-        self.notify_users(event_data.event.name)
-
-    def _notify_users(self, trigger):
+    def _notify_users(self, event):
+        '''Notify users of relevant state transitions.'''
         #  These notifications will be handled by the registration workflow
         #  Revisit this once more parent types are supported
         if not self.previous_response:
             return
 
-        template = EMAIL_TEMPLATES_PER_TRIGGER.get(trigger)
+        template = EMAIL_TEMPLATES_PER_EVENT.get(event)
         if not template:
             return
 
         email_context = {
             'resource_type': self.parent.__class__.__name__,
             'title': self.parent.title,
-            'parent_link': self.parent.absolute_url,
-            'update_link': self.absolute_url
+            'parent_url': self.parent.absolute_url,
+            'update_url': self.absolute_url
         }
 
         for contributor, _ in self.parent.get_active_contributors_recursive(unique_users=True):
             email_context['user'] = contributor
             email_context['can_write'] = self.parent.has_permission(contributor, 'write')
             email_context['is_approver'] = contributor in self.pending_approvers.all()
-            mails.send(to_addr=contributor.user_name, mail=template, **email_context)
+            mails.send_mail(to_addr=contributor.username, mail=template, **email_context)

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from nose.tools import assert_raises
@@ -6,10 +7,13 @@ from api.providers.workflows import Workflows
 from framework.exceptions import PermissionsError
 from osf.exceptions import PreviousSchemaResponseError, SchemaResponseStateError
 from osf.migrations import update_provider_auth_groups
-from osf.models import RegistrationSchema, RegistrationSchemaBlock, SchemaResponse, SchemaResponseBlock
+from osf.models import RegistrationSchema, RegistrationSchemaBlock, SchemaResponseBlock
+from osf.models import schema_response  # import module for mocking purposes
 from osf.utils.workflows import ApprovalStates, SchemaResponseTriggers
-from osf_tests.factories import AuthUserFactory, RegistrationFactory, RegistrationProviderFactory
+from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory, RegistrationProviderFactory
 from osf_tests.utils import get_default_test_schema
+
+from website.mails import mails
 
 # See osf_tests.utils.default_test_schema for block types and valid answers
 INITIAL_SCHEMA_RESPONSES = {
@@ -39,12 +43,16 @@ def registration(schema, admin_user):
 
 
 @pytest.fixture
-def schema_response(registration):
-    response = SchemaResponse.create_initial_response(
+def initial_response(registration):
+    response = schema_response.SchemaResponse.create_initial_response(
         initiator=registration.creator,
         parent=registration
     )
-    response.update_responses(INITIAL_SCHEMA_RESPONSES)
+    response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
+    response.save()
+    for block in response.response_blocks.all():
+        block.response = INITIAL_SCHEMA_RESPONSES[block.schema_key]
+        block.save()
     return response
 
 
@@ -53,7 +61,7 @@ def schema_response(registration):
 class TestCreateSchemaResponse():
 
     def test_create_initial_response_sets_attributes(self, registration, schema):
-        response = SchemaResponse.create_initial_response(
+        response = schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration,
             schema=schema
@@ -66,7 +74,7 @@ class TestCreateSchemaResponse():
         assert not response.submitted_timestamp
 
     def test_create_initial_response_uses_parent_schema_if_none_provided(self, registration):
-        response = SchemaResponse.create_initial_response(
+        response = schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration
         )
@@ -76,7 +84,7 @@ class TestCreateSchemaResponse():
     def test_create_initial_response_assigns_response_blocks_and_source_revision(
             self, registration, schema):
         assert not SchemaResponseBlock.objects.exists()
-        response = SchemaResponse.create_initial_response(
+        response = schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration,
             schema=schema
@@ -94,7 +102,7 @@ class TestCreateSchemaResponse():
         registration.registered_schema.clear()
         registration.save()
         with assert_raises(ValueError):
-            SchemaResponse.create_initial_response(
+            schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration
             )
@@ -104,7 +112,7 @@ class TestCreateSchemaResponse():
             id=registration.registration_schema.id
         ).first()
         with assert_raises(ValueError):
-            SchemaResponse.create_initial_response(
+            schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration,
                 schema=alt_schema
@@ -113,7 +121,7 @@ class TestCreateSchemaResponse():
     def test_create_initial_response_creates_blocks_for_each_schema_question(self, registration):
         assert not SchemaResponseBlock.objects.exists()
         schema = registration.registration_schema
-        SchemaResponse.create_initial_response(
+        schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration,
             schema=schema
@@ -130,20 +138,20 @@ class TestCreateSchemaResponse():
             assert created_response_blocks.filter(schema_key=key).exists()
 
     def test_cannot_create_initial_response_twice(self, registration):
-        SchemaResponse.create_initial_response(
+        schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration,
         )
 
         with assert_raises(PreviousSchemaResponseError):
-            SchemaResponse.create_initial_response(
+            schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration,
             )
 
     def test_create_initial_response_for_different_parent(self, registration):
         schema = registration.registration_schema
-        first_response = SchemaResponse.create_initial_response(
+        first_response = schema_response.SchemaResponse.create_initial_response(
             initiator=registration.creator,
             parent=registration,
         )
@@ -151,7 +159,7 @@ class TestCreateSchemaResponse():
         alternate_registration = RegistrationFactory(schema=schema)
         alternate_registration.schema_responses.clear()  # so we can use `create_initial_response` without validation
 
-        alternate_registration_response = SchemaResponse.create_initial_response(
+        alternate_registration_response = schema_response.SchemaResponse.create_initial_response(
             initiator=alternate_registration.creator,
             parent=alternate_registration,
         )
@@ -176,10 +184,8 @@ class TestCreateSchemaResponse():
             alternate_registration_response.response_blocks.all()
         ).exists()
 
-    def test_create_from_previous_response(self, registration, schema_response):
-        schema_response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
-        schema_response.save()
-        revised_response = SchemaResponse.create_from_previous_response(
+    def test_create_from_previous_response(self, registration, initial_response):
+        revised_response = schema_response.SchemaResponse.create_from_previous_response(
             initiator=registration.creator,
             previous_response=schema_response,
             justification='Leeeeerooooy Jeeeenkiiiinns'
@@ -187,13 +193,13 @@ class TestCreateSchemaResponse():
 
         assert revised_response.initiator == registration.creator
         assert revised_response.parent == registration
-        assert revised_response.schema == schema_response.schema
-        assert revised_response.previous_response == schema_response
+        assert revised_response.schema == initial_response.schema
+        assert revised_response.previous_response == initial_response
         assert revised_response.revision_justification == 'Leeeeerooooy Jeeeenkiiiinns'
 
-        assert revised_response != schema_response
+        assert revised_response != initial_response
         assert not revised_response.updated_response_blocks.exists()
-        assert set(revised_response.response_blocks.all()) == set(schema_response.response_blocks.all())
+        assert set(revised_response.response_blocks.all()) == set(initial_response.response_blocks.all())
 
     @pytest.mark.parametrize(
         'invalid_response_state',
@@ -208,24 +214,21 @@ class TestCreateSchemaResponse():
         ]
     )
     def test_create_from_previous_response_fails_if_parent_has_unapproved_response(
-            self, invalid_response_state, schema_response):
+            self, invalid_response_state, initial_response):
         # Making a valid revised response, then pushing the initial response into an
         # invalid state to ensure that `create_from_previous_response` fails if
         # *any* schema_response on the parent is unapproved
-        schema_response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
-        schema_response.save()
-
-        intermediate_response = SchemaResponse.create_from_previous_response(
+        intermediate_response = schema_response.SchemaResponse.create_from_previous_response(
             initiator=schema_response.initiator,
-            previous_response=schema_response
+            previous_response=initial_response
         )
         intermediate_response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
         intermediate_response.save()
 
-        schema_response.approvals_state_machine.set_state(invalid_response_state)
-        schema_response.save()
+        initial_response.approvals_state_machine.set_state(invalid_response_state)
+        initial_response.save()
         with assert_raises(PreviousSchemaResponseError):
-            SchemaResponse.create_from_previous_response(
+            schema_response.SchemaResponse.create_from_previous_response(
                 initiator=schema_response.initiator,
                 previous_response=intermediate_response
             )
@@ -236,29 +239,27 @@ class TestCreateSchemaResponse():
 class TestUpdateSchemaResponses():
 
     @pytest.fixture
-    def revised_response(self, schema_response):
-        schema_response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
-        schema_response.save()
-        return SchemaResponse.create_from_previous_response(
-            initiator=schema_response.initiator,
-            previous_response=schema_response,
+    def revised_response(self, initial_response):
+        return schema_response.SchemaResponse.create_from_previous_response(
+            initiator=initial_response.initiator,
+            previous_response=initial_response,
             justification='Leeeeerooooy Jeeeenkiiiinns'
         )
 
-    def test_all_responses_property(self, schema_response):
-        assert schema_response.all_responses == INITIAL_SCHEMA_RESPONSES
-        for block in schema_response.response_blocks.all():
-            assert schema_response.all_responses[block.schema_key] == block.response
+    def test_all_responses_property(self, initial_response):
+        assert initial_response.all_responses == INITIAL_SCHEMA_RESPONSES
+        for block in initial_response.response_blocks.all():
+            assert initial_response.all_responses[block.schema_key] == block.response
 
-    def test_uodated_response_keys_property(self, schema_response, revised_response, schema):
-        # schema_response "updates" all keys
+    def test_uodated_response_keys_property(self, initial_response, revised_response, schema):
+        # initial_response "updates" all keys
         all_keys = set(
             RegistrationSchemaBlock.objects.filter(
                 schema=schema, registration_response_key__isnull=False
             ).values_list('registration_response_key', flat=True)
         )
 
-        assert schema_response.updated_response_keys == all_keys
+        assert initial_response.updated_response_keys == all_keys
 
         # No updated_responses on the standard revised_response
         assert not revised_response.updated_response_keys
@@ -266,40 +267,44 @@ class TestUpdateSchemaResponses():
         revised_response.update_responses({'q1': 'I has a new  answer'})
         assert revised_response.updated_response_keys == {'q1'}
 
-    def test_update_responses(self, schema_response):
-        assert schema_response.all_responses == INITIAL_SCHEMA_RESPONSES
+    def test_update_responses(self, initial_response):
+        assert initial_response.all_responses == INITIAL_SCHEMA_RESPONSES
 
         updated_responses = {
             'q1': 'Hello there',
             'q2': 'This is a new response',
             'q3': 'B',
             'q4': ['E'],
-            'q5': [schema_response.initiator.id],
+            'q5': [initial_response.initiator.id],
             'q6': 'SomeFile',
         }
-        schema_response.update_responses(updated_responses)
+        initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
+        initial_response.save()
+        initial_response.update_responses(updated_responses)
 
-        schema_response.refresh_from_db()
-        assert schema_response.all_responses == updated_responses
-        for block in schema_response.response_blocks.all():
+        initial_response.refresh_from_db()
+        assert initial_response.all_responses == updated_responses
+        for block in initial_response.response_blocks.all():
             assert block.response == updated_responses[block.schema_key]
 
-    def test_update_to_schema_response_updates_response_blocks_in_place(self, schema_response):
+    def test_update_to_initial_response_updates_response_blocks_in_place(self, initial_response):
         # Call set to force evaluation
-        initial_block_ids = set(schema_response.response_blocks.values_list('id', flat=True))
+        initial_block_ids = set(initial_response.response_blocks.values_list('id', flat=True))
 
-        schema_response.update_responses(
+        initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
+        initial_response.save()
+        initial_response.update_responses(
             {
                 'q1': 'Hello there',
                 'q2': 'This is a new response',
                 'q3': 'B',
                 'q4': ['E'],
-                'q5': [schema_response.initiator.id],
+                'q5': [initial_response.initiator.id],
                 'q6': 'SomeFile'
             }
         )
-        schema_response.refresh_from_db()
-        updated_block_ids = set(schema_response.response_blocks.values_list('id', flat=True))
+        initial_response.refresh_from_db()
+        updated_block_ids = set(initial_response.response_blocks.values_list('id', flat=True))
         assert initial_block_ids == updated_block_ids
 
     def test_initial_update_to_revised_response_creates_new_block(self, revised_response):
@@ -373,9 +378,9 @@ class TestUpdateSchemaResponses():
         assert revised_response.response_blocks.get(schema_key='q3').id == original_q3_block.id
         assert revised_response.response_blocks.get(schema_key='q4').id == original_q4_block.id
 
-    def test_update_with_unsupported_key_raises(self, schema_response):
+    def test_update_with_unsupported_key_raises(self, revised_response):
         with assert_raises(ValueError):
-            schema_response.update_responses({'q7': 'sneaky'})
+            revised_response.update_responses({'q7': 'sneaky'})
 
     @pytest.mark.parametrize(
         'updated_responses',
@@ -386,9 +391,9 @@ class TestUpdateSchemaResponses():
         ]
     )
     def test_update_with_unsupported_key_and_supported_keys_writes_and_raises(
-            self, updated_responses, schema_response):
+            self, updated_responses, revised_response):
         with assert_raises(ValueError):
-            schema_response.update_responses(updated_responses)
+            revised_response.update_responses(updated_responses)
 
         schema_response.refresh_from_db()
         assert schema_response.all_responses['q1'] == updated_responses['q1']
@@ -406,28 +411,27 @@ class TestUpdateSchemaResponses():
             ApprovalStates.COMPLETED,
         ]
     )
-    def test_update_fails_if_state_is_invalid(self, invalid_response_state, schema_response):
-        schema_response.approvals_state_machine.set_state(invalid_response_state)
+    def test_update_fails_if_state_is_invalid(self, invalid_response_state, initial_response):
+        initial_response.approvals_state_machine.set_state(invalid_response_state)
         with assert_raises(SchemaResponseStateError):
-            schema_response.update_responses({'q1': 'harrumph'})
+            initial_response.update_responses({'q1': 'harrumph'})
 
 
 @pytest.mark.django_db
 class TestDeleteSchemaResponse():
 
-    def test_delete_schema_response_deletes_schema_response_blocks(self, schema_response):
-        # schema_response is the only current source of SchemaResponseBlocks,
+    def test_delete_schema_response_deletes_schema_response_blocks(self, initial_response):
+        # initial_response is the only current source of SchemaResponseBlocks,
         # so all should be deleted
-        schema_response.delete()
+        initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
+        initial_response.save()
+        initial_response.delete()
         assert not SchemaResponseBlock.objects.exists()
 
-    def test_delete_revised_response_only_deletes_updated_blocks(self, schema_response):
-        schema_response.approvals_state_machine.set_state(ApprovalStates.APPROVED)
-        schema_response.save()
-
-        revised_response = SchemaResponse.create_from_previous_response(
-            previous_response=schema_response,
-            initiator=schema_response.initiator
+    def test_delete_revised_response_only_deletes_updated_blocks(self, initial_response):
+        revised_response = schema_response.SchemaResponse.create_from_previous_response(
+            previous_response=initial_response,
+            initiator=initial_response.initiator
         )
         revised_response.update_responses({'q1': 'blahblahblah', 'q2': 'whoopdedoo'})
 
@@ -452,10 +456,11 @@ class TestDeleteSchemaResponse():
             ApprovalStates.COMPLETED,
         ]
     )
-    def test_delete_fails_if_state_is_invalid(self, invalid_response_state, schema_response):
-        schema_response.approvals_state_machine.set_state(invalid_response_state)
+    def test_delete_fails_if_state_is_invalid(self, invalid_response_state, initial_response):
+        initial_response.approvals_state_machine.set_state(invalid_response_state)
+        initial_response.save()
         with assert_raises(SchemaResponseStateError):
-            schema_response.delete()
+            initial_response.delete()
 
 
 @pytest.mark.enable_bookmark_creation
@@ -467,17 +472,17 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         return AuthUserFactory()
 
     def test_submit_response_adds_pending_approvers(
-            self, schema_response, admin_user, alternate_user):
-        assert schema_response.state is ApprovalStates.IN_PROGRESS
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+            self, initial_response, admin_user, alternate_user):
+        assert initial_response.state is ApprovalStates.IN_PROGRESS
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
 
-        assert schema_response.state is ApprovalStates.UNAPPROVED
-        for user in [schema_response.initiator, alternate_user]:
-            assert user in schema_response.pending_approvers.all()
+        assert initial_response.state is ApprovalStates.UNAPPROVED
+        for user in [admin_user, alternate_user]:
+            assert user in initial_response.pending_approvers.all()
 
-    def test_submit_response_writes_schema_response_action(self, schema_response, admin_user):
-        assert not schema_response.actions.exists()
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+    def test_submit_response_writes_schema_response_action(self, initial_response, admin_user):
+        assert not initial_response.actions.exists()
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
         new_action = schema_response.actions.last()
         assert new_action.creator == admin_user
@@ -485,117 +490,117 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         assert new_action.to_state == ApprovalStates.UNAPPROVED.db_name
         assert new_action.trigger == SchemaResponseTriggers.SUBMIT.db_name
 
-    def test_submit_response_requires_user(self, schema_response, admin_user):
+    def test_submit_response_requires_user(self, initial_response, admin_user):
         with assert_raises(ValueError):
-            schema_response.submit(required_approvers=[admin_user])
+            initial_response.submit(required_approvers=[admin_user])
 
-    def test_submit_resposne_requires_required_approvers(self, schema_response, admin_user):
+    def test_submit_resposne_requires_required_approvers(self, initial_response, admin_user):
         with assert_raises(ValueError):
-            schema_response.submit(user=admin_user)
+            initial_response.submit(user=admin_user)
 
-    def test_non_parent_admin_cannot_submit_response(self, schema_response, alternate_user):
+    def test_non_parent_admin_cannot_submit_response(self, initial_response, alternate_user):
         with assert_raises(PermissionsError):
-            schema_response.submit(user=alternate_user)
+            initial_response.submit(user=alternate_user)
 
     def test_approve_response_requires_all_approvers(
-            self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+            self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
 
-        schema_response.approve(user=schema_response.initiator)
-        assert schema_response.state is ApprovalStates.UNAPPROVED
+        initial_response.approve(user=schema_response.initiator)
+        assert initial_response.state is ApprovalStates.UNAPPROVED
 
-        schema_response.approve(user=alternate_user)
-        assert schema_response.state is ApprovalStates.APPROVED
+        initial_response.approve(user=alternate_user)
+        assert initial_response.state is ApprovalStates.APPROVED
 
     def test_approve_response_writes_schema_response_action(
-            self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
-        schema_response.approve(user=admin_user)
+            self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+        initial_response.approve(user=admin_user)
 
         # Confirm that action for first "approve" still has to_state of UNAPPROVED
-        new_action = schema_response.actions.last()
+        new_action = initial_response.actions.last()
         assert new_action.creator == admin_user
         assert new_action.from_state == ApprovalStates.UNAPPROVED.db_name
         assert new_action.to_state == ApprovalStates.UNAPPROVED.db_name
         assert new_action.trigger == SchemaResponseTriggers.APPROVE.db_name
 
-        schema_response.approve(user=alternate_user)
+        initial_response.approve(user=alternate_user)
 
         # Confifm that action for final "approve" has to_state of APPROVED
-        new_action = schema_response.actions.last()
+        new_action = initial_response.actions.last()
         assert new_action.creator == alternate_user
         assert new_action.from_state == ApprovalStates.UNAPPROVED.db_name
         assert new_action.to_state == ApprovalStates.APPROVED.db_name
         assert new_action.trigger == SchemaResponseTriggers.APPROVE.db_name
 
         # Confirm that final approval writes only one action
-        assert schema_response.actions.filter(
+        assert initial_response.actions.filter(
             trigger=SchemaResponseTriggers.APPROVE.db_name
         ).count() == 2
 
-    def test_approve_response_requires_user(self, schema_response, admin_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+    def test_approve_response_requires_user(self, initial_response, admin_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
         with assert_raises(ValueError):
-            schema_response.approve()
+            initial_response.approve()
 
     def test_non_approver_cannot_approve_response(
-            self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+            self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
         with assert_raises(PermissionsError):
-            schema_response.approve(user=alternate_user)
+            initial_response.approve(user=alternate_user)
 
-    def test_reject_response_moves_state_to_in_progress(self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+    def test_reject_response_moves_state_to_in_progress(self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
 
         # Implicitly confirm that only one reject call is needed to advance state
-        schema_response.reject(user=admin_user)
-        assert schema_response.state is ApprovalStates.IN_PROGRESS
+        initial_response.reject(user=admin_user)
+        assert initial_response.state is ApprovalStates.IN_PROGRESS
 
     def test_reject_response_clears_pending_approvers(
-            self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
-        schema_response.reject(user=schema_response.initiator)
+            self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+        initial_response.reject(user=schema_response.initiator)
 
-        assert not schema_response.pending_approvers.exists()
+        assert not initial_response.pending_approvers.exists()
 
-    def test_reject_response_writes_schema_response_action(self, schema_response, admin_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
-        schema_response.reject(user=admin_user)
-        new_action = schema_response.actions.last()
+    def test_reject_response_writes_schema_response_action(self, initial_response, admin_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
+        initial_response.reject(user=admin_user)
+        new_action = initial_response.actions.last()
 
         assert new_action.creator == admin_user
         assert new_action.from_state == ApprovalStates.UNAPPROVED.db_name
         assert new_action.to_state == ApprovalStates.IN_PROGRESS.db_name
         assert new_action.trigger == SchemaResponseTriggers.ADMIN_REJECT.db_name
 
-    def test_reject_response_requires_user(self, schema_response, admin_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+    def test_reject_response_requires_user(self, initial_response, admin_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
         with assert_raises(ValueError):
-            schema_response.reject()
+            initial_response.reject()
 
     def test_non_approver_cannnot_reject_response(
-            self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+            self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
         with assert_raises(PermissionsError):
-            schema_response.reject(user=alternate_user)
+            initial_response.reject(user=alternate_user)
 
-    def test_approver_cannot_call_accept_directly(self, schema_response, admin_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
+    def test_approver_cannot_call_accept_directly(self, initial_response, admin_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
         with assert_raises(ValueError):
-            schema_response.accept(user=schema_response.initiator)
+            initial_response.accept(user=schema_response.initiator)
 
-    def test_internal_accept_advances_state(self, schema_response, admin_user, alternate_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
+    def test_internal_accept_advances_state(self, initial_response, admin_user, alternate_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user, alternate_user])
         schema_response.accept()
 
-        assert schema_response.state is ApprovalStates.APPROVED
+        assert initial_response.state is ApprovalStates.APPROVED
 
-    def test_internal_accept_clears_pending_approvers(self, schema_response, admin_user):
-        schema_response.submit(user=admin_user, required_approvers=[admin_user])
-        schema_response.accept()
+    def test_internal_accept_clears_pending_approvers(self, initial_response, admin_user):
+        initial_response.submit(user=admin_user, required_approvers=[admin_user])
+        initial_response.accept()
         assert not schema_response.pending_approvers.exists()
 
 
@@ -624,7 +629,6 @@ class TestModeratedSchemaResponseApprovalFlows():
     @pytest.fixture
     def moderated_response(self, moderated_registration):
         moderated_response = moderated_registration.schema_responses.get()
-        moderated_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         return moderated_response
 
     def test_moderated_response_requires_moderation(self, moderated_response, admin_user):
@@ -715,3 +719,56 @@ class TestModeratedSchemaResponseApprovalFlows():
         moderated_response.approve(user=admin_user)
         with assert_raises(ValueError):
             moderated_response.accept()
+
+
+@pytest.mark.django_db
+class TestSchemaResponseNotfications:
+
+    @pytest.fixture
+    def alternate_contributor(self, registration):
+        user = AuthUserFactory()
+        registration.add_contributor(user, 'read')
+        return user
+
+    @pytest.fixture
+    def nested_registration(self, registration, schema):
+        project = ProjectFactory(parent=registration.registered_from)
+        project.save()
+        return RegistrationFactory(project=project, parent=registration, schema=schema)
+
+    @pytest.fixture
+    def nested_contributor(self, nested_registration):
+        return nested_registration.creator
+
+    @pytest.fixture
+    def recipient_emails(self, admin_user, alternative_contributor, nested_contributor):
+        return {user.username for user in [admin_user, alternative_contributor, nested_contributor]}
+
+    @pytest.mark.parametrize(
+        'start_state, trigger, template',
+        [
+            (ApprovalStates.IN_PROGRESS, 'submit', mails.SCHEMA_RESPONSE_SUBMITTED),
+            (ApprovalStates.UNAPPROVED, 'accept', mails.SCHEMA_RESPONSE_APPROVED),
+            (ApprovalStates.PENDING_MODERATION, 'accept', mails.SCHEMA_RESPONSE_APPROVED),
+            (ApprovalStates.UNAPPROVED, 'reject', mails.SCHEMA_RESPONSE_REJECTED),
+            (ApprovalStates.PENDING_MODERATION, 'reject', mails.SCHEMA_RESPONSE_REJECTED),
+        ]
+    )
+    def test_notifications_sent_on_state_machine_triggers(
+            self, initial_response, admin_user, recipient_emails, start_state, trigger, template):
+        initial_response.approvals_state_machine.set_state(start_state)
+        initial_response.save()
+        with mock.patch.object(schema_response.mails, 'send_mail', autospec=True) as mock_send:
+            trigger = getattr(initial_response, trigger)
+            trigger(user=admin_user)
+
+        assert mock_send.call_count == len(recipient_emails)
+        for call_args in mock_send.call_args_list:
+            # Confirm that no unexpected users were emailed
+            recipient = call_args[1]['to_addr']
+            assert recipient in recipient_emails
+            # Pop the recipient to confirm that no user recieved multiple emails.
+            # Combined with call_count assert, this also ensures that all
+            # exppected recipients were emailed.
+            recipient_emails.pop(recipient)
+            assert call_args[1]['mail'] == template

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -480,3 +480,45 @@ INSTITUTION_DEACTIVATION = Mail(
     'institution_deactivation',
     subject='Your OSF login has changed - here\'s what you need to know!'
 )
+
+
+class ApprovalEmail(Mail):
+
+    TEMPLATE_FOR_ROLE = {}
+    DEFAULT_TEMPLATE = None
+    SUBJECT_TEMPLATE = None
+
+    def __init__(self, resource, role):
+        subject = self.SUBJECT_TEMPLATE.format(name=resource.name)
+        super().__init__(
+            subject=subject,
+            tpl_prefix=self.TEMPLATE_FOR_ROLE.get(role, self.DEFAULT_TEMPLATE)
+        )
+
+class SchemaResponseInitiated(ApprovalEmail):
+
+    SUBJECT_TEMPLATE = 'Updates are in-progress for your registration {name}'
+    DEFAULT_TEMPLATE = 'updates_initiated'
+
+class SchemaResponseSubmitted(ApprovalEmail):
+
+    SUBJECT_TEMPLATE = 'Updates to your registration {name} are pending admin approval'
+    DEFAULT_TEMPLATE = 'updates_pending_approval'
+
+
+class SchemaResponseRejected(ApprovalEmail):
+
+    SUBJECT_TEMPLATE = 'Updates NOT accepted for your registration {name}'
+    DEFAULT_TEMPLATE = 'updates_rejected'
+
+
+class SchemaResponsePendingModeration(ApprovalEmail):
+
+    SUBJECT_TEMPLATE = 'Updates to your registration {name} are pending moderator approval'
+    DEFAULT_TEMPLATE = 'udpates_pending_moderation'
+
+
+class SchemaResponseApproved(ApprovalEmail):
+
+    SUBJECT_TEMPLATE = 'Updates to your registration {name} have been approved'
+    DEFAULT_TEMPLATE = 'udpates_approved'

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -482,43 +482,25 @@ INSTITUTION_DEACTIVATION = Mail(
 )
 
 
-class ApprovalEmail(Mail):
-
-    TEMPLATE_FOR_ROLE = {}
-    DEFAULT_TEMPLATE = None
-    SUBJECT_TEMPLATE = None
-
-    def __init__(self, resource, role):
-        subject = self.SUBJECT_TEMPLATE.format(name=resource.name)
-        super().__init__(
-            subject=subject,
-            tpl_prefix=self.TEMPLATE_FOR_ROLE.get(role, self.DEFAULT_TEMPLATE)
-        )
-
-class SchemaResponseInitiated(ApprovalEmail):
-
-    SUBJECT_TEMPLATE = 'Updates are in-progress for your registration {name}'
-    DEFAULT_TEMPLATE = 'updates_initiated'
-
-class SchemaResponseSubmitted(ApprovalEmail):
-
-    SUBJECT_TEMPLATE = 'Updates to your registration {name} are pending admin approval'
-    DEFAULT_TEMPLATE = 'updates_pending_approval'
+SCHEMA_RESPONSE_INITIATED = Mail(
+    'updates_initiated',
+    subject='Updates in in-progress for your {resource_type} {title}'
+)
 
 
-class SchemaResponseRejected(ApprovalEmail):
-
-    SUBJECT_TEMPLATE = 'Updates NOT accepted for your registration {name}'
-    DEFAULT_TEMPLATE = 'updates_rejected'
-
-
-class SchemaResponsePendingModeration(ApprovalEmail):
-
-    SUBJECT_TEMPLATE = 'Updates to your registration {name} are pending moderator approval'
-    DEFAULT_TEMPLATE = 'udpates_pending_moderation'
+SCHEMA_RESPONSE_SUBMITTED = Mail(
+    'updates_pending_approval',
+    subject='Updates to your {resource_type} {title} are pending admin approval'
+)
 
 
-class SchemaResponseApproved(ApprovalEmail):
+SCHEMA_RESPONSE_APPROVED = Mail(
+    'updates_approved',
+    subject='Updates to your {resource_type} {title} have been approved'
+)
 
-    SUBJECT_TEMPLATE = 'Updates to your registration {name} have been approved'
-    DEFAULT_TEMPLATE = 'udpates_approved'
+
+SCHEMA_RESPONSE_REJECTED = Mail(
+    'updates_rejected',
+    subject='Changes requested for the proposed updates to your {resource_type} {title}'
+)

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -484,23 +484,23 @@ INSTITUTION_DEACTIVATION = Mail(
 
 SCHEMA_RESPONSE_INITIATED = Mail(
     'updates_initiated',
-    subject='Updates in in-progress for your {resource_type} {title}'
+    subject='Updates in in-progress for your ${resource_type} ${title}'
 )
 
 
 SCHEMA_RESPONSE_SUBMITTED = Mail(
     'updates_pending_approval',
-    subject='Updates to your {resource_type} {title} are pending admin approval'
+    subject='Updates to your ${resource_type} ${title} are pending admin approval'
 )
 
 
 SCHEMA_RESPONSE_APPROVED = Mail(
     'updates_approved',
-    subject='Updates to your {resource_type} {title} have been approved'
+    subject='Updates to your ${resource_type} ${title} have been approved'
 )
 
 
 SCHEMA_RESPONSE_REJECTED = Mail(
     'updates_rejected',
-    subject='Changes requested for the proposed updates to your {resource_type} {title}'
+    subject='Changes requested for the proposed updates to your ${resource_type} ${title}'
 )

--- a/website/reviews/listeners.py
+++ b/website/reviews/listeners.py
@@ -69,54 +69,57 @@ def reviews_submit_notification_moderators(self, timestamp, context):
     resource = context['reviewable']
     provider = resource.provider
 
+    # Set submission url
+    if provider.type == 'osf.preprintprovider':
+        context['reviews_submission_url'] = (
+            f'{DOMAIN}reviews/preprints/{provider._id}/{resource._id}'
+        )
+    elif provider.type == 'osf.registrationprovider':
+        context['reviews_submission_url'] = f'{DOMAIN}{resource._id}?mode=moderator'
+    else:
+        raise NotImplementedError(f'unsupported provider type {provider.type}')
+
+    # Set url for profile image of the submitter
+    context['profile_image_url'] = get_profile_image_url(context['referrer'])
+
+    # Set message
+    if context['revision_id']:
+        context['message'] = f'submitted updates to "{resource.title}".'
+        context['reviews_submission_url'] += '&revisionId=<revision_id>'
+    else:
+        context['message'] = f'submitted "{resource.title}".'
+
     # Get NotificationSubscription instance, which contains reference to all subscribers
     provider_subscription, created = NotificationSubscription.objects.get_or_create(
         _id=f'{provider._id}_new_pending_submissions',
         provider=provider
     )
 
-    # Set message
-    context['message'] = f'submitted "{resource.title}".'
-    # Set url for profile image of the submitter
-    context['profile_image_url'] = get_profile_image_url(context['referrer'])
-    # Set submission url
-    if provider.type == 'osf.preprintprovider':
-        url_segment = 'preprints'
-        flag_suffix = ''
-    elif provider.type == 'osf.registrationprovider':
-        url_segment = 'registries'
-        flag_suffix = '?mode=moderator'
-    else:
-        raise NotImplementedError(f'unsupported provider type {provider.type}')
+    # "transactional" subscribers receive notifications "Immediately" (i.e. at 5 minute intervals)
+    # "digest" subscribers receive emails daily
+    recipients_per_subscription_type = {
+        'email_transactional': list(
+            provider_subscription.email_transactional.all().values_list('guids___id', flat=True)
+        ),
+        'email_digest': list(
+            provider_subscription.email_digest.all().values_list('guids___id', flat=True)
+        )
+    }
 
-    context['reviews_submission_url'] = f'{DOMAIN}reviews/{url_segment}/{provider._id}/{resource._id}{flag_suffix}'
+    for subscription_type, recipient_ids in recipients_per_subscription_type.items():
+        if not recipient_ids:
+            continue
 
-    email_transactional_ids = list(provider_subscription.email_transactional.all().values_list('guids___id', flat=True))
-    email_digest_ids = list(provider_subscription.email_digest.all().values_list('guids___id', flat=True))
-
-    # Store emails to be sent to subscribers instantly (at a 5 min interval)
-    store_emails(
-        email_transactional_ids,
-        'email_transactional',
-        'new_pending_submissions',
-        context['referrer'],
-        resource,
-        timestamp,
-        abstract_provider=provider,
-        **context
-    )
-
-    # Store emails to be sent to subscribers daily
-    store_emails(
-        email_digest_ids,
-        'email_digest',
-        'new_pending_submissions',
-        context['referrer'],
-        resource,
-        timestamp,
-        abstract_provider=provider,
-        **context
-    )
+        store_emails(
+            recipient_ids,
+            subscription_type,
+            'new_pending_submissions',
+            context['referrer'],
+            resource,
+            timestamp,
+            abstract_provider=provider,
+            **context
+        )
 
 # Handle email notifications to notify moderators of new submissions.
 @reviews_signals.reviews_withdraw_requests_notification_moderators.connect

--- a/website/reviews/listeners.py
+++ b/website/reviews/listeners.py
@@ -83,9 +83,10 @@ def reviews_submit_notification_moderators(self, timestamp, context):
     context['profile_image_url'] = get_profile_image_url(context['referrer'])
 
     # Set message
-    if context['revision_id']:
+    revision_id = context.get('revision_id')
+    if revision_id:
         context['message'] = f'submitted updates to "{resource.title}".'
-        context['reviews_submission_url'] += '&revisionId=<revision_id>'
+        context['reviews_submission_url'] += f'&revisionId={revision_id}'
     else:
         context['message'] = f'submitted "{resource.title}".'
 

--- a/website/templates/emails/updates_approved.html.mako
+++ b/website/templates/emails/updates_approved.html.mako
@@ -11,7 +11,7 @@
 	<p>
     The updated responses will be visible by default to all viewers of the ${resource_type}
     along with the reason for the changes. All previously approved updates will remain accessible
-    for comparrison through the "Updates" dropdown on the Registration overview page.
+    for comparrison through the "Updates" dropdown on the ${resource_type} overview page.
 	<p>
     Sincerely yours,<br>
     The OSF Robots<br>

--- a/website/templates/emails/updates_approved.html.mako
+++ b/website/templates/emails/updates_approved.html.mako
@@ -6,10 +6,10 @@
     <%!from website import settings%>
     Hello ${user.fullname},
     <p>
-    The proposed updates to your Registration
-    <a href="${response.parent.absolute_url}">${response.parent.title}</a> have been approved.
+    The proposed updates to your ${resource_type} <a href="${parent_url}">"${title}"</a>
+    have been approved.
 	<p>
-    The updated responses will be visible by default to all viewers of the registration
+    The updated responses will be visible by default to all viewers of the ${resource_type}
     along with the reason for the changes. All previously approved updates will remain accessible
     for comparrison through the "Updates" dropdown on the Registration overview page.
 	<p>

--- a/website/templates/emails/updates_approved.html.mako
+++ b/website/templates/emails/updates_approved.html.mako
@@ -1,0 +1,19 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <%!from website import settings%>
+    Hello ${user.fullname},
+    <p>
+    The proposed updates to your Registration
+    <a href="${response.parent.absolute_url}">${response.parent.title}</a> have been approved.
+	<p>
+    The updated responses will be visible by default to all viewers of the registration
+    along with the reason for the changes. All previously approved updates will remain accessible
+    for comparrison through the "Updates" dropdown on the Registration overview page.
+	<p>
+    Sincerely yours,<br>
+    The OSF Robots<br>
+</tr>
+</%def>

--- a/website/templates/emails/updates_initiated.html.mako
+++ b/website/templates/emails/updates_initiated.html.mako
@@ -6,9 +6,13 @@
     <%!from website import settings%>
     Hello ${user.fullname},
     <p>
-    Your Registration <a href="${response.parent.absolute_url}">{response.parent.title}</a>
-    is in the process of being updated. You can view and contribute to the updates by clicking
-    <a href="${response.osf_url}">here</a>
+    Your ${resource_type} <a href="${parent_url}">"${title}"</a> is in the process of being updated.
+    <p>
+    % if can_write:
+        You can review and contribute to the updates by clicking <a href="${update_url}">here</a>.
+    % else:
+        You can review the updates by clicking <a href="${update_url}">here</a>.
+    % endif
     <p>
     Sincerely yours,<br>
     The OSF Robots<br>

--- a/website/templates/emails/updates_initiated.html.mako
+++ b/website/templates/emails/updates_initiated.html.mako
@@ -1,0 +1,16 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <%!from website import settings%>
+    Hello ${user.fullname},
+    <p>
+    Your Registration <a href="${response.parent.absolute_url}">{response.parent.title}</a>
+    is in the process of being updated. You can view and contribute to the updates by clicking
+    <a href="${response.osf_url}">here</a>
+    <p>
+    Sincerely yours,<br>
+    The OSF Robots<br>
+</tr>
+</%def>

--- a/website/templates/emails/updates_pending_approval.html.mako
+++ b/website/templates/emails/updates_pending_approval.html.mako
@@ -14,7 +14,7 @@
         From that page, You will be able to either approve the updates or request further changes.
     % endif
     <p>
-    %if resposne.is_moderated:
+    %if is_moderated:
     If the proposed updates are approved by all "admin" users on the ${resource_type},
     they will be submitted for moderator review.
     %endif

--- a/website/templates/emails/updates_pending_approval.html.mako
+++ b/website/templates/emails/updates_pending_approval.html.mako
@@ -6,18 +6,22 @@
     <%!from website import settings%>
     Hello ${user.fullname},
     <p>
-    Your ${resource_type} <a href="${parent_link}">${title}</a> has updates that are pending approval.
-	You can review the updated responses by clicking <a href="${update_link}">here</a>.
+    Your ${resource_type} <a href="${parent_link}">"${title}"</a> has updates that are
+    pending approval.
+    <p>
+    You can review the updated responses by clicking <a href="${update_link}">here</a>.
+    % if is_approver:
+        From that page, You will be able to either approve the updates or request further changes.
+    % endif
     <p>
     %if resposne.is_moderated:
-    If the proposed updates are approved by all registration admins, they will be submitted
-    for moderator review.
+    If the proposed updates are approved by all "admin" users on the ${resource_type},
+    they will be submitted for moderator review.
     %endif
     Once the updates have received all required approvals, the updated responses and the
-    reason for the changes will be visible by default for all users viewing your registration.
-    <p>
+    reason for the changes will be visible by default for all users viewing your ${resource_type}.
     All previously approved updates will remain accessible for comparrison through the
-    "Updates" dropdown on the main Registration page.
+    "Updates" dropdown on the main ${resource_type} page.
     <p>
     Sincerely yours,<br>
     The OSF Robots<br>

--- a/website/templates/emails/updates_pending_approval.html.mako
+++ b/website/templates/emails/updates_pending_approval.html.mako
@@ -1,0 +1,25 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <%!from website import settings%>
+    Hello ${user.fullname},
+    <p>
+    Your ${resource_type} <a href="${parent_link}">${title}</a> has updates that are pending approval.
+	You can review the updated responses by clicking <a href="${update_link}">here</a>.
+    <p>
+    %if resposne.is_moderated:
+    If the proposed updates are approved by all registration admins, they will be submitted
+    for moderator review.
+    %endif
+    Once the updates have received all required approvals, the updated responses and the
+    reason for the changes will be visible by default for all users viewing your registration.
+    <p>
+    All previously approved updates will remain accessible for comparrison through the
+    "Updates" dropdown on the main Registration page.
+    <p>
+    Sincerely yours,<br>
+    The OSF Robots<br>
+</tr>
+</%def>

--- a/website/templates/emails/updates_pending_approval.html.mako
+++ b/website/templates/emails/updates_pending_approval.html.mako
@@ -6,10 +6,10 @@
     <%!from website import settings%>
     Hello ${user.fullname},
     <p>
-    Your ${resource_type} <a href="${parent_link}">"${title}"</a> has updates that are
+    Your ${resource_type} <a href="${parent_url}">"${title}"</a> has updates that are
     pending approval.
     <p>
-    You can review the updated responses by clicking <a href="${update_link}">here</a>.
+    You can review the updated responses by clicking <a href="${update_url}">here</a>.
     % if is_approver:
         From that page, You will be able to either approve the updates or request further changes.
     % endif

--- a/website/templates/emails/updates_rejected.html.mako
+++ b/website/templates/emails/updates_rejected.html.mako
@@ -5,11 +5,15 @@
   <td style="border-collapse: collapse;">
     Hello ${user.fullname},
     <p>
-    Further changes have been requested for the proposed updates to your Registration
-	<a href="${response.parent.absolute_url}">${response.parent.title}</a>.
-	<p>
-    You can view and contribute to the updates in-progress by clicking
-    <a href="${response.osf_url}">here</a>.
+    Further changes have been requested for the proposed updates to your ${resource_type}
+    <a href="${parent_url}">"${title}"</a>.
+    <p>
+    % if can_write:
+        You can view and contribute to the updates in-progress by clicking
+        <a href="${update_url}">here</a>.
+    % else:
+        You can view the updates in-progress by clocking <a href="${update_url}">here</a>.
+    % endif
     <p>
     Sincerely yours,<br>
     The OSF Robots<br>

--- a/website/templates/emails/updates_rejected.html.mako
+++ b/website/templates/emails/updates_rejected.html.mako
@@ -1,0 +1,17 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    Hello ${user.fullname},
+    <p>
+    Further changes have been requested for the proposed updates to your Registration
+	<a href="${response.parent.absolute_url}">${response.parent.title}</a>.
+	<p>
+    You can view and contribute to the updates in-progress by clicking
+    <a href="${response.osf_url}">here</a>.
+    <p>
+    Sincerely yours,<br>
+    The OSF Robots<br>
+</tr>
+</%def>

--- a/website/templates/emails/updates_rejected.html.mako
+++ b/website/templates/emails/updates_rejected.html.mako
@@ -12,7 +12,7 @@
         You can view and contribute to the updates in-progress by clicking
         <a href="${update_url}">here</a>.
     % else:
-        You can view the updates in-progress by clocking <a href="${update_url}">here</a>.
+        You can view the updates in-progress by clicking <a href="${update_url}">here</a>.
     % endif
     <p>
     Sincerely yours,<br>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add the logical plumbing for sending emails to contributors and moderators as part of the registration update flow (plus placeholder emails).

## Changes
* Added Email templates for the major milestones in the update process
* Added logic to SchemaResponse to send emails with appropriate events
* Added new tests to confirm notifications render and are sent to all users
  *  Refactored `schema_response` fixture to `initial_response` in order to free up the "schema_response" name for `mock`ing purposes
* Fixed an implementation that made `node.get_active_contributors_recursive` and `node.get_admin_contributors_recursive` take O(n^2) time instead of O(n) time when getting only unique contributors

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
