### PR TITLE
[No Ticket] Fix response key Q2 in CL's long-form schema (V3)

### DIFF
--- a/website/project/metadata/character-lab-long-form-registration.json
+++ b/website/project/metadata/character-lab-long-form-registration.json
@@ -13,11 +13,11 @@
 		"registration_response_key": "Q1",
 		"block_type": "long-text-input"
 	}, {
-		"registration_response_key": "Q2",
 		"block_type": "question-label",
 		"help_text": "These outcomes were developed by the Impact Genome Project \u00ae and are licensed under a Creative Commons BY-NC-ND 4.0 license. ",
 		"display_text": "Expected outcomes"
 	}, {
+		"registration_response_key": "Q2",
 		"block_type": "multi-select-input"
 	}, {
 		"block_type": "select-input-option",


### PR DESCRIPTION
## Purpose

https://github.com/CenterForOpenScience/osf.io/commit/0d07bb62a6c79f98b2ad52850f431f42813596a3#diff-2ed7a42a3982287e5b8df01e2b54d7ddfc470549e5c3f4dc8465469e7c6a3e0bL16-L22 introduced a bug that moved `registration_response_key` away from the correct location for `Expected outcomes`. This led to `Q2` not being set and an automatically generated `48-4` is used. Here is the error message during bulk upload.

> "Invalid column ID:
> This Column ID does not match with the ones used by this registration template. It’s likely it was manually edited after it was downloaded or the registration template is outdated. Contact the help desk at support@osf.io for the current ID or a new csv file. Invalid IDs: Q2. Missing IDs: 48-4."

## Changes

Fixed `Q2`

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
