### PR TITLE
[Hotfix] Optimize No-Project api.DraftRegistrationList.post

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1034,14 +1034,16 @@ class TestNotificationUtils(OsfTestCase):
         all_global_subscriptions_none = utils.check_if_all_global_subscriptions_are_none(self.user)
         assert_false(all_global_subscriptions_none)
 
-    def test_check_if_all_global_subscriptions_are_none_true(self):
-        for x in self.user_subscription:
-            x.none.add(self.user)
-            x.email_transactional.remove(self.user)
-        for x in self.user_subscription:
-            x.save()
-        all_global_subscriptions_none = utils.check_if_all_global_subscriptions_are_none(self.user)
-        assert_true(all_global_subscriptions_none)
+    # # Business logic prevents this from being an applicable unit test;
+    # # global_mentions cannot be unsubscribed from
+    # def test_check_if_all_global_subscriptions_are_none_true(self):
+    #     for x in self.user_subscription:
+    #         x.none.add(self.user)
+    #         x.email_transactional.remove(self.user)
+    #     for x in self.user_subscription:
+    #         x.save()
+    #     all_global_subscriptions_none = utils.check_if_all_global_subscriptions_are_none(self.user)
+    #     assert_true(all_global_subscriptions_none)
 
     def test_format_data_user_settings(self):
         data = utils.format_user_and_project_subscriptions(self.user)

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -426,16 +426,11 @@ def get_global_notification_type(global_subscription, user):
 
 
 def check_if_all_global_subscriptions_are_none(user):
-    all_global_subscriptions_none = False
-    user_sunscriptions = get_all_user_subscriptions(user)
-    for user_subscription in user_sunscriptions:
-        if user_subscription.event_name.startswith('global_'):
-            all_global_subscriptions_none = True
-            global_notification_type = get_global_notification_type(user_subscription, user)
-            if global_notification_type != 'none':
-                return False
-
-    return all_global_subscriptions_none
+    # This function predates comment mentions, which is a global_ notification that cannot be disabled
+    # Therefore, an actual check would never return True.
+    # If this changes, an optimized query would look something like:
+    # not NotificationSubscription.objects.filter(Q(event_name__startswith='global_') & (Q(email_digest=user.pk)|Q(email_transactional=user.pk))).exists()
+    return False
 
 
 def subscribe_user_to_global_notifications(user):


### PR DESCRIPTION
## Purpose
DraftRegistrations created without a project often take 6s or more to create. This is in part due to some unnecessary queries  against `osf_notificationsubscription`.

## Changes
- Remove unnecessary queries
- Disable inapplicable test.

## Side Effects
Some other things may also speed up

## Ticket
Unknown