### PR TITLE
[WIP] Check draft registrations serializer permissions

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -10,7 +10,6 @@ from api.nodes.serializers import (
     DraftRegistrationDetailLegacySerializer,
     update_institutions,
     get_license_details,
-    NodeSerializer,
     NodeLicenseSerializer,
     NodeLicenseRelationshipField,
     NodeContributorsSerializer,
@@ -124,7 +123,8 @@ class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, Taxonomizab
         return validated_data.pop('branched_from', None)
 
     def get_current_user_permissions(self, obj):
-        return NodeSerializer.get_current_user_permissions(self, obj)
+        user = self.context['request'].user
+        return obj.get_permissions(user)
 
     def expect_subjects_as_relationships(self, request):
         """Determines whether subjects should be serialized as a relationship.

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -168,10 +168,10 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         assert res.json['data']['attributes']['current_user_permissions'] == [READ]
 
         res = app.get(url_draft_registrations, auth=user_write_contrib.auth, expect_errors=False)
-        assert res.json['data']['attributes']['current_user_permissions'] == [WRITE, READ]
+        assert set(res.json['data']['attributes']['current_user_permissions']) == set([WRITE, READ])
 
         res = app.get(url_draft_registrations, auth=user.auth, expect_errors=False)
-        assert res.json['data']['attributes']['current_user_permissions'] == [ADMIN, WRITE, READ]
+        assert set(res.json['data']['attributes']['current_user_permissions']) == set([ADMIN, WRITE, READ])
 
 
 class TestUpdateEditableFieldsTestCase:


### PR DESCRIPTION
## Purpose

This fixes a bug where draft registrations in a wrong state cause a 502 at the `v2/draft_registrations` endpoint. sentry error: https://sentry2.cos.io/cos/osf-back-end/issues/38043/

## Changes

- uses built-in method for checking permissions

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
