### PR TITLE
[No ticket] Relax python version requirement from 3.6 to 3 for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.6
+  python: python3
 repos:
 - repo: https://github.com/asottile/add-trailing-comma
   rev: v0.7.0


### PR DESCRIPTION
## Purpose

Relax python version requirement from 3.6 to 3 for pre-commit.

### Context

I upgraded my macOS to 12.4 and somehow `pyenv` can no longer install python 3.6 and I am using 3.7 for my outside-docker env. Local OSF runs in docker and I run `pytest` and other command in docker (where python 3.6 is installed with the image) so that I can live with my `pyenv` python 3.7. This local one is only used two purpose:
  * I can access library code in PyCharm: not much difference between 3.7 and 3.6
  * Pre-commit needs a python environment: this is what breaks (see attached logs)

```
➜  osf git:(hotfix/osfi-maglab-test) ✗ git commit
...
[INFO] Restored changes from /Users/longzechen/.cache/pre-commit/patch1658172825-36641.
An unexpected error has occurred: CalledProcessError: command: ('/Users/longzechen/.pyenv/versions/3.7.13/envs/osf/bin/python3.7', '-mvirtualenv', '/Users/longzechen/.cache/pre-commit/repoolkjy7fz/py_env-python3.6', '-p', 'python3.6')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.6'

stderr: (none)
Check the log at /Users/longzechen/.cache/pre-commit/pre-commit.log
```

### Suggestion

Instead of trying non-official hack-ish solutions that gets me 3.6 with `pyenv` or moving back to `virtualenv`, I believe relaxing the language requirement for pre-commit seems a reasonable change, especially I am not aware of any specific reason why we have to ping that to 3.6. This also save us the trouble to fix this when we upgrade python in the future.

### Note

This cannot be kept as a local change only since pre-commit requires .`pre-commit-config.yaml` to be at least staged.

## Changes

N/A

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
