### PR TITLE
[ENG-3836] Follow-up: Add PyYAML to Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ citeproc-py==0.4.0
 boto3==1.4.7
 django-waffle==0.13.0
 pymongo==3.7.1
+PyYAML==6.0
 tqdm==4.28.1
 # Python markdown extensions for comment emails
 git+https://github.com/CenterForOpenScience/mdx_del_ins.git


### PR DESCRIPTION
## Purpose

Add `PyYAML` to Requirements

## Changes

Jenkins build failure reveals a missing package [`PyYAML`](https://pypi.org/project/PyYAML/) which is introduced in [`import yaml`](https://github.com/CenterForOpenScience/osf.io/pull/9950/files#diff-13b1f8258ce709fc64de14e9d995864e9497d9089b948357d24e7f3cfe78f552R3).

However, we all missed this one since builds consistently succeed in both local and GitHub action. This is because `PyYAML` is a dependency of `pre-commit` which is not available for server builds.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3836 follow-up fix
