### PR TITLE
[No Ticket] Add generic demo institution to the test server

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -1115,6 +1115,18 @@ INSTITUTIONS = {
         ],
     'test': [
             {
+                '_id': 'osfidemo',
+                'name': 'OSF Demo Institution',
+                'description': 'Here is the place to put in links to other resources, security and data policies, research guidelines, and/or a contact for user support within your institution.',
+                'banner_name': 'placeholder-banner.png',
+                'logo_name': 'placeholder-shield.png',
+                'login_url': None,
+                'logout_url': None,
+                'domains': [],
+                'email_domains': [],
+                'delegation_protocol': '',
+            },
+            {
                 '_id': 'a2jlab',
                 'name': 'Access to Justice Lab [Test]',
                 'description': 'Based within Harvard Law School, the <a href="https://a2jlab.org/">Access to Justice Lab</a> works with court administrators, legal service providers, and other stakeholders in the U.S. legal system to design and implement randomized field experiments evaluating interventions that impact access to justice.',


### PR DESCRIPTION
## Purpose

As product requested, created a demo institution on the test server.

## Changes

* Add a institution with name `OSF Demo Institution` and ID `osfidemo`
* Use placeholder assets and descriptions
* `email_domains` is left empty on purpose for product owner to modify later

## DevOps Notes

- No CAS or Shibboleth
- Test server only and no need to deploy prod
- [ ] Run `python3 -m scripts.populate_institutions -e test -i osfidemo` to add the institution after deployment

## Product Notes

* When a potential institution wants to test OSF, the product owner can modify the `email_domains` field in the Admin app.

![Screen Shot 2022-06-10 at 4 12 54 PM](https://user-images.githubusercontent.com/3750414/173143921-bca6d6ef-4c97-4fff-b36a-96fbfa0c71cf.png)

* The institution project aggregate page will be https://test.osf.io/institutions/osfidemo/


## QA Notes

N/A

## Documentation

See: https://docs.google.com/document/d/1t57_9ZBK75e8ggvcnSPWjq-4VAcoCKO7BvzaXS2xvJw/edit

## Side Effects

N/A

## Ticket

N/A
