### PR TITLE
[CR] fix api1_and_js gha javascript tests

### DIFF
--- a/.github/actions/start-build/action.yml
+++ b/.github/actions/start-build/action.yml
@@ -26,6 +26,9 @@ runs:
       invoke requirements --dev --addons
       pip uninstall uritemplate.py --yes
       pip install uritemplate.py==0.3.0
-      sudo npm install -g bower
-      npm install @centerforopenscience/list-of-licenses@^1.1.0
-      bower install "https://github.com/CenterForOpenScience/styles.git#88e6ed31a91e9f5a480b486029cda97b535935d4"
+      # use yarn add --exact to match versions in yarn.lock w/o installing all deps
+      yarn add --exact bower@^1.8.8
+      yarn add --exact @centerforopenscience/list-of-licenses@^1.1.0
+      # styles.git is a ruby project that contains a lot of useful data files. This
+      # just clones the repo into bower_components, where we can access them.
+      ./node_modules/.bin/bower install "https://github.com/CenterForOpenScience/styles.git#88e6ed31a91e9f5a480b486029cda97b535935d4"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -153,9 +153,9 @@ jobs:
           sudo apt update
           sudo apt-get install libxml2-dev libxslt-dev python-dev
       - uses: ./.github/actions/start-build
-        #      - name: NVM & yarn install
-        #         run: |
-        #         invoke assets --dev
+      - name: NVM & yarn install
+        run: |
+          invoke assets --dev
       - name: Run test
         run: invoke test_travis_api1_and_js -n 1
 


### PR DESCRIPTION
## Purpose

Fix and re-enable js tests to build and run on GHA.

## Changes

 * Stop using both npm & yarn to build js deps in GitHub Actions.
   Replace usage of `npm install` with `yarn add --exact`.

   The `invoke assets --dev` step of the `api1_and_js` test started
   failing recently.  That command calls `yarn install
   --frozen-lockfile`, which was crashing with the error 'An
   unexpected error occurred: "Commit hash required".'

   Real talk: I have no idea why this is happening, but commenting out
   the `npm install` step in action.yml fixes it.  npm yells loudly
   about mixing it with yarn, so let's take them at their word and
   replace it.  Running `yarn install` in the "Start Build" action
   could fix it, but I suspect it was split up to avoid installing the
   full yarn deps for tests that don't need them.  Passing `yarn add`
   the `--exact` switch and the version specified in `package.json`
   seems to do the trick w/o modifying `yarn.lock`.

   THIS IS A HACK, but I don't know enough about js dep building infra
   to do anything better.

 * Re-enable `invoke assets --dev` in `api1_and_js`.  This was
   temporarily disabled while troubleshooting the failure.

## QA Notes

*None.*  This only affects CI.

## Documentation

Comments were added to the affected files for future reference.

## Side Effects

None expected.

## Ticket

No ticket.
