### PR TITLE
[ENG-3832] Add redirect based for unauthed files page user

### DIFF
--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -221,6 +221,17 @@ class TestGetMetadataHook(HookTestCase):
             self.node,
             expect_errors=True,
         )
+        assert_equal(res.status_code, 302)
+        assert '/login?service=' in res.location
+
+        self.node.is_public = True
+        self.node.save()
+        res = self.send_hook(
+            'osfstorage_get_metadata',
+            {'fid': '/not/fo/u/nd/'}, {},
+            self.node,
+            expect_errors=True,
+        )
         assert_equal(res.status_code, 404)
 
 

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -161,6 +161,51 @@ class TestResolveGuid(OsfTestCase):
         )
         assert res.status_code == 404
 
+    def test_resolve_guid_no_auth_redirect_to_cas_includes_public(self):
+        """
+        Unauthenticated users are sent to login when visiting private projects, but not if the projects are public.
+        """
+        res = self.app.get(
+            self.node.web_url_for('resolve_guid', guid=self.node._id),
+            expect_errors=True,
+        )
+        assert res.status_code == 302
+        assert '/login?service=' in res.location
+
+        self.node.is_public = True
+        self.node.save()
+        res = self.app.get(
+            self.node.web_url_for('resolve_guid', guid=self.node._id),
+            expect_errors=True,
+        )
+        assert res.status_code == 200
+
+    def test_resolve_guid_private_request_access_or_redirect_to_cas(self):
+        """
+        Authenticated users are sent to the request access page when it is set to true on the node, otherwise they get a
+        legacy Forbidden page.
+        """
+        non_contrib = AuthUserFactory()
+        self.node.access_requests_enabled = False
+        self.node.save()
+        res = self.app.get(
+            self.node.web_url_for('resolve_guid', guid=self.node._id),
+            auth=non_contrib.auth,
+            expect_errors=True,
+        )
+        assert '<title>OSF | Forbidden</title>' in res.body.decode()
+        assert res.status_code == 403
+
+        self.node.access_requests_enabled = True
+        self.node.save()
+        res = self.app.get(
+            self.node.web_url_for('resolve_guid', guid=self.node._id),
+            auth=non_contrib.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 403
+        assert '<title>OSF | Request Access</title>' in res.body.decode()
+
     def test_resolve_guid_download_file(self):
         pp = PreprintFactory(finish=True)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To route unauthenticated users properly to CAS when they visit a node they don't have access to, even when going to the new emberized `files/` endpoint.

## Changes

- Check users permissions and redirect them to CAS

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify that `<project-guid>/files/` redirect to CAS for an unauthenticated user.
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3832
