### PR TITLE
[Django Upgrade] [ENG-3947] Move file metadata population to unit test fixtures

### DIFF
--- a/api_tests/files/views/test_file_metadata_record_detail.py
+++ b/api_tests/files/views/test_file_metadata_record_detail.py
@@ -11,6 +11,8 @@ from osf_tests.factories import (
     PreprintFactory,
 )
 
+from osf.migrations import ensure_datacite_file_schema
+
 @pytest.fixture()
 def user():
     return AuthUserFactory()
@@ -27,6 +29,10 @@ def preprint_record(user, preprint):
 
 @pytest.mark.django_db
 class TestFileMetadataRecordDetail:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def private_record(self, user):
@@ -99,8 +105,13 @@ class TestFileMetadataRecordDetail:
         assert res.status_code == 200
         assert res.json['data']['id'] == unpublished_preprint_record._id
 
+
 @pytest.mark.django_db
 class TestFileMetadataRecordUpdate:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user_write(self):

--- a/api_tests/files/views/test_file_metadata_record_detail.py
+++ b/api_tests/files/views/test_file_metadata_record_detail.py
@@ -13,13 +13,21 @@ from osf_tests.factories import (
 
 from osf.migrations import ensure_datacite_file_schema
 
+
+@pytest.fixture(autouse=True)
+def datacite_file_schema():
+    return ensure_datacite_file_schema()
+
+
 @pytest.fixture()
 def user():
     return AuthUserFactory()
 
+
 @pytest.fixture()
 def preprint(user):
     return PreprintFactory(creator=user)
+
 
 @pytest.fixture()
 def preprint_record(user, preprint):
@@ -29,10 +37,6 @@ def preprint_record(user, preprint):
 
 @pytest.mark.django_db
 class TestFileMetadataRecordDetail:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def private_record(self, user):
@@ -108,10 +112,6 @@ class TestFileMetadataRecordDetail:
 
 @pytest.mark.django_db
 class TestFileMetadataRecordUpdate:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user_write(self):

--- a/api_tests/files/views/test_file_metadata_record_download.py
+++ b/api_tests/files/views/test_file_metadata_record_download.py
@@ -10,12 +10,13 @@ from osf_tests.factories import (
 from osf.migrations import ensure_datacite_file_schema
 
 
+@pytest.fixture(autouse=True)
+def datacite_file_schema():
+    return ensure_datacite_file_schema()
+
+
 @pytest.mark.django_db
 class TestFileMetadataRecordDownload:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user(self):

--- a/api_tests/files/views/test_file_metadata_record_download.py
+++ b/api_tests/files/views/test_file_metadata_record_download.py
@@ -7,8 +7,15 @@ from osf_tests.factories import (
     ProjectFactory
 )
 
+from osf.migrations import ensure_datacite_file_schema
+
+
 @pytest.mark.django_db
 class TestFileMetadataRecordDownload:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user(self):

--- a/api_tests/schemas/views/test_file_metadata_schema_detail.py
+++ b/api_tests/schemas/views/test_file_metadata_schema_detail.py
@@ -6,9 +6,15 @@ from osf_tests.factories import (
     AuthUserFactory,
 )
 
+from osf.migrations import ensure_datacite_file_schema
+
 
 @pytest.mark.django_db
 class TestFileMetadataSchemaDetail:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user(self):

--- a/api_tests/schemas/views/test_file_metadata_schema_detail.py
+++ b/api_tests/schemas/views/test_file_metadata_schema_detail.py
@@ -9,12 +9,13 @@ from osf_tests.factories import (
 from osf.migrations import ensure_datacite_file_schema
 
 
+@pytest.fixture(autouse=True)
+def datacite_file_schema():
+    return ensure_datacite_file_schema()
+
+
 @pytest.mark.django_db
 class TestFileMetadataSchemaDetail:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def user(self):

--- a/osf/migrations/0136_add_datacite_file_metadata_schema.py
+++ b/osf/migrations/0136_add_datacite_file_metadata_schema.py
@@ -40,5 +40,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_datacite_schema, remove_datacite_schema)
     ]

--- a/osf/migrations/0137_add_fm_record_to_osfstorage_files.py
+++ b/osf/migrations/0137_add_fm_record_to_osfstorage_files.py
@@ -54,6 +54,4 @@ class Migration(migrations.Migration):
         ('osf', '0136_add_datacite_file_metadata_schema'),
     ]
 
-    operations = [
-        migrations.RunPython(add_records_to_files_sql, remove_records_from_files),
-    ]
+    operations = []

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
+import json
 import logging
 
 from django.apps import apps
@@ -228,5 +229,20 @@ def ensure_default_storage_region():
             'waterbutler_credentials': osfstorage_config.WATERBUTLER_CREDENTIALS,
             'waterbutler_settings': osfstorage_config.WATERBUTLER_SETTINGS,
             'waterbutler_url': osf_settings.WATERBUTLER_URL
+        }
+    )
+
+
+def ensure_datacite_file_schema():
+    ''' Test use only '''
+    from osf.models import FileMetadataSchema
+    with open('osf/metadata/schemas/datacite.json') as f:
+        jsonschema = json.load(f)
+    _, created = FileMetadataSchema.objects.get_or_create(
+        _id='datacite',
+        schema_version=1,
+        defaults={
+            'name': 'datacite',
+            'schema': jsonschema
         }
     )

--- a/osf_tests/test_file_metadata.py
+++ b/osf_tests/test_file_metadata.py
@@ -7,6 +7,7 @@ from framework.exceptions import PermissionsError
 from website.settings import DOI_FORMAT, DATACITE_PREFIX
 from website.project.licenses import set_license
 from osf.models import FileMetadataSchema, NodeLicense, NodeLog
+from osf.migrations import ensure_datacite_file_schema
 from osf_tests.factories import ProjectFactory, SubjectFactory, AuthUserFactory
 from osf.utils.permissions import READ
 from api_tests.utils import create_test_file
@@ -30,6 +31,10 @@ def inject_placeholder_doi(json_data):
 
 @pytest.mark.django_db
 class TestFileMetadataRecordSerializer:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     def test_record_created_post_save(self, node, osf_file):
         # check there's a record for every FileMetadataSchema
@@ -121,6 +126,10 @@ class TestFileMetadataRecordSerializer:
 
 @pytest.mark.django_db
 class TestFileMetadataRecord:
+
+    @pytest.fixture(autouse=True)
+    def datacite_file_schema(self):
+        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def initial_metadata(self):

--- a/osf_tests/test_file_metadata.py
+++ b/osf_tests/test_file_metadata.py
@@ -13,13 +13,20 @@ from osf.utils.permissions import READ
 from api_tests.utils import create_test_file
 
 
+@pytest.fixture(autouse=True)
+def datacite_file_schema():
+    return ensure_datacite_file_schema()
+
+
 @pytest.fixture()
 def node():
     return ProjectFactory()
 
+
 @pytest.fixture()
 def osf_file(node):
     return create_test_file(target=node, user=node.creator)
+
 
 def inject_placeholder_doi(json_data):
     # the OSF cannot currently issue DOIs for a file, which is required for datacite schema validation.
@@ -31,10 +38,6 @@ def inject_placeholder_doi(json_data):
 
 @pytest.mark.django_db
 class TestFileMetadataRecordSerializer:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     def test_record_created_post_save(self, node, osf_file):
         # check there's a record for every FileMetadataSchema
@@ -126,10 +129,6 @@ class TestFileMetadataRecordSerializer:
 
 @pytest.mark.django_db
 class TestFileMetadataRecord:
-
-    @pytest.fixture(autouse=True)
-    def datacite_file_schema(self):
-        return ensure_datacite_file_schema()
 
     @pytest.fixture()
     def initial_metadata(self):


### PR DESCRIPTION
## Purpose

Pull the not fully implemented file metadata out of the migration stream. This is similar to the other PRs involving post-migration signals, but because this wasn't a fully implemented feature it's doesn't need a signal.

## Changes

## QA Notes

## Documentation


## Side Effects

## Ticket
