### PR TITLE
fix NodeFileHyperLinkField disambiguation to allow for registrations

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -146,7 +146,10 @@ class FileNodeRelationshipField(RelationshipField):
             raise SkipField
         return super(FileNodeRelationshipField, self).to_representation(value)
 
-def disambiguate_files_relationship(node):
+
+def disambiguate_files_related_view(node):
+    if isinstance(node, Preprint):
+        return 'preprints:preprint-files'
     if node.type == 'osf.draftnode':
         return 'draft_nodes:node-files'
     if node.type == 'osf.node':
@@ -154,6 +157,16 @@ def disambiguate_files_relationship(node):
     if node.type == 'osf.registration':
         return 'registrations:registration-files'
 
+
+def disambiguate_files_related_view_kwargs(filenode):
+    if isinstance(filenode.target, Preprint):
+        return {'preprint_id': '<target._id>'}
+    else:
+        return {
+            'node_id': '<target._id>',
+            'path': '<path>',
+            'provider': '<provider>',
+        }
 
 class BaseFileSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
@@ -198,9 +211,9 @@ class BaseFileSerializer(JSONAPISerializer):
         help_text='The folder in which this file exists',
     )
     files = NodeFileHyperLinkField(
-        related_view=lambda node: disambiguate_files_relationship(node),
+        related_view=lambda node: disambiguate_files_related_view(node),
         view_lambda_argument='target',
-        related_view_kwargs={'node_id': '<target._id>', 'path': '<path>', 'provider': '<provider>'},
+        related_view_kwargs=lambda filenode: disambiguate_files_related_view_kwargs(filenode),
         kind='folder',
     )
     versions = NodeFileHyperLinkField(


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make it so the files link for the FilesDetail Relationship works for registrations, instead of point to the nodes files detail. 


## Changes

Simply improved the cureent lamba function to allow for registrations case. 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
