### PR TITLE
[ENG-3840] Univ. of SC SSO Update (Test Server)

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1701,7 +1701,7 @@ INSTITUTIONS = {
                 'banner_name': 'sc-banner.png',
                 'logo_name': 'sc-shield.png',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(
-                    encode_uri_component('urn:mace:incommon:sc.edu')),
+                    encode_uri_component('https://cas.auth.sc.edu/cas/idp')),
                 'logout_url': SHIBBOLETH_SP_LOGOUT.format(
                     encode_uri_component('https://test.osf.io/goodbye')),
                 'domains': ['test-osf-sc.cos.io'],


### PR DESCRIPTION
## Purpose

Univ. of SC is migrating from InCommon Shibboleth to Apereo CAS.
We decided to test the migration on the `test` server first.

## Changes

The only change in the OSF repo is the login URL update which uses the new entity ID `https://cas.auth.sc.edu/cas/idp`.

## DevOps Notes

**TEST SERVER ONLY**

### CAS

- [x] `institutions-auth.xsl`: add the following under the section `<xsl:when test="$delegation-protocol = 'saml-shib'">` where transformation of attributes from SAML institutions are listed. If we have them configured on `test` before, then replace it.
```xml
<!-- University of South Carolina (SC) [Test] -->
<xsl:when test="$idp='https://cas.auth.sc.edu/cas/idp'">
    <id>sc</id>
    <user>
        <username><xsl:value-of select="//attribute[@name='mail']/@value"/></username>
        <familyName><xsl:value-of select="//attribute[@name='sn']/@value"/></familyName>
        <givenName><xsl:value-of select="//attribute[@name='givenname']/@value"/></givenName>
        <fullname/>
        <middleNames/>
        <suffix/>
    </user>
</xsl:when>
```

### Shibboleth

- [x] Entity ID `https://cas.auth.sc.edu/cas/idp` verified in metadata https://cas.auth.sc.edu/cas/idp/metadata
- [x] `attribute-map.xml`: N/A (SC's new IdP releases `eduPerson` attributes as we discussed)
- [x] `shibboleth2.xml`: add the following metadata configuration
```xml
<!-- University of South Carolina Libraries (SC) [Test] -->
<MetadataProvider type="XML"
                  uri="https://cas.auth.sc.edu/cas/idp/metadata"
                  backingFilePath="sc-idp-test-metadata.xml"
                  reloadInterval="180000" />
```

### OSF

- [x] After OSF deployment, run the institution population script on `test`
```bash
python3 -m scripts.populate_institutions -e test -i sc
```

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3840
