### PR TITLE
[ENG-3714] Reroute users to new help guide

### DIFF
--- a/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    The wiki uses the <a href="https://daringfireball.net/projects/markdown/">Markdown</a> syntax. For more information and examples, go to our <a href="https://openscience.zendesk.com/hc/en-us/sections/360003569274">Guides.</a>
+                    The wiki uses the <a href="https://daringfireball.net/projects/markdown/">Markdown</a> syntax. For more information and examples, go to our <a href="https://help.osf.io/">Guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    The wiki uses the <a href="https://daringfireball.net/projects/markdown/">Markdown</a> syntax. For more information and examples, go to our <a href="https://help.osf.io/">Guides.</a>
+                    The wiki uses the <a href="https://daringfireball.net/projects/markdown/">Markdown</a> syntax. For more information and examples, go to our <a href="https://help.osf.io/article/389-wiki">Guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -208,7 +208,7 @@ INSTITUTIONS = {
             {
                 '_id': 'cfa',
                 'name': 'Center for Astrophysics | Harvard & Smithsonian',
-                'description': 'Open Source Project Management Tools for the CfA Community: About <a href="https://cos.io/our-products/osf/">OSF</a> | <a href="https://www.cfa.harvard.edu/researchtopics">Research at the CfA</a> | <a href="https://library.cfa.harvard.edu/">CfA Library</a> | <a href="https://openscience.zendesk.com/hc/en-us">Get Help</a>',
+                'description': 'Open Source Project Management Tools for the CfA Community: About <a href="https://cos.io/our-products/osf/">OSF</a> | <a href="https://www.cfa.harvard.edu/researchtopics">Research at the CfA</a> | <a href="https://library.cfa.harvard.edu/">CfA Library</a> | <a href="https://help.osf.io/">Get Help</a>',
                 'banner_name': 'cfa-banner.png',
                 'logo_name': 'cfa-shield.png',
                 'login_url': None,
@@ -1224,7 +1224,7 @@ INSTITUTIONS = {
             {
                 '_id': 'cfa',
                 'name': 'Center for Astrophysics | Harvard & Smithsonian [Test]',
-                'description': 'Open Source Project Management Tools for the CfA Community: About <a href="https://cos.io/our-products/osf/">OSF</a> | <a href="https://www.cfa.harvard.edu/researchtopics">Research at the CfA</a> | <a href="https://library.cfa.harvard.edu/">CfA Library</a> | <a href="https://openscience.zendesk.com/hc/en-us">Get Help</a>',
+                'description': 'Open Source Project Management Tools for the CfA Community: About <a href="https://cos.io/our-products/osf/">OSF</a> | <a href="https://www.cfa.harvard.edu/researchtopics">Research at the CfA</a> | <a href="https://library.cfa.harvard.edu/">CfA Library</a> | <a href="https://help.osf.io/">Get Help</a>',
                 'banner_name': 'cfa-banner.png',
                 'logo_name': 'cfa-shield.png',
                 'login_url': None,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4760,7 +4760,7 @@ class TestStaticFileViews(OsfTestCase):
     def test_getting_started_page(self):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'https://help.osf.io/')
+        assert_equal(res.location, 'https://help.osf.io/article/342-getting-started-on-the-osf')
     def test_help_redirect(self):
         res = self.app.get('/help/')
         assert_equal(res.status_code,302)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4760,7 +4760,7 @@ class TestStaticFileViews(OsfTestCase):
     def test_getting_started_page(self):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'https://help.osf.io/article/')
+        assert_equal(res.location, 'https://help.osf.io/')
     def test_help_redirect(self):
         res = self.app.get('/help/')
         assert_equal(res.status_code,302)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4760,7 +4760,7 @@ class TestStaticFileViews(OsfTestCase):
     def test_getting_started_page(self):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 302)
-        assert_equal(res.location, 'https://openscience.zendesk.com/hc/en-us')
+        assert_equal(res.location, 'https://help.osf.io/article/')
     def test_help_redirect(self):
         res = self.app.get('/help/')
         assert_equal(res.status_code,302)

--- a/website/language.py
+++ b/website/language.py
@@ -146,8 +146,8 @@ BEFORE_REGISTER_HAS_POINTERS = (
     u'This {category} contains links to other projects. These links will be '
     u'copied into your registration, but the projects that they link to will '
     u'not be registered. If you wish to register the linked projects, they '
-    u'must be registered separately. Learn more about <a href="https://help.osf.io/article/199-link-to-a-project'
-    u'/m/links_forks/l/524112-link-to-a-project">links</a>.'
+    u'must be registered separately. Learn more about <a href="https://help.osf.io'
+    u'/article/199-link-to-a-project">links</a>.'
 )
 
 BEFORE_FORK_HAS_POINTERS = (

--- a/website/language.py
+++ b/website/language.py
@@ -146,7 +146,7 @@ BEFORE_REGISTER_HAS_POINTERS = (
     u'This {category} contains links to other projects. These links will be '
     u'copied into your registration, but the projects that they link to will '
     u'not be registered. If you wish to register the linked projects, they '
-    u'must be registered separately. Learn more about <a href="http://help.osf.io'
+    u'must be registered separately. Learn more about <a href="https://help.osf.io/article/199-link-to-a-project'
     u'/m/links_forks/l/524112-link-to-a-project">links</a>.'
 )
 

--- a/website/language.py
+++ b/website/language.py
@@ -13,7 +13,7 @@ from website import settings
 # (upon clicking primary email confirmation link)
 WELCOME_MESSAGE = """
 <h1>Welcome to the OSF!</h1>
-<p>Visit our <a href="https://openscience.zendesk.com/hc/en-us" target="_blank" rel="noreferrer">Guides</a> to learn about creating a project, or get inspiration from <a href="https://osf.io/explore/activity/#popularPublicProjects">popular public projects</a>.</p>
+<p>Visit our <a href="https://help.osf.io/" target="_blank" rel="noreferrer">Guides</a> to learn about creating a project, or get inspiration from <a href="https://osf.io/explore/activity/#popularPublicProjects">popular public projects</a>.</p>
 """
 
 TERMS_OF_SERVICE = """

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -269,7 +269,7 @@ var AddProject = {
                                     m('i', ' This component will inherit the same license as ',
                                         m('b', options.parentTitle),
                                         '. ',
-                                        m('a[target="_blank"][href="https://help.osf.io/"]', 'Learn more.' )
+                                        m('a[target="_blank"][href="https://help.osf.io/article/288-license-your-project"]', 'Learn more.' )
                                     )
                                 )
                         ]): '',

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -269,7 +269,7 @@ var AddProject = {
                                     m('i', ' This component will inherit the same license as ',
                                         m('b', options.parentTitle),
                                         '. ',
-                                        m('a[target="_blank"][href="https://openscience.zendesk.com/hc/en-us/articles/360019737854"]', 'Learn more.' )
+                                        m('a[target="_blank"][href="https://help.osf.io/"]', 'Learn more.' )
                                     )
                                 )
                         ]): '',

--- a/website/static/js/components/publicNodes.js
+++ b/website/static/js/components/publicNodes.js
@@ -202,7 +202,7 @@ var PublicNodes = {
                         'You have no public ' + ctrl.nodeType + '.',
                         m('p', {}, [
                             'Find out how to make your ' + ctrl.nodeType + ' ',
-                            m('a', {'href': 'https://openscience.zendesk.com/hc/en-us/articles/360018981414', 'target': '_blank'}, 'public'),
+                            m('a', {'href': 'https://help.osf.io/', 'target': '_blank'}, 'public'),
                             '.'
                         ])
                     ])

--- a/website/static/js/components/publicNodes.js
+++ b/website/static/js/components/publicNodes.js
@@ -202,7 +202,7 @@ var PublicNodes = {
                         'You have no public ' + ctrl.nodeType + '.',
                         m('p', {}, [
                             'Find out how to make your ' + ctrl.nodeType + ' ',
-                            m('a', {'href': 'https://help.osf.io/', 'target': '_blank'}, 'public'),
+                            m('a', {'href': 'https://help.osf.io/article/285-control-your-privacy-settings', 'target': '_blank'}, 'public'),
                             '.'
                         ])
                     ])

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -812,7 +812,7 @@ var MyProjects = {
                         } else {
                             template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',
-                            m('a', {href: 'https://openscience.zendesk.com/hc/en-us/categories/360001550953'}, 'Guides'), ' to learn how registrations work.' );
+                            m('a', {href: 'https://help.osf.io'}, 'Guides'), ' to learn how registrations work.' );
                         }
                     } else if (lastcrumb.data.nodeType === 'preprints'){
                         template = m('.db-non-load-template.m-md.p-md.osf-box', [m('span', 'You have not made any preprints yet. Learn more about preprints in the '), m('a[href="https://openscience.zendesk.com/hc/en-us/categories/360001530554"]', 'OSF Guides'), m('span', ' or '), m('a[href="/preprints/"]', 'make one now.')]);

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -812,10 +812,10 @@ var MyProjects = {
                         } else {
                             template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',
-                            m('a', {href: 'https://help.osf.io/'}, 'Guides'), ' to learn how registrations work.' );
+                            m('a', {href: 'https://help.osf.io/article/330-welcome-to-registrations'}, 'Guides'), ' to learn how registrations work.' );
                         }
                     } else if (lastcrumb.data.nodeType === 'preprints'){
-                        template = m('.db-non-load-template.m-md.p-md.osf-box', [m('span', 'You have not made any preprints yet. Learn more about preprints in the '), m('a[href="https://help.osf.io/"]', 'OSF Guides'), m('span', ' or '), m('a[href="/preprints/"]', 'make one now.')]);
+                        template = m('.db-non-load-template.m-md.p-md.osf-box', [m('span', 'You have not made any preprints yet. Learn more about preprints in the '), m('a[href="https://help.osf.io/article/376-preprints-home-page"]', 'OSF Guides'), m('span', ' or '), m('a[href="/preprints/"]', 'make one now.')]);
                     } else if (lodashGet(lastcrumb, 'data.node.attributes.bookmarks')) {
                         template = m('.db-non-load-template.m-md.p-md.osf-box', 'You have no bookmarks. You can add projects or registrations by dragging them into your bookmarks or by clicking the Add to Bookmark button on the project or registration.');
                     } else {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -812,10 +812,10 @@ var MyProjects = {
                         } else {
                             template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',
-                            m('a', {href: 'https://help.osf.io'}, 'Guides'), ' to learn how registrations work.' );
+                            m('a', {href: 'https://help.osf.io/'}, 'Guides'), ' to learn how registrations work.' );
                         }
                     } else if (lastcrumb.data.nodeType === 'preprints'){
-                        template = m('.db-non-load-template.m-md.p-md.osf-box', [m('span', 'You have not made any preprints yet. Learn more about preprints in the '), m('a[href="https://openscience.zendesk.com/hc/en-us/categories/360001530554"]', 'OSF Guides'), m('span', ' or '), m('a[href="/preprints/"]', 'make one now.')]);
+                        template = m('.db-non-load-template.m-md.p-md.osf-box', [m('span', 'You have not made any preprints yet. Learn more about preprints in the '), m('a[href="https://help.osf.io/"]', 'OSF Guides'), m('span', ' or '), m('a[href="/preprints/"]', 'make one now.')]);
                     } else if (lodashGet(lastcrumb, 'data.node.attributes.bookmarks')) {
                         template = m('.db-non-load-template.m-md.p-md.osf-box', 'You have no bookmarks. You can add projects or registrations by dragging them into your bookmarks or by clicking the Add to Bookmark button on the project or registration.');
                     } else {

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -172,7 +172,7 @@
                     <div>
                         <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="${web_url_for('index')}#signUp">Create an Account</a>
 
-                        <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="https://openscience.zendesk.com/hc/en-us" target="_blank" rel="noreferrer">Learn More</a>
+                        <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="https://help.osf.io/" target="_blank" rel="noreferrer">Learn More</a>
                         <a data-bind="click: dismiss">Hide this message</a>
                     </div>
                 </div>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -172,7 +172,7 @@
                     <div>
                         <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="${web_url_for('index')}#signUp">Create an Account</a>
 
-                        <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="https://help.osf.io/" target="_blank" rel="noreferrer">Learn More</a>
+                        <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="https://help.osf.io/article/384-managing-projects" target="_blank" rel="noreferrer">Learn More</a>
                         <a data-bind="click: dismiss">Hide this message</a>
                     </div>
                 </div>

--- a/website/templates/emails/conference_submitted.html.mako
+++ b/website/templates/emails/conference_submitted.html.mako
@@ -22,9 +22,9 @@
     * Collaborators/contributors to the submission<br>
     * Charts, graphs, and data that didn't make it onto the submission<br>
     * Links to related publications or reference lists<br>
-    * Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons <a href="https://openscience.zendesk.com/hc/en-us/categories/360001550973/?utm_source=notification&utm_medium=email&utm_campaign=conference_submitted">here.</a><br>
+    * Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons <a href="https://help.osf.io/article/377-add-ons-api-home-page">here.</a><br>
     <br>
-    To learn more about OSF, read the <a href="https://openscience.zendesk.com/hc/en-us/?utm_source=notification&utm_medium=email&utm_campaign=conference_submitted">Guides</a>.<br>
+    To learn more about OSF, read the <a href="https://help.osf.io/">Guides</a>.<br>
     <br>
     Sincerely,<br>
     <br>

--- a/website/templates/emails/new_public_project.html.mako
+++ b/website/templates/emails/new_public_project.html.mako
@@ -17,7 +17,7 @@
             !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
         </script>
         <br>
-        If you would like to learn more about how to take advantage of any of these features, visit our <a href="https://openscience.zendesk.com/hc/en-us/?utm_source=notification&utm_medium=email&utm_campaign=new_public_project" target="_blank" rel="noreferrer">Guides</a>.</a>.
+        If you would like to learn more about how to take advantage of any of these features, visit our <a href="https://help.osf.io" target="_blank" rel="noreferrer">Guides</a>.</a>.
         <br><br>
         Sincerely,
         <br>

--- a/website/templates/emails/no_login.html.mako
+++ b/website/templates/emails/no_login.html.mako
@@ -14,7 +14,7 @@
             <li>You can connect to third-party services like Dropbox or Google Drive</li>
         </ul>
         To get started now, visit your dashboard and click on “Create a project.”
-        Need help getting started with a project? Check out the <a href="https://openscience.zendesk.com/hc/en-us?utm_source=notification&utm_medium=email&utm_campaign=no_login">OSF Help Guides</a> or one of our recent <a href="https://www.youtube.com/channel/UCGPlVf8FsQ23BehDLFrQa-g">OSF 101 webinars</a>.
+        Need help getting started with a project? Check out the <a href="https://help.osf.io/article/383-creating-a-project">OSF Help Guides</a> or one of our recent <a href="https://www.youtube.com/channel/UCGPlVf8FsQ23BehDLFrQa-g">OSF 101 webinars</a>.
         <br><br>
         Sincerely,
         <br>

--- a/website/templates/emails/reviews_submission_confirmation.html.mako
+++ b/website/templates/emails/reviews_submission_confirmation.html.mako
@@ -57,8 +57,8 @@
                                         Now that you've shared your ${document_type}, take advantage of more OSF features:
                                             <ul>
                                                 <li>Upload supplemental, materials, data, and code to an OSF project associated with your ${document_type}.
-                                                    <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930533-Upload-a-Preprint#add-supplemental-materials" target="_blank">Learn how</a></li>
-                                                <li>Preregister your next study. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930893">Read more</a></li>
+                                                    <a href="https://help.osf.io/" target="_blank">Learn how</a></li>
+                                                <li>Preregister your next study. <a href="https://help.osf.io/">Read more</a></li>
                                                 <li>Or share on social media: Tell your friends through:
                                                     <table style="display: inline-table;" width="53" border="0" cellspacing="0" cellpadding="0" align="center">
                                                         <tbody>

--- a/website/templates/emails/reviews_submission_confirmation.html.mako
+++ b/website/templates/emails/reviews_submission_confirmation.html.mako
@@ -57,8 +57,8 @@
                                         Now that you've shared your ${document_type}, take advantage of more OSF features:
                                             <ul>
                                                 <li>Upload supplemental, materials, data, and code to an OSF project associated with your ${document_type}.
-                                                    <a href="https://help.osf.io/" target="_blank">Learn how</a></li>
-                                                <li>Preregister your next study. <a href="https://help.osf.io/">Read more</a></li>
+                                                    <a href="https://help.osf.io/article/177-upload-a-preprint" target="_blank">Learn how</a></li>
+                                                <li>Preregister your next study. <a href="https://help.osf.io/article/145-preregistration">Read more</a></li>
                                                 <li>Or share on social media: Tell your friends through:
                                                     <table style="display: inline-table;" width="53" border="0" cellspacing="0" cellpadding="0" align="center">
                                                         <tbody>

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -55,12 +55,12 @@
                             Now that you've shared your ${document_type}, take advantage of more OSF features:
                             <ul>
                                 % if has_psyarxiv_chronos_text:
-                                    <li>Submit your preprint to an APA-published journal. <a href="https://help.osf.io/">Learn more</a></li>
+                                    <li>Submit your preprint to an APA-published journal. <a href="https://help.osf.io/article/401-submitting-to-a-moderated-preprint-service ">Learn more</a></li>
                                 % endif
 
                                 <li>Upload supplemental, materials, data, and code to the OSF project associated with your ${document_type}.
-                                    <a href="https://help.osf.io/" target="_blank">Learn how</a></li>
-                                <li>Preregister your next study. <a href="https://help.osf.io/">Read more</a></li>
+                                    <a href="https://help.osf.io/article/177-upload-a-preprint" target="_blank">Learn how</a></li>
+                                <li>Preregister your next study. <a href="https://help.osf.io/345-create-registrations">Read more</a></li>
                                 <li>Or share on social media: Tell your friends through:
                                     <table style="display: inline-table;" width="53" border="0" cellspacing="0" cellpadding="0" align="center">
                                         <tbody>

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -55,12 +55,12 @@
                             Now that you've shared your ${document_type}, take advantage of more OSF features:
                             <ul>
                                 % if has_psyarxiv_chronos_text:
-                                    <li>Submit your preprint to an APA-published journal. <a href="https://help.osf.io/hc/en-us/articles/360044820913-Submit-to-APA-Journals-via-PsyArXiv">Learn more</a></li>
+                                    <li>Submit your preprint to an APA-published journal. <a href="https://help.osf.io/">Learn more</a></li>
                                 % endif
 
                                 <li>Upload supplemental, materials, data, and code to the OSF project associated with your ${document_type}.
-                                    <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930533-Upload-a-Preprint#add-supplemental-materials" target="_blank">Learn how</a></li>
-                                <li>Preregister your next study. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930893-Register-Your-Project">Read more</a></li>
+                                    <a href="https://help.osf.io/" target="_blank">Learn how</a></li>
+                                <li>Preregister your next study. <a href="https://help.osf.io/">Read more</a></li>
                                 <li>Or share on social media: Tell your friends through:
                                     <table style="display: inline-table;" width="53" border="0" cellspacing="0" cellpadding="0" align="center">
                                         <tbody>

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -25,7 +25,7 @@ Archive your materials, data, manuscripts, or anything else associated with your
 <br>
 
 <h4>Share your work</h4>
-Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/201-create-a-view-only-link-for-a-project">Explore privacy settings.</a><br>
+Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/285-control-your-privacy-settings">Explore privacy settings.</a><br>
 <br>
 
 <h4>Register your research</h4>

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -21,34 +21,34 @@ Files can be stored in a location you specify from the available geographic regi
 % endif
 
 <h4>Store your files</h4>
-Archive your materials, data, manuscripts, or anything else associated with your work during the research process or after it is complete. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930613?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn how.</a><br>
+Archive your materials, data, manuscripts, or anything else associated with your work during the research process or after it is complete. <a href="https://help.osf.io/article/353-welcome-to-projects">Learn how.</a><br>
 <br>
 
 <h4>Share your work</h4>
-Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://openscience.zendesk.com/hc/en-us/articles/360018981414?utm_source=notification&utm_medium=email&utm_campaign=welcome">Explore privacy settings.</a><br>
+Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/201-create-a-view-only-link-for-a-project">Explore privacy settings.</a><br>
 <br>
 
 <h4>Register your research</h4>
-Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930893/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Read about registrations.</a><br>
+Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report. <a href="https://help.osf.io/article/330-welcome-to-registrations">Read about registrations.</a><br>
 <br>
 
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019931013/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn more.</a><br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research. <a href="https://help.osf.io/article/220-create-dois">Learn more.</a><br>
 <br>
 
 <h4>Measure your impact</h4>
-You can monitor traffic to your public projects and downloads of your public files. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019737874/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Discover analytics.</a><br>
+You can monitor traffic to your public projects and downloads of your public files. <a href="https://help.osf.io/article/289-view-project-analytics">Discover analytics.</a><br>
 <br>
 
 <h4>Connect services that you use</h4>
-OSF integrates with GitHub, Dropbox, Google Drive, Box, Dataverse, figshare, Amazon S3, ownCloud, Bitbucket, GitLab, OneDrive, Mendeley, and Zotero. Link the services that you use to your OSF projects so that all parts of your research are in one place <a href="https://openscience.zendesk.com/hc/en-us/categories/360001550973/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn about add-ons.</a><br>
+OSF integrates with GitHub, Dropbox, Google Drive, Box, Dataverse, figshare, Amazon S3, ownCloud, Bitbucket, GitLab, OneDrive, Mendeley, and Zotero. Link the services that you use to your OSF projects so that all parts of your research are in one place <a href="https://help.osf.io/article/377-add-ons-api-home-page">Learn about add-ons.</a><br>
 <br>
 
 <h4>Collaborate</h4>
-Add your collaborators to have a shared environment for maintaining your research materials and data and never lose files again. <a href="https://openscience.zendesk.com/hc/en-us/categories/360001530674/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Start collaborating.</a><br>
+Add your collaborators to have a shared environment for maintaining your research materials and data and never lose files again. <a href="https://help.osf.io/article/385-collaborating-on-projects">Start collaborating.</a><br>
 <br>
 
-Learn more about OSF by reading the <a href="https://openscience.zendesk.com/hc/en-us/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Guides</a>.<br>
+Learn more about OSF by reading the <a href="https://help.osf.io/">Guides</a>.<br>
 <br>
 Sincerely,<br>
 <br>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -21,7 +21,7 @@ Files can be stored in a location you specify from the available geographic regi
 % endif
 
 <h4>Store your files</h4>
-Archive your materials, data, manuscripts, or anything else associated with your work during the research process or after it is complete. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930613/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn how.</a><br>
+Archive your materials, data, manuscripts, or anything else associated with your work during the research process or after it is complete. <a href="https://help.osf.io/article/353-welcome-to-projects">Learn how.</a><br>
 <br>
 
 <h4>Affiliate your projects with your institution</h4>
@@ -29,30 +29,30 @@ Associate your projects with your institution. They will be added to your instit
 <br>
 
 <h4>Share your work</h4>
-Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://openscience.zendesk.com/hc/en-us/articles/360018981414/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Explore privacy settings.</a><br>
+Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/201-create-a-view-only-link-for-a-project">Explore privacy settings.</a><br>
 <br>
 
 <h4>Register your research</h4>
-Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019930893/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Read about registrations.</a><br>
+Create a permanent, time-stamped version of your projects and files.  Do this to preregister your design and analysis plan to conduct a confirmatory study, or archive your materials, data, and analysis scripts when publishing a report. <a href="https://help.osf.io/article/330-welcome-to-registrations">Read about registrations.</a><br>
 <br>
 
 <h4>Make your work citable</h4>
-Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019931013/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn more.</a><br>
+Every project and file on the OSF has a permanent unique identifier, and every registration can be assigned a DOI.  Citations for public projects are generated automatically so that visitors can give you credit for your research. <a href="https://help.osf.io/article/220-create-dois">Learn more.</a><br>
 <br>
 
 <h4>Measure your impact</h4>
-You can monitor traffic to your public projects and downloads of your public files. <a href="https://openscience.zendesk.com/hc/en-us/articles/360019737874/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Discover analytics.</a><br>
+You can monitor traffic to your public projects and downloads of your public files. <a href="https://help.osf.io/article/289-view-project-analytics">Discover analytics.</a><br>
 <br>
 
 <h4>Connect services that you use</h4>
-OSF integrates with GitHub, Dropbox, Google Drive, Box, Dataverse, figshare, Amazon S3, ownCloud, Bitbucket, GitLab, OneDrive, Mendeley, and Zotero. Link the services that you use to your OSF projects so that all parts of your research are in one place <a href="https://openscience.zendesk.com/hc/en-us/categories/360001550973/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Learn about add-ons.</a><br>
+OSF integrates with GitHub, Dropbox, Google Drive, Box, Dataverse, figshare, Amazon S3, ownCloud, Bitbucket, GitLab, OneDrive, Mendeley, and Zotero. Link the services that you use to your OSF projects so that all parts of your research are in one place <a href="https://help.osf.io/article/377-add-ons-api-home-page">Learn about add-ons.</a><br>
 <br>
 
 <h4>Collaborate</h4>
-Add your collaborators to have a shared environment for maintaining your research materials and data and never lose files again. <a href="https://openscience.zendesk.com/hc/en-us/categories/360001530674-Collaborating/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Start collaborating.</a><br>
+Add your collaborators to have a shared environment for maintaining your research materials and data and never lose files again. <a href="https://help.osf.io/article/385-collaborating-on-projects">Start collaborating.</a><br>
 <br>
 
-Learn more about OSF by reading the <a href="https://openscience.zendesk.com/hc/en-us/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Guides</a>.<br>
+Learn more about OSF by reading the <a href="https://help.osf.io/">Guides</a>.<br>
 <br>
 Sincerely,<br>
 <br>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -29,7 +29,7 @@ Associate your projects with your institution. They will be added to your instit
 <br>
 
 <h4>Share your work</h4>
-Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/201-create-a-view-only-link-for-a-project">Explore privacy settings.</a><br>
+Keep your research materials and data private, make it accessible to specific others with view-only links, or make it publicly accessible. You have full control of what parts of your research are public and what remains private. <a href="https://help.osf.io/article/285-control-your-privacy-settings">Explore privacy settings.</a><br>
 <br>
 
 <h4>Register your research</h4>

--- a/website/templates/emails/welcome_osf4m.html.mako
+++ b/website/templates/emails/welcome_osf4m.html.mako
@@ -17,7 +17,7 @@
             <li>You have one place to reference when looking for your research materials</li>
             <li>You can monitor interest in your data and materials by tracking downloads, just like you can for your ${conference} presentation.</li>
         </ul>
-        To learn more about how the OSF can help you manage your research, read our <a href="https://openscience.zendesk.com/hc/en-us/?utm_source=notification&utm_medium=email&utm_campaign=welcome">Guides</a>.
+        To learn more about how the OSF can help you manage your research, read our <a href="https://help.osf.io/">Guides</a>.
         The best part? It’s all free! OSF is supported by the non-profit technology company, the <a href="https://cos.io/">Center for Open Science</a>.
         <br><br>
         Best wishes,

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -432,7 +432,7 @@
                             <li>institutional logos to be displayed on public projects</li>
                             <li>public projects to be discoverable on specific institutional landing pages</li>
                             <li>single sign-on to the OSF with institutional credentials</li>
-                            <li><a href="https://openscience.zendesk.com/hc/en-us/categories/360001550913">FAQ</a></li>
+                            <li><a href="https://help.osf.io/">FAQ</a></li>
                          </ul>
                          <!-- /ko -->
                      </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -432,7 +432,7 @@
                             <li>institutional logos to be displayed on public projects</li>
                             <li>public projects to be discoverable on specific institutional landing pages</li>
                             <li>single sign-on to the OSF with institutional credentials</li>
-                            <li><a href="https://help.osf.io/">FAQ</a></li>
+                            <li><a href="https://help.osf.io/article/203-faqs">FAQ</a></li>
                          </ul>
                          <!-- /ko -->
                      </div>

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -3,7 +3,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://openscience.zendesk.com/hc/en-us/categories/360001550933')}
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/')}
 </%def>
 
 <%def name="content()">

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -3,7 +3,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/')}
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/article/397-osf-meetings')}
 </%def>
 
 <%def name="content()">

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -4,7 +4,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://openscience.zendesk.com/hc/en-us/categories/360001550933')}
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/')}
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -4,7 +4,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/')}
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='https://help.osf.io/article/397-osf-meetings')}
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -36,7 +36,7 @@
         You have no public ${pluralized_node_type}.
             <p>
                 Find out how to make your ${pluralized_node_type}
-                <a href="https://openscience.zendesk.com/hc/en-us/articles/360018981414" target="_blank">public</a>.
+                <a href="https://help.osf.io/" target="_blank">public</a>.
             </p>
         </div>
     % elif profile is not UNDEFINED:  ## On profile page and user has no public projects/components

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -36,7 +36,7 @@
         You have no public ${pluralized_node_type}.
             <p>
                 Find out how to make your ${pluralized_node_type}
-                <a href="https://help.osf.io/" target="_blank">public</a>.
+                <a href="https://help.osf.io/article/285-control-your-privacy-settings" target="_blank">public</a>.
             </p>
         </div>
     % elif profile is not UNDEFINED:  ## On profile page and user has no public projects/components

--- a/website/views.py
+++ b/website/views.py
@@ -349,9 +349,9 @@ def redirect_howosfworks(**kwargs):
     return redirect('/getting-started/')
 
 
-# redirect osf.io/getting-started to https://openscience.zendesk.com/hc/en-us
+# redirect osf.io/getting-started to https://help.osf.io/
 def redirect_getting_started(**kwargs):
-    return redirect('https://openscience.zendesk.com/hc/en-us')
+    return redirect('https://help.osf.io/')
 
 
 # Redirect to home page

--- a/website/views.py
+++ b/website/views.py
@@ -349,9 +349,9 @@ def redirect_howosfworks(**kwargs):
     return redirect('/getting-started/')
 
 
-# redirect osf.io/getting-started to https://help.osf.io/
+# redirect osf.io/getting-started to https://help.osf.io/article/342-getting-started-on-the-osf 
 def redirect_getting_started(**kwargs):
-    return redirect('https://help.osf.io/')
+    return redirect('https://help.osf.io/article/342-getting-started-on-the-osf')
 
 
 # Redirect to home page

--- a/website/views.py
+++ b/website/views.py
@@ -349,7 +349,7 @@ def redirect_howosfworks(**kwargs):
     return redirect('/getting-started/')
 
 
-# redirect osf.io/getting-started to https://help.osf.io/article/342-getting-started-on-the-osf 
+# redirect osf.io/getting-started to https://help.osf.io/article/342-getting-started-on-the-osf
 def redirect_getting_started(**kwargs):
     return redirect('https://help.osf.io/article/342-getting-started-on-the-osf')
 


### PR DESCRIPTION
## Purpose
- Route users to the new helpguide

## Changes
- Update openscience.zendesk.com links to new help guides

## QA Notes
- This updates all the links that are currently taking users to the old helpguides (openscience.zendesk)

## Documentation
- NA
## Side Effects
-NA
## Ticket
[ENG-3714]


[ENG-3714]: https://openscience.atlassian.net/browse/ENG-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ