### PR TITLE
[ENG-3622] Framing the async affiliation task and update ORCiD SSO flow

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -9,7 +9,9 @@ import requests
 
 from framework.auth import authenticate, external_first_login_authenticate
 from framework.auth.core import get_user, generate_verification_key
+from framework.auth.tasks import update_affiliation_for_orcid_sso_users
 from framework.auth.utils import print_cas_log, LogLevel
+from framework.celery_tasks.handlers import enqueue_task
 from framework.flask import redirect
 from framework.exceptions import HTTPError
 from website import settings
@@ -376,6 +378,8 @@ def get_user_from_cas_resp(cas_resp):
                             external_id=external_credential['id'])
             # existing user found
             if user:
+                # Send to celery the following async task to affiliate the user with eligible institutions if verified
+                enqueue_task(update_affiliation_for_orcid_sso_users.s(user._id, external_credential['id']))
                 return user, external_credential, 'authenticate'
             # user first time login through external identity provider
             else:

--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -9,7 +9,6 @@ import requests
 
 from framework.auth import authenticate, external_first_login_authenticate
 from framework.auth.core import get_user, generate_verification_key
-from framework.auth.tasks import update_affiliation_for_orcid_sso_users
 from framework.auth.utils import print_cas_log, LogLevel
 from framework.celery_tasks.handlers import enqueue_task
 from framework.flask import redirect
@@ -379,6 +378,7 @@ def get_user_from_cas_resp(cas_resp):
             # existing user found
             if user:
                 # Send to celery the following async task to affiliate the user with eligible institutions if verified
+                from framework.auth.tasks import update_affiliation_for_orcid_sso_users
                 enqueue_task(update_affiliation_for_orcid_sso_users.s(user._id, external_credential['id']))
                 return user, external_credential, 'authenticate'
             # user first time login through external identity provider

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -4,7 +4,7 @@ import pytz
 from framework.celery_tasks import app as celery_app
 from osf.models import Institution, OSFUser
 from osf.models.institution import IntegrationType
-from website.settings import DATE_LAST_LOGIN_THROTTLE_DELTA
+from website.settings import DATE_LAST_LOGIN_THROTTLE_DELTA, EXTERNAL_IDENTITY_PROFILE
 
 
 @celery_app.task()
@@ -37,7 +37,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     institution affiliations.
     """
     user = OSFUser.load(user_id)
-    if not user:
+    if not user or not verify_user_orcid_id(user, orcid_id):
         # This should not happen as long as this task is called at the right place at the right time.
         # TODO: Log errors, raise exceptions and inform Sentry
         return
@@ -45,6 +45,14 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     if institution and not user.is_affiliated_with_institution(institution):
         user.affiliated_institutions.add(institution)
         user.save()
+
+
+def verify_user_orcid_id(user, orcid_id):
+    """Verify that the given ORCiD ID is verified for the given user.
+    """
+    provider = EXTERNAL_IDENTITY_PROFILE.get('OrcidProfile')
+    status = user.external_identity.get(provider, {}).get(orcid_id, None)
+    return True if status and status == 'VERIFIED' else False
 
 
 def check_institution_affiliation(orcid_id):

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -1,11 +1,13 @@
 from datetime import datetime
 import pytz
 
-from framework.celery_tasks import app
+from framework.celery_tasks import app as celery_app
+from osf.models import Institution, OSFUser
+from osf.models.institution import IntegrationType
 from website.settings import DATE_LAST_LOGIN_THROTTLE_DELTA
 
 
-@app.task
+@celery_app.task()
 def update_user_from_activity(user_id, login_time, cas_login=False, updates=None):
     from osf.models import OSFUser
     if not updates:
@@ -27,3 +29,58 @@ def update_user_from_activity(user_id, login_time, cas_login=False, updates=None
         should_save = True
     if should_save:
         user.save()
+
+
+@celery_app.task()
+def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
+    """This is an asynchronous task that runs during CONFIRMED ORCiD SSO logins and makes eligible
+    institution affiliations.
+    """
+    user = OSFUser.load(user_id)
+    if not user:
+        # This should not happen as long as this task is called at the right place at the right time.
+        # TODO: Log errors, raise exceptions and inform Sentry
+        return
+    institution = check_institution_affiliation(orcid_id)
+    if institution and not user.is_affiliated_with_institution(institution):
+        user.affiliated_institutions.add(institution)
+        user.save()
+
+
+def check_institution_affiliation(orcid_id):
+    """Check user's public ORCiD record and return eligible institution affiliations.
+
+    Note: Current implementation only support one affiliation (i.e. loop returns once eligible
+          affiliation is found, which improves performance). In the future, if we have multiple
+          institutions using this feature, we can update the loop easily.
+    """
+    employment_records = get_orcid_employment_records(orcid_id)
+    education_records = get_orcid_education_records(orcid_id)
+    via_orcid_institutions = Institution.objects.filter(
+        delegation_protocol=IntegrationType.AFFILIATION_VIA_ORCID.value,
+        is_deleted=False
+    )
+    # Check both employment and education records
+    for record in employment_records + education_records:
+        source = record.get('source')
+        if not source:
+            continue
+        # check source against all "affiliation-via-orcid" institutions
+        for institution in via_orcid_institutions:
+            if source == institution.orcid_record_verified_source:
+                return institution
+    return None
+
+
+def get_orcid_employment_records(orcid_id):
+    """Retrieve employment records for the given ORCiD ID.
+    """
+    # TODO: this will be implemented in ENG-3621
+    return []
+
+
+def get_orcid_education_records(orcid_id):
+    """Retrieve education records for the given ORCiD ID.
+    """
+    # TODO: this will be implemented in ENG-3621
+    return []

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -1,9 +1,8 @@
 from datetime import datetime
+
 import pytz
 
 from framework.celery_tasks import app as celery_app
-from osf.models import Institution, OSFUser
-from osf.models.institution import IntegrationType
 from website.settings import DATE_LAST_LOGIN_THROTTLE_DELTA, EXTERNAL_IDENTITY_PROFILE
 
 
@@ -36,6 +35,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     """This is an asynchronous task that runs during CONFIRMED ORCiD SSO logins and makes eligible
     institution affiliations.
     """
+    from osf.models import OSFUser
     user = OSFUser.load(user_id)
     if not user or not verify_user_orcid_id(user, orcid_id):
         # This should not happen as long as this task is called at the right place at the right time.
@@ -62,6 +62,8 @@ def check_institution_affiliation(orcid_id):
           affiliation is found, which improves performance). In the future, if we have multiple
           institutions using this feature, we can update the loop easily.
     """
+    from osf.models import Institution
+    from osf.models.institution import IntegrationType
     employment_records = get_orcid_employment_records(orcid_id)
     education_records = get_orcid_education_records(orcid_id)
     via_orcid_institutions = Institution.objects.filter(

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -19,7 +19,6 @@ from framework.auth.exceptions import DuplicateEmailError, ExpiredTokenError, In
 from framework.auth.core import generate_verification_key
 from framework.auth.decorators import block_bing_preview, collect_auth, must_be_logged_in
 from framework.auth.forms import ResendConfirmationForm, ForgotPasswordForm, ResetPasswordForm
-from framework.auth.tasks import update_affiliation_for_orcid_sso_users
 from framework.auth.utils import ensure_external_identity_uniqueness, validate_recaptcha
 from framework.celery_tasks.handlers import enqueue_task
 from framework.exceptions import HTTPError
@@ -674,6 +673,7 @@ def external_login_confirm_email_get(auth, uid, token):
         )
 
     # Send to celery the following async task to affiliate the user with eligible institutions if verified
+    from framework.auth.tasks import update_affiliation_for_orcid_sso_users
     enqueue_task(update_affiliation_for_orcid_sso_users.s(user._id, provider_id))
 
     # redirect to CAS and authenticate the user with the verification key


### PR DESCRIPTION
## Purpose

Create a celery task for the affiliation process and update the ORCiD SSO flow.

## Changes

* Framed the affiliation task without making ORCiD API request and parsing the response
* Instrumented the ORCiD SSO flow with the task

## QA Notes

* QA notes will be updated when the full feature is ready for test

## Documentation

N/A

## Side Effects

* Without the implementation of [ENG-3621](https://openscience.atlassian.net/browse/) missing, the task remains a no-op action for now since `check_institution_affiliation()` always returns `None`.
* As documented in the code, current implementation only supports one affiliation (i.e. loop returns once eligible affiliation is found, which improves performance). In the future, if we have multiple institutions using this feature, we can easily update the loop and affiliation process.

## Ticket

https://openscience.atlassian.net/browse/ENG-3622
