### PR TITLE
[ENG-3404] Remove the 'Delete' and 'Check out' buttons on Registration file viewer

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -491,7 +491,7 @@ var FileViewPage = {
                 ctrl.isLatestVersion ? m('.btn.btn-sm.btn-default', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null
             ]) : '',
             ctrl.canEdit() && (!ctrl.file.checkoutUser) && (ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-default', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
+                ctrl.isLatestVersion && !window.contextVars.node.isRegistration ? m('.btn.btn-sm.btn-default', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
             ]) : '',
             (ctrl.canEdit() && (ctrl.file.checkoutUser === ctrl.context.currentUser.id) ) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkin')}, 'Check in') : null
@@ -505,7 +505,7 @@ var FileViewPage = {
                 (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) &&
                 (document.URL.indexOf('version=latest-published') < 0)
             ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-default.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null
+                ctrl.isLatestVersion && !window.contextVars.node.isRegistration ? m('button.btn.btn-sm.btn-default.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null
             ]) : '',
             m('.btn-group.m-t-xs', [
                 ctrl.isLatestVersion ? m('a.btn.btn-sm.btn-primary.file-download', {href: 'download'}, 'Download') : null

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -14,7 +14,7 @@ $(function() {
     // Tag input
     $('#fileTags').tagsInput({
         width: '100%',
-        interactive: window.contextVars.currentUser.canEdit,
+        interactive: window.contextVars.currentUser.canEdit && !window.contextVars.node.isRegistration,
         maxChars: 128,
         defaultText: 'Add a tag to enhance discoverability',
         onAddTag: function (tag) {


### PR DESCRIPTION
## Purpose

The registration file view is displaying buttons users don't have the permission to press, this PR stops those buttons from displaying.

## Changes

- adds small amount of js to make delete and check out buttons disappear and disable the tags input

## QA Notes

- Verify that the buttons are gone
- Verify that tag box is disabled


## Documentation

🐛  fix, no docs.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/ENG-3404