### PR TITLE
[fix] prevent creating a phantom BaseFileNode with Guid

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -762,15 +762,6 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         )
     )
 
-    # There's no download action redirect to the Ember front-end file view and create guid.
-    if action != 'download':
-        if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
-            guid = file_node.get_guid(create=True)
-            return redirect(f'{settings.DOMAIN}{guid._id}/')
-        if isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
-            guid = file_node.get_guid(create=True)
-            return redirect(f'{settings.DOMAIN}{guid._id}/')
-
     if version is None:
         # File is either deleted or unable to be found in the provider location
         # Rollback the insertion of the file_node
@@ -798,6 +789,15 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         return addon_deleted_file(target=target, file_node=file_node, path=path, **kwargs)
     else:
         transaction.savepoint_commit(savepoint_id)
+
+    # There's no download action redirect to the Ember front-end file view and create guid.
+    if action != 'download':
+        if isinstance(target, Node) and waffle.flag_is_active(request, features.EMBER_FILE_PROJECT_DETAIL):
+            guid = file_node.get_guid(create=True)
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
+        if isinstance(target, Registration) and waffle.flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
+            guid = file_node.get_guid(create=True)
+            return redirect(f'{settings.DOMAIN}{guid._id}/')
 
     # TODO clean up these urls and unify what is used as a version identifier
     if request.method == 'HEAD':


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
if the ember files detail page is waffled on, then visiting `/<guid>/files/osfstorage/<...>` (where `<...>` is not a real file id) creates a phantom `OsfStorageFileNode` with its own guid (e.g. https://api.osf.io/v2/files/yp4su/ )

i don't see any significant consequences to this, but it's not _good_.
<!-- Describe the purpose of your changes -->

## Changes
wait to create a guid and redirect to the file detail page until after verifying the file exists.
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
