### PR TITLE
Add better logic for routing Dataverse files and their stupid duplicate

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -726,7 +726,11 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
             })
 
     savepoint_id = transaction.savepoint()
-    file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(target, path)
+
+    extra_filters = {}
+    if provider == 'dataverse':
+        extra_filters = {'_history__0__extra__datasetVersion': extras.get('version', 'latest-publised')}
+    file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(target, path, extra_filters)
 
     # Note: Cookie is provided for authentication to waterbutler
     # it is overridden to force authentication as the current user

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -266,8 +266,12 @@ class BaseFileSerializer(JSONAPISerializer):
 
     def absolute_url(self, obj):
         if obj.is_file:
+            params = furl._absent
+            if obj.provider == 'dataverse':
+                params = {'version': obj.history[-1]['extra']['datasetVersion']}
             return furl.furl(settings.DOMAIN).set(
                 path=(obj.target._id, 'files', obj.provider, obj.path.lstrip('/')),
+                query_params=params,
             ).url
 
     def get_download_link(self, obj):

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -191,10 +191,15 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         return cls(**kwargs)
 
     @classmethod
-    def get_or_create(cls, target, path):
+    def get_or_create(cls, target, path, extra_filters):
         content_type = ContentType.objects.get_for_model(target)
         try:
-            obj = cls.objects.get(target_object_id=target.id, target_content_type=content_type, _path='/' + path.lstrip('/'))
+            obj = cls.objects.get(
+                target_object_id=target.id,
+                target_content_type=content_type,
+                _path='/' + path.lstrip('/'),
+                **extra_filters
+            )
         except cls.DoesNotExist:
             obj = cls(target_object_id=target.id, target_content_type=content_type, _path='/' + path.lstrip('/'))
         return obj


### PR DESCRIPTION
paths

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add the ability to differentiate between versions of Dataverse files on the `html` link and related routing

## Changes
* Add the `datasetVersion` as a query-param to the `html` link on Dataverse files
* Add the ability to include this param to help filtering of Dataverse files on the `addon_view_or_download_file` view

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
