### PR TITLE
[Hotfix][ENG-3347] Generalize user login/activity update task

### DIFF
--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -8,7 +8,7 @@ from framework.auth import signals
 from framework.auth.core import Auth
 from framework.auth.core import get_user, generate_verification_key
 from framework.auth.exceptions import DuplicateEmailError
-from framework.auth.tasks import update_user_from_login
+from framework.auth.tasks import update_user_from_activity
 from framework.auth.utils import LogLevel, print_cas_log
 from framework.celery_tasks.handlers import enqueue_task
 from framework.sessions import session, create_session
@@ -39,7 +39,7 @@ def authenticate(user, access_token, response, user_updates=None):
         'auth_user_access_token': access_token,
     })
     print_cas_log(f'Finalizing authentication - data updated: user=[{user._id}]', LogLevel.INFO)
-    enqueue_task(update_user_from_login.s(user._id, timezone.now(), user_updates))
+    enqueue_task(update_user_from_activity.s(user._id, timezone.now(), cas_login=True, updates=user_updates))
     print_cas_log(f'Finalizing authentication - user update queued: user=[{user._id}]', LogLevel.INFO)
     response = create_session(response, data=data)
     print_cas_log(f'Finalizing authentication - session created: user=[{user._id}]', LogLevel.INFO)

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -1,16 +1,24 @@
 from framework.celery_tasks import app
+from website.settings import DATE_LAST_LOGIN_THROTTLE_DELTA
+
 
 @app.task
-def update_user_from_login(user_id, login_time, updates=None):
+def update_user_from_activity(user_id, login_time, cas_login=False, updates=None):
     from osf.models import OSFUser
     if not updates:
         updates = {}
     user = OSFUser.load(user_id)
-    user.update_date_last_login(login_time)
-    user.clean_email_verifications()
-    user.update_affiliated_institutions_by_email_domain()
-    if 'accepted_terms_of_service' in updates:
-        user.accepted_terms_of_service = updates['accepted_terms_of_service']
-    if 'verification_key' in updates:
-        user.verification_key = updates['verification_key']
-    user.save()
+    should_save = False
+    if not user.date_last_login or user.date_last_login < login_time - DATE_LAST_LOGIN_THROTTLE_DELTA:
+        user.update_date_last_login(login_time)
+        should_save = True
+    if cas_login:
+        user.clean_email_verifications()
+        user.update_affiliated_institutions_by_email_domain()
+        if 'accepted_terms_of_service' in updates:
+            user.accepted_terms_of_service = updates['accepted_terms_of_service']
+        if 'verification_key' in updates:
+            user.verification_key = updates['verification_key']
+        should_save = True
+    if should_save:
+        user.save()

--- a/osf_tests/users/test_last_login_date.py
+++ b/osf_tests/users/test_last_login_date.py
@@ -13,6 +13,7 @@ from osf_tests.factories import (
     SessionFactory
 )
 from tests.base import OsfTestCase
+from tests.utils import run_celery_tasks
 
 @pytest.mark.django_db
 @pytest.mark.enable_enqueue_task
@@ -38,7 +39,8 @@ class TestUserLastLoginDate(OsfTestCase):
         assert self.user.date_last_login is None
 
         self.app.set_cookie(settings.COOKIE_NAME, self.cookie)
-        self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
+        with run_celery_tasks():
+            self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
 
         self.user.refresh_from_db()
         assert self.user.date_last_login == now
@@ -53,7 +55,8 @@ class TestUserLastLoginDate(OsfTestCase):
         # Time is mocked one second below the last login date threshold, so it should not change.
         mock_time.return_value = now + (settings.DATE_LAST_LOGIN_THROTTLE_DELTA - timedelta(seconds=1))
         self.app.set_cookie(settings.COOKIE_NAME, self.cookie)
-        self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
+        with run_celery_tasks():
+            self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
 
         self.user.refresh_from_db()
         # date_last_login is unchanged
@@ -70,7 +73,8 @@ class TestUserLastLoginDate(OsfTestCase):
         new_time = now + (settings.DATE_LAST_LOGIN_THROTTLE_DELTA + timedelta(seconds=1))
         mock_time.return_value = new_time
         self.app.set_cookie(settings.COOKIE_NAME, self.cookie)
-        self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
+        with run_celery_tasks():
+            self.app.get(f'{settings.DOMAIN}{self.user._id}')  # user page will fail because not emberized
 
         self.user.refresh_from_db()
         # date_last_login is changed!


### PR DESCRIPTION
## Purpose
Further prevent conditions that may lead to deadlock. Follow-up to #9816 

## Changes
- Avoid costly OSFUser update on every request

## Side Effects
None expected.

## Ticket
[ENG-3347](https://openscience.atlassian.net/browse/ENG-3347)