### PR TITLE
[ENG-3868] Move blocked email domains to post-migrate signal

### DIFF
--- a/osf/apps.py
+++ b/osf/apps.py
@@ -1,12 +1,15 @@
 import logging
+
 from django.apps import AppConfig as BaseAppConfig
 from django.db.models.signals import post_migrate
+
 from osf.migrations import (
+    add_registration_schemas,
+    create_cache_table,
+    update_blocked_email_domains,
+    update_license,
     update_permission_groups,
     update_waffle_flags,
-    create_cache_table,
-    update_license,
-    add_registration_schemas
 )
 
 logger = logging.getLogger(__file__)
@@ -44,4 +47,9 @@ class AppConfig(BaseAppConfig):
         post_migrate.connect(
             create_cache_table,
             dispatch_uid='osf.apps.create_cache_table'
+        )
+
+        post_migrate.connect(
+            update_blocked_email_domains,
+            dispatch_uid='osf.apps.update_blocked_email_domains'
         )

--- a/osf/migrations/0136_preprint_node_divorce.py
+++ b/osf/migrations/0136_preprint_node_divorce.py
@@ -11,6 +11,7 @@ from bulk_update.helper import bulk_update
 
 logger = logging.getLogger(__name__)
 
+
 def reverse_func(apps, schema_editor):
     PreprintContributor = apps.get_model('osf', 'PreprintContributor')
     PreprintTags = apps.get_model('osf', 'Preprint_Tags')
@@ -83,7 +84,9 @@ def reverse_func(apps, schema_editor):
     modified_field.auto_now = True
     node_modified_field.auto_now = True
 
+
 group_format = 'preprint_{self.id}_{group}'
+
 
 def format_group(self, name):
     return group_format.format(self=self, group=name)

--- a/osf/migrations/0147_blacklistedemaildomain.py
+++ b/osf/migrations/0147_blacklistedemaildomain.py
@@ -39,6 +39,4 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
         ),
-        migrations.RunPython(populate_blacklisted_domains, remove_blacklisted_domains)
-
     ]

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -157,7 +157,8 @@ def update_blocked_email_domains(sender, verbosity=0, **kwargs):
     if getattr(sender, 'label', None) == 'osf':
         from django.apps import apps
         NotableEmailDomain = apps.get_model('osf', 'NotableEmailDomain')
-        NotableEmailDomain.objects.bulk_create([
-            NotableEmailDomain(domain=domain, note=NotableEmailDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION)
-            for domain in osf_settings.DENY_EMAIL_DOMAINS
-        ])
+        for domain in osf_settings.DENY_EMAIL_DOMAINS:
+            NotableEmailDomain.objects.update_or_create(
+                domain=domain,
+                defaults={'note': NotableEmailDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION},
+            )

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 from api.base import settings as api_settings
 from osf.management.commands.manage_switch_flags import manage_waffle
 from osf.utils.migrations import ensure_schemas, map_schemas_to_schemablocks
+from website import settings as osf_settings
 
 logger = logging.getLogger(__file__)
 
@@ -150,3 +151,13 @@ def add_registration_schemas(sender, verbosity=0, **kwargs):
     if getattr(sender, 'label', None) == 'osf':
         ensure_schemas()
         map_schemas_to_schemablocks()
+
+
+def update_blocked_email_domains(sender, verbosity=0, **kwargs):
+    if getattr(sender, 'label', None) == 'osf':
+        from django.apps import apps
+        NotableEmailDomain = apps.get_model('osf', 'NotableEmailDomain')
+        NotableEmailDomain.objects.bulk_create([
+            NotableEmailDomain(domain=domain, note=NotableEmailDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION)
+            for domain in osf_settings.DENY_EMAIL_DOMAINS
+        ])

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -157,7 +157,7 @@ def update_blocked_email_domains(sender, verbosity=0, **kwargs):
     if getattr(sender, 'label', None) == 'osf':
         from django.apps import apps
         NotableEmailDomain = apps.get_model('osf', 'NotableEmailDomain')
-        for domain in osf_settings.DENY_EMAIL_DOMAINS:
+        for domain in osf_settings.BLACKLISTED_DOMAINS:
             NotableEmailDomain.objects.update_or_create(
                 domain=domain,
                 defaults={'note': NotableEmailDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION},

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -758,7 +758,7 @@ ORCID_RECORD_EMPLOYMENT_PATH = '/employments'
 ORCID_RECORD_EDUCATION_PATH = '/educations'
 
 # Source: https://github.com/maxd/fake_email_validator/blob/master/config/fake_domains.list
-BLACKLISTED_DOMAINS = [
+DENY_EMAIL_DOMAINS = [
     '0-mail.com',
     '0815.ru',
     '0815.su',

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -758,7 +758,7 @@ ORCID_RECORD_EMPLOYMENT_PATH = '/employments'
 ORCID_RECORD_EDUCATION_PATH = '/educations'
 
 # Source: https://github.com/maxd/fake_email_validator/blob/master/config/fake_domains.list
-DENY_EMAIL_DOMAINS = [
+BLACKLISTED_DOMAINS = [
     '0-mail.com',
     '0815.ru',
     '0815.su',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This makes population of Blocked Email Domains a post-migration signal in preparation of the Django upgrade.

## Changes

- removes license migration from the migration stream
- add new signal to populate migrations

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3868