### PR TITLE
[Django Upgrade] [ENG-3947] Direct assignment fix for Django 3

### DIFF
--- a/admin/meetings/views.py
+++ b/admin/meetings/views.py
@@ -65,7 +65,7 @@ class MeetingFormView(PermissionRequiredMixin, FormView):
         custom_fields, data = get_custom_fields(form.cleaned_data)
         if 'admins' in form.changed_data:
             admin_users = get_admin_users(data.get('admins'))
-            self.conf.admins = admin_users
+            self.conf.admins.set(admin_users)
         self.conf.name = data.get('name')
         self.conf.info_url = data.get('info_url')
         self.conf.logo_url = data.get('logo_url')

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -1200,7 +1200,7 @@ class TestPreprintUpdateLicense:
     @pytest.fixture()
     def preprint_provider(self, cc0_license, no_license):
         preprint_provider = PreprintProviderFactory()
-        preprint_provider.licenses_acceptable = [cc0_license, no_license]
+        preprint_provider.licenses_acceptable.add(*[cc0_license, no_license])
         preprint_provider.save()
         return preprint_provider
 


### PR DESCRIPTION
## Purpose

Note: PR description added by reviewer

This incompatibility comes from [Feature Removed in 2.0](https://docs.djangoproject.com/en/4.1/releases/2.0/#features-removed-in-2-0)

> Support for direct assignment to a reverse foreign key or many-to-many relation is removed.

This might have been missed by (or was added after) https://github.com/CenterForOpenScience/osf.io/pull/9300.

## Changes

Replaced direct assignment with `.add()` and/or `.set()`.

## QA Notes

## Documentation

## Side Effects

## Ticket

Part of https://openscience.atlassian.net/browse/ENG-3947
