### PR TITLE
[HOTFIX] Fix `check_contributor_auth` infinite loop

### DIFF
--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -465,7 +465,7 @@ def check_contributor_auth(node, auth, include_public, include_view_only_anon, i
                 redirect_url = check_key_expired(key=auth.private_key, node=node, url=request.url)
                 if request.headers.get('Content-Type') == 'application/json':
                     raise HTTPError(http_status.HTTP_401_UNAUTHORIZED)
-                else:
+                elif user is None:
                     response = redirect(cas.get_login_url(redirect_url))
 
     return response


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The `check_contributor_auth` decorator was ~always redirecting to CAS in the case of a failed `check_can_access` check -- which would then redirect a logged-in user back to the url for the resource and back to CAS ad nauseam

## Changes
Only redirect to CAS in the case where `user` is `None` (i.e., the user isn't already logged in). Otherwise, just return None and let the App decide what to do (403 or 404).

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
