### PR TITLE
Set cookie samesite to 'Lax' for local env

### DIFF
--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -70,7 +70,8 @@ COOKIE_NAME = 'osf'
 OSF_COOKIE_DOMAIN = None
 SECRET_KEY = 'CHANGEME'
 SESSION_COOKIE_SECURE = SECURE_MODE
-SESSION_COOKIE_SAMESITE = 'None'
+# Cookie will be blocked if set to 'None' in local env with HTTP where COOKIE_SECURE is disabled
+SESSION_COOKIE_SAMESITE = 'Lax'
 OSF_SERVER_KEY = None
 OSF_SERVER_CERT = None
 


### PR DESCRIPTION
## Purpose

`SameSite=None` breaks local environment since it is blocked by the browser when OSF tries to set it via HTTP.

As is confirmed by [SameSite#none](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none)

> Cookies will be sent in all contexts, i.e. in responses to both first-party and cross-site requests. If SameSite=None is set, the cookie Secure attribute must also be set (or the cookie will be blocked).

### Note

I am not sure what the settings are for our servers. This change only affects local env but may create a difference between local and server.

## Changes

`SESSION_COOKIE_SAMESITE` is now set to `'Lax'` instead of `'None'` for local development

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
