### PR TITLE
[ENG-3945]Validate DOIs on PATCH

### DIFF
--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -10,7 +10,7 @@ from api.base.serializers import (
     VersionedDateTimeField,
 )
 from api.base.utils import absolute_reverse
-from osf.exceptions import CannotFinalizeArtifactError, NoPIDError
+from osf.exceptions import CannotFinalizeArtifactError, InvalidPIDError, NoPIDError
 from osf.models import Outcome, OutcomeArtifact, Registration
 from osf.utils.outcomes import ArtifactTypes
 
@@ -97,9 +97,9 @@ class ResourceSerializer(JSONAPISerializer):
         if updated_pid is not None and updated_pid != instance.pid:
             try:
                 instance.update_identifier(updated_pid, api_request=self.context['request'])
-            except NoPIDError:
+            except InvalidPIDError as e:
                 raise JSONAPIException(
-                    detail=f'Cannot remove PID for Resource with id [{instance._id}].',
+                    detail=f'Error updating PID for Resource with id [{instance._id}]: {e.message}',
                     source={'pointer': '/data/attributes/pid'},
                 )
 

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -229,8 +229,30 @@ class IdentifierHasReferencesError(OSFError):
     pass
 
 
-class NoPIDError(OSFError):
+class NoSuchPIDValidatorError(OSFError):
     pass
+
+
+class InvalidPIDError(OSFError):
+
+    ERROR_MESSAGE = 'Invalid PID of type {category} with value {value}'
+
+    def __init__(self, pid_value, pid_category):
+        self.message = self.ERROR_MESSAGE.format(value=pid_value, category=pid_category.upper())
+
+
+class NoPIDError(InvalidPIDError):
+
+    def __init__(self):
+        self.message = 'Must provide a PID value'
+
+
+class InvalidPIDFormatError(InvalidPIDError):
+    ERROR_MESSAGE = '{value} does not follow the proper formatting for a PID of type {category}'
+
+
+class NoSuchPIDError(InvalidPIDError):
+    ERROR_MESSAGE = 'Could not find any record of PID of type {category} with valuea {value}'
 
 
 class CannotFinalizeArtifactError(OSFError):

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -252,7 +252,7 @@ class InvalidPIDFormatError(InvalidPIDError):
 
 
 class NoSuchPIDError(InvalidPIDError):
-    ERROR_MESSAGE = 'Could not find any record of PID of type {category} with valuea {value}'
+    ERROR_MESSAGE = 'Could not find any record of PID with type {category} and value {value}'
 
 
 class CannotFinalizeArtifactError(OSFError):

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -243,8 +243,8 @@ class InvalidPIDError(OSFError):
 
 class NoPIDError(InvalidPIDError):
 
-    def __init__(self):
-        self.message = 'Must provide a PID value'
+    def __init__(self, message):
+        self.message = message
 
 
 class InvalidPIDFormatError(InvalidPIDError):

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -95,11 +95,10 @@ class IdentifierMixin(models.Model):
         return identifier.value if identifier else None
 
     def set_identifier_value(self, category, value):
-        identifier, created = Identifier.objects.get_or_create(
-            referent=self,
-            category=category,
-            defaults=dict(value=value)
-        )
+        identifier, created = Identifier.objects.get_or_create(object_id=self.pk,
+                                                               content_type=ContentType.objects.get_for_model(self),
+                                                               category=category,
+                                                               defaults=dict(value=value))
         if not created:
             identifier.value = value
             identifier.save()

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from osf.exceptions import (
     CannotFinalizeArtifactError,
     IdentifierHasReferencesError,
+    InvalidPIDError,
     NoPIDError
 )
 from osf.models.base import BaseModel, ObjectIDMixin
@@ -115,12 +116,20 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         api_request: The api_request data from the API call that initiated the change.
         '''
         if not new_pid_value:
-            raise NoPIDError(f'Cannot assign an empty PID to OutcomeArtifact with ID {self._id}')
+            raise NoPIDError()
 
-        previous_identifier = self.identifier
-        self.identifier, _ = Identifier.objects.get_or_create(
+        new_identifier, created = Identifier.objects.get_or_create(
             value=new_pid_value, category=pid_type
         )
+        if created:
+            try:
+                new_identifier.validate_identifier_value()
+            except InvalidPIDError as e:
+                new_identifier.delete()
+                raise e
+
+        previous_identifier = self.identifier
+        self.identifier = new_identifier
         self.save()
         if previous_identifier:
             try:

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -116,7 +116,7 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         api_request: The api_request data from the API call that initiated the change.
         '''
         if not new_pid_value:
-            raise NoPIDError()
+            raise NoPIDError('Cannot assign an empty PID value')
 
         new_identifier, created = Identifier.objects.get_or_create(
             value=new_pid_value, category=pid_type

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 
 import requests
 
+from framework import sentry
 from osf.exceptions import (
     InvalidPIDError,
     InvalidPIDFormatError,
@@ -69,6 +70,10 @@ class DOIValidator(PIDValidator):
         elif error_status == 'Invalid DOI':
             pid_exception = InvalidPIDFormatError
         else:
+            sentry.log_message(
+                f'Unexpected response when checking Registration Agency for DOI {doi_value}: '
+                f'{response_data}'
+            )
             pid_exception = InvalidPIDError
 
         raise pid_exception(pid_value=doi_value, pid_category='DOI')

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -48,7 +48,6 @@ class DOIValidator(PIDValidator):
         #Local-development and test environments should
         if not self.validation_endpoint:
             return True
-
         # An Invalid DOI will not have a Registration Agency
         return self.get_registration_agency(doi_value) is not None
 

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -23,6 +23,9 @@ class PIDValidator(abc.ABC):
         for subclass in cls.__subclasses__():
             if subclass.IDENTIFIER_CATEGORY == category:
                 return subclass()
+        sentry.log_message(
+            f'Attempted to validate Identifier with unsupported category {category}.'
+        )
         raise NoSuchPIDValidatorError(
             f'PID validation not currently supported for PIDs of type {category}'
         )

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -1,0 +1,73 @@
+import abc
+from urllib.parse import urljoin
+
+import requests
+
+from osf.exceptions import (
+    InvalidPIDError,
+    InvalidPIDFormatError,
+    NoSuchPIDError,
+    NoSuchPIDValidatorError
+)
+from website.settings import (
+    PID_VALIDATION_ENABLED,
+    PID_VALIDATION_ENDPOINTS,
+)
+
+
+class PIDValidator(abc.ABC):
+
+    @classmethod
+    def for_identifier_category(cls, category):
+        for subclass in cls.__subclasses__():
+            if subclass.IDENTIFIER_CATEGORY == category:
+                return subclass()
+        raise NoSuchPIDValidatorError(
+            f'PID validation not currently supported for PIDs of type {category}'
+        )
+
+    def __init__(self):
+        self._validation_endpoint = None
+
+    @property
+    def validation_endpoint(self):
+        if not PID_VALIDATION_ENABLED:
+            return None
+        return PID_VALIDATION_ENDPOINTS.get(self.IDENTIFIER_CATEGORY)
+
+    @abc.abstractmethod
+    def validate(self, pid_value):
+        pass
+
+
+class DOIValidator(PIDValidator):
+
+    IDENTIFIER_CATEGORY = 'doi'
+
+    def validate(self, doi_value):
+        #Local-development and test environments should
+        if not self.validation_endpoint:
+            return True
+
+        # An Invalid DOI will not have a Registration Agency
+        return self.get_registration_agency(doi_value) is not None
+
+    def get_registration_agency(self, doi_value):
+        with requests.get(urljoin(self.validation_endpoint, doi_value)) as response:
+            response_data = response.json()[0]
+
+        registration_agency = response_data.get('RA')
+        if registration_agency:
+            return registration_agency
+
+        # These error messages were copied from actual responses;
+        # If they change, still raise an error, just not the most descriptive one
+        error_status = response_data.get('status')
+        if error_status == 'DOI does not exist':
+            pid_exception = NoSuchPIDError
+        elif error_status == 'Invalid DOI':
+            pid_exception = InvalidPIDFormatError
+        else:
+            pid_exception = InvalidPIDError
+
+        raise pid_exception(pid_value=doi_value, pid_category='DOI')

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -45,10 +45,12 @@ class DOIValidator(PIDValidator):
     IDENTIFIER_CATEGORY = 'doi'
 
     def validate(self, doi_value):
-        #Local-development and test environments should
+        # Either validation is turned off or we don't know how to validate
+        # Either way, just let the people do what they want
         if not self.validation_endpoint:
             return True
-        # An Invalid DOI will not have a Registration Agency
+
+        # An Invalid DOI will raise an exception error. Let the caller handle what to do there.
         return self.get_registration_agency(doi_value) is not None
 
     def get_registration_agency(self, doi_value):

--- a/osf_tests/test_identifiers.py
+++ b/osf_tests/test_identifiers.py
@@ -1,0 +1,96 @@
+from unittest import mock
+from urllib.parse import urljoin
+
+import pytest
+import responses
+
+from osf.exceptions import (
+    InvalidPIDError,
+    InvalidPIDFormatError,
+    NoSuchPIDError,
+)
+from osf.models import Identifier
+from osf.utils.identifiers import PID_VALIDATION_ENDPOINTS
+from osf_tests.factories import RegistrationFactory
+
+
+DOI_VALIDATION_ENDPOINT = PID_VALIDATION_ENDPOINTS['doi']
+
+VALID_RESPONSE = '[{"RA": "DataCite"}]'
+INVALID_DOI_RESPONSE = '[{"status": "Invalid DOI"}]'
+NO_SUCH_DOI_RESPONSE = '[{"status": "DOI does not exist"}]'
+UNRECOGNIZED_DOI_RESPONSE = '[{"status": "Here there be monsters"}]'
+
+@pytest.mark.django_db
+@mock.patch('osf.utils.identifiers.PID_VALIDATION_ENABLED', True)
+class TestIdentifier:
+
+    @pytest.fixture
+    def external_identifier(self):
+        return Identifier.objects.create(
+            referent=None,
+            value='DOI',
+            category='doi'
+        )
+
+    @pytest.fixture
+    def internal_identifier(self):
+        registration = RegistrationFactory(has_doi=True)
+        return registration.get_identifier('doi')
+
+    @responses.activate
+    def test_validate__valid_value(self, external_identifier):
+        responses.add(
+            method=responses.GET,
+            url=urljoin(DOI_VALIDATION_ENDPOINT, external_identifier.value),
+            body=VALID_RESPONSE,
+            status=200,
+            content_type='application/json'
+        )
+
+        assert external_identifier.validate_identifier_value()
+        assert responses.calls
+
+    @pytest.mark.parametrize(
+        'response_body, expected_error',
+        [
+            (INVALID_DOI_RESPONSE, InvalidPIDFormatError),
+            (NO_SUCH_DOI_RESPONSE, NoSuchPIDError),
+            (UNRECOGNIZED_DOI_RESPONSE, InvalidPIDError),
+        ]
+    )
+    @responses.activate
+    def test_validate__invalid_value_reraises(self, response_body, expected_error, external_identifier):
+        responses.add(
+            method=responses.GET,
+            url=urljoin(DOI_VALIDATION_ENDPOINT, external_identifier.value),
+            body=response_body,
+            status=200,
+            content_type='application/json'
+        )
+
+        with pytest.raises(expected_error):
+            external_identifier.validate_identifier_value()
+
+        assert responses.calls
+
+    @responses.activate
+    def test_validate__internal_identifier_bypasses_validation(self, internal_identifier):
+        with responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(
+                responses.GET,
+                urljoin(DOI_VALIDATION_ENDPOINT, internal_identifier.value),
+                body=INVALID_DOI_RESPONSE,
+                status=200,
+                content_type='application/json'
+            )
+            assert internal_identifier.validate_identifier_value()
+
+        # The validation endpoint should not have been hit
+        assert not rsps.calls
+
+    def test_validate__unsupported_pid_type_returns_true(self, external_identifier):
+        external_identifier.category = 'arbitrary'
+        external_identifier.save()
+
+        assert external_identifier.validate_identifier_value()

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -320,6 +320,11 @@ WATERBUTLER_INTERNAL_URL = WATERBUTLER_URL
 ####################
 #   Identifiers   #
 ###################
+PID_VALIDATION_ENABLED = False
+PID_VALIDATION_ENDPOINTS = {
+    'doi': 'https://doi.org/ra/'
+}
+
 DOI_URL_PREFIX = 'https://doi.org/'
 
 # General Format for DOIs


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We want to alert users when they try to assign an invalid DOI to a resource. For DOIs, we do this by curling against `https://doi.or/ra/<doi_value>`. This will tell is where the DOI is registered if it is valid. Otherwise, it will tell us if the DOI is either malformed or simply hasn't been registered.  We skip this step for DOIs that we generated (i.e. DOIs that have an OSF `referent`), since we have a high level of confidence in their correctness.

Pinging the `/ra/` endpoint also empowers future work to store the registering agency to enable querying of PID metadata in the future.

## Changes
* Add a `PIDValidator` Abstract class and `DOIValidator` subclass to handle validation for `Identifier` values
  * Add `settings` values to control if validation happens and what endpoints to use
  * Add informative exceptions for different types of errors
* Add `Identifier.validate_identifier_value` and call it when `OutcomeArtifact.update_identifier` creates a new identifier
* Update error handling in `ResourceSerializer.update` to handle the new exceptions
* Tests

The `PIDValidator` functionality is prematurely abstractified in order to lay explicit groundwork for expansion to future PID types.

## QA Notes
The DOIs we generate for Registrations on test are only registered with Datacite's test server (i.e. doi.org does not know about them) and as such will fail validation. We have to use real-live DOIs to try this out where `settings.DOI_VALIDATION_ENABLED` is True.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-3945
