### PR TITLE
[Hotfix][ENG-3347] Apply auth-related user updates async 

### DIFF
--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+from django.utils import timezone
+
 from framework import bcrypt
 from framework.auth import signals
 from framework.auth.core import Auth
 from framework.auth.core import get_user, generate_verification_key
 from framework.auth.exceptions import DuplicateEmailError
+from framework.auth.tasks import update_user_from_login
 from framework.auth.utils import LogLevel, print_cas_log
+from framework.celery_tasks.handlers import enqueue_task
 from framework.sessions import session, create_session
 from framework.sessions.utils import remove_session
 
@@ -26,7 +30,7 @@ __all__ = [
 check_password = bcrypt.check_password_hash
 
 
-def authenticate(user, access_token, response):
+def authenticate(user, access_token, response, user_updates=None):
     data = session.data if session._get_current_object() else {}
     data.update({
         'auth_user_username': user.username,
@@ -35,11 +39,8 @@ def authenticate(user, access_token, response):
         'auth_user_access_token': access_token,
     })
     print_cas_log(f'Finalizing authentication - data updated: user=[{user._id}]', LogLevel.INFO)
-    user.update_date_last_login()
-    user.clean_email_verifications()
-    user.update_affiliated_institutions_by_email_domain()
-    user.save()
-    print_cas_log(f'Finalizing authentication - user updated: user=[{user._id}]', LogLevel.INFO)
+    enqueue_task(update_user_from_login.s(user._id, timezone.now(), user_updates))
+    print_cas_log(f'Finalizing authentication - user update queued: user=[{user._id}]', LogLevel.INFO)
     response = create_session(response, data=data)
     print_cas_log(f'Finalizing authentication - session created: user=[{user._id}]', LogLevel.INFO)
     return response

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -1,0 +1,16 @@
+from framework.celery_tasks import app
+
+@app.task
+def update_user_from_login(user_id, login_time, updates=None):
+    from osf.models import OSFUser
+    if not updates:
+        updates = {}
+    user = OSFUser.load(user_id)
+    user.update_date_last_login(login_time)
+    user.clean_email_verifications()
+    user.update_affiliated_institutions_by_email_domain()
+    if 'accepted_terms_of_service' in updates:
+        user.accepted_terms_of_service = updates['accepted_terms_of_service']
+    if 'verification_key' in updates:
+        user.verification_key = updates['verification_key']
+    user.save()

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1468,8 +1468,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         for group in self.osf_groups:
             group.update_search()
 
-    def update_date_last_login(self):
-        self.date_last_login = timezone.now()
+    def update_date_last_login(self, login_time=None):
+        self.date_last_login = login_time or timezone.now()
 
     def get_summary(self, formatter='long'):
         return {


### PR DESCRIPTION
## Purpose
Avoid deadlock edge cases during login.

## Changes
- Apply auth-related user updates async

## QA Notes
Dev test; run various logins and ensure fields are updated

## Side Effects
None expected

## Ticket
[ENG-3347](https://openscience.atlassian.net/browse/ENG-3347)