### PR TITLE
[Hotfix] Get revision_state from root

### DIFF
--- a/api/registrations/annotations.py
+++ b/api/registrations/annotations.py
@@ -3,7 +3,7 @@ from osf.models import SchemaResponse
 
 REVISION_STATE = Subquery(
     SchemaResponse.objects.filter(
-        nodes__id=OuterRef('id'),
+        nodes__id=OuterRef('root_id'),
     ).order_by('-created').values('reviews_state')[:1],
     output_field=CharField(),
 )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -444,7 +444,10 @@ class RegistrationSerializer(NodeSerializer):
         return obj.files_count or 0
 
     def get_original_response_id(self, obj):
-        return obj.root.schema_responses.last()._id
+        original_response = obj.root.schema_responses.last()
+        if original_response:
+            return original_response._id
+        return None
 
     def get_latest_response_id(self, obj):
         latest_approved = obj.root.schema_responses.filter(

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -1547,6 +1547,15 @@ class TestRegistrationResponses:
         assert responses == approved_schema_response.all_responses
         assert nested_registration.registration_responses != approved_schema_response.all_responses
 
+    @pytest.mark.parametrize('revision_state', ApprovalStates)
+    def test_nested_registration_surfaces_root_revision_state(
+            self, app, nested_registration, approved_schema_response, revision_state):
+        approved_schema_response.state = revision_state
+        approved_schema_response.save()
+
+        resp = app.get(self.get_registration_detail_url(nested_registration))
+        assert resp.json['data']['attributes']['revision_state'] == revision_state.db_name
+
     def test_original_response_relationship(
             self, app, registration, approved_schema_response, revised_schema_response, admin):
         resp = app.get(self.get_registration_detail_url(registration), auth=admin.auth)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Nested registrations don't have their own revisions, they inherit them from the root. That should include the `revision_state` attribute.

## Changes
* When annotating `revision_state`, look for a SchemaResponse on the root
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
