### PR TITLE
[Hotfix] Only create SchemaBlocks for new schemas

### DIFF
--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.contrib.auth.mixins import PermissionRequiredMixin
 
 from osf.management.commands.manage_switch_flags import manage_waffle
-# from osf.management.commands.update_registration_schemas import update_registration_schemas
+from osf.management.commands.update_registration_schemas import update_registration_schemas
 from scripts.find_spammy_content import manage_spammy_content
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
@@ -32,9 +32,8 @@ class WaffleFlag(ManagementCommandPermissionView):
 class UpdateRegistrationSchemas(ManagementCommandPermissionView):
 
     def post(self, request, *args, **kwargs):
-        # update_registration_schemas()
-        # messages.success(request, 'Registration schemas have been successfully updated.')
-        messages.success(request, 'This has been temporarily disabled')
+        update_registration_schemas()
+        messages.success(request, 'Registration schemas have been successfully updated.')
         return redirect(reverse('management:commands'))
 
 class GetSpamDataCSV(ManagementCommandPermissionView):

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -27,8 +27,7 @@
             <h4> <u>Update Registration Schemas and Schema Blocks </u>
             </h4>
             <ul>
-                Under Repair
-                <!--Use this management command to update the schemas and schma blocks
+                Use this management command to update the schemas and schma blocks
                 for Registrations to match values in website/project/metadata
                 <br>
                 <form method="post"
@@ -36,7 +35,7 @@
                     {% csrf_token %}
                     <input class="btn btn-success" type="submit"
                            value="Run" />
-                </form> -->
+                </form>
             </ul>
             <h4> <u>Download CSV of spam </u>
             </h4>

--- a/osf/management/commands/update_registration_schemas.py
+++ b/osf/management/commands/update_registration_schemas.py
@@ -1,17 +1,33 @@
 import logging
+
 from django.core.management.base import BaseCommand
-from osf.utils.migrations import ensure_schemas, map_schemas_to_schemablocks
+from django.db import transaction
+from osf.utils import migrations
 
 logger = logging.getLogger(__name__)
 
-def update_registration_schemas():
+@transaction.atomic
+def update_registration_schemas(dry_run=False):
     """Update the regitration schemas to match the locally defined schemas."""
     logger.debug('Updating Registration Schemas')
-    ensure_schemas()
+    migrations.ensure_schemas()
     logger.debug('Updating Registration Schema Blocks')
-    map_schemas_to_schemablocks()
+    migrations.map_schemas_to_schemablocks()
+    if dry_run:
+        raise RuntimeError('Dry run, transaction rolled back')
+
 
 class Command(BaseCommand):
 
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--dry',
+            action='store_true',
+            dest='dry_run',
+            help='Dry run',
+        )
+
     def handle(self, *args, **options):
-        update_registration_schemas()
+        dry_run = options.get('dry_run')
+        update_registration_schemas(dry_run=dry_run)

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -451,7 +451,6 @@ def map_schemas_to_schemablocks(*args):
 
     WARNING: Deletes existing schema blocks
     """
-    assert False, 'This deletes too much, temporarily disabling'
     state = args[0] if args else apps
     try:
         schema_model = state.get_model('osf', 'registrationschema')
@@ -459,11 +458,15 @@ def map_schemas_to_schemablocks(*args):
         # Use MetaSchema model if migrating from a version before RegistrationSchema existed
         schema_model = state.get_model('osf', 'metaschema')
 
-    # TODO: Not this
-    # # Delete all existing schema blocks (avoid creating duplicates)
-    # unmap_schemablocks(*args)
+    try:
+        RegistrationSchemaBlock = state.get_model('osf', 'registrationschemablock')
+    except LookupError:
+        return  # can't create SchemaBlocks if they don't exist
 
     for rs in schema_model.objects.all():
+        if RegistrationSchemaBlock.objects.filter(schema_id=rs.id).exists():
+            continue
+
         logger.info('Migrating schema {}, version {} to schema blocks.'.format(rs.name, rs.schema_version))
         if rs.schema.get('atomicSchema'):
             create_schema_blocks_for_atomic_schema(rs)
@@ -483,11 +486,8 @@ def map_schemas_to_schemablocks(*args):
 
 
 def unmap_schemablocks(*args):
-    assert False, 'This deletes too much, temporarily disabling'
-    # state = args[0] if args else apps
-    # schema_block_model = state.get_model('osf', 'registrationschemablock')
-
-    # schema_block_model.objects.all().delete()
+    '''Noop for historical purposes'''
+    return
 
 
 class UpdateRegistrationSchemas(Operation):

--- a/osf_tests/default_test_schema.py
+++ b/osf_tests/default_test_schema.py
@@ -2,7 +2,7 @@ DEFAULT_TEST_SCHEMA_NAME = '***OSF Internal Test Schema***'
 TEST_SCHEMA_SINGLE_SELECT_OPTIONS = ['A', 'B', 'A and B', 'None of the Above']
 TEST_SCHEME_MULTI_SELECT_OPTIONS = ['D', 'E', 'F', 'G']
 DEFAULT_TEST_SCHEMA = {
-    'title': DEFAULT_TEST_SCHEMA_NAME,
+    'name': DEFAULT_TEST_SCHEMA_NAME,
     'version': 1,
     'description': 'Test Registration Schema for internal use only',
     'atomicSchema': True,

--- a/osf_tests/management_commands/test_update_registration_schemas.py
+++ b/osf_tests/management_commands/test_update_registration_schemas.py
@@ -1,0 +1,88 @@
+import copy
+import mock
+import random
+import pytest
+
+from osf.management.commands import update_registration_schemas
+from osf.models import RegistrationSchema, RegistrationSchemaBlock
+from osf_tests.default_test_schema import DEFAULT_TEST_SCHEMA, DEFAULT_TEST_SCHEMA_NAME
+from website.project.metadata.schemas import get_osf_meta_schemas
+
+
+@pytest.mark.django_db
+class TestUpdateRegistrationSchemas:
+
+    @pytest.fixture
+    def updated_schema(self):
+        known_schemas = get_osf_meta_schemas()
+        schema_to_update = copy.deepcopy(random.choice(known_schemas))
+        # some schemas have multiple versions present in get_osf_metaschemas
+        # increment by a silly number to account for this
+        schema_to_update['version'] += 100
+        return schema_to_update
+
+    def test_update_schemas_creates_new_schemas(self, updated_schema):
+        assert not RegistrationSchema.objects.filter(
+            name=DEFAULT_TEST_SCHEMA_NAME
+        ).exists()
+        assert not RegistrationSchema.objects.filter(
+            name=(updated_schema.get('title') or updated_schema.get('name')),
+            schema_version=updated_schema['version']
+        ).exists()
+
+        test_schemas = get_osf_meta_schemas() + [updated_schema, DEFAULT_TEST_SCHEMA]
+        with mock.patch.object(
+            update_registration_schemas.migrations,
+            'get_osf_meta_schemas',
+            return_value=test_schemas
+        ):
+            update_registration_schemas.update_registration_schemas()
+
+        assert RegistrationSchema.objects.filter(
+            name=DEFAULT_TEST_SCHEMA_NAME
+        ).exists()
+        assert RegistrationSchema.objects.filter(
+            name=updated_schema.get('name'),
+            schema_version=updated_schema['version']
+        ).exists()
+
+    def test_update_schemas_only_creates_schemablocks_for_new_schemas(self, updated_schema):
+        assert not RegistrationSchemaBlock.objects.filter(
+            schema__name=DEFAULT_TEST_SCHEMA_NAME
+        ).exists()
+        assert not RegistrationSchemaBlock.objects.filter(
+            schema__name=updated_schema.get('name'),
+            schema__schema_version=updated_schema['version']
+        ).exists()
+
+        initial_block_ids = set(RegistrationSchemaBlock.objects.values_list('id', flat=True))
+        test_schemas = get_osf_meta_schemas() + [updated_schema, DEFAULT_TEST_SCHEMA]
+        with mock.patch.object(
+            update_registration_schemas.migrations,
+            'get_osf_meta_schemas',
+            return_value=test_schemas
+        ):
+            update_registration_schemas.update_registration_schemas()
+
+        block_ids_for_new_schema = set(
+            RegistrationSchemaBlock.objects.filter(
+                schema__name=DEFAULT_TEST_SCHEMA_NAME
+            ).values_list('id', flat=True)
+        )
+        assert block_ids_for_new_schema
+
+        block_ids_for_updated_schema = set(
+            RegistrationSchemaBlock.objects.filter(
+                schema__name=(updated_schema.get('title') or updated_schema.get('name')),
+                schema__schema_version=updated_schema['version']
+            ).values_list('id', flat=True)
+        )
+        assert block_ids_for_updated_schema
+
+        expected_block_ids = (
+            initial_block_ids
+            | block_ids_for_new_schema
+            | block_ids_for_updated_schema
+        )
+        all_block_ids = set(RegistrationSchemaBlock.objects.values_list('id', flat=True))
+        assert all_block_ids == expected_block_ids


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We previously re-built the SchemaBlocks for all schemas as part of our update process in case any schemas had in-place changes. By not allowing in-place changes to Schemas, we improve transparency by making sure registrations always look the way they did when they were filled out, and we remove possible failure points by not frivolously deleting RegistrationSchemaBlocks

## Changes
* When invoking `map_schemas_to_schema_blocks` function, only create RegistrationSchemaBlocks for schemas/versions that don't currently have any
  * Make `unmap_schemablocks` a noop, since it is explicitly called in some migrations
*  Restore access to `Update Registration Schemas` management command in the admin app
*  Add a dry_run mode to the `update_registration_schemas` management command and make it transactional
*  Add tests for the `update_registration_schemas` management command

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
