### PR TITLE
Fix DOI Updating

### DIFF
--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -1,5 +1,4 @@
 import datetime
-import mock
 
 import pytest
 from django.core.management import call_command
@@ -16,7 +15,6 @@ from website.identifiers.clients import CrossRefClient
 
 
 @pytest.mark.django_db
-@mock.patch('website.settings.DATACITE_ENABLED', True)
 class TestSyncDOIs:
 
     @pytest.fixture()

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -1,8 +1,10 @@
-import pytest
 import datetime
+import mock
+
+import pytest
+from django.core.management import call_command
 from django.utils import timezone
 
-from django.core.management import call_command
 
 from osf_tests.factories import (
     PreprintFactory,
@@ -14,6 +16,7 @@ from website.identifiers.clients import CrossRefClient
 
 
 @pytest.mark.django_db
+@mock.patch('website.settings.DATACITE_ENABLED', True)
 class TestSyncDOIs:
 
     @pytest.fixture()
@@ -26,8 +29,9 @@ class TestSyncDOIs:
     @pytest.fixture()
     def registration(self):
         registration = RegistrationFactory()
-        doi = registration.request_identifier_update('doi')
-        registration.set_identifier_value('doi', doi)
+        doi = registration.request_identifier('doi')['doi']
+        print(doi)
+        registration.set_identifier_value(category='doi', value=doi)
         registration.is_public = True
         registration.save()
         return registration

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -30,7 +30,6 @@ class TestSyncDOIs:
     def registration(self):
         registration = RegistrationFactory()
         doi = registration.request_identifier('doi')['doi']
-        print(doi)
         registration.set_identifier_value(category='doi', value=doi)
         registration.is_public = True
         registration.save()

--- a/osf/management/commands/sync_doi_metadata.py
+++ b/osf/management/commands/sync_doi_metadata.py
@@ -7,7 +7,6 @@ from django.core.management.base import BaseCommand
 from osf.models import Identifier
 
 from framework.celery_tasks import app
-from framework.celery_tasks.handlers import enqueue_task
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ def sync_doi_metadata(modified_date, batch_size=100, dry_run=True, sync_private=
     for identifier in identifiers:
         if not dry_run:
             if (identifier.referent.is_public and not identifier.referent.deleted and not identifier.referent.is_retracted) or sync_private:
-                enqueue_task(sync_identifier_doi.s(identifier))
+                sync_identifier_doi.apply_async(kwargs={'identifier': identifier})
 
         logger.info(f'{"[DRY RUN]: " if dry_run else ""}'
                     f' doi minting for {identifier.value} started')

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -152,7 +152,7 @@ class DataCiteClient(AbstractIdentifierClient):
             raise NotImplementedError('Updating metadata not supported for {}'.format(category))
 
         # Reuse create logic to post updated metadata if the resource is still public
-        if node.is_public and not node.is_deleted:
+        if node.is_public and not node.deleted:
             return self.create_identifier(node, category)
 
         doi = node.get_identifier_value('doi') or self.build_doi(node)

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import logging
 
-import re
 import datetime
+import logging
+import re
 
-from website.identifiers.clients.base import AbstractIdentifierClient
-from website import settings
 from datacite import DataCiteMDSClient, schema43
 from django.core.exceptions import ImproperlyConfigured
+
 from osf.metadata.utils import datacite_format_subjects, datacite_format_contributors, datacite_format_creators
+from website.identifiers.clients.base import AbstractIdentifierClient
+from website import settings
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +30,9 @@ class DataCiteClient(AbstractIdentifierClient):
             prefix=getattr(node.provider, 'doi_prefix', None) or settings.DATACITE_PREFIX
         )
 
-    def build_metadata(self, node, as_xml=True):
+    def build_metadata(self, node, doi_value=None, as_xml=True):
         """Return the formatted datacite metadata XML as a string.
-         """
+        """
         non_bib_contributors = node.contributors.filter(
             contributor__visible=False,
             contributor__node=node.id
@@ -61,7 +62,7 @@ class DataCiteClient(AbstractIdentifierClient):
         data = {
             'identifiers': [
                 {
-                    'identifier': self.build_doi(node),
+                    'identifier': doi_value or self.build_doi(node),
                     'identifierType': 'DOI',
                 }
             ],
@@ -130,29 +131,34 @@ class DataCiteClient(AbstractIdentifierClient):
         self._client.doi_get(identifier)
 
     def create_identifier(self, node, category):
-        if category == 'doi':
-            metadata = self.build_metadata(node)
-            if settings.DATACITE_ENABLED:
-                resp = self._client.metadata_post(metadata)
-                # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695
-                doi = re.match(r'OK \((?P<doi>[a-zA-Z0-9 .\/]{0,})\)', resp).groupdict()['doi']
-                self._client.doi_post(doi, node.absolute_url)
-                return {'doi': doi, 'metadata': metadata}
-            logger.info('TEST ENV: DOI built but not minted')
-            return {'doi': self.build_doi(node), 'metadata': metadata}
-        else:
+        if category != 'doi':
             raise NotImplementedError('Creating an identifier with category {} is not supported'.format(category))
 
-    def update_identifier(self, node, category):
-        if settings.DATACITE_ENABLED and not node.is_public or node.is_deleted:
-            if category == 'doi':
-                doi = self.build_doi(node)
-                self._client.metadata_delete(doi)
-                return {'doi': doi}
-            else:
-                raise NotImplementedError('Updating metadata not supported for {}'.format(category))
+        doi_value = node.get_identifier_value('doi') or self.build_doi(node)
+        metadata = self.build_metadata(node, doi_value=doi_value)
+        if settings.DATACITE_ENABLED:
+            resp = self._client.metadata_post(metadata)
+            # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695
+            doi = re.match(r'OK \((?P<doi>[a-zA-Z0-9 .\/]{0,})\)', resp).groupdict()['doi']
+            self._client.doi_post(doi, node.absolute_url)
+            return {'doi': doi, 'metadata': metadata}
         else:
+            logger.info('TEST ENV: DOI built but not minted')
+
+        return {'doi': doi_value, 'metadata': metadata}
+
+    def update_identifier(self, node, category):
+        if category != 'doi':
+            raise NotImplementedError('Updating metadata not supported for {}'.format(category))
+
+        # Reuse create logic to post updated metadata if the resource is still public
+        if node.is_public and not node.is_deleted:
             return self.create_identifier(node, category)
+
+        doi = node.get_identifier_value('doi') or self.build_doi(node)
+        if settings.DATACITE_ENABLED:
+            self._client.metadata_delete(doi)
+        return {'doi': doi}
 
 
 def _format_related_identifiers(node):
@@ -160,13 +166,18 @@ def _format_related_identifiers(node):
 
     related_identifiers = []
     if node.type == 'osf.registration':
+        # Only include active resources and only include each resource once
+        related_pids = OutcomeArtifact.objects.for_registration(node).filter(
+            finalized=True,
+            deleted__isnull=True
+        ).order_by('artifact_type').values_list('pid', flat=True)
         related_identifiers = [
             {
-                'relatedIdentifier': artifact.pid,
+                'relatedIdentifier': pid,
                 'relatedIdentifierType': 'DOI',
                 'relationType': 'IsSupplementedBy',
             }
-            for artifact in OutcomeArtifact.objects.for_registration(node)
+            for pid in set(related_pids)
         ]
 
     if node.article_doi:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
DOI update was failing validation due to the inclusion of duplicates. It also wasn't excluding deleted Resources or non-final Resources, and there were some lingering issues with the existing Datacite update logic to be resolved.

## Changes
* Only list each resource as a `relatedIdentifier` one time
* Exclude deleted and non-finalized Resources from the `relatedIdentifiers`
* Add tests for these cases
* Use known DOI values for the node when updating DOIs instead of always inferring
* Fix the logical flow within `DataciteClient.update_identifier`
* Fix tests for the sync_dois management command


<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
