### PR TITLE
File-specific response comparison

### DIFF
--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -523,9 +523,9 @@ def _is_updated_response(response_block, new_response):
     '''
     current_response = response_block.response
     if response_block.source_schema_block.block_type != 'file-input':
-        return current_response == new_response
+        return current_response != new_response
 
     # `files-input` blocks contain a list of dictinoaries containinf file information in the form
     current_file_ids = {entry['file_id'] for entry in current_response}
     new_file_ids = {entry['file_id'] for entry in new_response}
-    return current_file_ids == new_file_ids
+    return current_file_ids != new_file_ids

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -240,7 +240,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         for block in self.response_blocks.all():
             # Remove values from updated_responses to help detect unsupported keys
             latest_response = updated_responses.pop(block.schema_key, None)
-            if latest_response is None or latest_response == block.response:
+            if latest_response is None or not _is_updated_response(block, latest_response):
                 continue
 
             if not self._response_reverted(block, latest_response):
@@ -264,7 +264,7 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
         previous_response_block = self.previous_response.response_blocks.get(
             schema_key=current_block.schema_key
         )
-        if latest_response != previous_response_block.response:
+        if _is_updated_response(previous_response_block, latest_response):
             return False
 
         current_block.delete()
@@ -513,3 +513,19 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             email_context['can_write'] = self.parent.has_permission(contributor, 'write')
             email_context['is_approver'] = contributor in self.pending_approvers.all()
             mails.send_mail(to_addr=contributor.username, mail=template, **email_context)
+
+
+def _is_updated_response(response_block, new_response):
+    '''block-type aware comparison for SchemaResponseBlock response values.
+
+    This is important for helping us catch cases where files have simply been re-ordered
+    or where older registrations use a different 'html' link from the Files API.
+    '''
+    current_response = response_block.response
+    if response_block.source_schema_block.block_type != 'file-input':
+        return current_response == new_response
+
+    # `files-input` blocks contain a list of dictinoaries containinf file information in the form
+    current_file_ids = {entry['file_id'] for entry in current_response}
+    new_file_ids = {entry['file_id'] for entry in new_response}
+    return current_file_ids == new_file_ids

--- a/osf_tests/management_commands/test_fix_initial_schema_responses.py
+++ b/osf_tests/management_commands/test_fix_initial_schema_responses.py
@@ -12,7 +12,7 @@ FILE_INPUT_KEY = 'q6'  # File input key from DEFAULT_TEST_SCHEMA
 @pytest.fixture
 def registration():
     registration = RegistrationFactory(schema=get_default_test_schema())
-    registration.registration_responses[FILE_INPUT_KEY] = ['some', 'updated', 'file', 'metadata']
+    registration.registration_responses[FILE_INPUT_KEY] = [{'file_id': '123456'}]
     registration.save()
     return registration
 
@@ -70,7 +70,7 @@ class TestFixEarlySchemaResponses:
         updated_response = SchemaResponse.create_from_previous_response(
             previous_response=schema_response, initiator=schema_response.initiator
         )
-        updated_response.update_responses({FILE_INPUT_KEY: ['intentionall', 'updated', 'value']})
+        updated_response.update_responses({FILE_INPUT_KEY: [{'file_id': '654321'}]})
 
         fixed_count, _ = fix_initial_schema_responses()
         assert fixed_count == 1  # initial response

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -531,6 +531,15 @@ class TestUpdateSchemaResponses():
         assert updated_responses['q1'] == original_responses['q1']
         assert updated_responses['q6'] == new_responses['q6']
 
+    def test_update_file_is_noop_if_no_change_in_ids(self, revised_response):
+        revised_response.update_responses({'q6': [{'file_id': '123456'}, {'file_id': '654321'}]})
+        revised_response.update_responses(
+            {'q1': 'Real update', 'q6': [{'file_id': '654321'}, {'file_id': '123456'}]}
+        )
+
+        assert revised_response.all_responses['q1'] == 'Real update'
+        assert revised_response.all_responses['q6'] == [{'file_id': '123456'}, {'file_id': '654321'}]
+
 
 @pytest.mark.django_db
 class TestDeleteSchemaResponse():

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -360,7 +360,7 @@ class TestUpdateSchemaResponses():
             'q3': 'B',
             'q4': ['E'],
             'q5': 'Roonil Wazlib, et al',
-            'q6': ['some', 'file', 'metadata'],
+            'q6': [{'file_id': '123456'}],
         }
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         initial_response.save()
@@ -384,7 +384,7 @@ class TestUpdateSchemaResponses():
                 'q3': 'B',
                 'q4': ['E'],
                 'q5': 'Roonil Wazlib, et al',
-                'q6': ['some', 'file', 'metadata'],
+                'q6': [{'file_id': '123456'}],
             }
         )
         initial_response.refresh_from_db()
@@ -521,7 +521,7 @@ class TestUpdateSchemaResponses():
     def test_update_file_references(self, initial_response):
         original_responses = initial_response.all_responses
         new_responses = dict(
-            original_responses, q1='new value', q6=['some', 'file', 'metadata']
+            original_responses, q1='new value', q6=[{'file_id': '123456'}]
         )
 
         initial_response._update_file_references(new_responses)


### PR DESCRIPTION
avoid file-input weirdness

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When checking to see if a `files-input` response has changed, compare the set of file_ids instead of the full dictionaries. This fixes two bugs in Registration Update:

One, the case where the `html` link create by Archiver for the file reference doesn't match the Files API's `html` link, leading to unanticipated updates to `file-input` respone blocks.

Two, the case where users remove and then re-add files as part of an update (or restore the files in an answer to match the previous version). Previously, this would also have looked like a change when it really wasn't.

## Changes
* Add an `_is_updated_response` helper method to `schema_response.py` and use it when checking to see if a response has been updated or reverted
  * `_is_updated_response` just checks the response value if the `source_schema_block` has a `block_type` other than `file-input`
  * If the `source_schema_block` has a `block_type` of `file-input`, then `_is_updated_response` generates the set of `file_ids` in the current response and the new response two lists and compares them

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
