### PR TITLE
[ENG-3962] Fix issues with Resource (A)VOLs

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1111,7 +1111,7 @@ class LinksField(ser.Field):
         return obj
 
     def _extend_url_with_vol_key(self, url):
-        return utils.extend_query_string_if_key_exists(url, self.context['request'], 'view_only')
+        return utils.extend_querystring_if_key_exists(url, self.context['request'], 'view_only')
 
     def to_representation(self, obj):
         ret = {}

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1110,11 +1110,8 @@ class LinksField(ser.Field):
         # not just the field attribute.
         return obj
 
-    def extend_absolute_info_url(self, obj):
-        return utils.extend_querystring_if_key_exists(obj.get_absolute_info_url(), self.context['request'], 'view_only')
-
-    def extend_absolute_url(self, obj):
-        return utils.extend_querystring_if_key_exists(obj.get_absolute_url(), self.context['request'], 'view_only')
+    def _extend_url_with_vol_key(self, url):
+        return utils.extend_query_string_if_key_exists(url, self.context['request'], 'view_only')
 
     def to_representation(self, obj):
         ret = {}
@@ -1123,16 +1120,18 @@ class LinksField(ser.Field):
                 url = _url_val(value, obj=obj, serializer=self.parent, request=self.context['request'])
             except SkipField:
                 continue
+
+            if name in ['self', 'info']:
+                ret[name] = self._extend_url_with_vol_key(url)
             else:
                 ret[name] = url
-        if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
-            ret['self'] = self.extend_absolute_url(obj)
+
+        if 'self' not in ret and hasattr(obj, 'get_absolute_url'):
+            ret['self'] = self._extend_url_with_vol_key(obj.get_absolute_url())
 
         if 'info' in ret:
             if hasattr(obj, 'get_absolute_info_url'):
-                ret['info'] = self.extend_absolute_info_url(obj)
-            else:
-                ret['info'] = utils.extend_querystring_if_key_exists(ret['info'], self.context['request'], 'view_only')
+                ret['info'] = self._extend_url_with_vol_key(obj.get_absolute_info_url())
 
         return ret
 

--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -40,8 +40,9 @@ class ResourceSerializer(JSONAPISerializer):
         'date_created',
         'date_modified',
         'description',
-        'registration',
         'links',
+        'registration',
+        'resource_type',
     ])
 
     class Meta:

--- a/api_tests/registrations/views/test_registration_resource_list.py
+++ b/api_tests/registrations/views/test_registration_resource_list.py
@@ -176,6 +176,15 @@ class TestRegistrationResourceListGETBehavior:
         resp = app.get(make_api_url(registration, vol_key=avol.key), auth=admin_user.auth)
         data = resp.json['data'][0]
         assert 'pid' not in data['attributes']
+        assert 'resource_type' in data['attributes']
+        assert 'description' in data['attributes']
+
+    def test_self_link_contains_vol_key(self, app, registration, artifact_one):
+        avol = PrivateLinkFactory(anonymous=True)
+        avol.nodes.add(registration)
+
+        resp = app.get(make_api_url(registration, vol_key=avol.key), auth=None)
+        assert resp.json['data'][0]['links']['self'].endswith(avol.key)
 
     def test_filtering(self, app, registration, artifact_one, artifact_two, admin_user):
         base_url = make_api_url(registration)

--- a/api_tests/resources/views/test_resource_detail.py
+++ b/api_tests/resources/views/test_resource_detail.py
@@ -165,7 +165,16 @@ class TestResourceDetailGETBehavior:
         resp = app.get(make_api_url(test_artifact, vol_key=avol.key), auth=None)
         data = resp.json['data']
         assert 'pid' not in data['attributes']
+        assert 'resource_type' in data['attributes']
+        assert 'description' in data['attributes']
 
+    def test_self_link_contains_vol_key(self, app):
+        test_artifact, test_auth, registration = configure_test_preconditions()
+        avol = PrivateLinkFactory(anonymous=True)
+        avol.nodes.add(registration)
+
+        resp = app.get(make_api_url(test_artifact, vol_key=avol.key), auth=None)
+        assert resp.json['data']['links']['self'].endswith(avol.key)
 
 @pytest.mark.django_db
 @mock.patch('osf.utils.identifiers.PID_VALIDATION_ENABLED', False)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Resources were not surfacing the `resource_type` in Anonymized contexts, and the `self` link for the Resources omitted the VOL, potentially leaking information for public registrations.

See:
https://www.notion.so/cos/Resource-self-link-does-not-inherit-VOL-key-723d274267cb4ad18768a2b6378cf6fe
https://www.notion.so/cos/resource-type-not-serialized-in-AVOLs-c09186bfee9e4b04b3ce2a02b22d51d8

## Changes
* Add `resource_type` to the `nonanonymized_fields` for a Resource
* Update `LinkFields` to always append an vol key to `self` links

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
 https://openscience.atlassian.net/browse/ENG-3962
