### PR TITLE
Script to auto-approve registration updates

### DIFF
--- a/osf/management/commands/approve_pending_schema_responses.py
+++ b/osf/management/commands/approve_pending_schema_responses.py
@@ -26,7 +26,6 @@ def approve_pending_schema_responses(dry_run=False):
     # Get all non-initial SchemaResponses that have been pending Admin Approval
     # for longer than the environment's auto-approval threshold
     auto_approval_threshold = timezone.now() - REGISTRATION_UPDATE_APPROVAL_TIME
-    print(auto_approval_threshold)
     pending_schema_responses = SchemaResponse.objects.filter(
         reviews_state=ApprovalStates.UNAPPROVED.db_name,
         submitted_timestamp__lte=auto_approval_threshold,

--- a/osf/management/commands/approve_pending_schema_responses.py
+++ b/osf/management/commands/approve_pending_schema_responses.py
@@ -1,0 +1,63 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+from framework.celery_tasks import app as celery_app
+
+from osf.models import SchemaResponse
+from osf.utils.workflows import ApprovalStates
+
+from website.settings import REGISTRATION_APPROVAL_TIME
+
+logger = logging.getLogger(__name__)
+
+THRESHOLD_HOURS = int(REGISTRATION_APPROVAL_TIME.total_seconds() / 3600)
+
+@celery_app.task(name='management.commands.approve_pending_schema_responses')
+@transaction.atomic
+def approve_pending_schema_responses(dry_run=False):
+    '''Migrate registration_responses into a SchemaResponse for historical registrations.'''
+    logger.info(
+        f'{"[DRY RUN] " if dry_run else ""}'
+        f'Auto-Approving SchemaResponses submitted longer than {THRESHOLD_HOURS} hours ago'
+    )
+    # Get all non-initial SchemaResponses that have been pending Admin Approval
+    # for longer than the environment's auto-approval threshold
+    auto_approval_threshold = timezone.now() - REGISTRATION_APPROVAL_TIME
+    print(auto_approval_threshold)
+    pending_schema_responses = SchemaResponse.objects.filter(
+        reviews_state=ApprovalStates.UNAPPROVED.db_name,
+        submitted_timestamp__lte=auto_approval_threshold,
+        previous_response__isnull=False,
+    )
+    count = 0
+
+    for schema_response in pending_schema_responses:
+        logger.info(
+            f'{"[DRY RUN] " if dry_run else ""}'
+            f'Auto-approving SchemaResponse with id [{schema_response._id}] '
+            f'for Registration with guid [{schema_response.parent._id}]'
+        )
+        schema_response.accept(comment=f'Auto-approved following {THRESHOLD_HOURS} hour threshhold')
+        count += 1
+
+    if dry_run:
+        raise RuntimeError('Dry run, transaction rolled back')
+
+    return count
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--dry',
+            action='store_true',
+            dest='dry_run',
+            help='Dry run',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run')
+        approve_pending_schema_responses(dry_run=dry_run)

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -512,7 +512,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             'title': self.parent.title,
             'parent_url': self.parent.absolute_url,
             'update_url': self.absolute_url,
-            'initiator': event_initiator.fullname,
+            'initiator': event_initiator.fullname if event_initiator else None,
             'pending_moderation': self.state is ApprovalStates.PENDING_MODERATION,
             'provider': self.parent.provider.name if self.parent.provider else '',
         }

--- a/osf_tests/management_commands/test_approve_pending_schema_responses.py
+++ b/osf_tests/management_commands/test_approve_pending_schema_responses.py
@@ -7,11 +7,11 @@ from osf.management.commands.approve_pending_schema_responses import approve_pen
 from osf.models import SchemaResponse
 from osf.utils.workflows import ApprovalStates
 from osf_tests.factories import RegistrationFactory
-from website.settings import REGISTRATION_APPROVAL_TIME
+from website.settings import REGISTRATION_UPDATE_APPROVAL_TIME
 
 
 EXCLUDED_STATES = [state for state in ApprovalStates if state is not ApprovalStates.UNAPPROVED]
-AUTO_APPROVE_TIMESTAMP = timezone.now() - REGISTRATION_APPROVAL_TIME
+AUTO_APPROVE_TIMESTAMP = timezone.now() - REGISTRATION_UPDATE_APPROVAL_TIME
 
 
 @pytest.mark.django_db

--- a/osf_tests/management_commands/test_approve_pending_schema_responses.py
+++ b/osf_tests/management_commands/test_approve_pending_schema_responses.py
@@ -1,0 +1,127 @@
+import pytest
+
+from django.utils import timezone
+from unittest import mock
+
+from osf.management.commands.approve_pending_schema_responses import approve_pending_schema_responses
+from osf.models import SchemaResponse
+from osf.utils.workflows import ApprovalStates
+from osf_tests.factories import RegistrationFactory
+from website.settings import REGISTRATION_APPROVAL_TIME
+
+
+EXCLUDED_STATES = [state for state in ApprovalStates if state is not ApprovalStates.UNAPPROVED]
+AUTO_APPROVE_TIMESTAMP = timezone.now() - REGISTRATION_APPROVAL_TIME
+
+
+@pytest.mark.django_db
+class TestApprovePendingSchemaResponses:
+
+    @pytest.fixture
+    def control_response(self):
+        reg = RegistrationFactory()
+        initial_response = reg.schema_responses.last()
+        initial_response.state = ApprovalStates.APPROVED
+        initial_response.save()
+
+        revision = SchemaResponse.create_from_previous_response(
+            previous_response=initial_response, initiator=reg.creator
+        )
+        revision.state = ApprovalStates.UNAPPROVED
+        revision.submitted_timestamp = AUTO_APPROVE_TIMESTAMP
+        revision.save()
+        return revision
+
+    @pytest.fixture
+    def test_response(self):
+        reg = RegistrationFactory()
+        initial_response = reg.schema_responses.last()
+        initial_response.state = ApprovalStates.APPROVED
+        initial_response.save()
+
+        return SchemaResponse.create_from_previous_response(
+            previous_response=initial_response, initiator=reg.creator
+        )
+
+    @pytest.mark.parametrize(
+        'is_moderated, expected_state',
+        [(False, ApprovalStates.APPROVED), (True, ApprovalStates.PENDING_MODERATION)]
+    )
+    def test_auto_approval(self, control_response, is_moderated, expected_state):
+        with mock.patch(
+            'osf.models.schema_response.SchemaResponse.is_moderated',
+            new_callaoble=mock.PropertyMock
+        ) as mock_is_moderated:
+            mock_is_moderated.return_value = is_moderated
+            count = approve_pending_schema_responses()
+
+        assert count == 1
+
+        control_response.refresh_from_db()
+        assert control_response.state is expected_state
+
+    def test_auto_approval_with_multiple_pending_schema_responses(
+            self, control_response, test_response):
+        test_response.state = ApprovalStates.UNAPPROVED
+        test_response.submitted_timestamp = AUTO_APPROVE_TIMESTAMP
+        test_response.save()
+
+        count = approve_pending_schema_responses()
+        assert count == 2
+
+        control_response.refresh_from_db()
+        test_response.refresh_from_db()
+        assert control_response.state is ApprovalStates.APPROVED
+        assert test_response.state is ApprovalStates.APPROVED
+
+    @pytest.mark.parametrize('revision_state', EXCLUDED_STATES)
+    def test_auto_approval_only_approves_unapproved_schema_responses(
+            self, control_response, test_response, revision_state):
+        test_response.state = revision_state
+        test_response.submitted_timestamp = AUTO_APPROVE_TIMESTAMP
+        test_response.save()
+
+        count = approve_pending_schema_responses()
+        assert count == 1
+
+        control_response.refresh_from_db()
+        test_response.refresh_from_db()
+        assert control_response.state is ApprovalStates.APPROVED
+        assert test_response.state is revision_state
+
+    def test_auto_approval_only_approves_schema_responses_older_than_threshold(
+            self, control_response, test_response):
+        test_response.state = ApprovalStates.UNAPPROVED
+        test_response.submitted_timestamp = timezone.now()
+        test_response.save()
+
+        count = approve_pending_schema_responses()
+        assert count == 1
+
+        control_response.refresh_from_db()
+        test_response.refresh_from_db()
+        assert control_response.state is ApprovalStates.APPROVED
+        assert test_response.state is ApprovalStates.UNAPPROVED
+
+    def test_auto_approval_does_not_pick_up_initial_responses(
+            self, control_response, test_response):
+        test_response = test_response.previous_response
+        test_response.state = ApprovalStates.UNAPPROVED
+        test_response.submitted_timestamp = timezone.now()
+        test_response.save()
+
+        count = approve_pending_schema_responses()
+        assert count == 1
+
+        control_response.refresh_from_db()
+        test_response.refresh_from_db()
+        assert control_response.state is ApprovalStates.APPROVED
+        assert test_response.state is ApprovalStates.UNAPPROVED
+
+    def test_dry_run(self, control_response):
+
+        with pytest.raises(RuntimeError):
+            approve_pending_schema_responses(dry_run=True)
+
+        control_response.refresh_from_db()
+        assert control_response.state is ApprovalStates.UNAPPROVED

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -686,7 +686,6 @@ class CeleryConfig:
                 'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m
                 'kwargs': {'dry_run': False},
             },
-            ,
         }
 
         # Tasks that need metrics and release requirements

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -65,6 +65,7 @@ RETRACTION_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_TERMINATION_PENDING_TIME = datetime.timedelta(days=2)
 REGISTRATION_APPROVAL_TIME = datetime.timedelta(days=2)
+REGISTRATION_UPDATE_APPROVAL_TIME = datetime.timedelta(days=2)
 # Date range for embargo periods
 EMBARGO_END_DATE_MIN = datetime.timedelta(days=2)
 EMBARGO_END_DATE_MAX = datetime.timedelta(days=1460)  # Four years
@@ -443,7 +444,8 @@ class CeleryConfig:
         'scripts.refresh_addon_tokens',
         'scripts.retract_registrations',
         'website.archiver.tasks',
-        'scripts.add_missing_identifiers_to_preprints'
+        'scripts.add_missing_identifiers_to_preprints',
+        'osf.management.commands.approve_pending_schema_response',
     }
 
     try:
@@ -512,6 +514,7 @@ class CeleryConfig:
         'osf.management.commands.sync_datacite_doi_metadata',
         'osf.management.commands.archive_registrations_on_IA',
         'osf.management.commands.populate_initial_schema_responses',
+        'osf.management.commands.approve_pending_schema_responses',
         'api.providers.tasks'
     )
 
@@ -678,6 +681,12 @@ class CeleryConfig:
                 'schedule': crontab(minute='*/5'),  # Every 5 minutes for staging server QA test
                 'kwargs': {'dry_run': False}
             },
+            'approve_registration_updates': {
+                'task': 'osf.management.commands.approve_pending_schema_responses',
+                'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m
+                'kwargs': {'dry_run': False},
+            },
+            ,
         }
 
         # Tasks that need metrics and release requirements

--- a/website/templates/emails/updates_pending_approval.html.mako
+++ b/website/templates/emails/updates_pending_approval.html.mako
@@ -18,10 +18,10 @@
     % if is_approver:
       <a href="${update_url}">Click here</a> to review and either approve or reject the
       submitted updates. Decisions must be made within
-      ${int(settings.REGISTRATION_APPROVAL_TIME.total_seconds() / 3600)} hours.
+      ${int(settings.REGISTRATION_UPDATE_APPROVAL_TIME.total_seconds() / 3600)} hours.
     % else:
       <a href="${update_url}">Click here</a> to review the submited updates.
-      Admins have up to ${int(settings.REGISTRATION_APPROVAL_TIME.total_seconds() / 3600)} hours
+      Admins have up to ${int(settings.REGISTRATION_UPDATE_APPROVAL_TIME.total_seconds() / 3600)} hours
       to make their decision.
     % endif
     <p>


### PR DESCRIPTION
## Purpose
Registration Updates should auto-approve (at the admin level) just like the initial Registration.
## Changes
* Script to identify and approve `UNAPPROVED` SchemaResponses with submission timestamp longer than the environment's auto-approval threshold.
* Tests
* 
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
