### PR TITLE
Add route for new Registration resources subpage (take 2)

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -99,7 +99,14 @@ def json_api_exception_handler(exc, context):
             response['X-OSF-OTP'] = 'required; app'
 
         if isinstance(exc, JSONAPIException):
-            errors.extend([{'source': exc.source or {}, 'detail': exc.detail, 'meta': exc.meta or {}}])
+            errors.extend([
+                {
+                    'source': exc.source or {},
+                    'detail': exc.detail,
+                    'meta': exc.meta or {},
+                    'status': exc.status_code,
+                },
+            ])
         elif isinstance(message, dict):
             errors.extend(dict_error_formatting(message, context, index=None))
         else:

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -104,7 +104,7 @@ def json_api_exception_handler(exc, context):
                     'source': exc.source or {},
                     'detail': exc.detail,
                     'meta': exc.meta or {},
-                    'status': exc.status_code,
+                    'status': str(exc.status_code),
                 },
             ])
         elif isinstance(message, dict):

--- a/website/views.py
+++ b/website/views.py
@@ -332,7 +332,7 @@ def resolve_guid(guid, suffix=None):
             return redirect(resource.absolute_url, http_status.HTTP_301_MOVED_PERMANENTLY)
         return stream_emberapp(EXTERNAL_EMBER_APPS['preprints']['server'], preprints_dir)
 
-    elif isinstance(resource, Registration) and (not suffix or suffix.rstrip('/').lower() in ('comments', 'links', 'components',)) and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
+    elif isinstance(resource, Registration) and (not suffix or suffix.rstrip('/').lower() in ('comments', 'links', 'components', 'resources',)) and waffle.flag_is_active(request, features.EMBER_REGISTRIES_DETAIL_PAGE):
         return stream_emberapp(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], ember_osf_web_dir)
 
     elif isinstance(resource, Registration) and suffix and suffix.rstrip('/').lower() in ('files', 'files/osfstorage') and waffle.flag_is_active(request, features.EMBER_REGISTRATION_FILES):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Redirect to Ember App when users navigate to `[environment.]osf.io/<registration_guid>/resources`

## Changes
Update `website.views.resolve_guid` logic to be aware of the new route

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
