### PR TITLE
admin fix: don't break when share already knows 

### DIFF
--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -230,10 +230,14 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
                 'Content-Type': 'application/vnd.api+json'
             }
         )
-        resp.raise_for_status()
+        # if 409 Conflict, share already had a source by that name,
+        # but it includes that data in the response, so there's no problem.
+        if resp.status_code != 409:
+            resp.raise_for_status()
         resp_json = resp.json()
 
         self.share_source = resp_json['data']['attributes']['longTitle']
+        self.share_title = self.share_source
         for data in resp_json['included']:
             if data['type'] == 'ShareUser':
                 self.access_token = data['attributes']['token']


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
avoid a silly 502 in the admin
<!-- Describe the purpose of your changes -->

## Changes
handle `409 Conflict` response in AbstractProvider.setup_share_source (it means the source already exists in share, so there's no problem)

relevant [share view](https://github.com/CenterForOpenScience/SHARE/blob/84c969956290cf85fb9b28737b9a1997b65bb835/api/sources/views.py#L52-L58)
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
