### PR TITLE
Normalize PID input

### DIFF
--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -12,6 +12,7 @@ from osf.models.base import BaseModel, ObjectIDMixin
 from osf.models.identifiers import Identifier
 from osf.utils import outcomes as outcome_utils
 from osf.utils.fields import NonNaiveDateTimeField
+from osf.utils.identifiers import normalize_identifier
 
 
 '''
@@ -165,8 +166,12 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
         if not new_pid_value:
             raise NoPIDError('Cannot assign an empty PID value')
 
+        normalized_pid_value = normalize_identifier(new_pid_value)
+        if self.identifier and normalized_pid_value == self.identifier.value:
+            return
+
         new_identifier, created = Identifier.objects.get_or_create(
-            value=new_pid_value, category=pid_type
+            value=normalized_pid_value, category=pid_type
         )
 
         # Reraise these errors all the way to API

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -85,5 +85,5 @@ class DOIValidator(PIDValidator):
 
 def normalize_identifier(pid_value):
     '''Extract just the PID Value from a possible full URI.'''
-    pid_value_expression = '(http://|https://)?(doi.org/)?(?P<pid_value>.*)'
+    pid_value_expression = '(.*://)?(doi.org/)?(?P<pid_value>.*)'
     return re.match(pid_value_expression, pid_value).group('pid_value')

--- a/osf/utils/identifiers.py
+++ b/osf/utils/identifiers.py
@@ -1,4 +1,5 @@
 import abc
+import re
 from urllib.parse import urljoin
 
 import requests
@@ -80,3 +81,9 @@ class DOIValidator(PIDValidator):
             pid_exception = InvalidPIDError
 
         raise pid_exception(pid_value=doi_value, pid_category='DOI')
+
+
+def normalize_identifier(pid_value):
+    '''Extract just the PID Value from a possible full URI.'''
+    pid_value_expression = '(http://|https://)?(doi.org/)?(?P<pid_value>.*)'
+    return re.match(pid_value_expression, pid_value).group('pid_value')

--- a/osf_tests/test_outcomes.py
+++ b/osf_tests/test_outcomes.py
@@ -247,6 +247,16 @@ class TestOutcomeArtifact:
         assert test_artifact.identifier == project_doi
         assert not Identifier.objects.filter(value=invalid_identifier).exists()
 
+    @pytest.mark.parametrize('protocol', ['http://', 'https://', ''])
+    @pytest.mark.parametrize('domain', ['doi.org/', ''])
+    def test_update__new_pid__normalizes_pid_value(self, outcome, project_doi, protocol, domain):
+        test_artifact = outcome.artifact_metadata.create(identifier=project_doi)
+        base_pid_value = 'new_pid'
+        provided_pid_value = f'{protocol}{domain}{base_pid_value}'
+
+        test_artifact.update(new_pid_value=provided_pid_value)
+        assert test_artifact.identifier.value == base_pid_value
+
     def test_update__enforces_uniqueness_if_finalized(self, outcome, project_doi):
         outcome.artifact_metadata.create(
             identifier=project_doi, artifact_type=ArtifactTypes.DATA, finalized=True

--- a/osf_tests/test_outcomes.py
+++ b/osf_tests/test_outcomes.py
@@ -247,7 +247,7 @@ class TestOutcomeArtifact:
         assert test_artifact.identifier == project_doi
         assert not Identifier.objects.filter(value=invalid_identifier).exists()
 
-    @pytest.mark.parametrize('protocol', ['http://', 'https://', ''])
+    @pytest.mark.parametrize('protocol', ['http://', 'https://', 'ftp://', ''])
     @pytest.mark.parametrize('domain', ['doi.org/', ''])
     def test_update__new_pid__normalizes_pid_value(self, outcome, project_doi, protocol, domain):
         test_artifact = outcome.artifact_metadata.create(identifier=project_doi)

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -146,7 +146,9 @@ class TestDataCiteClient:
                 'relationType': 'IsSupplementTo',
             },
         ]
-        assert metadata_dict['relatedIdentifiers'] == expected_relationships
+        formatted_relationships = metadata_dict['relatedIdentifiers']
+        sort_func = lambda x: x['relatedIdentifier']
+        assert sorted(formatted_relationships, key=sort_func) == sorted(expected_relationships, key=sort_func)
 
     def test_datacite_format_related_resources__ignores_duplicate_pids(self, datacite_client):
         registration = RegistrationFactory(is_public=True, has_doi=True)

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -170,7 +170,7 @@ def _format_related_identifiers(node):
         related_pids = OutcomeArtifact.objects.for_registration(node).filter(
             finalized=True,
             deleted__isnull=True
-        ).order_by('artifact_type').values_list('pid', flat=True)
+        ).values_list('pid', flat=True)
         related_identifiers = [
             {
                 'relatedIdentifier': pid,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Apparently, when urljoin receives a properly-formed URL (with protocol) as its second argument, it just returns that. So we were following random links if given as a PID value. No bueno. We've also wanted to not blow up on users when they pass the full DOI URI (doi.org/<10.xyz>). This PR resolves both of those problems.

## Changes
* Add a `normalize_identifier` function to extract just the identifier value from a given pid uri
* Use `normalize_identifier` before attempting to update the PID
* Tests
* Fix unrelated probabilistic test fail
  * order_by works weird followed by value list and ordering of `relatedIdentifiers` doesn't really mater, so remove it and make the test pass another way
 
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
