### PR TITLE
[CR][ENG-865] Add redis to docker-compose to support WB rate-limiting

### DIFF
--- a/.docker-compose.wb.env
+++ b/.docker-compose.wb.env
@@ -16,3 +16,15 @@ OSF_AUTH_CONFIG_API_URL=http://192.168.168.167:5000/api/v1/files/auth/
 TASKS_CONFIG_BROKER_URL=amqp://guest:guest@192.168.168.167:5672//
 
 #PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs
+
+# Uncomment the following to enable & configure rate limiting in
+# WaterButler. Only the first needs to be uncommented to enable it.
+# The others are currently set to their default values. See
+# docs/rate-limiting.rst in the WB repo for more information.
+
+# SERVER_CONFIG_ENABLE_RATE_LIMITING=1
+# SERVER_CONFIG_RATE_LIMITING_FIXED_WINDOW_SIZE=3600
+# SERVER_CONFIG_RATE_LIMITING_FIXED_WINDOW_LIMIT=3600
+# SERVER_CONFIG_REDIS_HOST=192.168.168.197
+# SERVER_CONFIG_REDIS_PORT=6379
+# SERVER_CONFIG_REDIS_PASSWORD=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ volumes:
     external: false
   mongo_data_vol:
     external: false
+  redis_data_vol:
+    external: false
   elasticsearch_data_vol:
     external: false
   elasticsearch6_data_vol:
@@ -121,6 +123,17 @@ services:
 #      - 5555:5555
 #    environment:
 #      BROKER_URL: amqp://guest:guest@rabbitmq:5672/
+
+  redis:
+    image: redis
+    command: redis-server
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data_vol:/data
+    stdin_open: true
+
 
   #########################
   # Modular File Renderer #


### PR DESCRIPTION
# Meta

This PR replaces #9138. Some services have been renamed and some docs have been added.  Code is still mostly via @cslzchen.  This PR's text was copied from that PR with revisions.

# Purpose

Add Redis to OSF docker-compose for local development, where WB uses the `redis` service to rate-limit its API. The main feature is implemented at the WB side and the dedicated Redis servers for stagings/prod are managed by DevOps.

 * WaterButler takes care of the rate-limiting using Redis as of the [WBv21.2.0](https://github.com/CenterForOpenScience/waterbutler/tree/21.2.0) release.

# Changes

Add `redis` service to OSF's `docker-compose.yml` for local development.

# QA Notes

N/A

# Documentation

Some docs / sample config added to `.docker-compose.wb.env` including a pointer to more substantial docs in [waterbutler](https://github.com/CenterForOpenScience/waterbutler/blob/develop/docs/rate-limiting.rst).

# Side Effects

None expected.  This is not mandatory for local development.  Rate limiting in WB defaults to `off`.

# Ticket

https://openscience.atlassian.net/browse/ENG-865