### PR TITLE
Fix develop to retrieve SchemaResponse for registration_responses

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -34,8 +34,7 @@ from framework.auth.core import Auth
 from osf.exceptions import ValidationValueError, NodeStateError
 from osf.models import Node, AbstractNode
 from osf.utils.registrations import strip_registered_meta_comments
-# TODO: restore this import after running scripts in https://github.com/CenterForOpenScience/osf.io/pull/9790
-# from osf.utils.workflows import ApprovalStates
+from osf.utils.workflows import ApprovalStates
 from framework.sentry import log_exception
 
 class RegistrationSerializer(NodeSerializer):
@@ -398,13 +397,11 @@ class RegistrationSerializer(NodeSerializer):
         return None
 
     def get_registration_responses(self, obj):
-        # TODO: restore this logic after running scripts in
-        # https://github.com/CenterForOpenScience/osf.io/pull/9790
-        #  latest_approved_response = obj.schema_responses.filter(
-        #      reviews_state=ApprovalStates.APPROVED.db_name,
-        #  ).first()
-        #  if latest_approved_response is not None:
-        #      return self.anonymize_fields(obj, latest_approved_response.all_responses)
+        latest_approved_response = obj.root.schema_responses.filter(
+            reviews_state=ApprovalStates.APPROVED.db_name,
+        ).first()
+        if latest_approved_response is not None:
+            return self.anonymize_fields(obj, latest_approved_response.all_responses)
 
         if obj.registration_responses:
             return self.anonymize_registration_responses(obj)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We turned off pulling `registration_responses` from `schema_responses` in  https://github.com/CenterForOpenScience/osf.io/pull/9805 so as to not expose some lingering bugs on prod. These bugs are fixed in develop, so re-eneable that feature.

## Changes
Go back to retrieving the serialized `registration_responses` from the most recent approved SchemaResponse

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
