### PR TITLE
[hotfix] keen replacement followup

### DIFF
--- a/framework/sentry/__init__.py
+++ b/framework/sentry/__init__.py
@@ -35,7 +35,7 @@ def log_exception():
     })
 
 
-def log_message(message, extra_data=None):
+def log_message(message, extra_data=None, level=logging.ERROR):
     if not enabled:
         logger.warning(
             'Sentry called to log message, but is not active: %s' % message
@@ -48,4 +48,4 @@ def log_message(message, extra_data=None):
         extra_data = {}
     extra.update(extra_data)
 
-    return sentry.captureMessage(message, extra=extra)
+    return sentry.captureMessage(message, extra=extra, level=level)

--- a/osf/metrics/reporters/new_user_domain.py
+++ b/osf/metrics/reporters/new_user_domain.py
@@ -31,7 +31,7 @@ class NewUserDomainReporter(DailyReporter):
 
     def keen_events_from_report(self, report):
         events = [
-            {'domain': report.domain_name, 'date': report.report_date}
+            {'domain': report.domain_name, 'date': str(report.report_date)}
             for _ in range(report.new_user_count)
         ]
         return {

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -3,6 +3,7 @@
 import datetime
 import time
 import functools
+import logging
 
 import furl
 import itsdangerous
@@ -1667,7 +1668,11 @@ class TestAddonFileViews(OsfTestCase):
             'modified': '2016-08-22T13:54:32.100900'
         }
         file_node.update(revision=None, user=None, data=data)
-        mock_capture.assert_called_with(str('update() receives metatdata older than the newest entry in file history.'), extra={'session': {}})
+        mock_capture.assert_called_with(
+            'update() receives metatdata older than the newest entry in file history.',
+            extra={'session': {}},
+            level=logging.ERROR,
+        )
 
 class TestLegacyViews(OsfTestCase):
 

--- a/tests/test_institutions/test_affiliation_via_orcid.py
+++ b/tests/test_institutions/test_affiliation_via_orcid.py
@@ -14,6 +14,10 @@ from website.settings import ORCID_RECORD_EDUCATION_PATH, ORCID_RECORD_EMPLOYMEN
 
 @pytest.mark.django_db
 class TestInstitutionAffiliationViaOrcidSso:
+    @pytest.fixture(autouse=True)
+    def disable_sentry(self):
+        with mock.patch('framework.sentry.enabled', False):
+            yield
 
     @pytest.fixture()
     def response_content_educations(self):

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -8,7 +8,7 @@ from framework import sentry
 @queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
-    sentry.log_message(f'Updating DOI for [{target_guid}]')
+    sentry.log_message('Updating DOI for guid', extra_data={'guid': target_guid})
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     if target_object.get_identifier('doi'):

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -1,3 +1,4 @@
+import logging
 from django.apps import apps
 
 from framework.celery_tasks import app as celery_app
@@ -8,7 +9,7 @@ from framework import sentry
 @queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
-    sentry.log_message('Updating DOI for guid', extra_data={'guid': target_guid})
+    sentry.log_message('Updating DOI for guid', extra_data={'guid': target_guid}, level=logging.INFO)
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     if target_object.get_identifier('doi'):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fix some problems which arose overnight
<!-- Describe the purpose of your changes -->

## Changes
- explicitly stringify the `date` when sending `NewUserDomainReports` to keen
- replace naively recursive `_get_surrounding_guids` with iterative version, because turns out *some* nodes are >650 deep
- update unrelated sentry log to put the guid in `extra_data` so sentry knows how to aggregate it
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
