### PR TITLE
[Django Upgrade] [ENG-4072] The Rest - Part 2

### DIFF
--- a/admin_tests/institutions/test_views.py
+++ b/admin_tests/institutions/test_views.py
@@ -3,8 +3,8 @@ import json
 from nose import tools as nt
 from django.test import RequestFactory
 from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-
 
 from tests.base import AdminTestCase
 from osf_tests.factories import (
@@ -12,7 +12,7 @@ from osf_tests.factories import (
     InstitutionFactory,
     ProjectFactory
 )
-from osf.models import Institution, Node
+from osf.models import Institution, Node, AbstractNode
 
 from admin_tests.utilities import setup_form_view, setup_user_view
 
@@ -208,7 +208,10 @@ class TestAffiliatedNodeList(AdminTestCase):
         self.institution = InstitutionFactory()
 
         self.user = AuthUserFactory()
-        self.view_node = Permission.objects.get(codename='view_node')
+        self.view_node = Permission.objects.filter(
+            codename='view_node',
+            content_type_id=ContentType.objects.get_for_model(AbstractNode).id
+        ).first()
         self.user.user_permissions.add(self.view_node)
         self.user.affiliated_institutions.add(self.institution)
         self.user.save()

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -6,7 +6,7 @@ import pytz
 import datetime
 import responses
 
-from osf.models import AdminLogEntry, NodeLog
+from osf.models import AdminLogEntry, NodeLog, AbstractNode
 from admin.nodes.views import (
     NodeDeleteView,
     NodeRemoveContributorView,
@@ -29,6 +29,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from framework.auth.core import Auth
 
 from tests.base import AdminTestCase
@@ -97,7 +98,10 @@ class TestNodeView(AdminTestCase):
         node = ProjectFactory()
         guid = node._id
 
-        change_permission = Permission.objects.get(codename='view_node')
+        change_permission = Permission.objects.filter(
+            codename='view_node',
+            content_type_id=ContentType.objects.get_for_model(AbstractNode).id
+        ).first()
         user.user_permissions.add(change_permission)
         user.save()
 
@@ -153,7 +157,10 @@ class TestNodeDeleteView(AdminTestCase):
         guid = self.node._id
 
         change_permission = Permission.objects.get(codename='delete_node')
-        view_permission = Permission.objects.get(codename='view_node')
+        view_permission = Permission.objects.filter(
+            codename='view_node',
+            content_type_id=ContentType.objects.get_for_model(AbstractNode).id
+        ).first()
         user.user_permissions.add(change_permission)
         user.user_permissions.add(view_permission)
         user.save()
@@ -226,7 +233,10 @@ class TestRemoveContributor(AdminTestCase):
 
     def test_correct_view_permissions(self):
         change_permission = Permission.objects.get(codename='change_node')
-        view_permission = Permission.objects.get(codename='view_node')
+        view_permission = Permission.objects.filter(
+            codename='view_node',
+            content_type_id=ContentType.objects.get_for_model(AbstractNode).id
+        ).first()
         self.user.user_permissions.add(change_permission)
         self.user.user_permissions.add(view_permission)
         self.user.save()

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -414,7 +414,7 @@ class TestUserSearchView(AdminTestCase):
         nt.assert_true(form.is_valid())
         response = self.view.form_valid(form)
         nt.assert_equal(response.status_code, 302)
-        nt.assert_equal(response._headers['location'][1], '/users/{}/'.format(self.user_1.guids.first()._id))
+        nt.assert_equal(response.headers['location'], '/users/{}/'.format(self.user_1.guids.first()._id))
 
     def test_search_user_by_name(self):
         form_data = {
@@ -424,7 +424,7 @@ class TestUserSearchView(AdminTestCase):
         nt.assert_true(form.is_valid())
         response = self.view.form_valid(form)
         nt.assert_equal(response.status_code, 302)
-        nt.assert_equal(response._headers['location'][1], '/users/search/Hardy/')
+        nt.assert_equal(response.headers['location'], '/users/search/Hardy/')
 
     def test_search_user_by_name_with_punctuation(self):
         form_data = {
@@ -434,7 +434,7 @@ class TestUserSearchView(AdminTestCase):
         nt.assert_true(form.is_valid())
         response = self.view.form_valid(form)
         nt.assert_equal(response.status_code, 302)
-        nt.assert_equal(response._headers['location'][1], '/users/search/Dr.%20Sportello-Fay,%20PI%20@,%20%23,%20$,%20%25,%20%5E,%20&,%20*,%20(,%20),%20~/')
+        nt.assert_equal(response.headers['location'], '/users/search/Dr.%20Sportello-Fay,%20PI%20@,%20%23,%20$,%20%25,%20%5E,%20&,%20*,%20(,%20),%20~/')
 
     def test_search_user_by_username(self):
         form_data = {
@@ -444,7 +444,7 @@ class TestUserSearchView(AdminTestCase):
         nt.assert_true(form.is_valid())
         response = self.view.form_valid(form)
         nt.assert_equal(response.status_code, 302)
-        nt.assert_equal(response._headers['location'][1], '/users/{}/'.format(self.user_1.guids.first()._id))
+        nt.assert_equal(response.headers['location'], '/users/{}/'.format(self.user_1.guids.first()._id))
 
     def test_search_user_by_alternate_email(self):
         form_data = {
@@ -454,7 +454,7 @@ class TestUserSearchView(AdminTestCase):
         nt.assert_true(form.is_valid())
         response = self.view.form_valid(form)
         nt.assert_equal(response.status_code, 302)
-        nt.assert_equal(response._headers['location'][1], '/users/{}/'.format(self.user_2.guids.first()._id))
+        nt.assert_equal(response.headers['location'], '/users/{}/'.format(self.user_2.guids.first()._id))
 
     def test_search_user_list(self):
         view = views.UserSearchList()

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -20,13 +20,18 @@ from api.nodes.serializers import (
 )
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
 from osf.exceptions import DraftRegistrationStateError
+from osf.models import Node
 from website import settings
 
 
 class NodeRelationshipField(RelationshipField):
 
     def to_internal_value(self, node_id):
-        node = self.context['view'].get_node(node_id=node_id) if node_id else None
+        context_view = self.context['view']
+        if hasattr(context_view, 'get_node'):
+            node = self.context['view'].get_node(node_id=node_id) if node_id else None
+        else:
+            node = Node.load(node_id)
         return {'branched_from': node}
 
 

--- a/api/draft_registrations/serializers.py
+++ b/api/draft_registrations/serializers.py
@@ -20,14 +20,14 @@ from api.nodes.serializers import (
 )
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
 from osf.exceptions import DraftRegistrationStateError
-from osf.models import Node
 from website import settings
 
 
 class NodeRelationshipField(RelationshipField):
 
     def to_internal_value(self, node_id):
-        return {'branched_from': Node.load(node_id)}
+        node = self.context['view'].get_node(node_id=node_id) if node_id else None
+        return {'branched_from': node}
 
 
 class DraftRegistrationSerializer(DraftRegistrationLegacySerializer, TaxonomizableSerializerMixin):

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -72,10 +72,13 @@ class TestDraftRegistrationListNewWorkflow(TestDraftRegistrationList):
 
 
 class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
+
+    # Overrides `url_draft_registrations` in `TestDraftRegistrationCreate`
     @pytest.fixture()
     def url_draft_registrations(self, project_public):
         return '/{}draft_registrations/?'.format(API_BASE)
 
+    # Overrides `payload` in TestDraftRegistrationCreate`
     @pytest.fixture()
     def payload(self, metaschema_open_ended, provider, project_public):
         return {
@@ -105,15 +108,31 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
             }
         }
 
+    # Temporary alternative provider that supports `metaschema_open_ended` in `TestDraftRegistrationCreate`
+    # This provider is created to fix the first 3 tests in this test class due to test DB changes with the
+    # Django 3 Upgrade. A long-term solution is to create and/or use dedicated schemas for testing.
+    @pytest.fixture()
+    def provider_alt(self, metaschema_open_ended):
+        default_provider = RegistrationProvider.get_default()
+        default_provider.schemas.add(metaschema_open_ended)
+        default_provider.save()
+        return default_provider
+
+    # Similarly, this is a temporary alternative payload that uses the above `provider_alt`.
+    @pytest.fixture()
+    def payload_alt(self, payload, provider_alt):
+        new_payload = payload.copy()
+        new_payload['data']['relationships']['provider']['data']['id'] = provider_alt._id
+        return new_payload
+
     # Overrides TestDraftRegistrationList
-    def test_cannot_create_draft_errors(
-            self, app, user, project_public, payload, url_draft_registrations):
+    def test_cannot_create_draft_errors(self, app, user, payload_alt, project_public, url_draft_registrations):
         #   test_cannot_create_draft_from_a_registration
         registration = RegistrationFactory(
             project=project_public, creator=user)
-        payload['data']['relationships']['branched_from']['data']['id'] = registration._id
+        payload_alt['data']['relationships']['branched_from']['data']['id'] = registration._id
         res = app.post_json_api(
-            url_draft_registrations, payload, auth=user.auth,
+            url_draft_registrations, payload_alt, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 404
 
@@ -121,23 +140,23 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
         project = ProjectFactory(is_public=True, creator=user)
         project.is_deleted = True
         project.save()
-        payload['data']['relationships']['branched_from']['data']['id'] = project._id
+        payload_alt['data']['relationships']['branched_from']['data']['id'] = project._id
         res = app.post_json_api(
-            url_draft_registrations, payload,
+            url_draft_registrations, payload_alt,
             auth=user.auth, expect_errors=True)
         assert res.status_code == 410
         assert res.json['errors'][0]['detail'] == 'The requested node is no longer available.'
 
     #   test_cannot_create_draft_from_collection
         collection = CollectionFactory(creator=user)
-        payload['data']['relationships']['branched_from']['data']['id'] = collection._id
+        payload_alt['data']['relationships']['branched_from']['data']['id'] = collection._id
         res = app.post_json_api(
-            url_draft_registrations, payload, auth=user.auth,
+            url_draft_registrations, payload_alt, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 404
 
     def test_draft_registration_attributes_copied_from_node(self, app, project_public,
-            url_draft_registrations, user, payload):
+            url_draft_registrations, user, payload_alt):
 
         write_contrib = AuthUserFactory()
         read_contrib = AuthUserFactory()
@@ -156,12 +175,12 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
         project_public.add_contributor(write_contrib, WRITE)
         project_public.add_contributor(read_contrib, READ)
 
-        res = app.post_json_api(url_draft_registrations, payload, auth=write_contrib.auth, expect_errors=True)
+        res = app.post_json_api(url_draft_registrations, payload_alt, auth=write_contrib.auth, expect_errors=True)
         assert res.status_code == 201
-        res = app.post_json_api(url_draft_registrations, payload, auth=read_contrib.auth, expect_errors=True)
+        res = app.post_json_api(url_draft_registrations, payload_alt, auth=read_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
-        res = app.post_json_api(url_draft_registrations, payload, auth=user.auth)
+        res = app.post_json_api(url_draft_registrations, payload_alt, auth=user.auth)
         assert res.status_code == 201
         attributes = res.json['data']['attributes']
         assert attributes['title'] == project_public.title
@@ -180,14 +199,14 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     def test_cannot_create_draft(
             self, app, user_write_contrib,
             user_read_contrib, user_non_contrib,
-            project_public, payload, group,
+            project_public, payload_alt, group,
             url_draft_registrations, group_mem):
 
         #   test_write_only_contributor_cannot_create_draft
         assert user_write_contrib in project_public.contributors.all()
         res = app.post_json_api(
             url_draft_registrations,
-            payload,
+            payload_alt,
             auth=user_write_contrib.auth,
             expect_errors=True)
         assert res.status_code == 201
@@ -196,7 +215,7 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
         assert user_read_contrib in project_public.contributors.all()
         res = app.post_json_api(
             url_draft_registrations,
-            payload,
+            payload_alt,
             auth=user_read_contrib.auth,
             expect_errors=True)
         assert res.status_code == 403
@@ -204,13 +223,13 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     #   test_non_authenticated_user_cannot_create_draft
         res = app.post_json_api(
             url_draft_registrations,
-            payload, expect_errors=True)
+            payload_alt, expect_errors=True)
         assert res.status_code == 401
 
     #   test_logged_in_non_contributor_cannot_create_draft
         res = app.post_json_api(
             url_draft_registrations,
-            payload,
+            payload_alt,
             auth=user_non_contrib.auth,
             expect_errors=True)
         assert res.status_code == 403
@@ -218,7 +237,7 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
     #   test_group_admin_cannot_create_draft
         res = app.post_json_api(
             url_draft_registrations,
-            payload,
+            payload_alt,
             auth=group_mem.auth,
             expect_errors=True)
         assert res.status_code == 201
@@ -228,7 +247,7 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
         project_public.add_osf_group(group, WRITE)
         res = app.post_json_api(
             url_draft_registrations,
-            payload,
+            payload_alt,
             auth=group_mem.auth,
             expect_errors=True)
         assert res.status_code == 201

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-import mock
-import pytest
+from django.utils import timezone
 from future.moves.urllib.parse import urlparse
+import mock
 from nose.tools import *  # noqa:
-
+import pytest
+from rest_framework import exceptions
 
 from addons.wiki.tests.factories import WikiFactory, WikiVersionFactory
 from api.base.settings.defaults import API_BASE
@@ -33,7 +34,6 @@ from osf_tests.factories import (
     WithdrawnRegistrationFactory,
     DraftNodeFactory,
 )
-from rest_framework import exceptions
 from tests.base import fake
 from tests.utils import assert_latest_log, assert_latest_log_not
 from website.views import find_bookmark_collection
@@ -480,8 +480,12 @@ class TestNodeDetail:
         assert res.json['data']['relationships']['linked_by_nodes']['links']['related']['meta']['count'] == 1
         assert res.json['data']['relationships']['linked_by_registrations']['links']['related']['meta']['count'] == 1
 
+        log_date = timezone.now()
+        project_private.deleted_date = log_date
+        project_private.deleted = log_date
         project_private.is_deleted = True
         project_private.save()
+        registration.reload()
         project_public.reload()
 
         res = app.get(url)

--- a/api_tests/nodes/views/test_node_draft_registration_detail.py
+++ b/api_tests/nodes/views/test_node_draft_registration_detail.py
@@ -156,9 +156,10 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
 
     @pytest.fixture()
     def reg_schema(self):
-        return RegistrationSchema.objects.get(
-            name='OSF Preregistration',
-            schema_version=SCHEMA_VERSION)
+        schema = RegistrationSchema.objects.get_latest_version(name='OSF Preregistration')
+        schema.active = True
+        schema.save()
+        return schema
 
     @pytest.fixture()
     def draft_registration_prereg(self, user, project_public, reg_schema):
@@ -416,7 +417,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
         url = '/{}nodes/{}/draft_registrations/{}/'.format(
             API_BASE, project_public._id, draft_registration_prereg._id)
 
-        del metadata_registration['q1']
+        del metadata_registration['q3']
         draft_registration_prereg.metadata_registration = metadata_registration
         draft_registration_prereg.save()
 
@@ -426,7 +427,7 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
                 'type': 'draft_registrations',
                 'attributes': {
                     'registration_metadata': {
-                        'q3': {
+                        'q2': {
                             'value': 'New response'
                         }
                     }
@@ -438,17 +439,17 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             url, payload, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['registration_metadata']['q3']['value'] == 'New response'
-        assert 'q1' not in res.json['data']['attributes']['registration_metadata']
+        assert res.json['data']['attributes']['registration_metadata']['q2']['value'] == 'New response'
+        assert 'q3' not in res.json['data']['attributes']['registration_metadata']
 
     def test_required_registration_responses_questions_not_required_on_update(
             self, app, user, project_public, draft_registration_prereg):
 
-        url = '/{}nodes/{}/draft_registrations/{}/'.format(
+        url = '/{}nodes/{}/draft_registrations/{}/?version=2.20'.format(
             API_BASE, project_public._id, draft_registration_prereg._id)
 
         registration_responses = {
-            'q1': 'First question answered'
+            'q2': 'First question answered'
         }
 
         draft_registration_prereg.registration_responses = {}
@@ -469,8 +470,8 @@ class TestDraftRegistrationUpdate(DraftRegistrationTestCase):
             url, payload, auth=user.auth,
             expect_errors=True)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['registration_metadata']['q1']['value'] == registration_responses['q1']
-        assert res.json['data']['attributes']['registration_responses']['q1'] == registration_responses['q1']
+        assert res.json['data']['attributes']['registration_metadata']['q2']['value'] == registration_responses['q2']
+        assert res.json['data']['attributes']['registration_responses']['q2'] == registration_responses['q2']
 
     def test_registration_responses_must_be_a_dictionary(
             self, app, user, payload_with_registration_responses, url_draft_registrations):

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -108,10 +108,20 @@ class BaseModel(TimeStampedModel, QuerySetExplainMixin):
 
     def refresh_from_db(self, **kwargs):
         super(BaseModel, self).refresh_from_db(**kwargs)
-        # Django's refresh_from_db does not uncache GFKs
-        for field in self._meta.private_fields:
-            if hasattr(field, 'cache_attr') and field.cache_attr in self.__dict__:
-                del self.__dict__[field.cache_attr]
+        # Since Django 2.2, any cached relations are cleared from the reloaded instance.
+        # See https://docs.djangoproject.com/en/2.2/ref/models/instances/#django.db.models.Model.refresh_from_db
+        # However, the default `refresh_from_db()` doesn't refresh related fields. Neither can we refresh related
+        # field(s) since it will inevitably cause infinite loop; and Many/One-to-Many relations add to the complexity.
+        # The recommended behavior is to explicitly refresh the fields when necessary. In order to preserve pre-upgrade
+        # behavior, our customization only reloads GFKs.
+        for f in self._meta._get_fields(reverse=False):
+            # Note: the following `if` condition is how django internally identifies GFK
+            if f.is_relation and f.many_to_one and not (hasattr(f.remote_field, 'model') and f.remote_field.model):
+                if hasattr(self, f.name):
+                    try:
+                        getattr(self, f.name).refresh_from_db()
+                    except AttributeError:
+                        continue
 
     def clone(self):
         """Create a new, unsaved copy of this object."""

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -758,6 +758,7 @@ class TestArchiverUtils(ArchiverTestCase):
             {}
         )
         assert_equal(mock_send_mail.call_count, 2)
+        self.dst.reload()
         assert_true(self.dst.is_deleted)
 
     @mock.patch('website.mails.send_mail')

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -111,8 +111,9 @@ def handle_archive_fail(reason, src, dst, user, result):
         pass
     else:  # reason == ARCHIVER_UNCAUGHT_ERROR
         send_archiver_uncaught_error_mails(src, user, result, url)
-    dst.root.sanction.forcibly_reject()
-    dst.root.sanction.save()
+    if dst.root.sanction:
+        dst.root.sanction.forcibly_reject()
+        dst.root.sanction.save()
     dst.root.delete_registration_tree(save=True)
 
 def archive_provider_for(node, user):

--- a/website/static/urlValidatorTest.json
+++ b/website/static/urlValidatorTest.json
@@ -32,12 +32,12 @@
     "http://مثال.إختبار":"should accept valid unicode heavy website test 1",
     "http://例子.测试":"should accept valid unicode heavy website test 2",
     "http://उदाहरण.परीक्षा":"should accept valid unicode heavy website test 3",
-    "http://-.~_!$&()*+,;=:%40:80%2f::::::@example.com":"should accept valid website with user but crazy username",
+    "http://-.~_!%24%26()*%2B%2C%3B%3D%3A%40%3A80%2F%3A%3A%3A%3A%3A%3A@example.com":"should accept valid website with user but crazy username",
     "http://1337.net":"should accept valid website with just numbers in domain",
     "http://definitelyawebsite.com?real=yes&page=definitely":"should accept valid website with query",
     "http://a.b-c.de":"should accept valid website with dash",
     "http://website.com:3000/?q=400":"should accept valid website with port and query",
-    "http://asd/asd@asd.com/":"should accept valid website with unusual username"
+    "http://asd%2Fasd@asd.com/":"should accept valid website with unusual username"
   },
   "testsNegative": {
     "notevenclose": "should deny simple invalid website",


### PR DESCRIPTION
## Purpose
See: https://www.notion.so/cos/The-rest-of-the-fixes-ec6b2b2f96e74a2b902a1d57d2a8fe6a

## Tickets & PRs
* Ticket: https://openscience.atlassian.net/browse/ENG-4072
* Reference PR with initial attempts of fix: https://github.com/CenterForOpenScience/osf.io/pull/10048
* New Reference PR with following attempts + all tests passing: https://github.com/CenterForOpenScience/osf.io/pull/10074
* Part 1 of this PR: https://github.com/CenterForOpenScience/osf.io/pull/10070

## Changes
* Fix linked_by_nodes in node related counts test
* Add alt fixtures to prevent both siblings & parent/child conflicts
* Improve to_internal_value() in NodeRelationshipField
* Revert "Fix an issue where get_node() is not availalbe from context view"
* Update URLs for URL Validation tests with Django 3
* Use a different schema to fix tests failure due to django3 upgrade
* Fix handle_archive_fail and its tests
* Fix visible contributor query
* Rework refresh_from_db() to reload GFKs 
* Fix duplicate view_node permissions in node and instn view tests
* Fix admin user view tests by using HTTP response headers object
* Fix missing or insufficient permission test for admin preprints view