### PR TITLE
Proposed changes to the docker-compose and docker-compose-dist.override files

### DIFF
--- a/docker-compose-dist.override.yml
+++ b/docker-compose-dist.override.yml
@@ -113,3 +113,111 @@ version: "3.4"
 #      - ./ssl/celery-server.cert.pem:/etc/ssl/server_certificate.pem:ro
 #      - ./ssl/celery-server.key.pem:/etc/ssl/server_key.pem:ro
 #      - ./ssl/ca-chain.cert.pem:/etc/ssl/ca_certificate.pem:ro
+
+
+# Reference README-docker-compose.md for instructions.
+
+
+# overrides for the 
+services:
+
+  ###################
+  # Shared Services #
+  ###################
+
+  elasticsearch:
+    platform: linux/amd64
+
+  #######
+  # OSF #
+  #######
+
+  requirements:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+
+  assets:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+
+  admin_assets:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+
+  worker:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    # Add a comment to # - elasticsearch      #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+    depends_on:
+      - postgres
+      - rabbitmq
+      - elasticsearch
+
+  admin:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    # Add a comment to # - elasticsearch      #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+    depends_on:
+      - postgres
+      - rabbitmq
+      - elasticsearch
+
+  api:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    # Add a comment to # - elasticsearch      #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+    depends_on:
+      - postgres
+      - rabbitmq
+      - elasticsearch
+
+  web:
+    ###########################################
+    # Apple Chipset                           #
+    # Remove the comments below              #
+    # Add a comment to # - elasticsearch      #
+    ###########################################
+    # image: osf:develop-arm64
+    # platform: linux/arm64
+    # Need to allocate tty to be able to call invoke for requirements task
+    # tty: true
+    depends_on:
+      - postgres
+      - rabbitmq
+      - elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -414,10 +414,6 @@ services:
     image: quay.io/centerforopenscience/osf:develop
     command: invoke celery_worker
     restart: unless-stopped
-    depends_on:
-      - postgres
-      - rabbitmq
-      - elasticsearch
     environment:
       C_FORCE_ROOT: 1
       DJANGO_SETTINGS_MODULE: api.base.settings
@@ -442,10 +438,6 @@ services:
       DJANGO_SETTINGS_MODULE: admin.base.settings
     ports:
       - 8001:8001
-    depends_on:
-      - postgres
-      - rabbitmq
-      - elasticsearch
     env_file:
       - .docker-compose.env
     stdin_open: true
@@ -463,10 +455,6 @@ services:
     restart: unless-stopped
     ports:
       - 8000:8000
-    depends_on:
-      - postgres
-      - rabbitmq
-      - elasticsearch
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
     env_file:
@@ -484,10 +472,6 @@ services:
     restart: unless-stopped
     ports:
       - 5000:5000
-    depends_on:
-      - postgres
-      - rabbitmq
-      - elasticsearch
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
     env_file:


### PR DESCRIPTION
## Purpose

Proposed changes to the docker-compose and docker-compose-dist.override files files to make them more maintainable.

## Changes

Since the docker override merge feature does not allow for `subtractive` merging it will be best to have the `depends_on` in the override so if someone comments out a dependency it will be respected in the merged `docker-compose` file.

What are the areas of risk?

A typo?

## Documentation

Documentation changes are in another PR
