### PR TITLE
[ENG-3732] Make burst-rate-throttle allow cookies

### DIFF
--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -121,11 +121,13 @@ class SendEmailDeactivationThrottle(SendEmailThrottle):
         return super(SendEmailDeactivationThrottle, self).allow_request(request, view)
 
 
-class BurstRateThrottle(UserRateThrottle):
+class BurstRateThrottle(NonCookieAuthThrottle, UserRateThrottle):
     scope = 'burst'
+
 
 class FilesRateThrottle(NonCookieAuthThrottle, UserRateThrottle):
     scope = 'files'
+
 
 class FilesBurstRateThrottle(NonCookieAuthThrottle, UserRateThrottle):
     scope = 'files-burst'


### PR DESCRIPTION
## Purpose

Currently ember isn't denouncing it's requests, so it's frequently hitting the throttle so we'll disable the throttle for ember. Unfortunately our throttling tests were skipped a long time ago due to an issue with Travis so we will have to un-skip them and make minor fixes.

## Changes

- add `NonCookieAuthThrottle` class to `BurstRateThrottle`
- unskip and fix tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.

- Verify throttle is disabled. this is a script I used that can reliably hit it: https://gist.github.com/Johnetordoff/7502ac92e292be9874e952c35d2acb3c#file-gistfile1-txt

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

Now we disable throttling across the board if the user includes a valid cookie in the request.

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/issues/ENG-3732
