### PR TITLE
[ENG-3820] Create Cache Table for NodeStorage as a post-migrate signal

### DIFF
--- a/osf/apps.py
+++ b/osf/apps.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.apps import AppConfig as BaseAppConfig
 from django.db.models.signals import post_migrate
-from osf.migrations import update_permission_groups
+from osf.migrations import update_permission_groups, create_cache_table
 
 
 class AppConfig(BaseAppConfig):
@@ -15,4 +15,8 @@ class AppConfig(BaseAppConfig):
         post_migrate.connect(
             update_permission_groups,
             dispatch_uid='osf.apps.update_permissions_groups'
+        )
+        post_migrate.connect(
+            create_cache_table,
+            dispatch_uid='osf.apps.create_cache_table'
         )

--- a/osf/migrations/0156_create_cache_table.py
+++ b/osf/migrations/0156_create_cache_table.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from django.db import migrations
-from django.conf import settings
 
 
 class Migration(migrations.Migration):
@@ -9,15 +8,4 @@ class Migration(migrations.Migration):
         ('osf', '0155_merge_20190115_1437'),
     ]
     operations = [
-        migrations.RunSQL([
-            """
-            CREATE TABLE "{}" (
-                "cache_key" varchar(255) NOT NULL PRIMARY KEY,
-                "value" text NOT NULL,
-                "expires" timestamp with time zone NOT NULL
-            );
-            """.format(settings.CACHES[settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])
-        ], [
-            """DROP TABLE "{}"; """.format(settings.CACHES[settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])
-        ])
     ]

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
 from django.db.utils import ProgrammingError
+from django.core.management import call_command
+from api.base import settings
 
 logger = logging.getLogger(__file__)
 
@@ -119,3 +121,8 @@ def update_permission_groups(sender, verbosity=0, **kwargs):
     if getattr(sender, 'label', None) == 'osf':
         update_admin_permissions(verbosity)
         update_provider_auth_groups(verbosity)
+
+
+def create_cache_table(sender, verbosity=0, **kwargs):
+    if getattr(sender, 'label', None) == 'osf':
+        call_command('createcachetable', tablename=settings.CACHES[settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])


### PR DESCRIPTION
## Purpose

This is a small part of the larger Django Upgrade project which goal is to simplify the "migration stream" to include less archaic code. here we are moving the create cache migration into a post migration signal and using a managment command wrapper instead of raw SQL, to keep more in line in framework practices.

## Changes

- removes migrations dependent and merging with the createcache migration stream. 
- adds post-migrate signal that builds cache 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3820
