### PR TITLE
[Django Upgrade] [ENG-3947] Storage region slice subquery issue

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -981,7 +981,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def osfstorage_region(self):
         from addons.osfstorage.models import Region
         osfs_settings = self._settings_model('osfstorage')
-        region_subquery = osfs_settings.objects.filter(owner=self.id).values('region_id')
+        region_subquery = osfs_settings.objects.filter(owner=self.id).values_list('region_id', flat=True)[0]
         return Region.objects.get(id=region_subquery)
 
     @property


### PR DESCRIPTION
## Purpose

<s>Change to cachedprotery in 2.2 broke this
https://docs.djangoproject.com/en/4.0/releases/2.2/#cached-property-aliases
</s>

This issue was actually created by not retrieving the exact value from a sub-queryset and instead using a subquery as a value.

## Changes


## QA Notes

## Documentation

## Side Effects

## Ticket