### PR TITLE
[ENG-3110][fix] handle django admin's handling of IntEnum choices

### DIFF
--- a/osf/models/notable_email_domain.py
+++ b/osf/models/notable_email_domain.py
@@ -14,7 +14,7 @@ class NotableEmailDomain(BaseModel):
         @classmethod
         def choices(cls):
             return [
-                (enum_item, enum_item.name)
+                (int(enum_item), enum_item.name)
                 for enum_item in cls
             ]
 


### PR DESCRIPTION



<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
follow-up bug-fix for #9749 -- filtering and updating NotableEmailDomains in the admin breaks
<!-- Describe the purpose of your changes -->

## Changes
even though `IntEnum` subclasses `int`, django seems to get
confused when validating or filtering on `IntEnum` values --
explicitly cast the choice value to `int` instead.
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify can filter admin list of notable email domains
- Verify can create, update, delete, and bulk-add notable email domains

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-3110]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-3110]: https://openscience.atlassian.net/browse/ENG-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ