### PR TITLE
[Django Upgrade] [ENG-3947] Remove `password_change` view and route in admin

### DIFF
--- a/admin/base/urls.py
+++ b/admin/base/urls.py
@@ -21,7 +21,6 @@ urlpatterns = [
             url(r'^collection_providers/', include('admin.collection_providers.urls', namespace='collection_providers')),
             url(r'^registration_providers/', include('admin.registration_providers.urls', namespace='registration_providers')),
             url(r'^account/', include('admin.common_auth.urls', namespace='auth')),
-            url(r'^password/', include('password_reset.urls')),
             url(r'^nodes/', include('admin.nodes.urls', namespace='nodes')),
             url(r'^preprints/', include('admin.preprints.urls', namespace='preprints')),
             url(r'^subjects/', include('admin.subjects.urls', namespace='subjects')),

--- a/admin/common_auth/urls.py
+++ b/admin/common_auth/urls.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
 from django.conf.urls import url
-from django.urls import reverse_lazy
-from django.contrib.auth.views import password_change, password_change_done
 
 from admin.common_auth import views
 
@@ -12,12 +10,6 @@ urlpatterns = [
     url(r'^login/?$', views.LoginView.as_view(), name='login'),
     url(r'^logout/$', views.logout_user, name='logout'),
     url(r'^register/$', views.RegisterUser.as_view(), name='register'),
-    url(r'^password_change/$', password_change,
-        {'post_change_redirect': reverse_lazy('auth:password_change_done')},
-        name='password_change'),
-    url(r'^password_change/done/$', password_change_done,
-        {'template_name': 'password_change_done.html'},
-        name='password_change_done'),
     url(r'^settings/desk/$', views.DeskUserCreateFormView.as_view(), name='desk'),
     url(r'^settings/desk/update/$', views.DeskUserUpdateFormView.as_view(), name='desk_update'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,6 @@ django-guardian==1.4.9
 
 # Admin requirements
 django-webpack-loader==0.5.0
-django-password-reset==1.0
 sendgrid-django==2.0.0
 
 # Analytics requirements


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Upgrades password reset for Django 3 [django-password-reset Changealog](https://django-password-reset.readthedocs.io/en/latest/)

⚠️ See if this is being used and where.

https://www.notion.so/cos/10-Django-Reset-Password-Update-View-e34bbfb074d244aba6d12e4a5941c1e2

⚠️ Based on Lozenge's comment I removed the views.

## Changes

- updates requirements.txt and use different import path for urls.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
