### PR TITLE
[Hotfix] Construct a url for testing whether a matched string is a domain

### DIFF
--- a/osf/external/spam/tasks.py
+++ b/osf/external/spam/tasks.py
@@ -58,8 +58,13 @@ def _extract_domains(content):
         if not domain or domain in extracted_domains:
             continue
 
+        protocol = match.group('protocol') or 'https://'
+        www = match.group('www') or ''
+        path = match.group('path') or ''
+        constructed_url = f'{protocol}{www}{domain}{path}'
+
         try:
-            response = requests.head(match.group())
+            response = requests.head(constructed_url)
         except (requests.exceptions.ConnectionError, requests.exceptions.InvalidURL):
             continue
         except requests.exceptions.RequestException:

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -109,11 +109,22 @@ class TestDomainExtraction:
             domains = list(spam_tasks._extract_domains(sample_text))
         assert domains == ['redirect.me']
 
-    def test_extract_domains__redirect_with_full_url(self):
+    def test_extract_domains__redirect_with_full_url_no_protocol(self):
         mock_response = SimpleNamespace()
         mock_response.status_code = 301
         mock_response.headers = {'location': 'osf.io'}
         target_url = 'redirect.me/this-is-a-path/another-level-path/index.php'
+        sample_text = target_url
+        with mock.patch.object(spam_tasks.requests, 'head', return_value=mock_response) as mock_object:
+            domains = list(spam_tasks._extract_domains(sample_text))
+            mock_object.assert_called_once_with(f'https://{target_url}')
+        assert domains == ['osf.io']
+    
+    def test_extract_domains__redirect_with_full_url_and_protocol(self):
+        mock_response = SimpleNamespace()
+        mock_response.status_code = 301
+        mock_response.headers = {'location': 'osf.io'}
+        target_url = 'ftp://redirect.me/this-is-a-path/another-level-path/index.php'
         sample_text = target_url
         with mock.patch.object(spam_tasks.requests, 'head', return_value=mock_response) as mock_object:
             domains = list(spam_tasks._extract_domains(sample_text))

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -119,7 +119,7 @@ class TestDomainExtraction:
             domains = list(spam_tasks._extract_domains(sample_text))
             mock_object.assert_called_once_with(f'https://{target_url}')
         assert domains == ['osf.io']
-    
+
     def test_extract_domains__redirect_with_full_url_and_protocol(self):
         mock_response = SimpleNamespace()
         mock_response.status_code = 301


### PR DESCRIPTION

## Purpose

This is reverting the previous change to remove the constructed URL, but with the addition of `path` to the URL.
The reason we want to construct an URL is because `requests.head()` raises a `request.exceptions.MissingSchema` exception if the URL does not contain a `protocol` section. When that happens, it will be handled by the catch block on line 65 (line 70 after the change) and hit the `pass`. When that happens, the URL will be added as a NotableDomain regardless if it is really a valid URL. This PR fix the problem by constructed a URL with a protocol so that something that is not a URL would raise either `ConnectionError` or `InvalidURL`, and would not be added as a NotableDomain.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
