### PR TITLE
[Django Upgrade] [ENG-3947] Upgrade `django-elasticsearch-metrics`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ datacite==1.1.2
 
 
 # Metrics
-django-elasticsearch-metrics==5.0.0
+git+https://github.com/Johnetordoff/django-elasticsearch-metrics.git@update-django-3
 
 # Impact Metrics CSV Export
 djangorestframework-csv==2.1.0


### PR DESCRIPTION
## Purpose

Note: PR description added by reviewer.

Django 3.0 [Removed private Python 2 compatibility APIs](https://docs.djangoproject.com/en/4.0/releases/3.0/#removed-private-python-2-compatibility-apis) which includes the following change.

> `django.utils.six` - Remove usage of this vendored library or switch to `six`.

We have in-house library [django-elasticsearch-metrics](https://github.com/CenterForOpenScience/django-elasticsearch-metrics) that is affected. Here is the [PR](https://github.com/CenterForOpenScience/django-elasticsearch-metrics/pull/80) that updates the library.

## Changes

Update requirements to ping to a PR commit. It will be updated post-release when the aforementioned PR is merged.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

Part of https://openscience.atlassian.net/browse/ENG-3947
