### PR TITLE
[ENG-3760] add project files routes to guid routing

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -56,7 +56,6 @@ from osf.models import (
 )
 from osf.metrics import PreprintView, PreprintDownload
 from osf.utils import permissions
-from website.ember_osf_web.views import use_ember_app
 from website.profile.utils import get_profile_image_url
 from website.project import decorators
 from website.project.decorators import must_be_contributor_or_public, must_be_valid_project, check_contributor_auth
@@ -728,20 +727,18 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
 
     savepoint_id = transaction.savepoint()
     file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(target, path)
-    if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
-        return use_ember_app()
 
-    if action != 'download' and isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
-        if file_node.get_guid():
-            guid = file_node.get_guid()
-        else:
+    # There's no download action redirect to the Ember front-end file view and create guid.
+    if action != 'download':
+        if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
             guid = file_node.get_guid(create=True)
-            guid.save()
-            file_node.save()
-        return redirect(f'{settings.DOMAIN}{guid._id}/')
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
+        if isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
+            guid = file_node.get_guid(create=True)
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
 
     # Note: Cookie is provided for authentication to waterbutler
-    # it is overriden to force authentication as the current user
+    # it is overridden to force authentication as the current user
     # the auth header is also pass to support basic auth
     version = file_node.touch(
         request.headers.get('Authorization'),

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -1422,6 +1422,10 @@ class TestFileViews(StorageTestCase):
             assert not mock_ember.called
             res.follow()
             assert mock_ember.called
+            args, kwargs = mock_ember.call_args
+
+            assert args[0] == EXTERNAL_EMBER_APPS['ember_osf_web']['server']
+            assert args[1] == EXTERNAL_EMBER_APPS['ember_osf_web']['path'].rstrip('/')
 
     def test_download_file(self):
         file = create_test_file(target=self.node, user=self.user)

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -1417,12 +1417,11 @@ class TestFileViews(StorageTestCase):
             file = create_test_file(target=self.node, user=self.user)
             url = self.node.web_url_for('addon_view_or_download_file', path=file._id, provider=file.provider)
             res = self.app.get(url, auth=self.user.auth)
-            assert res.status_code == 200
+            assert res.status_code == 302
+            assert res.headers['Location'] == f'{settings.DOMAIN}{file.get_guid()._id}/'
+            assert not mock_ember.called
+            res.follow()
             assert mock_ember.called
-            args, kwargs = mock_ember.call_args
-
-            assert args[0] == EXTERNAL_EMBER_APPS['ember_osf_web']['server']
-            assert args[1] == EXTERNAL_EMBER_APPS['ember_osf_web']['path'].rstrip('/')
 
     def test_download_file(self):
         file = create_test_file(target=self.node, user=self.user)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Ensures the project file page and the project files page are routed to Ember on the correct waffle flag


## Changes

- add flag conditionals to `guid_resolve`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify `<project-guid>/files/<provider>` routes correctly on flag `EMBER_PROJECT_FILES`
- Verify `<file-project-guid>/` routes correctly on flag `EMBER_FILE_PROJECT_DETAIL`
- Verify `<file-project-guid>/?action=download` downloads the file
- Verify `files/<provider>/<id>/` routes correctly on flag `EMBER_FILE_PROJECT_DETAIL` to that files guid.


What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3760
