### PR TITLE
[ENG-3872] Fix dataverse 502s and pass version info to FE

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -35,6 +35,12 @@ class DataverseFile(DataverseFileNode, File):
         Call super to update _history and last_touched anyway.
         """
         version = super().update(None, data, user=user, save=save)
+        if data['extra']['datasetVersion'] == 'latest':
+            self.name += ' [Draft]'
+        if data['extra']['datasetVersion'] == 'latest-published':
+            self.name += ' [Published]'
+        if save:
+            self.save()
         version.identifier = revision
         return version
 

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -35,12 +35,6 @@ class DataverseFile(DataverseFileNode, File):
         Call super to update _history and last_touched anyway.
         """
         version = super().update(None, data, user=user, save=save)
-        if data['extra']['datasetVersion'] == 'latest':
-            self.name += ' [Draft]'
-        if data['extra']['datasetVersion'] == 'latest-published':
-            self.name += ' [Published]'
-        if save:
-            self.save()
         version.identifier = revision
         return version
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -651,18 +651,16 @@ class WaterButlerMixin(object):
                 file_obj = base_class(target=node, _path=_path, provider=base_class._provider)
                 objs_to_create[base_class].append(file_obj)
             except MultipleObjectsReturned as e:
-                # Dataverse provides us two sets of files with the same path, so we disambiguate the tiles, this
+                # Dataverse provides us two sets of files with the same path, so we disambiguate the paths, this
                 # preserves legacy behavior.
-                if attrs['provider'] == 'dataverse':
-                    dataverse_files = base_class.objects.filter(
+                if str(e) == 'get() returned more than one DataverseFile -- it returned 2!':
+                    file_obj = base_class.objects.get(
                         target_object_id=node.id,
                         target_content_type=content_type,
                         _path=_path,
+                        _history__0__extra__datasetVersion=attrs['extra']['datasetVersion'],
                     )
-                    for dataverse_file in dataverse_files:
-                        dataverse_file.update(None, attrs, user=self.request.user, save=False)
-                        file_objs.append(dataverse_file)
-                    continue
+                    file_objs.append(file_obj)
                 else:
                     raise e
             else:

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -5,6 +5,7 @@ from distutils.version import StrictVersion
 
 from django_bulk_update.helper import bulk_update
 from django.conf import settings as django_settings
+from django.core.exceptions import MultipleObjectsReturned
 from django.db import transaction
 from django.db.models import F, Q
 from django.http import JsonResponse
@@ -638,12 +639,32 @@ class WaterButlerMixin(object):
             )
 
             # mirrors BaseFileNode get_or_create
+            _path = '/' + attrs['path'].lstrip('/')
             try:
-                file_obj = base_class.objects.get(target_object_id=node.id, target_content_type=content_type, _path='/' + attrs['path'].lstrip('/'))
+                file_obj = base_class.objects.get(
+                    target_object_id=node.id,
+                    target_content_type=content_type,
+                    _path=_path,
+                )
             except base_class.DoesNotExist:
                 # create method on BaseFileNode appends provider, bulk_create bypasses this step so it is added here
-                file_obj = base_class(target=node, _path='/' + attrs['path'].lstrip('/'), provider=base_class._provider)
+                file_obj = base_class(target=node, _path=_path, provider=base_class._provider)
                 objs_to_create[base_class].append(file_obj)
+            except MultipleObjectsReturned as e:
+                # Dataverse provides us two sets of files with the same path, so we disambiguate the tiles, this
+                # preserves legacy behavior.
+                if attrs['provider'] == 'dataverse':
+                    dataverse_files = base_class.objects.filter(
+                        target_object_id=node.id,
+                        target_content_type=content_type,
+                        _path=_path,
+                    )
+                    for dataverse_file in dataverse_files:
+                        dataverse_file.update(None, attrs, user=self.request.user, save=False)
+                        file_objs.append(dataverse_file)
+                    continue
+                else:
+                    raise e
             else:
                 file_objs.append(file_obj)
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -319,7 +319,7 @@ class BaseFileSerializer(JSONAPISerializer):
             extras['downloads'] = obj.get_download_count()
 
         if obj.provider == 'dataverse':
-            extras.update(obj.history[0]['extra'])
+            extras.update(obj.history[-1]['extra'])
 
         return extras
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -317,6 +317,10 @@ class BaseFileSerializer(JSONAPISerializer):
         }
         if obj.provider == 'osfstorage' and obj.is_file:
             extras['downloads'] = obj.get_download_count()
+
+        if obj.provider == 'dataverse':
+            extras.update(obj.history[0]['extra'])
+
         return extras
 
     def get_current_user_can_comment(self, obj):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -150,7 +150,7 @@ from osf.models import (
     File,
     Folder,
 )
-from addons.osfstorage.models import Region, OsfStorageFileNode
+from addons.osfstorage.models import Region
 from osf.utils.permissions import ADMIN, WRITE_NODE
 from website import mails, settings
 

--- a/api_tests/files/views/test_file_list.py
+++ b/api_tests/files/views/test_file_list.py
@@ -71,18 +71,18 @@ class TestNodeFileList:
             node=node,
             provider='dataverse',
             files=[
-                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'extra': {'datasetVersion': 'latest'}, 'provider': 'dataverse'},
-                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'extra': {'datasetVersion': 'latest-published'}, 'provider': 'dataverse'},
+                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'modified': '2018-02-04T00:00:00.001Z', 'extra': {'datasetVersion': 'latest'}, 'provider': 'dataverse'},
+                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'modified': '2018-02-04T11:11:11.001Z', 'extra': {'datasetVersion': 'latest-published'}, 'provider': 'dataverse'},
             ]
         )
         res = app.get(
-            f'/{API_BASE}nodes/{node._id}/files/dataverse/',
+            f'/{API_BASE}nodes/{node._id}/files/dataverse/?sort=date_modified',
             auth=node.creator.auth
         )
         data = res.json['data']
         assert len(data) == 2
-        assert data[0]['attributes']['name'] == 'testpath [Draft]'
-        assert data[1]['attributes']['name'] == 'testpath [Published]'
+        assert data[0]['attributes']['extra'] == {'datasetVersion': 'latest', 'hashes': {'md5': None, 'sha256': None}}
+        assert data[1]['attributes']['extra'] == {'datasetVersion': 'latest-published', 'hashes': {'md5': None, 'sha256': None}}
 
 
 @pytest.mark.django_db

--- a/api_tests/files/views/test_file_list.py
+++ b/api_tests/files/views/test_file_list.py
@@ -141,8 +141,9 @@ class TestNodeFileList:
     @responses.activate
     def test_disambiguate_dataverse_paths_retrieve(self, app, user, node, dataverse, dataverse_draft_filenode, dataverse_published_filenode):
         '''
-        This test is for retrieving files from Dataverse and disambiguating thier corresponding OSF filenodes and
-        ensures their `extra` info is passed along to the front-end.
+        This test is for retrieving files from Dataverse and disambiguating their corresponding OSF filenodes and
+        ensures their `extra` info is passed along to the front-end. Waterbulter must also be mocked here, otherwise OSF
+        will assume the files are gone.
         '''
         prepare_mock_wb_response(
             path='/',

--- a/api_tests/files/views/test_file_list.py
+++ b/api_tests/files/views/test_file_list.py
@@ -10,6 +10,7 @@ from osf_tests.factories import (
 )
 from addons.dataverse.tests.factories import DataverseAccountFactory
 from api_tests.draft_nodes.views.test_draft_node_files_lists import prepare_mock_wb_response
+from addons.dataverse.models import DataverseFile
 
 
 @pytest.fixture()
@@ -49,6 +50,22 @@ class TestNodeFileList:
             node, user, filename='file_one')
 
     @pytest.fixture()
+    def dataverse_published_filenode(self, node):
+        return DataverseFile.objects.create(
+            target=node,
+            path='/testpath',
+            _history=[{'extra': {'datasetVersion': 'latest-published'}}],
+        )
+
+    @pytest.fixture()
+    def dataverse_draft_filenode(self, node):
+        return DataverseFile.objects.create(
+            target=node,
+            path='/testpath',
+            _history=[{'extra': {'datasetVersion': 'latest'}}],
+        )
+
+    @pytest.fixture()
     def deleted_file(self, user, node):
         deleted_file = api_utils.create_test_file(
             node, user, filename='file_two')
@@ -65,14 +82,39 @@ class TestNodeFileList:
         assert len(data) == 1
 
     @responses.activate
-    def test_does_disambiguate_dataverse_names(self, app, user, node, dataverse):
+    def test_disambiguate_dataverse_paths_initial(self, app, user, node, dataverse):
+        '''
+        This test is for retrieving files from Dataverse initially, (Osf is contacting Dataverse after a update to their
+        Dataverse files) this test ensures both files are made into OSF filenodes and their `extra` info is passed along
+        to the front-end.
+        '''
         prepare_mock_wb_response(
             path='/',
             node=node,
             provider='dataverse',
             files=[
-                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'modified': '2018-02-04T00:00:00.001Z', 'extra': {'datasetVersion': 'latest'}, 'provider': 'dataverse'},
-                {'name': 'testpath', 'path': '/testpath', 'materialized': '/testpath', 'kind': 'file', 'modified': '2018-02-04T11:11:11.001Z', 'extra': {'datasetVersion': 'latest-published'}, 'provider': 'dataverse'},
+                {
+                    'name': 'testpath',
+                    'path': '/testpath',
+                    'materialized': '/testpath',
+                    'kind': 'file',
+                    'modified': 'Wed, 20 Jul 2011 22:04:50 +0000',
+                    'extra': {
+                        'datasetVersion': 'latest'
+                    },
+                    'provider': 'dataverse'
+                },
+                {
+                    'name': 'testpath',
+                    'path': '/testpath',
+                    'materialized': '/testpath',
+                    'kind': 'file',
+                    'modified': 'Wed, 20 Jul 2011 22:04:50 +0000',
+                    'extra': {
+                        'datasetVersion': 'latest-published'
+                    },
+                    'provider': 'dataverse'
+                },
             ]
         )
         res = app.get(
@@ -81,8 +123,75 @@ class TestNodeFileList:
         )
         data = res.json['data']
         assert len(data) == 2
-        assert data[0]['attributes']['extra'] == {'datasetVersion': 'latest', 'hashes': {'md5': None, 'sha256': None}}
-        assert data[1]['attributes']['extra'] == {'datasetVersion': 'latest-published', 'hashes': {'md5': None, 'sha256': None}}
+        assert data[0]['attributes']['extra'] == {
+            'datasetVersion': 'latest',
+            'hashes': {
+                'md5': None,
+                'sha256': None
+            }
+        }
+        assert data[1]['attributes']['extra'] == {
+            'datasetVersion': 'latest-published',
+            'hashes': {
+                'md5': None,
+                'sha256': None
+            }
+        }
+
+    @responses.activate
+    def test_disambiguate_dataverse_paths_retrieve(self, app, user, node, dataverse, dataverse_draft_filenode, dataverse_published_filenode):
+        '''
+        This test is for retrieving files from Dataverse and disambiguating thier corresponding OSF filenodes and
+        ensures their `extra` info is passed along to the front-end.
+        '''
+        prepare_mock_wb_response(
+            path='/',
+            node=node,
+            provider='dataverse',
+            files=[
+                {
+                    'name': 'testpath',
+                    'path': '/testpath',
+                    'materialized': '/testpath',
+                    'kind': 'file',
+
+                    'extra': {
+                        'datasetVersion': 'latest',
+                    },
+                    'provider': 'dataverse',
+                },
+                {
+                    'name': 'testpath',
+                    'path': '/testpath',
+                    'materialized': '/testpath',
+                    'kind': 'file',
+                    'extra': {
+                        'datasetVersion': 'latest-published',
+                    },
+                    'provider': 'dataverse',
+                },
+            ]
+        )
+        res = app.get(
+            f'/{API_BASE}nodes/{node._id}/files/dataverse/?sort=date_modified',
+            auth=node.creator.auth
+        )
+        data = res.json['data']
+        assert len(data) == 2
+        assert data[0]['attributes']['extra'] == {
+            'datasetVersion': 'latest',
+            'hashes': {
+                'md5': None,
+                'sha256': None
+            }
+        }
+        assert data[1]['attributes']['extra'] == {
+            'datasetVersion': 'latest-published',
+            'hashes': {
+                'md5': None,
+                'sha256': None
+            }
+        }
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently Dataverse/WB send two versions of datverse files with the same path to osf.io, this is problematic because our FE/API can't distinguish which file to retrieve when asked to list files at that path. This PR adds a special case for dataverse so both files are listed at that path and passes the versioning infomation to the FE so they can style the files accordingly. 

This also removes an used branch of code by changing the logic of the `info` queryset retrieval code. Those are the changes in `api/nodes/views.py`.

## Changes

- add special `MultipleObjectsReturned` case for dataverse only
- passes `extra` version info to FE
- add tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3872