### PR TITLE
[ENG-3962] Prevent using the PID of the Primary Artifact as another Artifact

### DIFF
--- a/api_tests/resources/views/test_resource_detail.py
+++ b/api_tests/resources/views/test_resource_detail.py
@@ -391,6 +391,15 @@ class TestResourceDetailPATCHBehavior:
         assert resp.status_code == 400
         assert resp.json['errors'][0]['source']['pointer'] == '/data/attributes/pid'
 
+    def test_patch__pid__primary_artifact_pid_is_invalid(self, app):
+        test_artifact, test_auth, registration = configure_test_preconditions()
+        primary_doi = registration.get_identifier_value('doi')
+
+        payload = make_patch_payload(test_artifact, new_pid=primary_doi)
+        resp = app.patch_json_api(make_api_url(test_artifact), payload, auth=test_auth, expect_errors=True)
+        assert resp.status_code == 400
+        assert resp.json['errors'][0]['source']['pointer'] == '/data/attributes/pid'
+
     def test_patch__finalized__valid_resource(self, app):
         test_artifact, test_auth, _ = configure_test_preconditions()
         assert test_artifact.identifier.value

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -256,7 +256,7 @@ class NoSuchPIDError(InvalidPIDError):
 
 
 class IsPrimaryArtifactPIDError(InvalidPIDError):
-    ERROR_MESSAGE = '{value} is already in use as the PRIMARy PID for this Outcome'
+    ERROR_MESSAGE = 'Cannot assign {value} as a Resource {category}, as it represents the Registration itself'
 
 class UnsupportedArtifactTypeError(OSFError):
     pass

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -255,6 +255,9 @@ class NoSuchPIDError(InvalidPIDError):
     ERROR_MESSAGE = 'Could not find any record of PID with type {category} and value {value}'
 
 
+class IsPrimaryArtifactPIDError(InvalidPIDError):
+    ERROR_MESSAGE = '{value} is already in use as the PRIMARy PID for this Outcome'
+
 class UnsupportedArtifactTypeError(OSFError):
     pass
 

--- a/osf_tests/test_outcomes.py
+++ b/osf_tests/test_outcomes.py
@@ -8,6 +8,7 @@ from osf.exceptions import (
     CannotFinalizeArtifactError,
     InvalidPIDError,
     InvalidPIDFormatError,
+    IsPrimaryArtifactPIDError,
     NoPIDError,
     NoSuchPIDError,
     UnsupportedArtifactTypeError
@@ -227,6 +228,11 @@ class TestOutcomeArtifact:
 
         with pytest.raises(NoPIDError):
             test_artifact.update(new_pid_value='')
+
+    def test_update__new_pid__primary_pid_cannot_be_reused(self, outcome, registration_doi):
+        test_artifact = outcome.artifact_metadata.create(finalized=False)
+        with pytest.raises(IsPrimaryArtifactPIDError):
+            test_artifact.update(new_pid_value=registration_doi.value)
 
     @pytest.mark.parametrize('validation_error', [InvalidPIDError, InvalidPIDFormatError, NoSuchPIDError])
     def test_update__new_pid__reverts_and_reraises_on_invalid_pid(self, outcome, project_doi, validation_error):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Previously, you could add a Registration to its own list of Resources. Meanwhile the `RegistrationResourceList` was excluding entries  that referenced the Registration's DOI bu the but the `has_*` attributes on Registrations were not, leading to inconsistencies where the Registration was showing different badges than what was appearing on the Resources nav (in the case where the Registration was the only source of the badge).

It was [agreed](https://app.slack.com/client/T03LU72HEG4/C03SUSV5MS8/thread/C03SUSV5MS8-1660746232.846549) that we should prevent the Registration from being used as a resource (for now) but that we did not need to improve the filtering of the `has_*` attributes as the bad data is confined to Staging2.

See:
https://www.notion.so/cos/Difference-between-has-attributes-and-actual-resources-2cd2107b3e0e4780941a8dab1d5ec114

## Changes
* Add new exception class for when an Artifact is updated to use the PID of the PRIMARY Artifact on the Outcome
* Raise the error
* Tests for the error

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-3962
