### PR TITLE
[Hotfix] Fix Registration AVOLs for SchemaResponses, disable broken GHA workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -153,9 +153,9 @@ jobs:
           sudo apt update
           sudo apt-get install libxml2-dev libxslt-dev python-dev
       - uses: ./.github/actions/start-build
-      - name: NVM & yarn install
-        run: |
-         invoke assets --dev
+        #      - name: NVM & yarn install
+        #         run: |
+        #         invoke assets --dev
       - name: Run test
         run: invoke test_travis_api1_and_js -n 1
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -54,6 +54,8 @@ class RegistrationSerializer(NodeSerializer):
         'date_withdrawn',
         'embargo_end_date',
         'embargoed',
+        'latest_response',
+        'original_response',
         'pending_embargo_approval',
         'pending_embargo_termination_approval',
         'pending_registration_approval',
@@ -66,6 +68,7 @@ class RegistrationSerializer(NodeSerializer):
         'registration_responses',
         'registration_schema',
         'registration_supplement',
+        'schema_responses',
         'withdrawal_justification',
         'withdrawn',
     ]

--- a/api/schema_responses/serializers.py
+++ b/api/schema_responses/serializers.py
@@ -28,6 +28,20 @@ class RegistrationSchemaResponseSerializer(JSONAPISerializer):
         'revision_responses',
     ])
 
+    non_anonymized_fields = frozenset([
+        'id',
+        'date_created',
+        'date_modified',
+        'date_submitted',
+        'is_original_response',
+        'links',
+        'registration',
+        'registration_schema',
+        'revision_justification',
+        'revision_responses',
+        'updated_response_keys',
+    ])
+
     id = ser.CharField(source='_id', required=True, allow_null=True)
     type = TypeField()
     date_created = VersionedDateTimeField(source='created', required=False)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
AVOLs are currently broken for registrations, as is our GHA workflow. Replacement for https://github.com/CenterForOpenScience/osf.io/pull/9843

## Changes
* Surface SchemaResponse fields on anonymized Registration
*  Properly anonymize SchemaResponses
* Disable the NVM and Yarn Install workflow until the issue can be root-caused

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
