### PR TITLE
[ENG-3288] Part 1: refactor task `bulk_create_registrations`

### DIFF
--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -175,6 +175,13 @@ class PreviousSchemaResponseError(SchemaResponseError):
     pass
 
 
+class RegistrationBulkCreationContributorError(OSFError):
+    """Raised if contributor preparation has failed"""
+
+    def __init__(self, error=None):
+        self.error = error if error else 'Contributor preparation error'
+
+
 class RegistrationBulkCreationRowError(OSFError):
     """Raised if a draft registration failed creation during bulk upload"""
 


### PR DESCRIPTION
## Purpose

Refactor the `bulk_create_registrations` task

Update

- [x] Fully tested locally with CL's most up-to-date (Nov. 17th) schema

## Changes

* Refactored `handle_registration_row()` to use helper classes with improvements
  * `check_node()`
  * `prepare_subjects()`
  * `prepare_institutions()`
  * `prepare_contributors()`
  * `prepare_license()`
  * `bulk_upload_create_draft_registration()`
  * `set_draft_contributors()`
  * `set_affiliated_institutions()`
  * `bulk_upload_register_draft()`
* Moved error aggregation and outcome email sending to `bulk_upload_finish_job` with improvements
* Created `RegistrationBulkCreationContributorError` and `RegistrationBulkUploadContributors` to support the refactor

## QA Notes

TBD

## Documentation

TBD

## Side Effects

TBD

## Ticket

https://openscience.atlassian.net/browse/ENG-3288
