### PR TITLE
[ENG-3621] Retrieve verified source of affiliations from ORCiD public records

### DIFF
--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -56,7 +56,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
         return
     institution = check_institution_affiliation(orcid_id)
     if institution:
-        logger.info(f'Eligible institution affiliation found for ORCiD SSO user: '
+        logger.info(f'Eligible institution affiliation has been found for ORCiD SSO user: '
                     f'institution=[{institution._id}], user=[{user_id}], orcid_id=[{orcid_id}]')
         if not user.is_affiliated_with_institution(institution):
             user.affiliated_institutions.add(institution)
@@ -91,9 +91,10 @@ def check_institution_affiliation(orcid_id):
         # Check source against all "affiliation-via-orcid" institutions
         for institution in via_orcid_institutions:
             if source == institution.orcid_record_verified_source:
-                logger.debug(f'Institution [{institution.name}]found with matching source [{source}]')
+                logger.debug(f'Institution has been found with matching source: '
+                             f'institution=[{institution._id}], source=[{source}], orcid_id=[{orcid_id}]')
                 return institution
-    logger.debug(f'No institution with matching source has been found for ORCiD ID {orcid_id}')
+    logger.debug(f'No institution with matching source has been found: orcid_id=[{orcid_id}]')
     return None
 
 
@@ -102,7 +103,7 @@ def get_orcid_employment_sources(orcid_id):
     """
     employment_data = orcid_public_api_make_request(ORCID_RECORD_EMPLOYMENT_PATH, orcid_id)
     source_list = []
-    if employment_data:
+    if employment_data is not None:
         affiliation_groups = employment_data.findall('{http://www.orcid.org/ns/activities}affiliation-group')
         for affiliation_group in affiliation_groups:
             employment_summary = affiliation_group.find('{http://www.orcid.org/ns/employment}employment-summary')
@@ -117,7 +118,7 @@ def get_orcid_education_sources(orcid_id):
     """
     education_data = orcid_public_api_make_request(ORCID_RECORD_EDUCATION_PATH, orcid_id)
     source_list = []
-    if education_data:
+    if education_data is not None:
         affiliation_groups = education_data.findall('{http://www.orcid.org/ns/activities}affiliation-group')
         for affiliation_group in affiliation_groups:
             education_summary = affiliation_group.find('{http://www.orcid.org/ns/education}education-summary')

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -738,6 +738,13 @@ EXTERNAL_IDENTITY_PROFILE = {
     'OrcidProfile': 'ORCID',
 }
 
+ORCID_PUBLIC_API_ACCESS_TOKEN = None
+ORCID_PUBLIC_API_V3_URL = 'https://pub.orcid.org/v3.0/'
+ORCID_PUBLIC_API_REQUEST_TIMEOUT = None
+ORCID_RECORD_ACCEPT_TYPE = 'application/vnd.orcid+xml'
+ORCID_RECORD_EMPLOYMENT_PATH = '/employments'
+ORCID_RECORD_EDUCATION_PATH = '/educations'
+
 # Source: https://github.com/maxd/fake_email_validator/blob/master/config/fake_domains.list
 BLACKLISTED_DOMAINS = [
     '0-mail.com',


### PR DESCRIPTION
## Purpose

* Retrieve verified source of affiliations from ORCiD public records

## Changes

* Created a helper class `orcid_public_api_make_request()` to handle the request and return an `lxml.etree._Element`
* Updated `get_orcid_employment_sources()` and `get_orcid_education_sources()` to parse out affiliation source list
* Updated `check_institution_affiliation()` to work with the combined source list
* Added logging, sentry and exception handling

### Worker Logs

* Affiliation Eligible

```
[2022-03-09 20:16:41,843: INFO/MainProcess] Received task: framework.auth.tasks.update_affiliation_for_orcid_sso_users[a186c0db-d44e-43d4-93b2-22682c9d52f6]
[2022-03-09 20:16:41,845: DEBUG/MainProcess] TaskPool: Apply <function _fast_trace_task at 0x7f920b578d90> (args:('framework.auth.tasks.update_affiliation_for_orcid_sso_users', 'a186c0db-d44e-43d4-93b2-22682c9d52f6', {'lang': 'py', 'task': 'framework.auth.tasks.update_affiliation_for_orcid_sso_users', 'id': 'a186c0db-d44e-43d4-93b2-22682c9d52f6', 'eta': None, 'expires': None, 'group': '976a397c-e1ba-4d10-bec8-d7128a143f5b', 'retries': 0, 'timelimit': [None, None], 'root_id': 'a186c0db-d44e-43d4-93b2-22682c9d52f6', 'parent_id': None, 'argsrepr': "('krs8n', '0000-0002-9167-0821')", 'kwargsrepr': '{}', 'origin': 'gen382@161b84f011fb', 'reply_to': '75769717-5a80-396f-a99e-c25e14a1fffa', 'correlation_id': 'a186c0db-d44e-43d4-93b2-22682c9d52f6', 'delivery_info': {'exchange': '', 'routing_key': 'celery', 'priority': 0, 'redelivered': False}}, '[["krs8n", "0000-0002-9167-0821"], {}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]', 'application/json', 'utf-8') kwargs:{})
[2022-03-09 20:16:41,857: DEBUG/MainProcess] Task accepted: framework.auth.tasks.update_affiliation_for_orcid_sso_users[a186c0db-d44e-43d4-93b2-22682c9d52f6] pid:13
[2022-03-09 20:16:41,913: DEBUG/ForkPoolWorker-1] Starting new HTTPS connection (1): pub.orcid.org
[2022-03-09 20:16:42,205: DEBUG/ForkPoolWorker-1] https://pub.orcid.org:443 "GET /v3.0/0000-0002-9167-0821/employments HTTP/1.1" 200 None
[2022-03-09 20:16:42,257: DEBUG/ForkPoolWorker-1] Starting new HTTPS connection (1): pub.orcid.org
[2022-03-09 20:16:42,598: DEBUG/ForkPoolWorker-1] https://pub.orcid.org:443 "GET /v3.0/0000-0002-9167-0821/educations HTTP/1.1" 200 None
[2022-03-09 20:16:42,621: DEBUG/ForkPoolWorker-1] Institution has been found with matching source: institution=[osftype1], source=[OSF Integration], orcid_id=[0000-0002-9167-0821]
[2022-03-09 20:16:42,647: INFO/ForkPoolWorker-1] Eligible institution affiliation has been found for ORCiD SSO user: institution=[osftype1], user=[krs8n], orcid_id=[0000-0002-9167-0821]
[2022-03-09 20:16:42,664: INFO/ForkPoolWorker-1] Task framework.auth.tasks.update_affiliation_for_orcid_sso_users[a186c0db-d44e-43d4-93b2-22682c9d52f6] succeeded in 0.8169548260048032s: None
```
* Affiliation Not Eligible

```
[2022-03-09 20:20:13,417: INFO/MainProcess] Received task: framework.auth.tasks.update_affiliation_for_orcid_sso_users[f4e7d546-83c5-41fa-85bb-c7f23c9e083e]
[2022-03-09 20:20:13,420: DEBUG/MainProcess] TaskPool: Apply <function _fast_trace_task at 0x7f920b578d90> (args:('framework.auth.tasks.update_affiliation_for_orcid_sso_users', 'f4e7d546-83c5-41fa-85bb-c7f23c9e083e', {'lang': 'py', 'task': 'framework.auth.tasks.update_affiliation_for_orcid_sso_users', 'id': 'f4e7d546-83c5-41fa-85bb-c7f23c9e083e', 'eta': None, 'expires': None, 'group': '79f87c47-f544-4451-97ca-ce77636cea24', 'retries': 0, 'timelimit': [None, None], 'root_id': 'f4e7d546-83c5-41fa-85bb-c7f23c9e083e', 'parent_id': None, 'argsrepr': "('cvenb', '0000-0001-7364-3443')", 'kwargsrepr': '{}', 'origin': 'gen382@161b84f011fb', 'reply_to': '75769717-5a80-396f-a99e-c25e14a1fffa', 'correlation_id': 'f4e7d546-83c5-41fa-85bb-c7f23c9e083e', 'delivery_info': {'exchange': '', 'routing_key': 'celery', 'priority': 0, 'redelivered': False}}, '[["cvenb", "0000-0001-7364-3443"], {}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]', 'application/json', 'utf-8') kwargs:{})
[2022-03-09 20:20:13,447: DEBUG/MainProcess] Task accepted: framework.auth.tasks.update_affiliation_for_orcid_sso_users[f4e7d546-83c5-41fa-85bb-c7f23c9e083e] pid:13
[2022-03-09 20:20:13,477: DEBUG/ForkPoolWorker-1] Starting new HTTPS connection (1): pub.orcid.org
[2022-03-09 20:20:13,854: DEBUG/ForkPoolWorker-1] https://pub.orcid.org:443 "GET /v3.0/0000-0001-7364-3443/employments HTTP/1.1" 200 None
[2022-03-09 20:20:13,863: DEBUG/ForkPoolWorker-1] Starting new HTTPS connection (1): pub.orcid.org
[2022-03-09 20:20:14,094: DEBUG/ForkPoolWorker-1] https://pub.orcid.org:443 "GET /v3.0/0000-0001-7364-3443/educations HTTP/1.1" 200 None
[2022-03-09 20:20:14,102: DEBUG/ForkPoolWorker-1] No institution with matching source has been found: orcid_id=[0000-0001-7364-3443]
[2022-03-09 20:20:14,107: INFO/ForkPoolWorker-1] Task framework.auth.tasks.update_affiliation_for_orcid_sso_users[f4e7d546-83c5-41fa-85bb-c7f23c9e083e] succeeded in 0.6854342087171972s: None
```

### Demo Video

https://user-images.githubusercontent.com/3750414/157532148-3e1300aa-37d8-4621-b855-214ea1045182.mov

### Notes

* For local testing, need to configure a developer app in ORCiD, grab a public scope access token and then update `ORCID_PUBLIC_API_ACCESS_TOKEN = None` in your `local.py` under `website/settings`.
* In addition, you need to update the local institution to have a verified source that matches the test ORCiD account in order for affiliation to happen.
* Finally, you need OSF CAS running locally ...

## QA Notes

* QA notes will be updated when the full feature is ready for test

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3621
