### PR TITLE
[ENG-3903] Add artifacts to DOI metadata as `relatedIdentifiers`

### DIFF
--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -109,6 +109,7 @@ class ResourceSerializer(JSONAPISerializer):
                 new_description=updated_description,
                 new_artifact_type=updated_artifact_type,
                 new_pid_value=updated_pid_value,
+                api_request=self.context['request'],
             )
         except UnsupportedArtifactTypeError:
             current_type = ArtifactTypes(instance.artifact_type).name.lower()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1421,7 +1421,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         )
         assert res.status_code == 200
 
-    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change.s')
+    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change')
     def test_set_node_private_updates_doi(
             self, mock_update_doi_metadata, app, user, project_public,
             url_public, make_node_payload):
@@ -1593,7 +1593,7 @@ class TestNodeDelete(NodeCRUDTestCase):
         # Bookmark collections are collections, so a 404 is returned
         assert res.status_code == 404
 
-    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change.s')
+    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change')
     def test_delete_node_with_preprint_calls_preprint_update_status(
             self, mock_update_doi_metadata_on_change, app, user,
             project_public, url_public):
@@ -1603,7 +1603,7 @@ class TestNodeDelete(NodeCRUDTestCase):
 
         assert not mock_update_doi_metadata_on_change.called
 
-    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change.s')
+    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change')
     def test_delete_node_with_identifier_calls_preprint_update_status(
             self, mock_update_doi_metadata_on_change, app, user,
             project_public, url_public):

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1421,7 +1421,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         )
         assert res.status_code == 200
 
-    @mock.patch('website.identifiers.tasks.update_doi_metadata_on_change')
+    @mock.patch('osf.models.node.update_doi_metadata_on_change')
     def test_set_node_private_updates_doi(
             self, mock_update_doi_metadata, app, user, project_public,
             url_public, make_node_payload):

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -78,6 +78,10 @@ class IdentifierMixin(models.Model):
             return client.create_identifier(self, category)
 
     def request_identifier_update(self, category):
+        '''Noop if no existing identifier value for the category.'''
+        if not self.get_identifier_value(category):
+            return
+
         client = self.get_doi_client()
         if client:
             return client.update_identifier(self, category)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1256,7 +1256,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         # Update existing identifiers
         if self.get_identifier('doi'):
-            enqueue_task(update_doi_metadata_on_change.s(self._id))
+            update_doi_metadata_on_change.s(self._id)
         elif self.is_registration:
             doi = self.request_identifier('doi')['doi']
             self.set_identifier_value('doi', doi)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1256,7 +1256,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         # Update existing identifiers
         if self.get_identifier('doi'):
-            update_doi_metadata_on_change.s(self._id)
+            update_doi_metadata_on_change(self._id)
         elif self.is_registration:
             doi = self.request_identifier('doi')['doi']
             self.set_identifier_value('doi', doi)

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -197,13 +197,12 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         self.finalized = True
         self.save()
 
-        if api_request:
-            self.outcome.artifact_updated(
-                action=OutcomeActions.ADD,
-                artifact=self,
-                api_request=api_request,
-                new_identifier=self.identifier.value
-            )
+        self.outcome.artifact_updated(
+            action=OutcomeActions.ADD,
+            artifact=self,
+            api_request=api_request,
+            new_identifier=self.identifier.value
+        )
 
     def delete(self, api_request=None, **kwargs):
         '''Intercept `delete` behavior on the model instance and handles callbacks.
@@ -217,15 +216,14 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         '''
         identifier = self.identifier
         if self.finalized:
-            if api_request:
-                self.outcome.artifact_updated(
-                    action=OutcomeActions.REMOVE,
-                    artifact=self,
-                    api_request=api_request,
-                    obsolete_identifier=identifier.value
-                )
             self.deleted = timezone.now()
             self.save()
+            self.outcome.artifact_updated(
+                action=OutcomeActions.REMOVE,
+                artifact=self,
+                api_request=api_request,
+                obsolete_identifier=identifier.value
+            )
         else:
             super().delete(**kwargs)
 

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -227,7 +227,8 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         else:
             super().delete(**kwargs)
 
-        try:
-            identifier.delete()
-        except IdentifierHasReferencesError:
-            pass
+        if identifier:
+            try:
+                identifier.delete()
+            except IdentifierHasReferencesError:
+                pass

--- a/osf/models/outcomes.py
+++ b/osf/models/outcomes.py
@@ -83,7 +83,7 @@ class Outcome(ObjectIDMixin, EditableFieldsMixin, BaseModel):
 
     def artifact_updated(self, action, artifact, api_request, **log_params):
         nodelog_params = {'artifact_id': artifact._id, **log_params}
-        self.primary_osf_resource.associated_resource_updated(
+        self.primary_osf_resource.related_resource_updated(
             log_action=NODE_LOGS_FOR_OUTCOME_ACTION.get(action),
             api_request=api_request,
             **nodelog_params,

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -867,14 +867,18 @@ class Registration(AbstractNode):
         if settings.SHARE_ENABLED:
             update_share(self)
         if not log_action:
+            print('hrmm')
             return
+        print('Updating')
 
-        self.add_log(
-            action=log_action,
-            params=log_params,
-            auth=None,  # Grabbed from request
-            request=api_request,
-        )
+        if api_request:  # Only log user-initiated changes
+            self.add_log(
+                action=log_action,
+                params=log_params,
+                auth=None,  # Grabbed from request
+                request=api_request,
+            )
+
         update_doi_metadata_on_change(guid=self._id)
 
     class Meta:

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -867,9 +867,7 @@ class Registration(AbstractNode):
         if settings.SHARE_ENABLED:
             update_share(self)
         if not log_action:
-            print('hrmm')
             return
-        print('Updating')
 
         if api_request:  # Only log user-initiated changes
             self.add_log(

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -14,16 +14,13 @@ from guardian.models import (
 )
 from dirtyfields import DirtyFieldsMixin
 
+from api.share.utils import update_share
 from framework.auth import Auth
 from framework.exceptions import PermissionsError
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.permissions import ADMIN, READ, WRITE
 from osf.exceptions import NodeStateError, DraftRegistrationStateError
-from website.util import api_v2_url
-from website import settings
-from website.archiver import ARCHIVER_INITIATED
-from website.project import signals
-
+from osf.external.internet_archive.tasks import archive_to_ia, update_ia_metadata
 from osf.metrics import RegistriesModerationMetrics
 from osf.models import (
     Embargo,
@@ -35,35 +32,35 @@ from osf.models import (
     RegistrationSchema,
     Retraction,
 )
-
 from osf.models.action import RegistrationAction
 from osf.models.archive import ArchiveJob
 from osf.models.base import BaseModel, ObjectIDMixin
 from osf.models.draft_node import DraftNode
-from osf.models.node import AbstractNode
+from osf.models.licenses import NodeLicenseRecord
 from osf.models.mixins import (
     EditableFieldsMixin,
     Loggable,
     GuardianMixin,
+    RegistrationResponseMixin,
 )
+from osf.models.node import AbstractNode
 from osf.models.nodelog import NodeLog
 from osf.models.provider import RegistrationProvider
-from osf.models.mixins import RegistrationResponseMixin
 from osf.models.tag import Tag
-from osf.models.licenses import NodeLicenseRecord
 from osf.models.validators import validate_title
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
+from osf.utils import notifications as notify
 from osf.utils.workflows import (
     RegistrationModerationStates,
     RegistrationModerationTriggers,
     ApprovalStates,
     SanctionTypes
 )
-
-from osf.external.internet_archive.tasks import archive_to_ia, update_ia_metadata
-
-import osf.utils.notifications as notify
-from api.share.utils import update_share
+from website import settings
+from website.archiver import ARCHIVER_INITIATED
+from website.identifiers.tasks import update_doi_metadata_on_change
+from website.project import signals
+from website.util import api_v2_url
 
 
 logger = logging.getLogger(__name__)
@@ -866,7 +863,7 @@ class Registration(AbstractNode):
         for children in Registration.objects.get_children(self, active=True, include_root=True):
             archive_to_ia(children)
 
-    def associated_resource_updated(self, log_action=None, api_request=None, **log_params):
+    def related_resource_updated(self, log_action=None, api_request=None, **log_params):
         if settings.SHARE_ENABLED:
             update_share(self)
         if not log_action:
@@ -878,6 +875,7 @@ class Registration(AbstractNode):
             auth=None,  # Grabbed from request
             request=api_request,
         )
+        update_doi_metadata_on_change(guid=self._id)
 
     class Meta:
         # custom permissions for use in the OSF Admin App

--- a/website/identifiers/listeners.py
+++ b/website/identifiers/listeners.py
@@ -6,4 +6,4 @@ def update_status_on_delete(node):
     from website.identifiers.tasks import update_doi_metadata_on_change
 
     if node.get_identifier('doi'):
-        update_doi_metadata_on_change.s(node._id)
+        update_doi_metadata_on_change(node._id)

--- a/website/identifiers/listeners.py
+++ b/website/identifiers/listeners.py
@@ -1,5 +1,4 @@
 from website.project import signals
-from framework.celery_tasks.handlers import enqueue_task
 
 
 @signals.node_deleted.connect
@@ -7,4 +6,4 @@ def update_status_on_delete(node):
     from website.identifiers.tasks import update_doi_metadata_on_change
 
     if node.get_identifier('doi'):
-        enqueue_task(update_doi_metadata_on_change.s(node._id))
+        update_doi_metadata_on_change.s(node._id)

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -1,8 +1,10 @@
 from django.apps import apps
 
 from framework.celery_tasks import app as celery_app
+from framework.celery_tasks.handlers import queued_task
 
 
+@queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
     Guid = apps.get_model('osf.Guid')

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -2,11 +2,13 @@ from django.apps import apps
 
 from framework.celery_tasks import app as celery_app
 from framework.celery_tasks.handlers import queued_task
+from framework import sentry
 
 
 @queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
+    sentry.log_message('Updating DOI for [{target_guid}]')
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     if target_object.get_identifier('doi'):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Update our Registration DOI metadata to contain links to artifacts

Also resolves https://www.notion.so/cos/Can-t-delete-unfinalized-resource-2b48a647c38f4418a37cf1e0b2180711

## Changes
* Update the Datacite DOI client to include the Registration's artifacts as `relatedIdentifiers`
* Make `website.identifiers.tasks.update_doi_metadata_on_change` a `queued_task`
  * Update other call sites to remove the `enqueue_task` call that this applies
* Make `IdentifierMixin.request_identifier_update` a noop in the case where no value has been set
  * This is in support of our plan to give Embargoed Registrations an empty, placeholder identifier 
* Call `update_doi_metadata_on_change` in `Registration.related_resource_updated` in the case of an addition or deletion or a change to the DOI value 
* Clean up imports in `registration.py`
* Make `DataciteClient.create_identifier` always build (and return) the generated metadata instead of just when sending to Datacite to improve testability
* Allow `DataCiteClient.build_metadata` to optionally return the dict/json format instead of the XML to simplify testability

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-3903
