### PR TITLE
Hotfix/ignore schema responses

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -34,7 +34,8 @@ from framework.auth.core import Auth
 from osf.exceptions import ValidationValueError, NodeStateError
 from osf.models import Node, AbstractNode
 from osf.utils.registrations import strip_registered_meta_comments
-from osf.utils.workflows import ApprovalStates
+# TODO: restore this import after running scripts in https://github.com/CenterForOpenScience/osf.io/pull/9790
+# from osf.utils.workflows import ApprovalStates
 from framework.sentry import log_exception
 
 class RegistrationSerializer(NodeSerializer):
@@ -397,11 +398,13 @@ class RegistrationSerializer(NodeSerializer):
         return None
 
     def get_registration_responses(self, obj):
-        latest_approved_response = obj.schema_responses.filter(
-            reviews_state=ApprovalStates.APPROVED.db_name,
-        ).first()
-        if latest_approved_response is not None:
-            return self.anonymize_fields(obj, latest_approved_response.all_responses)
+        # TODO: restore this logic after running scripts in
+        # https://github.com/CenterForOpenScience/osf.io/pull/9790
+        #  latest_approved_response = obj.schema_responses.filter(
+        #      reviews_state=ApprovalStates.APPROVED.db_name,
+        #  ).first()
+        #  if latest_approved_response is not None:
+        #      return self.anonymize_fields(obj, latest_approved_response.all_responses)
 
         if obj.registration_responses:
             return self.anonymize_registration_responses(obj)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When SchemaResponses were rolled out, they were not integrated with Archiver to update file references post-archival. **But** the SchemaResponse becomes the source of truth for `registration_responses` through the API once the Registration is approved.

As such, file answers to questions on Registrations with SchemaResponses on Prod continue to point to the file on the node, causing certain permissions checks to fail.

This bug was fixed in https://github.com/CenterForOpenScience/osf.io/pull/9804, and a script to correct historical data is in review as part of https://github.com/CenterForOpenScience/osf.io/pull/9790, but we need to revert the serializer behavior while we wait for that fix/script to hit prod.

## Changes
Never use SchemaResponses to populate `registration_responses` on the serialized registration

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
