### PR TITLE
[Django Upgrade] [ ENG-3498] Fix Draft Registration Serializer

### DIFF
--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -143,6 +143,7 @@ class DraftRegistrationDetailSerializer(DraftRegistrationSerializer, DraftRegist
     Overrides DraftRegistrationLegacySerializer to make id required.
     registration_supplement, node, cannot be changed after draft has been created.
     """
+    id = IDField(source='_id', required=True)
 
     registration_schema = RegistrationSchemaRelationshipField(
         related_view='schemas:registration-schema-detail',

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -16,6 +16,7 @@ from api.nodes.serializers import (
     NodeContributorsSerializer,
     NodeContributorsCreateSerializer,
     NodeContributorDetailSerializer,
+    RegistrationSchemaRelationshipField,
 )
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
 from osf.exceptions import DraftRegistrationStateError
@@ -142,6 +143,13 @@ class DraftRegistrationDetailSerializer(DraftRegistrationSerializer, DraftRegist
     Overrides DraftRegistrationLegacySerializer to make id required.
     registration_supplement, node, cannot be changed after draft has been created.
     """
+
+    registration_schema = RegistrationSchemaRelationshipField(
+        related_view='schemas:registration-schema-detail',
+        related_view_kwargs={'schema_id': '<registration_schema._id>'},
+        required=False,
+        read_only=False,
+    )
 
     links = LinksField({
         'self': 'get_self_url',

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -19,14 +19,14 @@ from api.nodes.serializers import (
 )
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
 from osf.exceptions import DraftRegistrationStateError
+from osf.models import Node
 from website import settings
 
 
 class NodeRelationshipField(RelationshipField):
 
     def to_internal_value(self, node_id):
-        node = self.context['view'].get_node(node_id=node_id) if node_id else None
-        return {'branched_from': node}
+        return {'branched_from': Node.load(node_id)}
 
 
 class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, TaxonomizableSerializerMixin):


### PR DESCRIPTION
## Purpose

Replaces https://github.com/CenterForOpenScience/osf.io/pull/10034/
Reference PR: https://github.com/CenterForOpenScience/osf.io/pull/10057

## Changes

### Fixes for DRF MRO

For details of the DRF MRO change, refer to this [issue](https://github.com/encode/django-rest-framework/issues/5798) and [PR](https://github.com/encode/django-rest-framework/pull/6980) for DRF.

* `DraftRegistrationDetailSerializer` inherits from `DraftRegistrationSerializer` and `DraftRegistrationDetailLegacySerializer)`. Both of them define (or further inherits) `registration_schema = RegistrationSchemaRelationshipField(...)` with different params. The former inherits from `DraftRegistrationLegacySerializer` where `required=True` and `read_only=False`. The latter uses the default (both `False`). The DRF MRO upgrade led to `DraftRegistrationDetailSerializer` picking the wrong `registration_schema` to inherit and thus the fix is to define it here with the correct params.

* Similarly, `id = IDField(...)` needs to be defined the same way since parents/grandparents have different definitions of the same field (eg. `id = IDField(source='_id', required=True)` vs `id = IDField(source='_id', read_only=True)`. As expected, the wrong one is inherited after the DRF upgrade and the fix is to define it here.

### Other fixes

* Fixed an issue where `.get_node()` is not available from `self.context.get['view'] 

## QA Notes

## Documentation

## Side Effects

## Ticket
