### PR TITLE
[Hotfix] Fix Spam bans for QuickFilesNodes

### DIFF
--- a/osf/models/quickfiles.py
+++ b/osf/models/quickfiles.py
@@ -5,7 +5,9 @@ import logging
 from osf.models.node import (
     AbstractNode,
     AbstractNodeManager,
+    Node
 )
+from osf.models.nodelog import NodeLog
 
 from osf.exceptions import NodeStateError
 
@@ -34,7 +36,10 @@ class QuickFilesNodeManager(AbstractNodeManager):
         try:
             return QuickFilesNode.objects.get(creator=user)
         except AbstractNode.DoesNotExist:
-            return None
+            return Node.objects.filter(
+                logs__action=NodeLog.MIGRATED_QUICK_FILES,
+                creator=user
+            ).order_by('created').first()  # Returns None if there are none
 
 
 class QuickFilesNode(AbstractNode):

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -672,14 +672,15 @@ def update_user(user, index=None):
             # update files in their quickfiles node if the user has been marked as spam
             if user.spam_status == SpamStatus.SPAM:
                 quickfiles = QuickFilesNode.objects.get_for_user(user)
-                for quickfile_id in quickfiles.files.values_list('_id', flat=True):
-                    client().delete(
-                        index=index,
-                        doc_type='file',
-                        id=quickfile_id,
-                        refresh=True,
-                        ignore=[404]
-                    )
+                if quickfiles:
+                    for quickfile_id in quickfiles.files.values_list('_id', flat=True):
+                        client().delete(
+                            index=index,
+                            doc_type='file',
+                            id=quickfile_id,
+                            refresh=True,
+                            ignore=[404]
+                        )
         except NotFoundError:
             pass
         return


### PR DESCRIPTION
## Purpose
Fix Spam bans for QuickFilesNodes

## Changes
- Optionally return a users' recast QFN in `QuickFilesNodeManager.get_for_user`
- Conditionally skip deleting formerly-quick files from index if no suitable `AbstractNode` is found

## QA Notes
N/A

## Documentation
N/A

## Side Effects
None expected

## Ticket
None known.