### PR TITLE
[Django Upgrade] [ENG-3948] Fix session cookie decoding issue

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -12,6 +12,7 @@ from weakref import WeakKeyDictionary
 from werkzeug.local import LocalProxy
 
 from framework.celery_tasks.handlers import enqueue_task
+from osf.utils.fields import ensure_str
 from framework.flask import redirect
 from framework.sessions.utils import remove_session
 from website import settings
@@ -158,10 +159,10 @@ def before_request():
     cookie = request.cookies.get(settings.COOKIE_NAME)
     if cookie:
         try:
-            session_id = itsdangerous.Signer(settings.SECRET_KEY).unsign(cookie)
+            session_id = ensure_str(itsdangerous.Signer(settings.SECRET_KEY).unsign(cookie))
             user_session = Session.load(session_id) or Session(_id=session_id)
         except itsdangerous.BadData:
-            return
+            return None
         if not throttle_period_expired(user_session.created, settings.OSF_SESSION_TIMEOUT):
             # Update date last login when making non-api requests
             from framework.auth.tasks import update_user_from_activity

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -47,7 +47,7 @@ from osf.models.session import Session
 from osf.models.tag import Tag
 from osf.models.validators import validate_email, validate_social, validate_history_item
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
-from osf.utils.fields import NonNaiveDateTimeField, LowercaseEmailField
+from osf.utils.fields import NonNaiveDateTimeField, LowercaseEmailField, ensure_str
 from osf.utils.names import impute_names
 from osf.utils.requests import check_select_for_update
 from osf.utils.permissions import API_CONTRIBUTOR_PERMISSIONS, MANAGER, MEMBER, MANAGE, ADMIN
@@ -1746,12 +1746,11 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         secret = secret or settings.SECRET_KEY
 
         try:
-            token = itsdangerous.Signer(secret).unsign(cookie)
+            session_id = ensure_str(itsdangerous.Signer(secret).unsign(cookie))
         except itsdangerous.BadSignature:
             return None
 
-        user_session = Session.load(token)
-
+        user_session = Session.load(session_id)
         if user_session is None:
             return None
 


### PR DESCRIPTION
## Purpose

This PR fixes an issue with the session object that arose with our `itsdangerous` library during the Django upgrade. I'm unsure exactly why this changed because our `itsdangerous` library is still pegged at the same version, but the fix seems simple enough.

Updated by CR:

This might be related with Django removed `bytestring` support in 2.0

https://docs.djangoproject.com/en/4.1/releases/2.0/#removed-support-for-bytestrings-in-some-places

The `ensure_str()` that we added for the `drf` cookies is from @Johnetordoff 's upgrade touch-up PR: https://github.com/CenterForOpenScience/osf.io/pull/9398 ⭐ .

The two cases here are outside DRF, one for old `flask` session/auth and the other for v1 `addon/files`.

## Changes

## QA Notes

## Documentation

## Side Effects

## Ticket

Part of https://openscience.atlassian.net/browse/ENG-3948
