### PR TITLE
Fix issue creating ahistorical files

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -728,15 +728,6 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
     savepoint_id = transaction.savepoint()
     file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(target, path)
 
-    # There's no download action redirect to the Ember front-end file view and create guid.
-    if action != 'download':
-        if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
-            guid = file_node.get_guid(create=True)
-            return redirect(f'{settings.DOMAIN}{guid._id}/')
-        if isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
-            guid = file_node.get_guid(create=True)
-            return redirect(f'{settings.DOMAIN}{guid._id}/')
-
     # Note: Cookie is provided for authentication to waterbutler
     # it is overridden to force authentication as the current user
     # the auth header is also pass to support basic auth
@@ -747,6 +738,16 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
             cookie=request.cookies.get(settings.COOKIE_NAME)
         )
     )
+
+    # There's no download action redirect to the Ember front-end file view and create guid.
+    if action != 'download':
+        if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
+            guid = file_node.get_guid(create=True)
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
+        if isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
+            guid = file_node.get_guid(create=True)
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
+
     if version is None:
         # File is either deleted or unable to be found in the provider location
         # Rollback the insertion of the file_node


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Some addon file nodes seemlingly redirect before a history entry can be made, this breaks things.

## Changes

- move touch function so it's before the redirect

 
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://staging-sentry.cos.io/cos/osf-back-end-77/issues/13316/
