### PR TITLE
Add `has_papers` and `has_supplements` fields/annotations

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -99,7 +99,14 @@ def json_api_exception_handler(exc, context):
             response['X-OSF-OTP'] = 'required; app'
 
         if isinstance(exc, JSONAPIException):
-            errors.extend([{'source': exc.source or {}, 'detail': exc.detail, 'meta': exc.meta or {}}])
+            errors.extend([
+                {
+                    'source': exc.source or {},
+                    'detail': exc.detail,
+                    'meta': exc.meta or {},
+                    'status': exc.status_code,
+                },
+            ])
         elif isinstance(message, dict):
             errors.extend(dict_error_formatting(message, context, index=None))
         else:

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -104,7 +104,7 @@ def json_api_exception_handler(exc, context):
                     'source': exc.source or {},
                     'detail': exc.detail,
                     'meta': exc.meta or {},
-                    'status': exc.status_code,
+                    'status': str(exc.status_code),
                 },
             ])
         elif isinstance(message, dict):

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -82,6 +82,8 @@ class RegistrationSerializer(NodeSerializer):
         'has_data',
         'has_analytic_code',
         'has_materials',
+        'has_papers',
+        'has_supplements',
     ])
 
     ia_url = ser.URLField(read_only=True)
@@ -156,6 +158,8 @@ class RegistrationSerializer(NodeSerializer):
     has_data = HideIfWithdrawal(ser.BooleanField(read_only=True, required=False))
     has_analytic_code = HideIfWithdrawal(ser.BooleanField(read_only=True, required=False))
     has_materials = HideIfWithdrawal(ser.BooleanField(read_only=True, required=False))
+    has_papers = HideIfWithdrawal(ser.BooleanField(read_only=True, required=False))
+    has_supplements = HideIfWithdrawal(ser.BooleanField(read_only=True, required=False))
 
     registration_supplement = ser.SerializerMethodField()
     # Will be deprecated in favor of registration_responses

--- a/api/resources/annotations.py
+++ b/api/resources/annotations.py
@@ -39,4 +39,6 @@ def make_open_practice_badge_annotations():
         'has_data': _make_badge_subquery(ArtifactTypes.DATA),
         'has_analytic_code': _make_badge_subquery(ArtifactTypes.ANALYTIC_CODE),
         'has_materials': _make_badge_subquery(ArtifactTypes.MATERIALS),
+        'has_papers': _make_badge_subquery(ArtifactTypes.PAPERS),
+        'has_supplements': _make_badge_subquery(ArtifactTypes.SUPPLEMENTS),
     }

--- a/api_tests/resources/annotations/test_open_practice_badge_annotations.py
+++ b/api_tests/resources/annotations/test_open_practice_badge_annotations.py
@@ -44,7 +44,7 @@ class TestRegistrationDetailOpenPracticeAnnotations:
         return outcome.artifact_metadata.create(
             identifier=IdentifierFactory(),
             artifact_type=ArtifactTypes.ANALYTIC_CODE,
-            finalized=True
+            finalized=False,
         )
 
     @pytest.fixture
@@ -52,20 +52,27 @@ class TestRegistrationDetailOpenPracticeAnnotations:
         return outcome.artifact_metadata.create(
             identifier=IdentifierFactory(),
             artifact_type=ArtifactTypes.MATERIALS,
-            finalized=True
+            finalized=True,
+            deleted=timezone.now()
         )
 
     @pytest.fixture()
     def url(self, registration):
         return f'/{API_BASE}registrations/{registration._id}/'
 
-    def test_badge_annotations(self, app, registration, data_resource, code_resource, materials_resource, url):
+    @pytest.mark.parametrize('resource_type', ArtifactTypes.public_types())
+    def test_badge_annotations(self, app, registration, outcome, url, resource_type):
+        outcome.artifact_metadata.create(
+            identifier=IdentifierFactory(),
+            artifact_type=resource_type,
+            finalized=True,
+        )
+
         resp = app.get(url, auth=None, expect_errors=False)
         attributes = resp.json['data']['attributes']
 
-        assert attributes['has_data']
-        assert attributes['has_analytic_code']
-        assert attributes['has_materials']
+        badge_attribute = f'has_{resource_type.name.lower()}'
+        assert attributes[badge_attribute]
 
     def test_badge_annotations_exclude_nonvisible_results(
         self, app, registration, data_resource, code_resource, materials_resource, url
@@ -79,8 +86,13 @@ class TestRegistrationDetailOpenPracticeAnnotations:
         attributes = resp.json['data']['attributes']
 
         assert attributes['has_data']
+        # Not finalized
         assert not attributes['has_analytic_code']
+        # Deleted
         assert not attributes['has_materials']
+        # Do not exist
+        assert not attributes['has_papers']
+        assert not attributes['has_supplements']
 
     def test_registration_does_not_inherit_badges_from_primary_resource(self, app, registration, outcome, data_resource):
         artifact_registration = RegistrationFactory(is_public=True, has_doi=True)
@@ -128,8 +140,8 @@ class TestRegistrationListOpenPracticeAnnotations:
         provider.get_group('moderator').user_set.add(creator)
         return provider
 
-    @pytest.fixture
-    def open_data_reg(self, project, provider, creator):
+    @pytest.fixture(autouse=True)
+    def open_data(self, project, provider, creator):
         r = RegistrationFactory(
             project=project,
             provider=provider,
@@ -145,8 +157,8 @@ class TestRegistrationListOpenPracticeAnnotations:
         )
         return r
 
-    @pytest.fixture
-    def open_code_reg(self, project, provider, creator):
+    @pytest.fixture(autouse=True)
+    def open_code(self, project, provider, creator):
         r = RegistrationFactory(
             project=project,
             provider=provider,
@@ -162,8 +174,8 @@ class TestRegistrationListOpenPracticeAnnotations:
         )
         return r
 
-    @pytest.fixture
-    def open_materials_reg(self, project, provider, creator):
+    @pytest.fixture(autouse=True)
+    def open_materials(self, project, provider, creator):
         r = RegistrationFactory(
             project=project,
             provider=provider,
@@ -179,6 +191,40 @@ class TestRegistrationListOpenPracticeAnnotations:
         )
         return r
 
+    @pytest.fixture
+    def open_papers(self, project, provider, creator):
+        r = RegistrationFactory(
+            project=project,
+            provider=provider,
+            creator=creator,
+            is_public=True,
+            has_doi=True
+        )
+        o = Outcome.objects.for_registration(r, create=True)
+        o.artifact_metadata.create(
+            identifier=IdentifierFactory(),
+            artifact_type=ArtifactTypes.PAPERS,
+            finalized=True,
+        )
+        return r
+
+    @pytest.fixture
+    def open_supplements(self, project, provider, creator):
+        r = RegistrationFactory(
+            project=project,
+            provider=provider,
+            creator=creator,
+            is_public=True,
+            has_doi=True
+        )
+        o = Outcome.objects.for_registration(r, create=True)
+        o.artifact_metadata.create(
+            identifier=IdentifierFactory(),
+            artifact_type=ArtifactTypes.SUPPLEMENTS,
+            finalized=True,
+        )
+        return r
+
     @pytest.fixture(params=REGISTRATION_LIST_ROUTES)
     def api_url(self, request, project, provider, creator):
         format_dict = {
@@ -186,7 +232,9 @@ class TestRegistrationListOpenPracticeAnnotations:
         }
         return request.param.format(**format_dict)
 
-    def test_annotations(self, app, open_data_reg, open_code_reg, open_materials_reg, creator, api_url):
+    def test_annotations(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
         resp = app.get(api_url, auth=creator.auth, expect_errors=False)
         data = resp.json['data']
 
@@ -195,18 +243,24 @@ class TestRegistrationListOpenPracticeAnnotations:
                 'data': entry['attributes']['has_data'],
                 'code': entry['attributes']['has_analytic_code'],
                 'materials': entry['attributes']['has_materials'],
+                'papers': entry['attributes']['has_papers'],
+                'supplements': entry['attributes']['has_supplements'],
             }
             for entry in data
         }
         expected_results = {
-            open_data_reg._id: {'data': True, 'code': False, 'materials': False},
-            open_code_reg._id: {'data': False, 'code': True, 'materials': False},
-            open_materials_reg._id: {'data': False, 'code': False, 'materials': True}
+            open_data._id: {'data': True, 'code': False, 'materials': False, 'papers': False, 'supplements': False},
+            open_code._id: {'data': False, 'code': True, 'materials': False, 'papers': False, 'supplements': False},
+            open_materials._id: {'data': False, 'code': False, 'materials': True, 'papers': False, 'supplements': False},
+            open_papers._id: {'data': False, 'code': False, 'materials': False, 'papers': True, 'supplements': False},
+            open_supplements._id: {'data': False, 'code': False, 'materials': False, 'papers': False, 'supplements': True},
         }
 
         assert parsed_results == expected_results
 
-    def test_filtering__has_data(self, app, open_data_reg, open_code_reg, open_materials_reg, creator, api_url):
+    def test_filtering__has_data(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
         if api_url.startswith(f'/{API_BASE}nodes/'):
             pytest.xfail(reason='Filtering not implemented for NodeRegistratonsList')
         filter_url = f'{api_url}?filter[has_data]=True'
@@ -214,9 +268,11 @@ class TestRegistrationListOpenPracticeAnnotations:
         data = resp.json['data']
 
         response_ids = set(entry['id'] for entry in data)
-        assert response_ids == {open_data_reg._id}
+        assert response_ids == {open_data._id}
 
-    def test_filtering__has_code(self, app, open_data_reg, open_code_reg, open_materials_reg, creator, api_url):
+    def test_filtering__has_code(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
         if api_url.startswith(f'/{API_BASE}nodes/'):
             pytest.xfail(reason='Filtering not implemented for NodeRegistratonsList')
         filter_url = f'{api_url}?filter[has_analytic_code]=True'
@@ -224,9 +280,11 @@ class TestRegistrationListOpenPracticeAnnotations:
         data = resp.json['data']
 
         response_ids = set(entry['id'] for entry in data)
-        assert response_ids == {open_code_reg._id}
+        assert response_ids == {open_code._id}
 
-    def test_filtering__has_materials(self, app, open_data_reg, open_code_reg, open_materials_reg, creator, api_url):
+    def test_filtering__has_materials(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
         if api_url.startswith(f'/{API_BASE}nodes/'):
             pytest.xfail(reason='Filtering not implemented for NodeRegistratonsList')
         filter_url = f'{api_url}?filter[has_materials]=True'
@@ -234,4 +292,28 @@ class TestRegistrationListOpenPracticeAnnotations:
         data = resp.json['data']
 
         response_ids = set(entry['id'] for entry in data)
-        assert response_ids == {open_materials_reg._id}
+        assert response_ids == {open_materials._id}
+
+    def test_filtering__has_papers(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
+        if api_url.startswith(f'/{API_BASE}nodes/'):
+            pytest.xfail(reason='Filtering not implemented for NodeRegistratonsList')
+        filter_url = f'{api_url}?filter[has_papers]=True'
+        resp = app.get(filter_url, auth=creator.auth, expect_errors=False)
+        data = resp.json['data']
+
+        response_ids = set(entry['id'] for entry in data)
+        assert response_ids == {open_papers._id}
+
+    def test_filtering__has_supplements(
+        self, app, open_data, open_code, open_materials, creator, open_papers, open_supplements, api_url
+    ):
+        if api_url.startswith(f'/{API_BASE}nodes/'):
+            pytest.xfail(reason='Filtering not implemented for NodeRegistratonsList')
+        filter_url = f'{api_url}?filter[has_supplements]=True'
+        resp = app.get(filter_url, auth=creator.auth, expect_errors=False)
+        data = resp.json['data']
+
+        response_ids = set(entry['id'] for entry in data)
+        assert response_ids == {open_supplements._id}

--- a/osf/utils/outcomes.py
+++ b/osf/utils/outcomes.py
@@ -23,6 +23,16 @@ class ArtifactTypes(IntEnum):
     def choices(cls):
         return tuple((entry.value, entry.name) for entry in cls)
 
+    @classmethod
+    def public_types(cls):
+        return (
+            cls.DATA,
+            cls.ANALYTIC_CODE,
+            cls.MATERIALS,
+            cls.PAPERS,
+            cls.SUPPLEMENTS,
+        )
+
 
 class OutcomeActions(Enum):
     ADD = 0


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add `has_papers` and `has_supplements` annotations to Registrations

## Changes
*Add annotations for `has_papers` and `has_supplements` to `api/resources/annotations.make_open_practice_badge_annotations`
* Add `has_papers` and `has_supplements` fields to RegistrationSerializer and make them filterable
* Update tests to include the new fields

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
