### PR TITLE
[ENG-4087] Reclassification part 2

### DIFF
--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -35,4 +35,4 @@ def check_resource_for_domains(guid, content):
             defaults={'is_triaged': domain.note != NotableDomain.Note.UNKNOWN}
         )
     if mark_spam:
-        resource.confirm_spam(save=True)
+        resource.confirm_spam(save=True, domains=list(domains))

--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -31,7 +31,6 @@ def check_resource_for_domains(guid, content):
     domains = {match.group('domain') for match in re.finditer(DOMAIN_REGEX, content)}
     spammy_domains = []
     referrer_content_type = ContentType.objects.get_for_model(resource)
-    mark_spam = False
     for domain in domains:
         domain, _ = NotableDomain.objects.get_or_create(domain=domain)
         if domain.note == NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT:

--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 import re
 import logging
 from framework.celery_tasks import app as celery_app

--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -9,14 +9,14 @@ DOMAIN_REGEX = re.compile(r'(?P<protocol>\w+://)?(?P<www>www\.)?(?P<domain>[\w-]
 def reclassify_domain_references(notable_domain_id):
     from osf.models.notable_domain import DomainReference, NotableDomain
     from osf.models.spam import SpamStatus
-    spammy_domains_set = set(NotableDomain.objects.filter(note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT).values_list('domain'))
+    spammy_domains_set = set(NotableDomain.objects.filter(note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT).values_list('domain', flat=True))
     domain = NotableDomain.load(notable_domain_id)
     references = DomainReference.objects.filter(domain=domain)
     with transaction.atomic():
         for item in references:
             item.is_triaged = domain.note != NotableDomain.Note.UNKNOWN
             if domain.note == NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT:
-                item.referrer.confirm_spam(save=False)
+                item.referrer.confirm_spam(save=False, domains=[domain.domain])
             elif domain.note == NotableDomain.Note.UNKNOWN or domain.note == NotableDomain.Note.IGNORED:
                 if item.referrer.spam_status == SpamStatus.SPAM:
                     item.referrer.spam_data['domains'].remove(domain.domain)
@@ -30,11 +30,13 @@ def check_resource_for_domains(guid, content):
     from osf.models import Guid, NotableDomain, DomainReference
     resource = Guid.load(guid).referent
     domains = {match.group('domain') for match in re.finditer(DOMAIN_REGEX, content)}
+    spammy_domains = []
     referrer_content_type = ContentType.objects.get_for_model(resource)
     mark_spam = False
     for domain in domains:
         domain, _ = NotableDomain.objects.get_or_create(domain=domain)
         if domain.note == NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT:
+            spammy_domains.append(domain.domain)
             mark_spam = True
         DomainReference.objects.get_or_create(
             domain=domain,
@@ -43,4 +45,4 @@ def check_resource_for_domains(guid, content):
             defaults={'is_triaged': domain.note != NotableDomain.Note.UNKNOWN}
         )
     if mark_spam:
-        resource.confirm_spam(save=True, domains=list(domains))
+        resource.confirm_spam(save=True, domains=list(spammy_domains))

--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -9,7 +9,6 @@ DOMAIN_REGEX = re.compile(r'(?P<protocol>\w+://)?(?P<www>www\.)?(?P<domain>[\w-]
 def reclassify_domain_references(notable_domain_id):
     from osf.models.notable_domain import DomainReference, NotableDomain
     from osf.models.spam import SpamStatus
-    spammy_domains_set = set(NotableDomain.objects.filter(note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT).values_list('domain', flat=True))
     domain = NotableDomain.load(notable_domain_id)
     references = DomainReference.objects.filter(domain=domain)
     with transaction.atomic():
@@ -20,7 +19,7 @@ def reclassify_domain_references(notable_domain_id):
             elif domain.note == NotableDomain.Note.UNKNOWN or domain.note == NotableDomain.Note.IGNORED:
                 if item.referrer.spam_status == SpamStatus.SPAM:
                     item.referrer.spam_data['domains'].remove(domain.domain)
-                    if set(item.referrer.spam_data['domains']).isdisjoint(spammy_domains_set):
+                    if len(item.referrer.spam_data['domains']) == 0:
                         item.referrer.unspam(save=False)
             item.save()
             item.referrer.save()
@@ -37,12 +36,11 @@ def check_resource_for_domains(guid, content):
         domain, _ = NotableDomain.objects.get_or_create(domain=domain)
         if domain.note == NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT:
             spammy_domains.append(domain.domain)
-            mark_spam = True
         DomainReference.objects.get_or_create(
             domain=domain,
             referrer_object_id=resource.id,
             referrer_content_type=referrer_content_type,
             defaults={'is_triaged': domain.note != NotableDomain.Note.UNKNOWN}
         )
-    if mark_spam:
+    if spammy_domains:
         resource.confirm_spam(save=True, domains=list(spammy_domains))

--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -209,7 +209,7 @@ def update_blocked_email_domains(sender, verbosity=0, **kwargs):
         for domain in osf_settings.BLACKLISTED_DOMAINS:
             NotableDomain.objects.update_or_create(
                 domain=domain,
-                defaults={'note': NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION},
+                defaults={'note': NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT},
             )
 
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1999,8 +1999,8 @@ class SpamOverrideMixin(SpamMixin):
             self.save()
 
     def unspam(self, save=False):
-        self.undelete(save=save)
         super().unspam(save=save)
+        self.undelete(save=save)
 
     def confirm_spam(self, domains=[], save=True, train_akismet=True):
         """

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2002,13 +2002,13 @@ class SpamOverrideMixin(SpamMixin):
         super().unspam(save=save)
         self.undelete(save=save)
 
-    def confirm_spam(self, domains=[], save=True, train_akismet=True):
+    def confirm_spam(self, domains=None, save=True, train_akismet=True):
         """
         This should add behavior specific nodes/preprints confirmed to be spam.
         :param save:
         :return:
         """
-        super().confirm_spam(save=save, domains=domains, train_akismet=train_akismet)
+        super().confirm_spam(save=save, domains=domains or [], train_akismet=train_akismet)
         self.deleted = timezone.now()
         was_public = self.is_public
         self.set_privacy('private', auth=None, log=False, save=False, force=True)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1984,13 +1984,13 @@ class SpamOverrideMixin(SpamMixin):
     def get_spam_fields(self):
         return NotImplementedError()
 
-    def confirm_spam(self, save=True, train_akismet=True):
+    def confirm_spam(self, domains=[], save=True, train_akismet=True):
         """
         This should add behavior specific nodes/preprints confirmed to be spam.
         :param save:
         :return:
         """
-        super().confirm_spam(save=save, train_akismet=train_akismet)
+        super().confirm_spam(save=save, domains=domains, train_akismet=train_akismet)
         self.deleted = timezone.now()
         was_public = self.is_public
         self.set_privacy('private', auth=None, log=False, save=False, force=True)

--- a/osf/models/notable_domain.py
+++ b/osf/models/notable_domain.py
@@ -33,7 +33,7 @@ class NotableDomain(BaseModel):
         db_instance = NotableDomain.load(self.pk)
         super().save(*args, **kwargs)
         if db_instance and self.note != db_instance.note:
-            reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk})
+            reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk, 'previous_note': db_instance.note})
 
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self.domain} ({self.Note(self.note).name})>'

--- a/osf/models/notable_domain.py
+++ b/osf/models/notable_domain.py
@@ -30,7 +30,9 @@ class NotableDomain(BaseModel):
     )
 
     def save(self, *args, **kwargs):
-        reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk})
+        db_instance = NotableDomain.load(self.pk)
+        if not self._state.adding and self.note != db_instance.note:
+            reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk})
         return super().save(*args, **kwargs)
 
     def __repr__(self):

--- a/osf/models/notable_domain.py
+++ b/osf/models/notable_domain.py
@@ -32,6 +32,7 @@ class NotableDomain(BaseModel):
     def save(self, *args, **kwargs):
         db_instance = NotableDomain.load(self.pk)
         if not self._state.adding and self.note != db_instance.note:
+            super().save(*args, **kwargs)
             reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk})
         return super().save(*args, **kwargs)
 

--- a/osf/models/notable_domain.py
+++ b/osf/models/notable_domain.py
@@ -31,10 +31,9 @@ class NotableDomain(BaseModel):
 
     def save(self, *args, **kwargs):
         db_instance = NotableDomain.load(self.pk)
-        if not self._state.adding and self.note != db_instance.note:
-            super().save(*args, **kwargs)
+        super().save(*args, **kwargs)
+        if db_instance and self.note != db_instance.note:
             reclassify_domain_references.apply_async(kwargs={'notable_domain_id': self.pk})
-        return super().save(*args, **kwargs)
 
     def __repr__(self):
         return f'<{self.__class__.__name__}: {self.domain} ({self.Note(self.note).name})>'

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -196,7 +196,7 @@ class SpamMixin(models.Model):
         if save:
             self.save()
 
-    def confirm_spam(self, domains=[], save=False, train_akismet=True):
+    def confirm_spam(self, domains=None, save=False, train_akismet=True):
         if domains:
             if 'domains' in self.spam_data:
                 self.spam_data['domains'].extend(domains)

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -198,7 +198,10 @@ class SpamMixin(models.Model):
 
     def confirm_spam(self, domains=[], save=False, train_akismet=True):
         if domains:
-            self.spam_data['domains'] = domains
+            if 'domains' in self.spam_data:
+                self.spam_data['domains'].extend(domains)
+            else:
+                self.spam_data['domains'] = domains
         # not all mixins will implement check spam pre-req, only submit spam when it was incorrectly flagged
         if (
             settings.SPAM_CHECK_ENABLED and

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -174,7 +174,7 @@ class SpamMixin(models.Model):
         # not all mixins will implement check spam pre-req, only submit ham when it was incorrectly flagged
         if (
             settings.SPAM_CHECK_ENABLED and
-            self.spam_data and self.spam_status in [SpamStatus.FLAGGED, SpamStatus.SPAM] and
+            'headers' in self.spam_data and self.spam_status in [SpamStatus.FLAGGED, SpamStatus.SPAM] and
             train_akismet
         ):
             client = _get_akismet_client()
@@ -191,11 +191,13 @@ class SpamMixin(models.Model):
         if save:
             self.save()
 
-    def confirm_spam(self, save=False, train_akismet=True):
+    def confirm_spam(self, domains=[], save=False, train_akismet=True):
+        if domains:
+            self.spam_data['domains'] = domains
         # not all mixins will implement check spam pre-req, only submit spam when it was incorrectly flagged
         if (
             settings.SPAM_CHECK_ENABLED and
-            self.spam_data and self.spam_status in [SpamStatus.UNKNOWN, SpamStatus.HAM] and
+            'headers' in self.spam_data and self.spam_status in [SpamStatus.UNKNOWN, SpamStatus.HAM] and
             train_akismet
         ):
             client = _get_akismet_client()

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -170,6 +170,11 @@ class SpamMixin(models.Model):
         if save:
             self.save()
 
+    def unspam(self, save=False):
+        self.spam_status = SpamStatus.UNKNOWN
+        if save:
+            self.save()
+
     def confirm_ham(self, save=False, train_akismet=True):
         # not all mixins will implement check spam pre-req, only submit ham when it was incorrectly flagged
         if (

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -117,6 +117,8 @@ class TestNotableDomain:
         obj.reload()
         assert obj.spam_status == SpamStatus.SPAM
 
+@pytest.mark.django_db
+@pytest.mark.enable_enqueue_task
 class TestNotableDomainReclassification:
     @pytest.fixture()
     def spam_domain_one(self):
@@ -162,8 +164,6 @@ class TestNotableDomainReclassification:
             note=NotableDomain.Note.IGNORED,
         )
 
-    @pytest.mark.django_db
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_from_spam_to_unknown(self, factory, spam_domain_one, spam_domain_two, unknown_domain, ignored_domain, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
@@ -195,8 +195,6 @@ class TestNotableDomainReclassification:
         assert len(obj_one.spam_data['domains']) == 0
         assert set(obj_two.spam_data['domains']) == set([spam_domain_two.netloc])
 
-    @pytest.mark.django_db
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_from_spam_to_ignored(self, factory, spam_domain_one, spam_domain_two, unknown_domain, ignored_domain, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
@@ -228,8 +226,6 @@ class TestNotableDomainReclassification:
         assert len(obj_one.spam_data['domains']) == 0
         assert set(obj_two.spam_data['domains']) == set([spam_domain_two.netloc])
 
-    @pytest.mark.django_db
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_from_unknown_to_spam(self, factory, unknown_domain, ignored_domain, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
@@ -261,8 +257,6 @@ class TestNotableDomainReclassification:
         assert set(obj_one.spam_data['domains']) == set([unknown_domain.netloc])
         assert set(obj_two.spam_data['domains']) == set([unknown_domain.netloc])
 
-    @pytest.mark.django_db
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_from_ignored_to_spam(self, factory, unknown_domain, ignored_domain, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -250,8 +250,8 @@ class TestNotableDomainReclassification:
         obj_two.reload()
         assert obj_one.spam_status == SpamStatus.UNKNOWN
         assert obj_two.spam_status == SpamStatus.UNKNOWN
-        assert not 'domains' in obj_one.spam_data
-        assert not 'domains' in obj_two.spam_data
+        assert 'domains' not in obj_one.spam_data
+        assert 'domains' not in obj_two.spam_data
         unknown_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
         unknown_notable_domain.save()
         obj_one.reload()
@@ -283,8 +283,8 @@ class TestNotableDomainReclassification:
         obj_two.reload()
         assert obj_one.spam_status == SpamStatus.UNKNOWN
         assert obj_two.spam_status == SpamStatus.UNKNOWN
-        assert not 'domains' in obj_one.spam_data
-        assert not 'domains' in obj_two.spam_data
+        assert 'domains' not in obj_one.spam_data
+        assert 'domains' not in obj_two.spam_data
         ignored_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
         ignored_notable_domain.save()
         obj_one.reload()

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -71,6 +71,7 @@ class TestNotableDomain:
         ).count() == 1
         obj.reload()
         assert obj.spam_status == SpamStatus.SPAM
+        assert obj.spam_data['domains'] == [spam_domain.netloc]
         assert DomainReference.objects.filter(
             referrer_object_id=obj.id,
             referrer_content_type=ContentType.objects.get_for_model(obj),

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -120,200 +120,219 @@ class TestNotableDomain:
 @pytest.mark.django_db
 @pytest.mark.enable_enqueue_task
 class TestNotableDomainReclassification:
-    @pytest.fixture()
-    def spam_domain_one(self):
-        return urlparse('http://spammy-domain.io')
+    spam_domain_one = urlparse('http://spammy-domain.io')
+    spam_domain_two = urlparse('http://prosciutto-crudo.io')
+    unknown_domain = urlparse('https://unknown-domain.io')
+    ignored_domain = urlparse('https://cos.io')
 
     @pytest.fixture()
-    def spam_domain_two(self):
-        return urlparse('http://prosciutto-crudo.io')
-
-    @pytest.fixture()
-    def unknown_domain(self):
-        return urlparse('https://uknown-domain.io')
-
-    @pytest.fixture()
-    def ignored_domain(self):
-        return urlparse('https://cos.io')
-
-    @pytest.fixture()
-    def spam_notable_domain_one(self, spam_domain_one):
+    def spam_notable_domain_one(self):
         return NotableDomain.objects.create(
-            domain=spam_domain_one.netloc,
+            domain=self.spam_domain_one.netloc,
             note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT,
         )
 
     @pytest.fixture()
-    def spam_notable_domain_two(self, spam_domain_two):
+    def spam_notable_domain_two(self):
         return NotableDomain.objects.create(
-            domain=spam_domain_two.netloc,
+            domain=self.spam_domain_two.netloc,
             note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT,
         )
 
     @pytest.fixture()
-    def unknown_notable_domain(self, unknown_domain):
+    def unknown_notable_domain(self):
         return NotableDomain.objects.create(
-            domain=unknown_domain.netloc,
+            domain=self.unknown_domain.netloc,
             note=NotableDomain.Note.UNKNOWN,
         )
 
     @pytest.fixture()
-    def ignored_notable_domain(self, ignored_domain):
+    def ignored_notable_domain(self):
         return NotableDomain.objects.create(
-            domain=ignored_domain.netloc,
+            domain=self.ignored_domain.netloc,
             note=NotableDomain.Note.IGNORED,
         )
 
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
-    def test_from_spam_to_unknown(self, factory, spam_domain_one, spam_domain_two, unknown_domain, ignored_domain, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
+    def test_from_spam_to_unknown_one_spam_domain(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
-        obj_two = factory()
-        obj_three = factory()
         check_resource_for_domains.apply_async(
             kwargs=dict(
                 guid=obj_one.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
-            )
-        )
-        check_resource_for_domains.apply_async(
-            kwargs=dict(
-                guid=obj_two.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {spam_domain_two.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
-            )
-        )
-        obj_three.spam_data['who_flagged'] = 'some external spam checker'
-        obj_three.save()
-        check_resource_for_domains.apply_async(
-            kwargs=dict(
-                guid=obj_three.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
         )
         obj_one.reload()
-        obj_two.reload()
-        obj_three.reload()
         assert obj_one.spam_status == SpamStatus.SPAM
-        assert obj_two.spam_status == SpamStatus.SPAM
-        assert obj_three.spam_status == SpamStatus.SPAM
-        assert set(obj_one.spam_data['domains']) == set([spam_domain_one.netloc])
-        assert set(obj_two.spam_data['domains']) == set([spam_domain_one.netloc, spam_domain_two.netloc])
-        assert set(obj_three.spam_data['domains']) == set([spam_domain_one.netloc])
+        assert set(obj_one.spam_data['domains']) == set([self.spam_domain_one.netloc])
         spam_notable_domain_one.note = NotableDomain.Note.UNKNOWN
         spam_notable_domain_one.save()
         obj_one.reload()
-        obj_two.reload()
-        obj_three.reload()
         assert obj_one.spam_status == SpamStatus.UNKNOWN
-        assert obj_two.spam_status == SpamStatus.SPAM
-        assert obj_three.spam_status == SpamStatus.SPAM
         assert len(obj_one.spam_data['domains']) == 0
-        assert set(obj_two.spam_data['domains']) == set([spam_domain_two.netloc])
-        assert len(obj_three.spam_data['domains']) == 0
 
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
-    def test_from_spam_to_ignored(self, factory, spam_domain_one, spam_domain_two, unknown_domain, ignored_domain, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
-        obj_one = factory()
+    def test_from_spam_to_unknown_two_spam_domains(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
-        obj_three = factory()
-        check_resource_for_domains.apply_async(
-            kwargs=dict(
-                guid=obj_one.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
-            )
-        )
         check_resource_for_domains.apply_async(
             kwargs=dict(
                 guid=obj_two.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {spam_domain_two.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
+                content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
         )
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.SPAM
+        assert set(obj_two.spam_data['domains']) == set([self.spam_domain_one.netloc, self.spam_domain_two.netloc])
+        spam_notable_domain_one.note = NotableDomain.Note.UNKNOWN
+        spam_notable_domain_one.save()
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.SPAM
+        assert set(obj_two.spam_data['domains']) == set([self.spam_domain_two.netloc])
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_spam_to_unknown_marked_by_external(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
+        obj_three = factory()
         obj_three.spam_data['who_flagged'] = 'some external spam checker'
         obj_three.save()
         check_resource_for_domains.apply_async(
             kwargs=dict(
                 guid=obj_three.guids.first()._id,
-                content=f'{spam_domain_one.geturl()} {unknown_domain.geturl()} {ignored_domain.geturl()}',
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
         )
-        obj_one.reload()
-        obj_two.reload()
         obj_three.reload()
-        assert obj_one.spam_status == SpamStatus.SPAM
-        assert obj_two.spam_status == SpamStatus.SPAM
         assert obj_three.spam_status == SpamStatus.SPAM
-        assert set(obj_one.spam_data['domains']) == set([spam_domain_one.netloc])
-        assert set(obj_two.spam_data['domains']) == set([spam_domain_one.netloc, spam_domain_two.netloc])
-        assert set(obj_three.spam_data['domains']) == set([spam_domain_one.netloc])
-        spam_notable_domain_one.note = NotableDomain.Note.IGNORED
+        assert set(obj_three.spam_data['domains']) == set([self.spam_domain_one.netloc])
+        spam_notable_domain_one.note = NotableDomain.Note.UNKNOWN
         spam_notable_domain_one.save()
-        obj_one.reload()
-        obj_two.reload()
         obj_three.reload()
-        assert obj_one.spam_status == SpamStatus.UNKNOWN
-        assert obj_two.spam_status == SpamStatus.SPAM
         assert obj_three.spam_status == SpamStatus.SPAM
-        assert len(obj_one.spam_data['domains']) == 0
-        assert set(obj_two.spam_data['domains']) == set([spam_domain_two.netloc])
         assert len(obj_three.spam_data['domains']) == 0
 
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
-    def test_from_unknown_to_spam(self, factory, unknown_domain, ignored_domain, unknown_notable_domain, ignored_notable_domain):
+    def test_from_spam_to_ignored_one_spam_domain(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
-        obj_two = factory()
         check_resource_for_domains.apply_async(
             kwargs=dict(
                 guid=obj_one.guids.first()._id,
-                content=f'{unknown_domain.geturl()} {ignored_domain.geturl()}',
-            )
-        )
-        check_resource_for_domains.apply_async(
-            kwargs=dict(
-                guid=obj_two.guids.first()._id,
-                content=f'{unknown_domain.geturl()}',
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
         )
         obj_one.reload()
-        obj_two.reload()
+        assert obj_one.spam_status == SpamStatus.SPAM
+        assert set(obj_one.spam_data['domains']) == set([self.spam_domain_one.netloc])
+        spam_notable_domain_one.note = NotableDomain.Note.IGNORED
+        spam_notable_domain_one.save()
+        obj_one.reload()
         assert obj_one.spam_status == SpamStatus.UNKNOWN
-        assert obj_two.spam_status == SpamStatus.UNKNOWN
+        assert len(obj_one.spam_data['domains']) == 0
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_spam_to_ignored_two_spam_domains(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
+        obj_two = factory()
+        check_resource_for_domains.apply_async(
+            kwargs=dict(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
+            )
+        )
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.SPAM
+        assert set(obj_two.spam_data['domains']) == set([self.spam_domain_one.netloc, self.spam_domain_two.netloc])
+        spam_notable_domain_one.note = NotableDomain.Note.IGNORED
+        spam_notable_domain_one.save()
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.SPAM
+        assert set(obj_two.spam_data['domains']) == set([self.spam_domain_two.netloc])
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_spam_to_ignored_makred_by_external(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
+        obj_three = factory()
+        obj_three.spam_data['who_flagged'] = 'some external spam checker'
+        obj_three.save()
+        check_resource_for_domains.apply_async(
+            kwargs=dict(
+                guid=obj_three.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
+            )
+        )
+        obj_three.reload()
+        assert obj_three.spam_status == SpamStatus.SPAM
+        assert set(obj_three.spam_data['domains']) == set([self.spam_domain_one.netloc])
+        spam_notable_domain_one.note = NotableDomain.Note.IGNORED
+        spam_notable_domain_one.save()
+        obj_three.reload()
+        assert obj_three.spam_status == SpamStatus.SPAM
+        assert len(obj_three.spam_data['domains']) == 0
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_unknown_to_spam_unknown_plus_ignored(self, factory, unknown_notable_domain, ignored_notable_domain):
+        obj_one = factory()
+        check_resource_for_domains.apply_async(
+            kwargs=dict(
+                guid=obj_one.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
+            )
+        )
+        obj_one.reload()
+        assert obj_one.spam_status == SpamStatus.UNKNOWN
         assert 'domains' not in obj_one.spam_data
-        assert 'domains' not in obj_two.spam_data
         unknown_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
         unknown_notable_domain.save()
         obj_one.reload()
-        obj_two.reload()
         assert obj_one.spam_status == SpamStatus.SPAM
-        assert obj_two.spam_status == SpamStatus.SPAM
-        assert set(obj_one.spam_data['domains']) == set([unknown_domain.netloc])
-        assert set(obj_two.spam_data['domains']) == set([unknown_domain.netloc])
+        assert set(obj_one.spam_data['domains']) == set([self.unknown_domain.netloc])
 
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
-    def test_from_ignored_to_spam(self, factory, unknown_domain, ignored_domain, unknown_notable_domain, ignored_notable_domain):
-        obj_one = factory()
+    def test_from_unknown_to_spam_unknown_only(self, factory, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
         check_resource_for_domains.apply_async(
             kwargs=dict(
-                guid=obj_one.guids.first()._id,
-                content=f'{unknown_domain.geturl()} {ignored_domain.geturl()}',
+                guid=obj_two.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()}',
             )
         )
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.UNKNOWN
+        assert 'domains' not in obj_two.spam_data
+        unknown_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
+        unknown_notable_domain.save()
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.SPAM
+        assert set(obj_two.spam_data['domains']) == set([self.unknown_domain.netloc])
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_ignored_to_spam_unknown_plus_ignored(self, factory, unknown_notable_domain, ignored_notable_domain):
+        obj_one = factory()
         check_resource_for_domains.apply_async(
             kwargs=dict(
-                guid=obj_two.guids.first()._id,
-                content=f'{ignored_domain.geturl()}',
+                guid=obj_one.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
         )
         obj_one.reload()
-        obj_two.reload()
         assert obj_one.spam_status == SpamStatus.UNKNOWN
-        assert obj_two.spam_status == SpamStatus.UNKNOWN
         assert 'domains' not in obj_one.spam_data
-        assert 'domains' not in obj_two.spam_data
         ignored_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
         ignored_notable_domain.save()
         obj_one.reload()
-        obj_two.reload()
         assert obj_one.spam_status == SpamStatus.SPAM
+        assert set(obj_one.spam_data['domains']) == set([self.ignored_domain.netloc])
+
+    @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
+    def test_from_ignored_to_spam_ignored_only(self, factory, unknown_notable_domain, ignored_notable_domain):
+        obj_two = factory()
+        check_resource_for_domains.apply_async(
+            kwargs=dict(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.ignored_domain.geturl()}',
+            )
+        )
+        obj_two.reload()
+        assert obj_two.spam_status == SpamStatus.UNKNOWN
+        assert 'domains' not in obj_two.spam_data
+        ignored_notable_domain.note = NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT
+        ignored_notable_domain.save()
+        obj_two.reload()
         assert obj_two.spam_status == SpamStatus.SPAM
-        assert set(obj_one.spam_data['domains']) == set([ignored_domain.netloc])
-        assert set(obj_two.spam_data['domains']) == set([ignored_domain.netloc])
+        assert set(obj_two.spam_data['domains']) == set([self.ignored_domain.netloc])


### PR DESCRIPTION
## Purpose

To reclassify related resources when a `NotableDomain` is reclassified.

## Changes
- Take some logic out of the `confirm_ham` hook of the `SpamOverrideMixin` into an `undelete` hook
- Modified the `confirm_spam` hook of the `SpamMixin` to include domains in `spam_data` if the resource is marked as spam because of a spammy domain.
- Add a `unspam` hook to `SpamMixin` and `SpamMixinOverride`
  - Make use of the newly added `undelete` hook
- Modified the `save` hook of the `NotableDomain` class and only initiate the reclassification task when `note` has been changed.
- Modified the `reclassify_domain_references` task to spam and unspam related resources conditionally
- Add tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
