### PR TITLE
Add 'status' to JSONAPIError dictionary

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -99,7 +99,14 @@ def json_api_exception_handler(exc, context):
             response['X-OSF-OTP'] = 'required; app'
 
         if isinstance(exc, JSONAPIException):
-            errors.extend([{'source': exc.source or {}, 'detail': exc.detail, 'meta': exc.meta or {}}])
+            errors.extend([
+                {
+                    'source': exc.source or {},
+                    'detail': exc.detail,
+                    'meta': exc.meta or {},
+                    'status': exc.status_code,
+                },
+            ])
         elif isinstance(message, dict):
             errors.extend(dict_error_formatting(message, context, index=None))
         else:

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -104,7 +104,7 @@ def json_api_exception_handler(exc, context):
                     'source': exc.source or {},
                     'detail': exc.detail,
                     'meta': exc.meta or {},
-                    'status': exc.status_code,
+                    'status': str(exc.status_code),
                 },
             ])
         elif isinstance(message, dict):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Be consistent with JSONAPI error spec

## Changes
Add a `status` entry to the error dictionary, borrowing the `status_code` from the parsed exception

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
