### PR TITLE
[ENG-3863] Move schema ensuring and schema blocks update to post-migrate signals

### DIFF
--- a/osf/apps.py
+++ b/osf/apps.py
@@ -5,31 +5,42 @@ from osf.migrations import (
     update_permission_groups,
     update_waffle_flags,
     create_cache_table,
-    update_license
+    update_license,
+    add_registration_schemas
 )
 
 logger = logging.getLogger(__file__)
 
 
 class AppConfig(BaseAppConfig):
+
     name = 'osf'
     app_label = 'osf'
     managed = True
 
     def ready(self):
         super(AppConfig, self).ready()
+
+        post_migrate.connect(
+            add_registration_schemas,
+            dispatch_uid='osf.apps.add_registration_schemas'
+        )
+
         post_migrate.connect(
             update_permission_groups,
             dispatch_uid='osf.apps.update_permissions_groups'
         )
+
         post_migrate.connect(
             update_license,
             dispatch_uid='osf.apps.ensure_licenses',
         )
+
         post_migrate.connect(
             update_waffle_flags,
             dispatch_uid='osf.apps.update_waffle_flags'
         )
+
         post_migrate.connect(
             create_cache_table,
             dispatch_uid='osf.apps.create_cache_table'

--- a/osf/migrations/0038_ensure_schemas.py
+++ b/osf/migrations/0038_ensure_schemas.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
-
 
 logger = logging.getLogger(__file__)
 
@@ -17,6 +15,4 @@ class Migration(migrations.Migration):
         ('osf', '0037_ensure_licenses'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0077_ensure_schemas.py
+++ b/osf/migrations/0077_ensure_schemas.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
-
 
 logger = logging.getLogger(__file__)
 
@@ -17,6 +15,4 @@ class Migration(migrations.Migration):
         ('osf', '0076_action_rename'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0078_ensure_schemas.py
+++ b/osf/migrations/0078_ensure_schemas.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
-
 
 logger = logging.getLogger(__file__)
 
@@ -15,6 +13,4 @@ class Migration(migrations.Migration):
         ('osf', '0077_add_maintenance_permissions'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0080_ensure_schemas.py
+++ b/osf/migrations/0080_ensure_schemas.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
 
 
 logger = logging.getLogger(__file__)
@@ -15,6 +14,4 @@ class Migration(migrations.Migration):
         ('osf', '0079_merge_20180207_1545'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0096_ensure_schemas.py
+++ b/osf/migrations/0096_ensure_schemas.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
-
 
 logger = logging.getLogger(__file__)
 
@@ -15,6 +13,4 @@ class Migration(migrations.Migration):
         ('osf', '0095_reset_osf_abstractprovider_licenses_acceptable_id_seq'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0112_ensure_schemas.py
+++ b/osf/migrations/0112_ensure_schemas.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas, remove_schemas
-
 
 logger = logging.getLogger(__file__)
 
@@ -15,6 +13,4 @@ class Migration(migrations.Migration):
         ('osf', '0111_auto_20180605_1240'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, remove_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0136_preprint_node_divorce.py
+++ b/osf/migrations/0136_preprint_node_divorce.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db import migrations
 from django.db.models import Func, Value, F, Q
-from django.core.management.sql import emit_post_migrate_signal
 from bulk_update.helper import bulk_update
 
 logger = logging.getLogger(__name__)
@@ -88,11 +87,6 @@ group_format = 'preprint_{self.id}_{group}'
 
 def format_group(self, name):
     return group_format.format(self=self, group=name)
-
-def emit_signals(state, schema):
-    # this is to make sure that the permissions created earlier exist!
-    emit_post_migrate_signal(2, False, 'default')
-    logger.info('Starting preprint node divorce [SQL]:')
 
 
 class Migration(migrations.Migration):

--- a/osf/migrations/0137_transfer_preprint_service_permissions.py
+++ b/osf/migrations/0137_transfer_preprint_service_permissions.py
@@ -5,38 +5,10 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def unmigrate_preprint_service_permissions(state, schema):
-    Permission = state.get_model('auth', 'permission')
-
-    # New permission groups
-    Permission.objects.filter(codename='add_preprint').update(codename='add_preprintservice', name='Can add preprint service')
-    Permission.objects.filter(codename='change_preprint').update(codename='change_preprintservice', name='Can change preprint service')
-    Permission.objects.filter(codename='delete_preprint').update(codename='delete_preprintservice', name='Can delete preprint service')
-    Permission.objects.filter(codename='view_preprint').update(codename='view_preprintservice', name='Can view preprint service details in the admin app.')
-
-def migrate_preprint_service_permissions(state, schema):
-    """
-    Django permissions on the preprint model have new names.
-    """
-    Permission = state.get_model('auth', 'permission')
-
-    Permission.objects.filter(codename='add_preprint').delete()
-    Permission.objects.filter(codename='change_preprint').delete()
-    Permission.objects.filter(codename='delete_preprint').delete()
-    Permission.objects.filter(codename='view_preprint').delete()
-
-    # Old permission groups
-    Permission.objects.filter(codename='add_preprintservice').update(codename='add_preprint', name='Can add preprint')
-    Permission.objects.filter(codename='change_preprintservice').update(codename='change_preprint', name='Can change preprint')
-    Permission.objects.filter(codename='delete_preprintservice').update(codename='delete_preprint', name='Can delete preprint')
-    Permission.objects.filter(codename='view_preprintservice').update(codename='view_preprint', name='Can view preprint details in the admin app')
-
 class Migration(migrations.Migration):
 
     dependencies = [
         ('osf', '0136_preprint_node_divorce'),
     ]
 
-    operations = [
-        migrations.RunPython(migrate_preprint_service_permissions, unmigrate_preprint_service_permissions),
-    ]
+    operations = []

--- a/osf/migrations/0142_change_registration_schemas.py
+++ b/osf/migrations/0142_change_registration_schemas.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas
 
 
 logger = logging.getLogger(__file__)
@@ -16,6 +15,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # To reverse this migrations simply revert changes to the schema and re-run
-        migrations.RunPython(ensure_schemas, ensure_schemas),
     ]

--- a/osf/migrations/0152_ensure_schemas.py
+++ b/osf/migrations/0152_ensure_schemas.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas
 
 
 class Migration(migrations.Migration):
@@ -10,6 +9,4 @@ class Migration(migrations.Migration):
         ('osf', '0151_auto_20181215_1911'),
     ]
 
-    operations = [
-        migrations.RunPython(ensure_schemas, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0162_post_migrate.py
+++ b/osf/migrations/0162_post_migrate.py
@@ -4,14 +4,8 @@ from __future__ import unicode_literals
 
 import logging
 from django.db import migrations
-from django.core.management.sql import emit_post_migrate_signal
 
 logger = logging.getLogger(__name__)
-
-def post_migrate_signal(state, schema):
-    # this is to make sure that the permissions created earlier exist!
-    emit_post_migrate_signal(3, False, 'default')
-    logger.info('Starting guardian/groups migration [SQL]:')
 
 
 class Migration(migrations.Migration):

--- a/osf/migrations/0170_ensure_schemas.py
+++ b/osf/migrations/0170_ensure_schemas.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas
 
 
 class Migration(migrations.Migration):
@@ -11,7 +10,4 @@ class Migration(migrations.Migration):
         ('osf', '0169_merge_20190618_1429'),
     ]
 
-    operations = [
-        # To reverse this migrations simply revert changes to the schema and re-run
-        migrations.RunPython(ensure_schemas, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0172_ensure_schemas.py
+++ b/osf/migrations/0172_ensure_schemas.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas
 
 
 class Migration(migrations.Migration):
@@ -12,7 +11,4 @@ class Migration(migrations.Migration):
         ('osf', '0171_add_registration_files_count'),
     ]
 
-    operations = [
-        # To reverse this migrations simply revert changes to the schema and re-run
-        migrations.RunPython(ensure_schemas, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0173_ensure_schemas.py
+++ b/osf/migrations/0173_ensure_schemas.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import ensure_schemas
 
 
 class Migration(migrations.Migration):
@@ -12,7 +11,4 @@ class Migration(migrations.Migration):
         ('osf', '0172_ensure_schemas'),
     ]
 
-    operations = [
-        # To reverse this migrations simply revert changes to the schema and re-run
-        migrations.RunPython(ensure_schemas, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0191_migrate_schemas_to_schemablocks.py
+++ b/osf/migrations/0191_migrate_schemas_to_schemablocks.py
@@ -4,58 +4,8 @@ from __future__ import unicode_literals
 
 import logging
 from django.db import migrations
-from osf.utils.migrations import map_schemas_to_schemablocks, unmap_schemablocks
 
 logger = logging.getLogger(__file__)
-
-def remove_version_1_schemas(state, schema):
-    RegistrationSchema = state.get_model('osf', 'registrationschema')
-    assert RegistrationSchema.objects.filter(schema_version=1, abstractnode__isnull=False).count() == 0
-    assert RegistrationSchema.objects.filter(schema_version=1, draftregistration__isnull=False).count() == 0
-    RegistrationSchema.objects.filter(schema_version=1).delete()
-
-def update_schemaless_registrations(state, schema):
-    RegistrationSchema = state.get_model('osf', 'registrationschema')
-    AbstractNode = state.get_model('osf', 'abstractnode')
-
-    open_ended_schema = RegistrationSchema.objects.get(name='Open-Ended Registration', schema_version=2)
-    open_ended_meta = {
-        '{}'.format(open_ended_schema._id): {
-            'summary': {
-                'comments': [],
-                'extra': [],
-                'value': ''
-            }
-        }
-    }
-
-    schemaless_regs_with_meta = AbstractNode.objects.filter(type='osf.registration', registered_schema__isnull=True).exclude(registered_meta={})
-    schemaless_regs_without_meta = AbstractNode.objects.filter(type='osf.registration', registered_schema__isnull=True, registered_meta={})
-
-    for reg in schemaless_regs_without_meta.all():
-        reg.registered_schema.add(open_ended_schema)
-        reg.registered_meta = open_ended_meta
-        reg.save()
-
-    for reg in schemaless_regs_with_meta.all():
-        reg.registered_schema.add(RegistrationSchema.objects.get(_id=reg.registered_meta.keys()[0]))
-
-def update_schema_configs(state, schema):
-    RegistrationSchema = state.get_model('osf', 'registrationschema')
-    for rs in RegistrationSchema.objects.all():
-        if rs.schema.get('description', False):
-            rs.description = rs.schema['description']
-        if rs.schema.get('config', False):
-            rs.config = rs.schema['config']
-        rs.save()
-
-def unset_schema_configs(state, schema):
-    RegistrationSchema = state.get_model('osf', 'registrationschema')
-    RegistrationSchema.objects.update(
-        config=dict(),
-        description='',
-    )
-
 
 def noop(*args, **kwargs):
     pass
@@ -66,9 +16,4 @@ class Migration(migrations.Migration):
         ('osf', '0190_add_schema_block_models')
     ]
 
-    operations = [
-        migrations.RunPython(remove_version_1_schemas, noop),
-        migrations.RunPython(update_schemaless_registrations, noop),
-        migrations.RunPython(update_schema_configs, unset_schema_configs),
-        migrations.RunPython(map_schemas_to_schemablocks, unmap_schemablocks)
-    ]
+    operations = []

--- a/osf/migrations/0196_update_schemas.py
+++ b/osf/migrations/0196_update_schemas.py
@@ -1,17 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
-
-def make_egap_active_but_invisible(state, schema):
-        RegistrationSchema = state.get_model('osf', 'registrationschema')
-        egap_registration = RegistrationSchema.objects.get(name='EGAP Registration', schema_version=2)
-        egap_registration.visible = False
-        egap_registration.active = True
-        egap_registration.save()
-
-def noop(*args, **kwargs):
-    pass
 
 class Migration(migrations.Migration):
 
@@ -19,7 +8,4 @@ class Migration(migrations.Migration):
         ('osf', '0195_add_enable_chronos_waffle_flag'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-        migrations.RunPython(make_egap_active_but_invisible, noop),
-    ]
+    operations = []

--- a/osf/migrations/0199_draft_node_permissions.py
+++ b/osf/migrations/0199_draft_node_permissions.py
@@ -4,12 +4,6 @@ from __future__ import unicode_literals
 import logging
 from django.db import migrations
 
-from osf.migrations.sql.draft_nodes_migration import (
-    add_draft_read_write_admin_auth_groups,
-    remove_draft_auth_groups,
-    add_permissions_to_draft_registration_groups,
-    drop_draft_reg_group_object_permission_table)
-
 logger = logging.getLogger(__name__)
 
 
@@ -19,7 +13,4 @@ class Migration(migrations.Migration):
         ('osf', '0198_draft_node_models'),
     ]
 
-    operations = [
-        migrations.RunSQL(add_draft_read_write_admin_auth_groups, remove_draft_auth_groups),
-        migrations.RunSQL(add_permissions_to_draft_registration_groups, drop_draft_reg_group_object_permission_table),
-    ]
+    operations = []

--- a/osf/migrations/0204_ensure_schemas.py
+++ b/osf/migrations/0204_ensure_schemas.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 
 class Migration(migrations.Migration):
 
@@ -9,6 +8,4 @@ class Migration(migrations.Migration):
         ('osf', '0203_auto_20200312_1435'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-    ]
+    operations = []

--- a/osf/migrations/0207_ensure_schemas.py
+++ b/osf/migrations/0207_ensure_schemas.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 
 class Migration(migrations.Migration):
 
@@ -9,6 +8,4 @@ class Migration(migrations.Migration):
         ('osf', '0206_auto_20200528_1319'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-    ]
+    operations = []

--- a/osf/migrations/0207_update_schemas2.py
+++ b/osf/migrations/0207_update_schemas2.py
@@ -1,14 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 
-def make_egap_active_but_invisible(state, schema):
-        RegistrationSchema = state.get_model('osf', 'registrationschema')
-        new_egap_registration = RegistrationSchema.objects.get(name='EGAP Registration', schema_version=3)
-        new_egap_registration.visible = False
-        new_egap_registration.active = True
-        new_egap_registration.save()
 
 def noop(*args, **kwargs):
     pass
@@ -19,7 +12,4 @@ class Migration(migrations.Migration):
         ('osf', '0207_ensure_schemas'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-        migrations.RunPython(make_egap_active_but_invisible, noop),
-    ]
+    operations = []

--- a/osf/migrations/0208_update_EGAP_schema.py
+++ b/osf/migrations/0208_update_EGAP_schema.py
@@ -1,10 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
 
-def noop(*args, **kwargs):
-    pass
 
 class Migration(migrations.Migration):
 
@@ -12,6 +9,4 @@ class Migration(migrations.Migration):
         ('osf', '0207_update_schemas2'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-    ]
+    operations = []

--- a/osf/migrations/0221_add_schemas.py
+++ b/osf/migrations/0221_add_schemas.py
@@ -3,22 +3,6 @@ import logging
 from django.db import migrations
 
 logger = logging.getLogger(__file__)
-from osf.models import RegistrationSchema
-from osf.utils.migrations import ensure_schemas
-from website.project.metadata.schemas import ensure_schema_structure, from_json
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
-
-
-def add_invisible_schemas(apps, schema_editor):
-    schemas = [
-        ensure_schema_structure(from_json('asist-hypothesis-capability-registration.json')),
-        ensure_schema_structure(from_json('asist-results-registration.json')),
-        ensure_schema_structure(from_json('real-world-evidence.json')),
-    ]
-
-    schema_names = [schema['name'] for schema in schemas]
-
-    RegistrationSchema.objects.filter(name__in=schema_names).update(visible=False, active=True)
 
 
 class Migration(migrations.Migration):
@@ -27,7 +11,4 @@ class Migration(migrations.Migration):
         ('osf', '0219_auto_20201020_1836'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-        migrations.RunPython(add_invisible_schemas, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/0227_add_secondary_data.py
+++ b/osf/migrations/0227_add_secondary_data.py
@@ -3,16 +3,6 @@ import logging
 from django.db import migrations
 
 logger = logging.getLogger(__file__)
-from osf.models import RegistrationSchema
-from osf.utils.migrations import ensure_schemas
-from website.project.metadata.schemas import ensure_schema_structure, from_json
-from osf.utils.migrations import UpdateRegistrationSchemasAndSchemaBlocks
-
-
-def add_schema(apps, schema_editor):
-    schema = ensure_schema_structure(from_json('secondary-data.json'))
-
-    RegistrationSchema.objects.filter(name=schema['name']).update(visible=False, active=True)
 
 
 class Migration(migrations.Migration):
@@ -21,7 +11,4 @@ class Migration(migrations.Migration):
         ('osf', '0226_auto_20210224_1610'),
     ]
 
-    operations = [
-        UpdateRegistrationSchemasAndSchemaBlocks(),
-        migrations.RunPython(add_schema, ensure_schemas),
-    ]
+    operations = []

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import sys
 import logging
-from django.db.utils import ProgrammingError
-from osf.management.commands.manage_switch_flags import manage_waffle
-from django.core.management import call_command
-from api.base import settings as api_settings
 
+from django.db.utils import ProgrammingError
+from django.core.management import call_command
+
+from api.base import settings as api_settings
+from osf.management.commands.manage_switch_flags import manage_waffle
+from osf.utils.migrations import ensure_schemas, map_schemas_to_schemablocks
 
 logger = logging.getLogger(__file__)
 
@@ -142,3 +144,9 @@ def update_waffle_flags(sender, verbosity=0, **kwargs):
 def create_cache_table(sender, verbosity=0, **kwargs):
     if getattr(sender, 'label', None) == 'osf':
         call_command('createcachetable', tablename=api_settings.CACHES[api_settings.STORAGE_USAGE_CACHE_NAME]['LOCATION'])
+
+
+def add_registration_schemas(sender, verbosity=0, **kwargs):
+    if getattr(sender, 'label', None) == 'osf':
+        ensure_schemas()
+        map_schemas_to_schemablocks()

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -5,6 +5,7 @@ import builtins
 import json
 import logging
 import warnings
+import bson
 from math import ceil
 
 
@@ -13,7 +14,6 @@ from django.apps import apps
 from django.db import connection
 from django.db.migrations.operations.base import Operation
 
-from osf.models.base import generate_object_id
 from osf.utils.sanitize import strip_html, unescape_entities
 from website import settings
 from website.project.metadata.schemas import get_osf_meta_schemas
@@ -40,6 +40,11 @@ FORMAT_TYPE_TO_TYPE_MAP = {
     ('textarea-lg', 'string'): 'long-text-input',
     ('textarea-xl', 'string'): 'long-text-input',
 }
+
+
+def generate_object_id():
+    return str(bson.ObjectId())
+
 
 def get_osf_models():
     """

--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -5,7 +5,6 @@ import builtins
 import json
 import logging
 import warnings
-import bson
 from math import ceil
 
 
@@ -40,10 +39,6 @@ FORMAT_TYPE_TO_TYPE_MAP = {
     ('textarea-lg', 'string'): 'long-text-input',
     ('textarea-xl', 'string'): 'long-text-input',
 }
-
-
-def generate_object_id():
-    return str(bson.ObjectId())
 
 
 def get_osf_models():
@@ -354,6 +349,7 @@ def create_schema_blocks_for_question(state, rs, question, sub=False):
             create_schema_blocks_for_question(state, rs, subquestion, sub=True)
     else:
         # All schema blocks related to a particular question share the same schema_block_group_key.
+        from osf.models.base import generate_object_id
         schema_block_group_key = generate_object_id()
         title, description, help, example = find_title_description_help_example(rs, question)
 
@@ -417,6 +413,7 @@ def create_schema_blocks_for_atomic_schema(schema):
         # Each 'question-label' generates a 'schema_block_group_key' that is inherited
         # By all input and input-option blocks until the next question-label appears
         if block_type == 'question-label':
+            from osf.models.base import generate_object_id
             current_group_key = generate_object_id()
             block['schema_block_group_key'] = current_group_key
         elif block_type == 'paragraph':  # if a paragraph trails a question-label


### PR DESCRIPTION
## Purpose

Move schema ensuring and schema blocks update to post-migrate signals

Note: This is a shameless copy of @jwalz 's proof-of-concept PR: https://github.com/CenterForOpenScience/osf.io/pull/9938. There are only three minor updates:

* Included one extra `ensure_schema` migration: `0142_change_registration_schemas.py`
* Replace duplicate function with inline imports to fix circular imports.
* Reworked the commits

## TODO

- ~~This PR is rebased upon the latest develop, which is slightly ahead of the django upgrade feature branch: https://github.com/CenterForOpenScience/osf.io/tree/feature/django_upgrade, should we bring the feature branch up-to-date before re-targeting this PR?~~ I happened to make a favorable mistake where this branch is not rebased upon the latest develop.
- [x] Rebase upon https://github.com/CenterForOpenScience/osf.io/tree/feature/django_upgrade,  fix conflicts and retarget the PR.
- [x] There must be a reason for creating a duplicate function `generate_object_id` in https://github.com/CenterForOpenScience/osf.io/pull/9974/commits/0dbb5bf84ff2ca254a249ae41f36236c373a69e7.
  - [x] This is a circular import issue which will be updated with inline imports.

## Changes

### Major

Migrations that adds or alternates schemas, migrations that ensures schemas and migrations that updates schema blocks are moved to post-migrations signals.

In addition, removed manual calls to post-migrate signal.

### By-product

Removed several one-time migrations

* Preprint permissions
* Schema to schema blocks
* Draft node permissions

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3863