### PR TITLE
[ENG-3110] fix: skip spam checks for trusted wiki edits

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -20,7 +20,6 @@ from framework.forms.utils import sanitize
 from markdown.extensions import codehilite, fenced_code, wikilinks
 from osf.models import NodeLog, OSFUser, Comment
 from osf.models.base import BaseModel, GuidMixin, ObjectIDMixin
-from osf.models.spam import SpamStatus
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.requests import get_request_and_user_id, string_type_request_headers
 from osf.exceptions import NodeStateError
@@ -192,7 +191,7 @@ class WikiVersion(ObjectIDMixin, BaseModel):
             return False
         if settings.SPAM_CHECK_PUBLIC_ONLY and not node.is_public:
             return False
-        if user.spam_status == SpamStatus.HAM:
+        if user.is_hammy:
             return False
 
         content = self._get_spam_content(node)


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
follow-up fix for #9749 -- users with trusted email domains still getting their wiki edits spam-checked (and sometimes incorrectly flagged)
<!-- Describe the purpose of your changes -->

## Changes
in `addons.wiki.models.WikiVersion`, check `is_hammy` instead of comparing against `SpamStatus.HAM`
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
[ENG-3110]

[ENG-3110]: https://openscience.atlassian.net/browse/ENG-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ