### PR TITLE
[ENG-3981] Add placeholder Identifier to Embargoed Registrations

### DIFF
--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -98,11 +98,12 @@ class IdentifierMixin(models.Model):
         identifier = self.get_identifier(category)
         return identifier.value if identifier else None
 
-    def set_identifier_value(self, category, value):
+    def set_identifier_value(self, category, value=None):
+        defaults = {'value': value} if value is not None else {}
         identifier, created = Identifier.objects.get_or_create(object_id=self.pk,
                                                                content_type=ContentType.objects.get_for_model(self),
                                                                category=category,
-                                                               defaults=dict(value=value))
+                                                               defaults=defaults)
         if not created:
             identifier.value = value
             identifier.save()

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -104,7 +104,7 @@ class IdentifierMixin(models.Model):
                                                                content_type=ContentType.objects.get_for_model(self),
                                                                category=category,
                                                                defaults=defaults)
-        if not created:
+        if value and not created:
             identifier.value = value
             identifier.save()
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1255,7 +1255,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     status.push_status_message(message, kind='info', trust=False)
 
         # Update existing identifiers
-        if self.get_identifier('doi'):
+        if self.get_identifier_value('doi'):
             update_doi_metadata_on_change(self._id)
         elif self.is_registration:
             doi = self.request_identifier('doi')['doi']

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -617,6 +617,11 @@ class Embargo(SanctionCallbackMixin, EmailApprovableSanction):
                 'embargo_id': self._id,
             },
             auth=Auth(self.initiated_by), )
+
+        # Make placeholder identifiers for all Registrations to allow resources to be added
+        # This Identifier will be grabbed and populated when the Registration is made public
+        for registration in parent_registration.node_and_primary_descendants():
+            registration.set_identifier_value(category='doi', value=None)
         self.save()
 
     def approve_embargo(self, user, token):

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -5,8 +5,6 @@ import pytest
 import datetime
 
 from django.utils import timezone
-
-from nose.tools import assert_raises
 from transitions import MachineError
 
 from osf.models import NodeLog
@@ -102,7 +100,7 @@ class TestRegistrationEmbargoTermination:
         user_1_tok = embargo_termination.token_for_user(user, 'rejection')
         user_2_tok = embargo_termination.token_for_user(user2, 'approval')
         embargo_termination.reject(user=user, token=user_1_tok)
-        with assert_raises(MachineError):
+        with pytest.raises(MachineError):
             embargo_termination.approve(user=user2, token=user_2_tok)
 
         assert embargo_termination.is_rejected
@@ -164,3 +162,74 @@ class TestSanctionEmailRendering:
 
         registration.sanction.ask([(contributor, registration)])
         assert True  # mail rendered successfully
+
+
+@pytest.mark.django_db
+class TestDOICreation:
+
+    def make_test_registration(self, embargoed=False, moderated=False):
+        sanction = factories.EmbargoFactory() if embargoed else factories.RegistrationApprovalFactory()
+        registration = sanction.target_registration
+        if moderated:
+            provider = registration.provider
+            provider.reviews_workflow = 'pre-moderation'
+            provider.save()
+        return registration
+
+    def test_registration_approval__doi_minted_on_approval(self):
+        registration = self.make_test_registration(embargoed=False, moderated=False)
+        assert not registration.get_identifier(category='doi')
+
+        registration.registration_approval.accept()
+        assert registration.get_identifier_value(category='doi')
+
+    def test_embargo__identifier_created_but_not_minted_on_aproval(self):
+        registration = self.make_test_registration(embargoed=True, moderated=False)
+        assert not registration.get_identifier(category='doi')
+
+        registration.embargo.accept()
+        assert registration.get_identifier(category='doi')
+        assert not registration.get_identifier_value(category='doi')
+
+    def test_embargo__identifier_minted_on_complete(self):
+        registration = self.make_test_registration(embargoed=True, moderated=False)
+        assert not registration.get_identifier(category='doi')
+
+        registration.embargo.accept()
+        registration.terminate_embargo()
+        assert registration.get_identifier_value(category='doi')
+
+    @pytest.mark.parametrize('embargoed', [True, False])
+    def test_moderated_sanction__no_identifier_created_until_moderator_approval(self, embargoed):
+        registration = self.make_test_registration(embargoed=embargoed, moderated=True)
+        provider = registration.provider
+        provider.update_group_permissions()
+        moderator = factories.AuthUserFactory()
+        provider.get_group('moderator').user_set.add(moderator)
+
+        # Admin approval
+        registration.sanction.accept()
+        assert not registration.get_identifier(category='doi')
+
+        # Moderator approval
+
+        with mock.patch('osf.models.node.AbstractNode.update_search'):
+            registration.sanction.accept(user=moderator)
+        assert registration.get_identifier(category='doi')
+
+    @pytest.mark.parametrize('embargoed', [True, False])
+    def test_nested_registration_mints_identifier(self, embargoed):
+        registration = self.make_test_registration(embargoed=embargoed, moderated=False)
+
+        child_project = factories.ProjectFactory(parent=registration.registered_from)
+        grandchild_project = factories.ProjectFactory(parent=child_project)
+
+        child_registration = factories.RegistrationFactory(parent=registration, project=child_project)
+        grandchild_registration = factories.RegistrationFactory(parent=child_registration, project=grandchild_project)
+
+        assert not child_registration.get_identifier(category='doi')
+        assert not grandchild_registration.get_identifier(category='doi')
+
+        registration.sanction.accept()
+        assert child_registration.get_identifier(category='doi')
+        assert grandchild_registration.get_identifier(category='doi')

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -8,7 +8,7 @@ from framework import sentry
 @queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
-    sentry.log_message('Updating DOI for [{target_guid}]')
+    sentry.log_message(f'Updating DOI for [{target_guid}]')
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     if target_object.get_identifier('doi'):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
In order for a Registration to have related Resources, it needs to be the PRIMARY Artifact on an Outcome. In order to be an Artifact, it needs an Identifier.

To that end, create a placeholder Identifier for registrations when they have an approved Embargo while waiting to mint the DOI until after the Embargo is terminated

## Changes
* Modify `IdentifirMixin.set_identifier_value` to support `None` values
* Call `set_identifier_value(category='doi', value=None)` on every Registration in the tree in the `_on_complete` functionality of the Embargo model
* Update `Node.set_privacy` to check `get_identifier_value` instead of `get_identifier` when determining whether to "udpate" or "create" the DOI
  * This is so that we can have `IdentifierMixin.request_identifier_udpate` ignore identifiers with `value=None` and avoid accidentally creating/updating DOIs as part of the `save` logic for the Embargoed registrations
  * This works because `update_identifier` really just calls `create_identifier` under the hood for Datacite DOIs
* Tests and two small cleanup items
  * Replace use of nose.assert_raises with pytest.raises
  * Fix misformatted f-string in sentry logging of identifier updates
  * 
## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-3981
