### PR TITLE
[ENG-3894] Rewrite history to make OutcomeArtifact.identifier nullable

### DIFF
--- a/osf/migrations/0246_add_outcomes_and_artifacts.py
+++ b/osf/migrations/0246_add_outcomes_and_artifacts.py
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
                 ('artifact_type', models.IntegerField(choices=[(0, 'UNDEFINED'), (1, 'DATA'), (11, 'CODE'), (21, 'MATERIALS'), (31, 'PAPERS'), (41, 'SUPPLEMENTS'), (1001, 'PRIMARY')], default=osf.utils.outcomes.ArtifactTypes(0))),
                 ('title', models.TextField()),
                 ('description', models.TextField()),
-                ('identifier', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='artifact_metadata', to='osf.Identifier')),
+                ('identifier', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='artifact_metadata', to='osf.Identifier')),
                 ('outcome', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='artifact_metadata', to='osf.Outcome')),
             ],
             options={

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -73,6 +73,7 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
     )
     identifier = models.ForeignKey(
         'osf.identifier',
+        null=True,
         on_delete=models.CASCADE,
         related_name='artifact_metadata'
     )


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When we POST a new OutcomeArtifact (/Resource), we do it without a PID. As such, the `identifier` field must be Nullable to enable our workflow.

Doing this in the existing migration since it is only live on staging environments.

## Changes
* Update model and existing migration to reflect nullability of the FK to `osf.identifier`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-3894
