### PR TITLE
[ENG-3424] Fix non-bibliographic initiator during registration bulk creation

### DIFF
--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -453,10 +453,16 @@ def handle_registration_row(row, initiator, provider, schema, auto_approval=Fals
         )
         # Remove all contributors except the initiator if created from an existing node
         if node:
+            # Temporarily make initiator contributor visible so that removal of the others can succeed.
+            initiator_contributor = draft.contributor_set.get(user=initiator)
+            if not initiator_contributor.visible:
+                initiator_contributor.visible = True
+                initiator_contributor.save()
             contributor_set = draft.contributor_set.all()
             for contributor in contributor_set:
                 if initiator != contributor.user:
-                    draft.remove_contributor(contributor, auth)
+                    is_removed = draft.remove_contributor(contributor, auth)
+                    assert is_removed, 'Removal of an non-initiator contributor from the draft has failed'
             draft.save()
         assert len(draft.contributor_set.all()) == 1, 'Draft should only have one contributor upon creation.'
         # Remove the initiator from the citation list


### PR DESCRIPTION
## Purpose

Fix non-bibliographic initiator during registration bulk creation.

For details, see the discussion in FD: https://www.flowdock.com/app/cos/bulk-upload/threads/44f0XKRGNPuFMXCL3qzuqFwTMsx

## Changes

* Temporarily set the initiator contributor as visible before removing the others from the draft.

```python
Processing registration row [1: upload=100, row=233]
initiator contributor not visible
initiator contributor set to visible temporarily
# of initial contributors: 4
contributor: DraftRegistrationContributor object; user: longze@cos.io
contributor: DraftRegistrationContributor object; user: roger@cos.io
removed or not: True
contributor: DraftRegistrationContributor object; user: doudou@cos.io
removed or not: True
contributor: DraftRegistrationContributor object; user: naxin@cos.io
removed or not: True
# of final contributors: 1
```

* Added an assertion to confirm successful removal for redundancy.

```python
Processing registration row [1: upload=101, row=234]
Draft registration creation failed: [upload_id="101", row_id="234", title="Bulk Upload - Non-bibliographic Admin Contributor", external_id="ckrfdl76b0b9hyq49g3kfr0ha", error="AssertionError('Removal of an non-initiator contributor from the draft has failed',)"]
AssertionError('Removal of an non-initiator contributor from the draft has failed',)
```

## QA Notes

- [ ] Must test on the test server before deploy since local testing is based on the staging2 branch

## Dev / CR Notes

- [ ] Make sure that the PR diff is the same as it is tested on the staging2 branch: https://github.com/cslzchen/osf.io/commit/2612bdda15e3ed6e5958aa1b3b75d59b05552eee

- [ ] Unit tests will be added to the staging2 branch which will be a different release than this hotfix

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3424
