### PR TITLE
[No Ticket] Fix TOS via CAS Check

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -287,7 +287,8 @@ def make_response_from_ticket(ticket, service_url):
             # updates the user object if this is THE FINAL STEP of the login flow. DON'T update TOS consent status when
             # `external_credential == true` (i.e. w/ `action == 'authenticate'` or `action == 'external_first_login'`)
             # since neither is the final step of a login flow.
-            if cas_resp.attributes.get('termsOfServiceChecked', False):
+            tos_checked_via_cas = cas_resp.attributes.get('termsOfServiceChecked', 'false') == 'true'
+            if tos_checked_via_cas:
                 user.accepted_terms_of_service = timezone.now()
                 user.save()
                 print_cas_log(f'CAS TOS consent checked: {user.guids.first()._id}, {user.username}', LogLevel.INFO)


### PR DESCRIPTION
## Purpose

Fixed an issue where TOS timestamp was updated every time when user logs in. It should only be effective to SSO users who checked the TOS consent via CAS.

## Changes

* Fixed the Java `false` that got read by python as literal string instead of boolean.

Verified locally that logs no longer has TOS update.

```
web_1               | [framework.auth.utils]  INFO: Validating service ticket ["ST-46-1t55XfX9m6ALIf37H-CK0Ll0Stk-316eed0a73b1"]
web_1               | [framework.auth.utils]  INFO: Service ticket validation response: ticket=[ST-46-1t55XfX9m6ALIf37H-CK0Ll0Stk-316eed0a73b1], status=[200]
web_1               | [framework.auth.utils]  INFO: Service validation succeeded with status: ["authenticationSuccess"]
web_1               | [framework.auth.utils]  INFO: Parsed CAS response: attributes=[['(isFromNewLogin: true)', '(institutionId: none)', '(authenticationDate: 2021-10-20T16:26:26.431492Z)', '(givenName: Longze)', '(successfulAuthenticationHandlers: OsfPostgresAuthenticationHandler)', '(delegationProtocol: NONE)', '(credentialType: OsfPostgresCredential)', '(authenticationMethod: OsfPostgresAuthenticationHandler)', '(familyName: Chen)', '(termsOfServiceChecked: false)', '(remotePrincipal: false)', '(longTermAuthenticationRequestTokenUsed: false)', '(rememberMe: false)', '(username: longze@cos.io)', '(accessTokenScope: set())']]
web_1               | [framework.auth.utils]  INFO: CAS response - authenticating user: user=[t47ka], external=[None], action=[authenticate]
web_1               | [framework.auth.utils]  INFO: CAS response - finalizing authentication: user=[t47ka]
web_1               | [framework.auth.utils]  INFO: Finalizing authentication - data updated: user=[t47ka]
web_1               | [framework.auth.utils]  INFO: Finalizing authentication - user updated: user=[t47ka]
web_1               | [framework.auth.utils]  INFO: Finalizing authentication - session created: user=[t47ka]
```

## QA Notes

N/A

## Documentation

N/A
## Side Effects

N/A

## Ticket

N/A
