### PR TITLE
[Django Upgrade] [ENG-3947] Update markdown extension

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -67,16 +67,12 @@ def build_html_output(content, node):
         content,
         extensions=[
             wikilinks.WikiLinkExtension(
-                configs=[
-                    ('base_url', ''),
-                    ('end_url', ''),
-                    ('build_url', functools.partial(build_wiki_url, node))
-                ]
+                base_url='',
+                end_url='',
+                build_url=functools.partial(build_wiki_url, node)
             ),
             fenced_code.FencedCodeExtension(),
-            codehilite.CodeHiliteExtension(
-                [('css_class', 'highlight')]
-            )
+            codehilite.CodeHiliteExtension(css_class='highlight')
         ]
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Werkzeug==1.0.0
 Flask==1.0
 gevent==1.2.2
 Mako==1.0.7
-Markdown==2.6.9
+Markdown==3.3.7
 WTForms==1.0.4
 # Fork of celery 4.1.1 with https://github.com/celery/celery/pull/4278 backported,
 # which fixes a bug that was causing stuck registrations
@@ -40,7 +40,7 @@ pymongo==3.7.1
 PyYAML==6.0
 tqdm==4.28.1
 # Python markdown extensions for comment emails
-git+https://github.com/CenterForOpenScience/mdx_del_ins.git
+git+https://github.com/Johnetordoff/mdx_del_ins.git@django-3
 
 certifi==2020.12.5
 sendgrid==1.5.13

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -106,7 +106,7 @@ def update_comment_node(root_target_id, source_node, destination_node):
 
 
 def render_email_markdown(content):
-    return markdown.markdown(content, ['del_ins', 'markdown.extensions.tables', 'markdown.extensions.fenced_code'])
+    return markdown.markdown(content, extensions=['mdx_del_ins', 'markdown.extensions.tables', 'markdown.extensions.fenced_code'])
 
 
 @comment_added.connect


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Old versions of markdowns python library no longer work with Django so we have to upgrade Markdown to be compatible and update a few functions.Additionally Our forked markdown extension library https://github.com/CenterForOpenScience/mdx_del_ins/ is no longer compatible with markdown, so it had to have a minor fork. https://github.com/CenterForOpenScience/mdx_del_ins/pull/1

https://www.notion.so/cos/6188c43512ee482586da59bc5fdacf38?v=bb051c7d4d7346d69d9fcbbc979dd883&p=02a1b6368b0b47fbbab07a01d88135d9&pm=s


Error:
https://gist.github.com/Johnetordoff/84c900be9f2427db40ac57d18386cf6f

## Changes

- updates markdown to use new format for passing arguments
- forks mdx_del_ins to work with new version of markdown.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
