### PR TITLE
[Ticket TBD] Add missing response key Q10 to CL long-form schema

### DIFF
--- a/website/project/metadata/character-lab-long-form-registration.json
+++ b/website/project/metadata/character-lab-long-form-registration.json
@@ -263,6 +263,7 @@
 		"block_type": "question-label",
 		"display_text": "Study design"
 	}, {
+		"registration_response_key": "Q10",
 		"block_type": "multi-select-input"
 	}, {
 		"block_type": "select-input-option",


### PR DESCRIPTION
## Purpose

Character Lab's long-form registration schema is missing the `Q10` response key.
This results in upload fails with `invalid column ID`

## Changes

- [x] Added response key `Q10`
- [x] Verified that all choices are present
- [x] Kept the version to `3` unless otherwise informed
- [x] Judgment/Judgement "typo" pending CL feedback
  - Update: Judgment

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

TBD
