### PR TITLE
[Django Upgrade] Fix from_db_value & to_python in EncryptedJSONField

### DIFF
--- a/osf/utils/fields.py
+++ b/osf/utils/fields.py
@@ -98,8 +98,8 @@ class EncryptedJSONField(JSONField):
         return super(EncryptedJSONField, self).get_prep_value(value, **kwargs)
 
     def to_python(self, value):
-        value = rapply(value, decrypt_string, prefix=self.prefix)
-        return super(EncryptedJSONField, self).from_db_value(value, None, None)
+        return rapply(value, decrypt_string, prefix=self.prefix)
 
     def from_db_value(self, value, expression, connection):
+        value = super(EncryptedJSONField, self).from_db_value(value, expression, connection)
         return self.to_python(value)


### PR DESCRIPTION
* super.from_db_value must be called first since it is expected to only work on the raw value retrieved from DB
* moved super.from_db_value call to from_db_value and let to_python call from_db_value instead of the other way around
