### PR TITLE
[ENG-3514] Delete CollectionSubmissions when collected project is deleted/marked private

### DIFF
--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -2893,9 +2893,6 @@ class TestBulkDeleteCollectionNodeLinks:
             auth=user_one.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
-        errors = res.json['errors']
-        assert len(errors) == 1
-        assert errors[0]['detail'] == 'Node link does not belong to the requested node.'
 
 
 @pytest.mark.django_db

--- a/osf/models/collection.py
+++ b/osf/models/collection.py
@@ -304,7 +304,7 @@ class Collection(DirtyFieldsMixin, GuidMixin, BaseModel, GuardianMixin):
         else:
             # assume that we were passed the collected resource
             try:
-                obj = self.collectionsubmission_set.get(guid=objs.guids.first())
+                obj = self.collectionsubmission_set.get(guid=obj.guids.first())
             except CollectionSubmission.DoesNotExist:
                 raise ValueError(f'Resource [{obj.guid._id}] is not part of collection {self._id}')
 

--- a/osf/models/collection.py
+++ b/osf/models/collection.py
@@ -299,7 +299,7 @@ class Collection(DirtyFieldsMixin, GuidMixin, BaseModel, GuardianMixin):
         :param obj: object to remove from collection, if it exists. Acceptable types- CollectionSubmission, GuidMixin
         """
         if isinstance(obj, CollectionSubmission):
-            if obj.colection != self:
+            if obj.collection != self:
                 raise ValueError(f'Resource [{obj.guid._id}] is not part of collection {self._id}')
         else:
             # assume that we were passed the collected resource

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2404,8 +2404,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     def _remove_from_associated_collections(self):
         for submission in self.guids.first().collectionsubmission_set.all():
-            if submission.collection.is_bookmark_collection():
-                if self.contributors.filter(user=collection.creator).exists():
+            associated_collection = submission.collection
+            if associated_collection.is_bookmark_collection:
+                if self.contributors.filter(user=associated_collection.creator).exists():
                     continue
             submission.delete()
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2405,8 +2405,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def _remove_from_associated_collections(self):
         for submission in self.guids.first().collectionsubmission_set.all():
             associated_collection = submission.collection
-            if associated_collection.is_bookmark_collection:
-                if self.contributors.filter(user=associated_collection.creator).exists():
+            if associated_collection.is_bookmark_collection and not self.deleted:
+                if self.contributors.filter(pk=associated_collection.creator.id).exists():
                     continue
             submission.delete()
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1244,6 +1244,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
             self.is_public = False
             self.keenio_read_key = ''
+            self._remove_from_associated_collections()
         else:
             return False
 
@@ -2226,6 +2227,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             node.deleted = log_date
             node.add_remove_node_log(auth=auth, date=log_date)
             project_signals.node_deleted.send(node)
+            node._remove_from_associated_collections()
 
         bulk_update(hierarchy, update_fields=['is_deleted', 'deleted_date', 'deleted'])
 
@@ -2399,6 +2401,13 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             ]
         ).first() or osf_provider_tag
         contributor.add_system_tag(source_tag)
+
+    def _remove_from_associated_collections(self):
+        for submission in self.guids.first().collectionsubmission_set.all():
+            if submission.collection.is_bookmark_collection():
+                if self.contributors.filter(user=collection.creator).exists():
+                    continue
+            submission.delete()
 
 
 class NodeUserObjectPermission(UserObjectPermissionBase):

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -86,6 +86,7 @@ class TestImplicitRemoval:
     def standard_collection(self):
         return CollectionFactory()
 
+    @pytest.fixture
     def collected_node(self, bookmark_collection, alternate_bookmark_collection, standard_collection):
         node = ProjectFactory(creator=bookmark_collection.creator, public=True)
         bookmark_collection.collect_object(node)

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -103,10 +103,10 @@ class TestImplicitRemoval:
         assert associated_collections.count() == 1
         assert associated_collections.filter(collection=bookmark_collection).exists()
 
-    def test_node_removed_from_collection_on_delete(self, collected_node, bookmark_collection):
+    def test_node_removed_from_collection_on_delete(self, collected_node, bookmark_collection, auth):
         associated_collections = collected_node.guids.first().collectionsubmission_set
         assert associated_collections.count() == 3
 
-        collected_node.remove_node()
+        collected_node.remove_node(auth)
 
         assert associated_collections.count() == 0

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -88,7 +88,7 @@ class TestImplicitRemoval:
 
     @pytest.fixture
     def collected_node(self, bookmark_collection, alternate_bookmark_collection, standard_collection):
-        node = ProjectFactory(creator=bookmark_collection.creator, public=True)
+        node = ProjectFactory(creator=bookmark_collection.creator, is_public=True)
         bookmark_collection.collect_object(node)
         alternate_bookmark_collection.collect_object(node)
         standard_collection.collect_object(node)

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -92,6 +92,7 @@ class TestImplicitRemoval:
         bookmark_collection.collect_object(node, bookmark_collection.creator)
         alternate_bookmark_collection.collect_object(node, alternate_bookmark_collection.creator)
         standard_collection.collect_object(node, standard_collection.creator)
+        return node
 
     def test_node_removed_from_collection_on_privacy_change(self, collected_node, bookmark_collection):
         associated_collections = collected_node.guids.first().collectionsubmission_set

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -69,7 +69,7 @@ class TestBookmarkCollection:
 
 @pytest.mark.enable_bookmark_creation
 class TestImplicitRemoval:
-    
+
     @pytest.fixture
     def bookmark_collection(self, user):
         return find_bookmark_collection(user)
@@ -93,18 +93,18 @@ class TestImplicitRemoval:
         standard_collection.collect_object(node)
 
     def test_node_removed_from_collection_on_privacy_change(self, collected_node, bookmark_collection):
-        associated_collections = node.guids.first().collectionsubmission_set
-        assert associated_collections_qs.count() == 3
+        associated_collections = collected_node.guids.first().collectionsubmission_set
+        assert associated_collections.count() == 3
 
-        node.set_privacy('private')
+        collected_node.set_privacy('private')
 
-        assert associated_collections_qs.count() == 1
+        assert associated_collections.count() == 1
         assert associated_collections.filter(collection=bookmark_collection).exists()
 
-     def test_node_removed_from_collection_on_privacy_change(self, collected_node, bookmark_collection):
-        associated_collections = node.guids.first().collectionsubmission_set
-        assert associated_collections_qs.count() == 3
+    def test_node_removed_from_collection_on_delete(self, collected_node, bookmark_collection):
+        associated_collections = collected_node.guids.first().collectionsubmission_set
+        assert associated_collections.count() == 3
 
-        node.remove_node()
+        collected_node.remove_node()
 
-        assert associated_collections_qs.count() == 0
+        assert associated_collections.count() == 0

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -89,9 +89,9 @@ class TestImplicitRemoval:
     @pytest.fixture
     def collected_node(self, bookmark_collection, alternate_bookmark_collection, standard_collection):
         node = ProjectFactory(creator=bookmark_collection.creator, is_public=True)
-        bookmark_collection.collect_object(node)
-        alternate_bookmark_collection.collect_object(node)
-        standard_collection.collect_object(node)
+        bookmark_collection.collect_object(node, bookmark_collection.creator)
+        alternate_bookmark_collection.collect_object(node, alternate_bookmark_collection.creator)
+        standard_collection.collect_object(node, standard_collection.creator)
 
     def test_node_removed_from_collection_on_privacy_change(self, collected_node, bookmark_collection):
         associated_collections = collected_node.guids.first().collectionsubmission_set


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Prevent us from exposing details about a deleted or private project via the `CollectedMetaList` endpoint

## Changes
* Move logic for what happens when removing a collected item to the CollectionSubmisison.delete()
* Update `AbstractNode.set_privacy()` and `AbstractNode.remove_node()` to delete all CollectionSubmissions when a node is made private or deleted
  * Don't delete CollectionSubmissions for contributors' bookmark collections on make_private
* Add tests
* Remove brittle test that was checking an out-of-date error string

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
