### PR TITLE
[ENG-4136] Fix post-migration waffle and institution metrics

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -474,7 +474,8 @@ class InstitutionDepartmentList(InstitutionImpactList):
     serializer_class = InstitutionDepartmentMetricsSerializer
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES, ) + (InstitutionDepartmentMetricsCSVRenderer, )
 
-    ordering = ('-number_of_users', 'name',)
+    ordering_fields = ('-number_of_users', 'name', )
+    ordering = ('-number_of_users', 'name', )
 
     def _format_search(self, search, default_kwargs=None):
         results = search.execute()
@@ -498,7 +499,8 @@ class InstitutionUserMetricsList(InstitutionImpactList):
     serializer_class = InstitutionUserMetricsSerializer
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES, ) + (InstitutionUserMetricsCSVRenderer, )
 
-    ordering = ('user_name',)
+    ordering_fields = ('user_name', 'department', )
+    ordering = ('user_name', )
 
     def _format_search(self, search, default_kwargs=None):
         results = search.execute()

--- a/osf/features.yaml
+++ b/osf/features.yaml
@@ -200,7 +200,7 @@ switches:
   - flag_name: ENFORCE_CSRF
     name: enforce_csrf
     note: enforces csrf for OSF session authentication
-    active: true
+    active: false
 
   - flag_name: ENABLE_RAW_METRICS
     name: enable_raw_metrics


### PR DESCRIPTION
## Purpose

### Waffle Fix

* Fix one flipped waffle in post-migration.

* This is a temporary fix that prevents one waffle being set to the wrong value which breaks OSF during post-migration.

* The long-term solution is to disable waffle update in post-migration for non-local environment.

* Reference: https://github.com/CenterForOpenScience/osf.io/pull/9950

### Metrics Fix

* DRF change has led to MockQuerySet no longer have a model to use to validate "default" filterable fields.

  * Before (3.8): [`get_default_valid_fields()`](https://github.com/encode/django-rest-framework/blob/3.8.2/rest_framework/filters.py#L180)
  * After (3.13): [`get_default_valid_fields()`](https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/filters.py#L208)

* The solution is to define them in `ordering_fields` for affected views which are now used by [`get_valid_fields()`](https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/filters.py#L246).

Credit: @jwalz, @aaxelb and @mfraezz 

## Changes

N/A

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
