### PR TITLE
[Hotfix] Disable backend wiki rendering

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -146,7 +146,7 @@ class WikiVersion(ObjectIDMixin, BaseModel):
     def raw_text(self, node):
         """ The raw text of the page, suitable for using in a test search"""
 
-        return sanitize(self.html(node), tags=[], strip=True)
+        return sanitize(self.content, tags=[], strip=True)
 
     @property
     def rendered_before_update(self):

--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -331,6 +331,7 @@ class TestWikiViews(OsfTestCase):
         res = self.app.get(url, auth=self.user.auth)
         assert_in('Add important information, links, or images here to describe your project.', res)
 
+    @pytest.mark.skip('Content rendering handled by front-end')
     def test_project_dashboard_wiki_wname_get_shows_non_ascii_characters(self):
         # Regression test for:
         # https://github.com/CenterForOpenScience/openscienceframework.org/issues/1104
@@ -390,16 +391,18 @@ class TestWikiViews(OsfTestCase):
 
         self.sec_wiki.update(self.user, short_content)
         res = serialize_wiki_widget(self.second_project)
-        assert_in(short_content, res['wiki_content'])
-        assert_not_in('...', res['wiki_content'])
+        # Content rendering handled by front-end
+        # assert_in(short_content, res['wiki_content'])
+        # assert_not_in('...', res['wiki_content'])
         assert_false(res['more'])
 
     def test_wiki_widget_long_content_cutoff(self):
         long_content = 'a' * 600
         self.sec_wiki.update(self.user, long_content)
         res = serialize_wiki_widget(self.second_project)
-        assert_less(len(res['wiki_content']), 520)  # wiggle room for closing tags
-        assert_in('...', res['wiki_content'].decode())
+        # Content rendering handled by front-end
+        # assert_less(len(res['wiki_content']), 520)  # wiggle room for closing tags
+        # assert_in('...', res['wiki_content'].decode())
         assert_true(res['more'])
 
     def test_wiki_widget_with_multiple_short_pages_has_more(self):
@@ -444,6 +447,7 @@ class TestWikiViews(OsfTestCase):
         assert_equal(res.status_code, 200)
         assert_not_in('data-osf-panel="Edit"', res.text)
 
+    @pytest.mark.skip('Content rendering handled by front-end. Also, this view is now ember')
     def test_wiki_widget_not_show_in_registration_for_contributor(self):
         registration = RegistrationFactory(project=self.project)
         res = self.app.get(

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -6,7 +6,6 @@ import uuid
 import ssl
 from pymongo import MongoClient
 import requests
-from bs4 import BeautifulSoup
 from django.apps import apps
 
 from addons.wiki import settings as wiki_settings
@@ -239,15 +238,13 @@ def serialize_wiki_widget(node):
     more = node.wikis.filter(deleted__isnull=True).count() >= 2
     MAX_DISPLAY_LENGTH = 400
     rendered_before_update = False
-    if wiki_version and wiki_version.html(node):
-        wiki_html = BeautifulSoup(wiki_version.html(node)).text
-        if len(wiki_html) > MAX_DISPLAY_LENGTH:
-            wiki_html = BeautifulSoup(wiki_html[:MAX_DISPLAY_LENGTH] + '...', 'html.parser')
+    if wiki_version and wiki_version.content:
+        if len(wiki_version.content) > MAX_DISPLAY_LENGTH:
             more = True
-
         rendered_before_update = wiki_version.rendered_before_update
-    else:
-        wiki_html = None
+
+    # Content fetched and rendered by front-end
+    wiki_html = None
 
     wiki_widget_data = {
         'complete': True,

--- a/addons/wiki/views.py
+++ b/addons/wiki/views.py
@@ -224,7 +224,8 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
     if wiki_version:
         version = wiki_version.identifier
         is_current = wiki_version.is_current
-        content = wiki_version.html(node)
+        # Content fetched and rendered by frontend, but used in business logic
+        content = wiki_version.content
         rendered_before_update = wiki_version.rendered_before_update
     else:
         version = 'NA'


### PR DESCRIPTION
## Purpose
Fix Wiki rendering. In certain cases, backend rendering can hang. In all cases it is unnecessary; the front-end renders it.

## Changes
- Replace calls to `WikiVersion.html()` with `WikiVersion.content`

## QA Notes
- Verify wiki's render as expected in both widget and on wiki page

## Side Effects
- Leaves dead code.
- Introduces potential miscalculation for displaying "Read more"  link in wiki widget -- now counts by raw text rather than rendered length. At worst, will display "Read more" unnecessarily, and link to the `/<pid>/wiki/home`

## Ticket
N/A