### PR TITLE
[Django Upgrade] [ENG-3947] Move schema visibility/activeness update to `pytest` fixtures

### DIFF
--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -8,6 +8,7 @@ from api_tests.nodes.views.test_node_draft_registration_list import (
 )
 from api.base.settings.defaults import API_BASE
 
+from osf.migrations import ensure_invisible_and_inactive_schema
 from osf.models import DraftRegistration, NodeLicense, RegistrationProvider, Institution
 from osf_tests.factories import (
     RegistrationFactory,
@@ -19,6 +20,12 @@ from osf_tests.factories import (
 from osf.utils.permissions import READ, WRITE, ADMIN
 
 from website import mails, settings
+
+
+@pytest.fixture(autouse=True)
+def invisible_and_inactive_schema():
+    return ensure_invisible_and_inactive_schema()
+
 
 @pytest.mark.django_db
 class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):

--- a/api_tests/nodes/views/test_node_draft_registration_list.py
+++ b/api_tests/nodes/views/test_node_draft_registration_list.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
+from osf.migrations import ensure_invisible_and_inactive_schema
 from osf.models import RegistrationSchema, RegistrationProvider
 from osf_tests.factories import (
     ProjectFactory,
@@ -19,6 +20,12 @@ from website import settings
 
 OPEN_ENDED_SCHEMA_VERSION = 3
 SCHEMA_VERSION = 2
+
+
+@pytest.fixture(autouse=True)
+def invisible_and_inactive_schema():
+    return ensure_invisible_and_inactive_schema()
+
 
 @pytest.mark.django_db
 class DraftRegistrationTestCase:

--- a/api_tests/schemas/views/test_registration_schemas_detail.py
+++ b/api_tests/schemas/views/test_registration_schemas_detail.py
@@ -1,6 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
+from osf.migrations import ensure_invisible_and_inactive_schema
 from osf.models import RegistrationSchema
 from osf_tests.factories import (
     AuthUserFactory,
@@ -10,9 +11,11 @@ pytestmark = pytest.mark.django_db
 
 SCHEMA_VERSION = 2
 
+
 @pytest.fixture()
 def user():
     return AuthUserFactory()
+
 
 @pytest.fixture()
 def schema():
@@ -20,6 +23,11 @@ def schema():
         name='OSF Preregistration',
         schema_version=SCHEMA_VERSION
     ).first()
+
+
+@pytest.fixture(autouse=True)
+def invisible_and_inactive_schema():
+    return ensure_invisible_and_inactive_schema()
 
 
 class TestDeprecatedMetaSchemaDetail:

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -234,7 +234,7 @@ def ensure_default_storage_region():
 
 
 def ensure_datacite_file_schema():
-    ''' Test use only '''
+    """ Test use only """
     from osf.models import FileMetadataSchema
     with open('osf/metadata/schemas/datacite.json') as f:
         jsonschema = json.load(f)
@@ -246,3 +246,18 @@ def ensure_datacite_file_schema():
             'schema': jsonschema
         }
     )
+
+
+def ensure_invisible_and_inactive_schema():
+    """ Test use only """
+    from osf.models import RegistrationSchema
+    v2_inactive_schema = [
+        'EGAP Project',
+        'OSF Preregistration',
+        'Confirmatory - General',
+        'RIDIE Registration - Study Complete',
+        'RIDIE Registration - Study Initiation',
+    ]
+    v2_inactive_schema = v2_inactive_schema + ['Election Research Preacceptance Competition']
+    RegistrationSchema.objects.filter(name__in=v2_inactive_schema).update(visible=False)
+    RegistrationSchema.objects.filter(name__in=v2_inactive_schema).update(active=False)


### PR DESCRIPTION
## Purpose

Move schema visibility/activeness update to pytest fixtures to fix the following errors, which was caused by a registration schema named "Election Research Preacceptance Competition" being visible/active while the tests expect it not to be. This fix is similar to what we did in https://github.com/CenterForOpenScience/osf.io/pull/9994. 

```
___ TestDraftRegistrationCreateWithNode.test_registration_supplement_errors ____
api_tests/nodes/views/test_node_draft_registration_list.py:453: in test_registration_supplement_errors
    name='Election Research Preacceptance Competition', active=False)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/query.py:380: in get
    self.model._meta.object_name
E   osf.models.metaschema.DoesNotExist: RegistrationSchema matching query does not exist.

__ TestDraftRegistrationCreateWithoutNode.test_registration_supplement_errors __
api_tests/nodes/views/test_node_draft_registration_list.py:453: in test_registration_supplement_errors
    name='Election Research Preacceptance Competition', active=False)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/query.py:380: in get
    self.model._meta.object_name
E   osf.models.metaschema.DoesNotExist: RegistrationSchema matching query does not exist.

_______ TestDraftRegistrationCreate.test_registration_supplement_errors ________
api_tests/nodes/views/test_node_draft_registration_list.py:453: in test_registration_supplement_errors
    name='Election Research Preacceptance Competition', active=False)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/query.py:380: in get
    self.model._meta.object_name
E   osf.models.metaschema.DoesNotExist: RegistrationSchema matching query does not exist.

_________ TestRegistrationSchemaDetail.test_schemas_detail_visibility __________
api_tests/schemas/views/test_registration_schemas_detail.py:68: in test_schemas_detail_visibility
    name='Election Research Preacceptance Competition', active=False)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/query.py:380: in get
    self.model._meta.object_name
E   osf.models.metaschema.DoesNotExist: RegistrationSchema matching query does not exist.

_______ TestDraftRegistrationCreate.test_registration_supplement_errors ________
api_tests/nodes/views/test_node_draft_registration_list.py:453: in test_registration_supplement_errors
    name='Election Research Preacceptance Competition', active=False)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/manager.py:85: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/django/db/models/query.py:380: in get
    self.model._meta.object_name
E   osf.models.metaschema.DoesNotExist: RegistrationSchema matching query does not exist.
```

## Changes

* Added a helper method `ensure_invisible_and_inactive_schema()` in [osf/migrations/__init__.py](https://github.com/CenterForOpenScience/osf.io/pull/10029/files#diff-f9f622f16b6189ac69b1a76f13b68529cb4b067375da22ce25265bdf044525e9) to update invisible and inactive schemas.

* The following fixtures is added to each tests file that fails. The fixture is not explicitly used but is called before tests are run to update the schema in the test database.

```python
@pytest.fixture(autouse=True)
def invisible_and_inactive_schema():
    return ensure_invisible_and_inactive_schema()
```

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-3947