### PR TITLE
[No Ticket] Bulk Upload - Improvements and Bug Fixes for Tasks

### DIFF
--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -212,9 +212,13 @@ def bulk_create_registrations(upload_id, dry_run=True):
                     else:
                         row.delete()
         except Exception as e:
-            logger.error('Draft registration creation unexpected exception: [{}]'.format(repr(e)))
+            error = 'Bulk upload registration creation encountered an unexpected exception: ' \
+                    '[row="{}", error="{}"]'.format(row.id, repr(e))
+            logger.error(error)
+            sentry.log_message(error)
             sentry.log_exception()
-            draft_error_list.append('Row: {}'.format(row.id))
+            draft_error_list.append('Title: N/A, External ID: N/A, Row Hash: {}, '
+                                    'Error: Unexpected'.format(row.row_hash))
             if not dry_run:
                 if row.draft_registration:
                     row.draft_registration.delete()

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -366,6 +366,9 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
         except Institution.DoesNotExist:
             error = 'Institution not found: [name={}]'.format(name)
             raise RegistrationBulkCreationRowError(row.upload.id, row.id, row_title, row_external_id, error=error)
+        if not initiator.is_affiliated_with_institution(institution):
+            error = 'Initiator [{}] is not affiliated with institution [{}]'.format(initiator._id, institution._id)
+            raise RegistrationBulkCreationRowError(row.upload.id, row.id, row_title, row_external_id, error=error)
         affiliated_institutions.append(institution)
 
     # Prepare tags

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -266,7 +266,7 @@ def bulk_create_registrations(upload_id, dry_run=True):
                   'Upload ID: [{}], Draft Errors: [{}]'.format(upload_id, draft_error_list)
         sentry.log_message(message)
         logger.error(message)
-    elif len(draft_error_list) > 1 or len(approval_error_list) > 1:
+    elif len(draft_error_list) > 0 or len(approval_error_list) > 0:
         upload.state = JobState.DONE_PARTIAL
         message = 'Some registration rows failed during bulk creation. Upload ID: [{}]; Draft Errors: [{}]; ' \
                   'Approval Errors: [{}]'.format(upload_id, draft_error_list, approval_error_list)

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -138,6 +138,7 @@ def prepare_for_registration_bulk_creation(payload_hash, initiator_id, provider_
             fullname=initiator.fullname,
             count=initial_row_count,
             draft_errors=draft_error_list,
+            osf_support_email=settings.OSF_SUPPORT_EMAIL,
         )
         return
 
@@ -300,6 +301,7 @@ def bulk_create_registrations(upload_id, dry_run=True):
                 draft_errors=draft_error_list,
                 failures=len(draft_error_list),
                 pending_submissions_url=get_provider_submission_url(provider),
+                osf_support_email=settings.OSF_SUPPORT_EMAIL,
             )
         elif upload.state == JobState.DONE_ERROR:
             mails.send_mail(
@@ -308,6 +310,7 @@ def bulk_create_registrations(upload_id, dry_run=True):
                 fullname=initiator.fullname,
                 count=initial_row_count,
                 draft_errors=draft_error_list,
+                osf_support_email=settings.OSF_SUPPORT_EMAIL,
             )
         else:
             message = 'Failed to send registration bulk upload outcome email due to invalid ' \
@@ -556,6 +559,7 @@ def handle_internal_error(initiator=None, provider=None, message=None, dry_run=T
                 to_addr=initiator.username,
                 mail=mails.REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE,
                 fullname=initiator.fullname,
+                osf_support_email=settings.OSF_SUPPORT_EMAIL,
             )
         inform_product_of_errors(initiator=initiator, provider=provider, message=message)
 

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -240,6 +240,9 @@ def bulk_create_registrations(upload_id, dry_run=True):
     else:
         upload.state = JobState.DONE_FULL
         logger.info('All registration rows succeeded for bulk creation. Upload ID: [{}].'.format(upload_id))
+    # Reverse the error lists so that users see failed rows in the same order as the original CSV
+    draft_error_list.reverse()
+    approval_error_list.reverse()
     if not dry_run:
         upload.save()
         logger.info('Sending emails to initiator/uploader ...')

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -501,6 +501,11 @@ REGISTRATION_BULK_UPLOAD_FAILURE_ALL = Mail(
     subject='Registrations Were Not Bulk Uploaded to your Community\'s Registry'
 )
 
+REGISTRATION_BULK_UPLOAD_FAILURE_DUPLICATES = Mail(
+    'registration_bulk_upload_failure_duplicates',
+    subject='Registrations Were Not Bulk Uploaded to your Community\'s Registry'
+)
+
 REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE = Mail(
     'registration_bulk_upload_unexpected_failure',
     subject='Registrations Were Not Bulk Uploaded to your Community\'s Registry'

--- a/website/templates/emails/registration_bulk_upload_failure_all.html.mako
+++ b/website/templates/emails/registration_bulk_upload_failure_all.html.mako
@@ -9,7 +9,9 @@
   <td style="border-collapse: collapse;">
       Hello ${fullname},<br>
       <br>
-      All ${count} registrations could not be uploaded. Errors are listed below. Review the file and try to upload the registrations again. Contact the Help Desk at support@osf.io if you continue to have issues.<br>
+      All ${count} registrations could not be uploaded. Errors are listed below. Review the file and try to upload the
+      registrations again. Contact the Help Desk at <a href="mailto:${osf_support_email}">${osf_support_email}</a> if
+      you continue to have issues.<br>
       <br>
       <ul>
           % for error in draft_errors:

--- a/website/templates/emails/registration_bulk_upload_failure_duplicates.html.mako
+++ b/website/templates/emails/registration_bulk_upload_failure_duplicates.html.mako
@@ -9,9 +9,10 @@
   <td style="border-collapse: collapse;">
       Hello ${fullname},<br>
       <br>
-      All ${count} registrations could not be uploaded due to duplicate rows found either within the uploaded CSV
-      file or in our system. Duplicates are listed below. Review the file and try to upload the registrations
-      again after removing duplicates. Contact the Help Desk at support@osf.io if you continue to have issues.<br>
+      All ${count} registrations could not be uploaded due to duplicate rows found either within the uploaded csv file
+      or in our system. Duplicates are listed below. Review the file and try to upload the registrations again after
+      removing duplicates. Contact the Help Desk at <a href="mailto:${osf_support_email}">${osf_support_email}</a> if
+      you continue to have issues.<br>
       <br>
       <ul>
           % for error in draft_errors:

--- a/website/templates/emails/registration_bulk_upload_failure_duplicates.html.mako
+++ b/website/templates/emails/registration_bulk_upload_failure_duplicates.html.mako
@@ -1,0 +1,27 @@
+<%inherit file="notify_base.mako" />
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    <h3 class="text-center" style="padding: 0;margin: 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registrations Were Not Bulk Uploaded to your Community's Registry</h3>
+  </td>
+</tr>
+<tr>
+  <td style="border-collapse: collapse;">
+      Hello ${fullname},<br>
+      <br>
+      All ${count} registrations could not be uploaded due to duplicate rows found either within the uploaded CSV
+      file or in our system. Duplicates are listed below. Review the file and try to upload the registrations
+      again after removing duplicates. Contact the Help Desk at support@osf.io if you continue to have issues.<br>
+      <br>
+      <ul>
+          % for error in draft_errors:
+              <li>${error}</li>
+          % endfor
+      </ul>
+      <br>
+      Sincerely,<br>
+      <br>
+      The OSF Team<br>
+  </td>
+</tr>
+</%def>

--- a/website/templates/emails/registration_bulk_upload_product_owner.html.mako
+++ b/website/templates/emails/registration_bulk_upload_product_owner.html.mako
@@ -11,7 +11,7 @@
       <br>
       [${user}] from registry [${provider_name}] attempted to upload the registrations from a csv file. Review the
       file and inform the engineers of the issue. The registry has been notified of the problem and is waiting on a
-      response. Below is the error message.<br>
+      response. Below is the error message provided by the system.<br>
       <br>
       ${message}<br>
       <br>

--- a/website/templates/emails/registration_bulk_upload_success_all.html.mako
+++ b/website/templates/emails/registration_bulk_upload_success_all.html.mako
@@ -10,12 +10,15 @@
       Hello ${fullname},<br>
       <br>
       % if auto_approval:
-          All ${count} of your registrations were successfully uploaded! Click the link below to begin moderating the recently submitted registrations.<br>
+          All ${count} of your registrations were successfully uploaded! Click the link below to begin moderating the
+          recently submitted registrations.<br>
           <br>
           <a href="${pending_submissions_url}">${pending_submissions_url}</a><br>
           <br>
       % else:
-          All ${count} of your registration were successfully uploaded! An email was recently sent out to all the admin contributors asking them to approve the registration. You may begin moderating the registrations once the registrations are approved by their contributors or after 48 hours have passed.<br>
+          All ${count} of your registration were successfully uploaded! An email was recently sent out to all the
+          admin contributors asking them to approve the registration. You may begin moderating the registrations
+          once the registrations are approved by their contributors or after 48 hours have passed.<br>
       % endif
       <br>
       Sincerely,<br>

--- a/website/templates/emails/registration_bulk_upload_success_partial.html.mako
+++ b/website/templates/emails/registration_bulk_upload_success_partial.html.mako
@@ -10,14 +10,19 @@
       Hello ${fullname},<br>
       <br>
       % if auto_approval:
-          ${successes} out of ${total} of your registrations were successfully uploaded! Click the linkbutton below to begin moderating their recently submitted registrations.<br>
+          ${successes} out of ${total} of your registrations were successfully uploaded! Click the link below
+          to begin moderating their recently submitted registrations.<br>
           <br>
           <a href="${pending_submissions_url}">${pending_submissions_url}</a><br>
       % else:
-          ${successes} out of ${total} of your registrations were successfully uploaded! An email was recently sent out to all the admin contributors asking them to approve the registration. You may begin moderating the registrations once the registrations are approved by their contributors or after 48 hours have passed.<br>
+          ${successes} out of ${total} of your registrations were successfully uploaded! An email was recently sent
+          out to all the admin contributors asking them to approve the registration. You may begin moderating the
+          registrations once the registrations are approved by their contributors or after 48 hours have passed.<br>
       % endif
       <br>
-      The remaining ${failures} registrations could not be uploaded and are listed below. Create a new csv file containing these registrations. Review the registrations and upload the file. Contact the Help Desk at support@osf.io if you continue to have issues.<br>
+      The remaining ${failures} registrations could not be uploaded and are listed below. Create a new csv file
+      containing these registrations. Review the registrations and upload the file. Contact the Help Desk at
+      <a href="mailto:${osf_support_email}">${osf_support_email}</a> if you continue to have issues.<br>
       <br>
       <ul>
           % for error in draft_errors:

--- a/website/templates/emails/registration_bulk_upload_unexpected_failure.html.mako
+++ b/website/templates/emails/registration_bulk_upload_unexpected_failure.html.mako
@@ -9,9 +9,9 @@
   <td style="border-collapse: collapse;">
       Hello ${fullname},<br>
       <br>
-      Your reigistrations were not uploaded. Our team was notified of the issue and will
-      follow up after they start looking into the issue. Contact the Help Desk at support@osf.io if you continue to
-      have questions.<br>
+      Your registrations were not uploaded. Our team was notified of the issue and will follow up after they start
+      looking into the issue. Contact the Help Desk at <a href="mailto:${osf_support_email}">${osf_support_email}</a>
+      if you continue to have questions.<br>
       <br>
       Sincerely,<br>
       <br>


### PR DESCRIPTION
## Purpose

Fix bugs and add improvements to bulk upload tasks

## Changes

* Only send emails if not dry run
* Improve logging and error messages for unexpected exceptions during bulk upload registration row creation
* Reverse error list for bulk upload outcome emails so that uploader see the error rows in the same order as the CSV
* Check institution affiliation before draft creation
  * Note: post-creation affiliation check is not removed, which is provided by the class util method
* Detect duplicate rows in CSV and database
  * Duplicates will cause the upload preparation phase to fail. The task now preemptively check conflicts before the bulk create. This error is different from "some fail" and "all fail" since the errors are only on the duplicated rows while the entire upload will fail. A new email template is created for this special case.

## QA Notes

See https://www.notion.so/cos/Bugs-1802b3efdc92481ebb0fc437663cfb8f

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
