### PR TITLE
[ENG-3962] Enforce Integrity on update of `finalized` resources

### DIFF
--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -164,7 +164,7 @@ class ResourceSerializer(JSONAPISerializer):
             ]
         except IntegrityError:
             raise JSONAPIException(
-                detail='A Resource with the provided DOI and Resource Type already exists.',
+                detail='A Resource with the provided PID and Resource Type already exists.',
                 source={'pointer': '/data/attributes'},
             )
         else:

--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -26,6 +26,7 @@ MODEL_TO_SERIALIZER_FIELD_MAPPINGS = {
     'identifier__value': 'pid',
 }
 
+
 class ResourceSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'date_created',
@@ -126,6 +127,11 @@ class ResourceSerializer(JSONAPISerializer):
                 detail=f'Error updating PID for Resource with id [{instance._id}]: {e.message}',
                 source={'pointer': '/data/attributes/pid'},
             )
+        except IntegrityError:
+            raise JSONAPIException(
+                detail='A Resource with the provided PID and Resource Type already exists.',
+                source={'pointer': '/data/attributes'},
+            )
 
         finalized = validated_data.get('finalized')
         if finalized is not None:
@@ -156,9 +162,9 @@ class ResourceSerializer(JSONAPISerializer):
             error_sources = [
                 MODEL_TO_SERIALIZER_FIELD_MAPPINGS[field] for field in e.incomplete_fields
             ]
-        except IntegrityError as e:
+        except IntegrityError:
             raise JSONAPIException(
-                detail=str(e),
+                detail='A Resource with the provided DOI and Resource Type already exists.',
                 source={'pointer': '/data/attributes'},
             )
         else:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
We previously wouldn't let users `finalize` a resource that matched the PID and Resource Type of another `finalized` resource, but we had nothing in place to prevent them from updating an already `finalized` resource to match another `finalized` resource.

This PR fixes that broken expectation.

See: https://www.notion.so/cos/Integrity-not-enforced-for-already-finalized-resources-46e42f27b1f2431385acadb4d14d3567

## Changes
* Check for other (`finalized`, non-`deleted`) `OutcomeArtifacts` matching the current one after updating if the `OutcomeArtifact` being updated is `finalized` and raise an IntegrityError if any exists.
  * move the `@atomic` decorator to the `update` method instead of just the `_update_identifier helper method`
  * Similarly to the check in the `finalize` function, this explicit check can be replaced with a conditional constraint on the model following our Django upgrade.
* Update the Serializer to catch the `IntegrityError` from `update` instead of just from `finalize`
  * Update both error messages to be a bit more generic and exclude the specific details that were previously returned
* Tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-3962
