### PR TITLE
[Institution Rework] [ENG-4199] [ENG-4200] Update user-institution affiliation references

### DIFF
--- a/admin_tests/institutions/test_views.py
+++ b/admin_tests/institutions/test_views.py
@@ -213,7 +213,7 @@ class TestAffiliatedNodeList(AdminTestCase):
             content_type_id=ContentType.objects.get_for_model(AbstractNode).id
         ).first()
         self.user.user_permissions.add(self.view_node)
-        self.user.affiliated_institutions.add(self.institution)
+        self.user.add_or_update_affiliated_institution(self.institution)
         self.user.save()
 
         self.node1 = ProjectFactory(creator=self.user)

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -16,7 +16,7 @@ from framework import sentry
 from framework.auth import get_or_create_user
 
 from osf import features
-from osf.models import Institution, InstitutionAffiliation
+from osf.models import Institution
 from osf.models.institution import SharedSsoAffiliationFilterCriteriaAction
 
 from website.mails import send_mail, WELCOME_OSF4I
@@ -308,11 +308,10 @@ class InstitutionAuthentication(BaseAuthentication):
             )
 
         # Affiliate the user to the primary institution if not previously affiliated
-        if not user.is_affiliated_with_institution(institution):
-            InstitutionAffiliation.create(user, institution, sso_mail=username, sso_department=department)
+        user.add_one_affiliated_institution(institution, sso_mail=username, sso_department=department)
 
         # Affiliate the user to the secondary institution if not previously affiliated
-        if secondary_institution and not user.is_affiliated_with_institution(secondary_institution):
-            InstitutionAffiliation.create(user, institution, sso_mail=username, sso_department=department)
+        if secondary_institution:
+            user.add_one_affiliated_institution(secondary_institution, sso_mail=username, sso_department=department)
 
         return user, None

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -16,7 +16,7 @@ from framework import sentry
 from framework.auth import get_or_create_user
 
 from osf import features
-from osf.models import Institution
+from osf.models import Institution, InstitutionAffiliation
 from osf.models.institution import SharedSsoAffiliationFilterCriteriaAction
 
 from website.mails import send_mail, WELCOME_OSF4I
@@ -309,12 +309,10 @@ class InstitutionAuthentication(BaseAuthentication):
 
         # Affiliate the user to the primary institution if not previously affiliated
         if not user.is_affiliated_with_institution(institution):
-            user.affiliated_institutions.add(institution)
-            user.save()
+            InstitutionAffiliation.create(user, institution, sso_mail=username, sso_department=department)
 
         # Affiliate the user to the secondary institution if not previously affiliated
         if secondary_institution and not user.is_affiliated_with_institution(secondary_institution):
-            user.affiliated_institutions.add(secondary_institution)
-            user.save()
+            InstitutionAffiliation.create(user, institution, sso_mail=username, sso_department=department)
 
         return user, None

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -265,9 +265,6 @@ class InstitutionAuthentication(BaseAuthentication):
         # The `department` field is updated each login when it was changed.
         user_guid = user.guids.first()._id
         if department:
-            if user.department != department:
-                user.department = department
-                user.save()
             logger.info('Institution SSO: user w/ dept: user=[{}], email=[{}], inst=[{}], '
                         'dept=[{}]'.format(user_guid, username, institution._id, department))
         else:
@@ -308,10 +305,14 @@ class InstitutionAuthentication(BaseAuthentication):
             )
 
         # Affiliate the user to the primary institution if not previously affiliated
-        user.add_one_affiliated_institution(institution, sso_mail=username, sso_department=department)
+        user.add_or_update_affiliated_institution(institution, sso_mail=username, sso_department=department)
 
         # Affiliate the user to the secondary institution if not previously affiliated
         if secondary_institution:
-            user.add_one_affiliated_institution(secondary_institution, sso_mail=username, sso_department=department)
+            user.add_or_update_affiliated_institution(
+                secondary_institution,
+                sso_mail=username,
+                sso_department=department,
+            )
 
         return user, None

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -165,7 +165,7 @@ class InstitutionUserList(JSONAPIBaseView, ListFilterMixin, generics.ListAPIView
 
     def get_default_queryset(self):
         institution = self.get_institution()
-        return institution.osfuser_set.all()
+        return institution.get_institution_users()
 
     # overrides RetrieveAPIView
     def get_queryset(self):

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -140,7 +140,7 @@ def format_user(user):
     if user.external_identity.get('ORCID') and list(user.external_identity['ORCID'].values())[0] == 'VERIFIED':
         person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=list(user.external_identity['ORCID'].keys())[0]))
 
-    person.attrs['related_agents'] = [GraphNode('isaffiliatedwith', subject=person, related=GraphNode('institution', name=institution.name)) for institution in user.affiliated_institutions.all()]
+    person.attrs['related_agents'] = [GraphNode('isaffiliatedwith', subject=person, related=GraphNode('institution', name=institution.name)) for institution in user.get_affiliated_institutions()]
 
     return person
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -188,6 +188,7 @@ class UserSerializer(JSONAPISerializer):
         return Preprint.objects.can_view(user_preprints_query, auth_user, allow_contribs=False).count()
 
     def get_institutions_count(self, obj):
+        # TODO: Add a check to make sure that ``obj`` is an ``OSFUser``
         return obj.get_affiliated_institutions.count()
 
     def get_can_view_reviews(self, obj):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -188,8 +188,9 @@ class UserSerializer(JSONAPISerializer):
         return Preprint.objects.can_view(user_preprints_query, auth_user, allow_contribs=False).count()
 
     def get_institutions_count(self, obj):
-        # TODO: Add a check to make sure that ``obj`` is an ``OSFUser``
-        return obj.get_affiliated_institutions.count()
+        if isinstance(obj, OSFUser):
+            return obj.get_affiliated_institutions().count()
+        return obj.affiliated_institutions.count()
 
     def get_can_view_reviews(self, obj):
         group_qs = AbstractProviderGroupObjectPermission.objects.filter(group__user=obj, permission__codename='view_submissions')

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -188,7 +188,7 @@ class UserSerializer(JSONAPISerializer):
         return Preprint.objects.can_view(user_preprints_query, auth_user, allow_contribs=False).count()
 
     def get_institutions_count(self, obj):
-        return obj.affiliated_institutions.count()
+        return obj.get_affiliated_institutions.count()
 
     def get_can_view_reviews(self, obj):
         group_qs = AbstractProviderGroupObjectPermission.objects.filter(group__user=obj, permission__codename='view_submissions')

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -435,7 +435,7 @@ class UserInstitutions(JSONAPIBaseView, generics.ListAPIView, UserMixin):
 
     def get_queryset(self):
         user = self.get_user()
-        return user.affiliated_institutions.all()
+        return user.get_affiliated_institutions()
 
 
 class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMixin):
@@ -521,7 +521,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     def get_object(self):
         user = self.get_user(check_permissions=False)
         obj = {
-            'data': user.affiliated_institutions.all(),
+            'data': user.get_affiliated_institutions(),
             'self': user,
         }
         self.check_object_permissions(self.request, obj)
@@ -530,7 +530,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     def perform_destroy(self, instance):
         data = self.request.data['data']
         user = self.request.user
-        current_institutions = set(user.affiliated_institutions.values_list('_id', flat=True))
+        current_institutions = set(user.get_affiliated_institution__ids())
 
         # DELETEs normally dont get type checked
         # not the best way to do it, should be enforced everywhere, maybe write a test for it

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -530,7 +530,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     def perform_destroy(self, instance):
         data = self.request.data['data']
         user = self.request.user
-        current_institutions = set(user.get_affiliated_institution__ids())
+        current_institutions = user.get_affiliated_institution__id_set()
 
         # DELETEs normally dont get type checked
         # not the best way to do it, should be enforced everywhere, maybe write a test for it

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -530,7 +530,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     def perform_destroy(self, instance):
         data = self.request.data['data']
         user = self.request.user
-        current_institutions = user.get_affiliated_institution__id_set()
+        current_institutions = set(user.get_affiliated_institution__ids())
 
         # DELETEs normally dont get type checked
         # not the best way to do it, should be enforced everywhere, maybe write a test for it

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -530,7 +530,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     def perform_destroy(self, instance):
         data = self.request.data['data']
         user = self.request.user
-        current_institutions = set(user.get_affiliated_institution__ids())
+        current_institutions = set(user.get_institution_affiliations().values_list('institution___id', flat=True))
 
         # DELETEs normally dont get type checked
         # not the best way to do it, should be enforced everywhere, maybe write a test for it
@@ -539,7 +539,7 @@ class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
                 raise Conflict()
         for val in data:
             if val['id'] in current_institutions:
-                user.remove_institution(val['id'])
+                user.remove_affiliated_institution(val['id'])
         user.save()
 
 

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -311,7 +311,7 @@ class TestDraftRegistrationUpdateWithNode(TestDraftRegistrationUpdate, TestUpdat
 
     def test_update_editable_fields(self, app, url_draft_registrations, draft_registration, license, copyright_holders,
             year, institution_one, user, title, description, category, subject, editable_fields_payload):
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
 
         res = app.put_json_api(
             url_draft_registrations, editable_fields_payload,
@@ -376,7 +376,7 @@ class TestDraftRegistrationUpdateWithNode(TestDraftRegistrationUpdate, TestUpdat
     def test_editable_title(
             self, app, user, editable_fields_payload, url_draft_registrations, institution_one):
         # User must have permissions on the institution included in the editable_fields_payload
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
 
         # test blank title - should be allowed
         editable_fields_payload['data']['attributes']['title'] = ''

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -280,7 +280,7 @@ class TestDraftRegistrationCreateWithNode(TestDraftRegistrationCreate):
             auth=user.auth, expect_errors=True)
         assert res.status_code == 201
         draft_registration = DraftRegistration.load(res.json['data']['id'])
-        assert not draft_registration.affiliated_institutions.all() == user.affiliated_institutions.all()
+        assert not draft_registration.affiliated_institutions.all() == user.get_affiliated_institutions()
 
 
 class TestDraftRegistrationCreateWithoutNode(TestDraftRegistrationCreate):

--- a/api_tests/draft_registrations/views/test_draft_registration_relationship_institutions.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_relationship_institutions.py
@@ -61,22 +61,22 @@ class TestDraftRegistrationRelationshipInstitutions():
     @pytest.fixture()
     def user(self, institution_one, institution_two):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_two)
+        user.add_or_update_affiliated_institution(institution_one)
+        user.add_or_update_affiliated_institution(institution_two)
         user.save()
         return user
 
     @pytest.fixture()
     def write_contrib(self, write_contrib_institution):
         write_contrib = AuthUserFactory()
-        write_contrib.affiliated_institutions.add(write_contrib_institution)
+        write_contrib.add_or_update_affiliated_institution(write_contrib_institution)
         write_contrib.save()
         return write_contrib
 
     @pytest.fixture()
     def read_contrib(self, read_contrib_institution):
         read_contrib = AuthUserFactory()
-        read_contrib.affiliated_institutions.add(read_contrib_institution)
+        read_contrib.add_or_update_affiliated_institution(read_contrib_institution)
         read_contrib.save()
         return read_contrib
 
@@ -100,9 +100,9 @@ class TestDraftRegistrationRelationshipInstitutions():
             node, node_institutions_url, user,
             create_payload):
         user2 = AuthUserFactory()
-        user2.affiliated_institutions.add(institution_three)
-        user2.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_three)
+        user2.add_or_update_affiliated_institution(institution_three)
+        user2.add_or_update_affiliated_institution(institution_one)
+        user.add_or_update_affiliated_institution(institution_three)
         user.save()
         node.add_contributor(user)
         node.save()
@@ -123,7 +123,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             self, app, institution_one, node,
             node_institutions_url, create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user)
         node.save()
@@ -180,7 +180,7 @@ class TestDraftRegistrationRelationshipInstitutions():
 
         #   test_node_with_no_permissions
         unauthorized_user = AuthUserFactory()
-        unauthorized_user.affiliated_institutions.add(institution_one)
+        unauthorized_user.add_or_update_affiliated_institution(institution_one)
         unauthorized_user.save()
         res = app.put_json_api(
             node_institutions_url,
@@ -233,7 +233,7 @@ class TestDraftRegistrationRelationshipInstitutions():
 
     def test_user_with_institution_and_permissions(
             self, app, user, institution_three, node, node_institutions_url, create_payload):
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_three not in node.affiliated_institutions.all()
 
         res = app.post_json_api(
@@ -254,7 +254,7 @@ class TestDraftRegistrationRelationshipInstitutions():
     def test_user_with_institution_and_permissions_through_patch(
             self, app, user, institution_three,
             node, node_institutions_url, create_payload):
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_three not in node.affiliated_institutions.all()
 
         res = app.put_json_api(
@@ -307,7 +307,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             self, app, user, institution_one, institution_three,
             node, node_institutions_url, create_payload):
         node.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_one in node.affiliated_institutions.all()
         assert institution_three not in node.affiliated_institutions.all()
 
@@ -327,7 +327,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             node, node_institutions_url, create_payload):
         node.affiliated_institutions.add(institution_one)
         node.save()
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_one in node.affiliated_institutions.all()
         assert institution_three not in node.affiliated_institutions.all()
 
@@ -346,7 +346,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             self, app, user, institution_one, institution_three,
             node, node_institutions_url, create_payload):
         node.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_one in node.affiliated_institutions.all()
         assert institution_three not in node.affiliated_institutions.all()
 
@@ -391,7 +391,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             self, app, user, institution_one, institution_three,
             node, node_institutions_url, create_payload):
         node.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_three)
+        user.add_or_update_affiliated_institution(institution_three)
         assert institution_one in node.affiliated_institutions.all()
         assert institution_three not in node.affiliated_institutions.all()
 
@@ -426,7 +426,7 @@ class TestDraftRegistrationRelationshipInstitutions():
             self, app, institution_one, node,
             node_institutions_url, create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user, permissions=permissions.READ)
         node.affiliated_institutions.add(institution_one)

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -253,7 +253,7 @@ class TestInstitutionAuth:
         assert user.fullname == fullname
         assert user.family_name == 'Bar'
         assert user.given_name == 'Foo'
-        affiliation = user.get_institution_affiliation(institution)
+        affiliation = user.get_institution_affiliation(institution._id)
         assert affiliation.sso_department == 'Fake Department'
         # Existing active user keeps their password
         assert user.has_usable_password()
@@ -296,7 +296,7 @@ class TestInstitutionAuth:
         assert user.fullname == 'Fake User'
         assert user.family_name == 'User'
         assert user.given_name == 'Fake'
-        affiliation = user.get_institution_affiliation(institution)
+        affiliation = user.get_institution_affiliation(institution._id)
         assert affiliation.sso_department == 'Fake Department'
         # Unclaimed records must have been cleared
         assert not user.unclaimed_records

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -253,7 +253,8 @@ class TestInstitutionAuth:
         assert user.fullname == fullname
         assert user.family_name == 'Bar'
         assert user.given_name == 'Foo'
-        assert user.department == 'Fake Department'
+        affiliation = user.get_institution_affiliation(institution)
+        assert affiliation.department == 'Fake Department'
         # Existing active user keeps their password
         assert user.has_usable_password()
         assert user.check_password(password)
@@ -295,7 +296,8 @@ class TestInstitutionAuth:
         assert user.fullname == 'Fake User'
         assert user.family_name == 'User'
         assert user.given_name == 'Fake'
-        assert user.department == 'Fake Department'
+        affiliation = user.get_institution_affiliation(institution)
+        assert affiliation.department == 'Fake Department'
         # Unclaimed records must have been cleared
         assert not user.unclaimed_records
         # Previously unclaimed user must be assigned a usable password during institution auth

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -254,7 +254,7 @@ class TestInstitutionAuth:
         assert user.family_name == 'Bar'
         assert user.given_name == 'Foo'
         affiliation = user.get_institution_affiliation(institution)
-        assert affiliation.department == 'Fake Department'
+        assert affiliation.sso_department == 'Fake Department'
         # Existing active user keeps their password
         assert user.has_usable_password()
         assert user.check_password(password)
@@ -297,7 +297,7 @@ class TestInstitutionAuth:
         assert user.family_name == 'User'
         assert user.given_name == 'Fake'
         affiliation = user.get_institution_affiliation(institution)
-        assert affiliation.department == 'Fake Department'
+        assert affiliation.sso_department == 'Fake Department'
         # Unclaimed records must have been cleared
         assert not user.unclaimed_records
         # Previously unclaimed user must be assigned a usable password during institution auth

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -150,7 +150,7 @@ class TestInstitutionAuth:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution in user.affiliated_institutions.all()
+        assert institution in user.get_affiliated_institutions()
 
     def test_existing_user_found_but_not_affiliated(self, app, institution, url_auth_institution):
 
@@ -165,7 +165,7 @@ class TestInstitutionAuth:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert institution in user.affiliated_institutions.all()
+        assert institution in user.get_affiliated_institutions()
 
     def test_user_found_and_affiliated(self, app, institution, url_auth_institution):
 
@@ -258,7 +258,7 @@ class TestInstitutionAuth:
         assert user.has_usable_password()
         assert user.check_password(password)
         # Confirm affiliation
-        assert institution in user.affiliated_institutions.all()
+        assert institution in user.get_affiliated_institutions()
 
     def test_user_unclaimed(self, app, institution, url_auth_institution):
 
@@ -303,7 +303,7 @@ class TestInstitutionAuth:
         # User remains to be a contributor of the project
         assert project.is_contributor(user)
         # Confirm affiliation
-        assert institution in user.affiliated_institutions.all()
+        assert institution in user.get_affiliated_institutions()
 
     def test_user_unconfirmed(self, app, institution, url_auth_institution):
 
@@ -340,7 +340,7 @@ class TestInstitutionAuth:
         assert user.has_usable_password()
         assert not user.check_password(password)
         # Confirm affiliation
-        assert institution in user.affiliated_institutions.all()
+        assert institution in user.get_affiliated_institutions()
 
     def test_user_inactive(self, app, institution, url_auth_institution):
 
@@ -377,7 +377,7 @@ class TestInstitutionAuth:
         assert user.fullname == fullname
         assert user.given_name == 'Foo'
         assert user.family_name == 'Bar'
-        assert institution not in user.affiliated_institutions.all()
+        assert institution not in user.get_affiliated_institutions()
 
     def test_user_external_unconfirmed(self, app, institution, url_auth_institution):
 
@@ -431,7 +431,7 @@ class TestInstitutionAuth:
         assert user.fullname == fullname
         assert user.given_name == 'Foo'
         assert user.family_name == 'Bar'
-        assert institution not in user.affiliated_institutions.all()
+        assert institution not in user.get_affiliated_institutions()
         assert external_identity == user.external_identity
         assert email_verifications == user.email_verifications
         assert accepted_terms_of_service == user.accepted_terms_of_service
@@ -459,8 +459,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
     def test_new_user_primary_and_secondary(self, app, url_auth_institution, type_2_eligible_user_roles,
                                             institution_primary_type_2, institution_secondary_type_2):
@@ -480,8 +480,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
     def test_existing_user_primary_only_not_affiliated(self, app, url_auth_institution, type_2_ineligible_user_roles,
                                                        institution_primary_type_2, institution_secondary_type_2):
@@ -501,8 +501,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 1
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
     def test_existing_user_primary_only_affiliated(self, app, url_auth_institution, type_2_ineligible_user_roles,
                                                    institution_primary_type_2, institution_secondary_type_2):
@@ -523,8 +523,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
     def test_existing_user_both_not_affiliated(self, app, url_auth_institution, type_2_eligible_user_roles,
                                                institution_primary_type_2, institution_secondary_type_2):
@@ -545,8 +545,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 2
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
     def test_existing_user_both_affiliated(self, app, url_auth_institution, type_2_eligible_user_roles,
                                            institution_primary_type_2, institution_secondary_type_2):
@@ -569,8 +569,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
     def test_existing_user_secondary_not_affiliated(self, app, url_auth_institution, type_2_eligible_user_roles,
                                                     institution_primary_type_2, institution_secondary_type_2):
@@ -592,8 +592,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 1
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
     def test_invalid_criteria_action(self, app, url_auth_institution, type_2_eligible_user_roles,
                                      institution_primary_type_2, institution_secondary_type_2):
@@ -624,8 +624,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
     def test_invalid_institution_id(self, app, url_auth_institution, type_2_eligible_user_roles,
                                     institution_primary_type_2, institution_secondary_type_2):
@@ -656,8 +656,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
     def test_empty_criteria_value(self, app, url_auth_institution,
                                   institution_primary_type_2, institution_secondary_type_2):
@@ -688,8 +688,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_2 in user.affiliated_institutions.all()
-        assert institution_secondary_type_2 not in user.affiliated_institutions.all()
+        assert institution_primary_type_2 in user.get_affiliated_institutions()
+        assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
 
 @pytest.mark.django_db
@@ -710,8 +710,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
     def test_new_user_primary_and_secondary(self, app, url_auth_institution,
                                             institution_primary_type_1, institution_secondary_type_1):
@@ -731,8 +731,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
     def test_existing_user_primary_only_not_affiliated(self, app, url_auth_institution,
                                                        institution_primary_type_1, institution_secondary_type_1):
@@ -749,8 +749,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 1
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
     def test_existing_user_primary_only_affiliated(self, app, url_auth_institution,
                                                    institution_primary_type_1, institution_secondary_type_1):
@@ -768,8 +768,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
     def test_existing_user_both_not_affiliated(self, app, url_auth_institution,
                                                institution_primary_type_1, institution_secondary_type_1):
@@ -790,8 +790,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 2
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
     def test_existing_user_both_affiliated(self, app, url_auth_institution,
                                            institution_primary_type_1, institution_secondary_type_1):
@@ -814,8 +814,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
     def test_existing_user_secondary_not_affiliated(self, app, url_auth_institution,
                                                     institution_primary_type_1, institution_secondary_type_1):
@@ -837,8 +837,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations + 1
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
     def test_invalid_criteria_action(self, app, url_auth_institution,
                                      institution_primary_type_1, institution_secondary_type_1):
@@ -869,8 +869,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
     def test_invalid_institution_id(self, app, url_auth_institution,
                                     institution_primary_type_1, institution_secondary_type_1):
@@ -901,8 +901,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
     def test_invalid_criteria_value(self, app, url_auth_institution,
                                     institution_primary_type_1, institution_secondary_type_1):
@@ -933,8 +933,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert user.affiliated_institutions.count() == number_of_affiliations
-        assert institution_primary_type_1 in user.affiliated_institutions.all()
-        assert institution_secondary_type_1 not in user.affiliated_institutions.all()
+        assert institution_primary_type_1 in user.get_affiliated_institutions()
+        assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
 
 @pytest.mark.django_db
@@ -959,7 +959,7 @@ class TestInstitutionAuthnSelectiveSSO:
         assert user
         assert user.fullname == 'Fake User'
         assert user.accepted_terms_of_service is None
-        assert institution_selective in user.affiliated_institutions.all()
+        assert institution_selective in user.get_affiliated_institutions()
 
     def test_selective_sso_allowed_existing_user_not_affiliated(self, app, url_auth_institution, institution_selective):
 
@@ -979,7 +979,7 @@ class TestInstitutionAuthnSelectiveSSO:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert institution_selective in user.affiliated_institutions.all()
+        assert institution_selective in user.get_affiliated_institutions()
 
     def test_selective_sso_allowed_existing_user_affiliated(self, app, url_auth_institution, institution_selective):
 
@@ -1001,7 +1001,7 @@ class TestInstitutionAuthnSelectiveSSO:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert institution_selective in user.affiliated_institutions.all()
+        assert institution_selective in user.get_affiliated_institutions()
         assert number_of_affiliations == user.affiliated_institutions.count()
 
     def test_selective_sso_denied_empty_filter(self, app, url_auth_institution, institution_selective):

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -181,7 +181,7 @@ class TestInstitutionAuth:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == 1
+        assert user.get_affiliated_institutions().count() == 1
 
     def test_new_user_names_not_provided(self, app, institution, url_auth_institution):
 
@@ -488,7 +488,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         username = 'user_not_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -500,7 +500,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 1
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
@@ -510,7 +510,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -522,7 +522,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
@@ -532,7 +532,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         username = 'user_both_not_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -544,7 +544,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 2
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 2
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
@@ -556,7 +556,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.add_or_update_affiliated_institution(institution_secondary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -568,7 +568,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
@@ -579,7 +579,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -591,7 +591,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 1
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 in user.get_affiliated_institutions()
 
@@ -611,7 +611,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -623,7 +623,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
@@ -643,7 +643,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -655,7 +655,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
@@ -675,7 +675,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -687,7 +687,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_2 in user.get_affiliated_institutions()
         assert institution_secondary_type_2 not in user.get_affiliated_institutions()
 
@@ -739,7 +739,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         username = 'user_not_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(url_auth_institution, make_payload(institution_primary_type_1, username))
@@ -748,7 +748,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 1
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
@@ -758,7 +758,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(url_auth_institution, make_payload(institution_primary_type_1, username))
@@ -767,7 +767,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
@@ -777,7 +777,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         username = 'user_both_not_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -789,7 +789,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 2
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 2
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
@@ -801,7 +801,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.add_or_update_affiliated_institution(institution_secondary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -813,7 +813,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
@@ -824,7 +824,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -836,7 +836,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations + 1
+        assert user.get_affiliated_institutions().count() == number_of_affiliations + 1
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 in user.get_affiliated_institutions()
 
@@ -856,7 +856,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -868,7 +868,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
@@ -888,7 +888,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -900,7 +900,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
@@ -920,7 +920,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         with capture_signals() as mock_signals:
             res = app.post(
@@ -932,7 +932,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         user.reload()
         assert user.fullname == 'Foo Bar'
-        assert user.affiliated_institutions.count() == number_of_affiliations
+        assert user.get_affiliated_institutions().count() == number_of_affiliations
         assert institution_primary_type_1 in user.get_affiliated_institutions()
         assert institution_secondary_type_1 not in user.get_affiliated_institutions()
 
@@ -987,7 +987,7 @@ class TestInstitutionAuthnSelectiveSSO:
         user = make_user(username, 'Foo Bar')
         user.add_or_update_affiliated_institution(institution_selective)
         user.save()
-        number_of_affiliations = user.affiliated_institutions.count()
+        number_of_affiliations = user.get_affiliated_institutions().count()
 
         payload = make_payload(
             institution_selective,
@@ -1002,7 +1002,7 @@ class TestInstitutionAuthnSelectiveSSO:
         user.reload()
         assert user.fullname == 'Foo Bar'
         assert institution_selective in user.get_affiliated_institutions()
-        assert number_of_affiliations == user.affiliated_institutions.count()
+        assert number_of_affiliations == user.get_affiliated_institutions().count()
 
     def test_selective_sso_denied_empty_filter(self, app, url_auth_institution, institution_selective):
 

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -171,7 +171,7 @@ class TestInstitutionAuth:
 
         username = 'user_affiliated@osf.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
 
         with capture_signals() as mock_signals:
@@ -508,7 +508,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
                                                    institution_primary_type_2, institution_secondary_type_2):
         username = 'user_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -553,8 +553,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         username = 'user_both_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
-        user.affiliated_institutions.add(institution_secondary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_secondary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -577,7 +577,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         username = 'user_secondary_not@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -609,7 +609,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         username = 'user_invalid_criteria_action@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -641,7 +641,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         username = 'user_invalid_institution_id@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -673,7 +673,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType2:
 
         username = 'user_invalid_criteria_value@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_2)
+        user.add_or_update_affiliated_institution(institution_primary_type_2)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -756,7 +756,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
                                                    institution_primary_type_1, institution_secondary_type_1):
         username = 'user_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -798,8 +798,8 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         username = 'user_both_affiliated@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
-        user.affiliated_institutions.add(institution_secondary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_secondary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -822,7 +822,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         username = 'user_secondary_not@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -854,7 +854,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         username = 'user_invalid_criteria_action@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -886,7 +886,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         username = 'user_invalid_institution_id@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -918,7 +918,7 @@ class TestInstitutionAuthnSharedSSOCriteriaType1:
 
         username = 'user_invalid_criteria_value@primary.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_primary_type_1)
+        user.add_or_update_affiliated_institution(institution_primary_type_1)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 
@@ -985,7 +985,7 @@ class TestInstitutionAuthnSelectiveSSO:
 
         username = 'user_affiliated@osf.edu'
         user = make_user(username, 'Foo Bar')
-        user.affiliated_institutions.add(institution_selective)
+        user.add_or_update_affiliated_institution(institution_selective)
         user.save()
         number_of_affiliations = user.affiliated_institutions.count()
 

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -39,7 +39,7 @@ class TestInstitutionRelationshipNodes:
     @pytest.fixture()
     def user(self, institution):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
         return user
 
@@ -167,7 +167,7 @@ class TestInstitutionRelationshipNodes:
             institution
     ):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         node.add_contributor(user)
         node.save()
         res = app.post_json_api(
@@ -186,7 +186,7 @@ class TestInstitutionRelationshipNodes:
             institution
     ):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         node.add_contributor(user, permissions=permissions.READ)
         node.save()
 
@@ -397,7 +397,7 @@ class TestInstitutionRelationshipRegistrations:
     @pytest.fixture()
     def admin(self, institution):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
         return user
 
@@ -408,7 +408,7 @@ class TestInstitutionRelationshipRegistrations:
     @pytest.fixture()
     def affiliated_user(self, institution):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
         return user
 

--- a/api_tests/institutions/views/test_institution_users_list.py
+++ b/api_tests/institutions/views/test_institution_users_list.py
@@ -14,11 +14,11 @@ class TestInstitutionUsersList:
         institution = InstitutionFactory()
 
         user_one = UserFactory()
-        user_one.affiliated_institutions.add(institution)
+        user_one.add_or_update_affiliated_institution(institution)
         user_one.save()
 
         user_two = UserFactory()
-        user_two.affiliated_institutions.add(institution)
+        user_two.add_or_update_affiliated_institution(institution)
         user_two.save()
 
         url = '/{0}institutions/{1}/users/'.format(API_BASE, institution._id)

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -660,8 +660,8 @@ class NodeCRUDTestCase:
     @pytest.fixture()
     def user_two(self, institution_one, institution_two):
         auth_user = AuthUserFactory()
-        auth_user.affiliated_institutions.add(institution_one)
-        auth_user.affiliated_institutions.add(institution_two)
+        auth_user.add_or_update_affiliated_institution(institution_one)
+        auth_user.add_or_update_affiliated_institution(institution_two)
         return auth_user
 
     @pytest.fixture()

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1384,7 +1384,7 @@ class TestNodeCreate:
     @pytest.fixture()
     def user_one(self, institution_one):
         auth_user = AuthUserFactory()
-        auth_user.affiliated_institutions.add(institution_one)
+        auth_user.add_or_update_affiliated_institution(institution_one)
         return auth_user
 
     @pytest.fixture()
@@ -1772,7 +1772,7 @@ class TestNodeCreate:
         assert region_id == region._id
 
         institution_two = InstitutionFactory()
-        user_one.affiliated_institutions.add(institution_two)
+        user_one.add_or_update_affiliated_institution(institution_two)
 
         private_project['data']['relationships'] = {
             'affiliated_institutions': {

--- a/api_tests/nodes/views/test_node_relationship_institutions.py
+++ b/api_tests/nodes/views/test_node_relationship_institutions.py
@@ -42,22 +42,22 @@ class TestNodeRelationshipInstitutions:
     @pytest.fixture()
     def user(self, institution_one, institution_two):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_two)
+        user.add_or_update_affiliated_institution(institution_one)
+        user.add_or_update_affiliated_institution(institution_two)
         user.save()
         return user
 
     @pytest.fixture()
     def write_contrib(self, write_contrib_institution):
         write_contrib = AuthUserFactory()
-        write_contrib.affiliated_institutions.add(write_contrib_institution)
+        write_contrib.add_or_update_affiliated_institution(write_contrib_institution)
         write_contrib.save()
         return write_contrib
 
     @pytest.fixture()
     def read_contrib(self, read_contrib_institution):
         read_contrib = AuthUserFactory()
-        read_contrib.affiliated_institutions.add(read_contrib_institution)
+        read_contrib.add_or_update_affiliated_institution(read_contrib_institution)
         read_contrib.save()
         return read_contrib
 
@@ -91,7 +91,7 @@ class TestNodeRelationshipInstitutions:
 
         #   test_node_with_no_permissions
         unauthorized_user = AuthUserFactory()
-        unauthorized_user.affiliated_institutions.add(institution_one)
+        unauthorized_user.add_or_update_affiliated_institution(institution_one)
         unauthorized_user.save()
         res = app.put_json_api(
             node_institutions_url,
@@ -237,7 +237,7 @@ class TestNodeRelationshipInstitutions:
             node, node_institutions_url,
             create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user)
         node.save()
@@ -374,7 +374,7 @@ class TestNodeRelationshipInstitutions:
             self, app, institution_one, node,
             node_institutions_url, create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user)
         node.affiliated_institutions.add(institution_one)
@@ -392,7 +392,7 @@ class TestNodeRelationshipInstitutions:
             self, app, institution_one, node,
             node_institutions_url, create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user, permissions=permissions.READ)
         node.affiliated_institutions.add(institution_one)

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -447,7 +447,7 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
         assert res.json['errors'][0]['detail'] == '"data visualization" is not a valid choice.'
 
     #   test_some_registration_fields_are_editable
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         year = '2009'
         copyright_holders = ['Grapes McGee']
         description = 'New description'

--- a/api_tests/registrations/views/test_registration_relationship_institutions.py
+++ b/api_tests/registrations/views/test_registration_relationship_institutions.py
@@ -48,7 +48,7 @@ class TestRegistrationRelationshipInstitutions(TestNodeRelationshipInstitutions)
             node, node_institutions_url,
             create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user)
         node.save()
@@ -69,7 +69,7 @@ class TestRegistrationRelationshipInstitutions(TestNodeRelationshipInstitutions)
             self, app, institution_one, node,
             node_institutions_url, create_payload):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
+        user.add_or_update_affiliated_institution(institution_one)
         user.save()
         node.add_contributor(user)
         node.affiliated_institutions.add(institution_one)

--- a/api_tests/search/views/test_views.py
+++ b/api_tests/search/views/test_views.py
@@ -74,7 +74,7 @@ class ApiSearchTestCase:
     @pytest.fixture()
     def user_two(self, institution):
         user_two = AuthUserFactory(fullname='Chance The Rapper')
-        user_two.affiliated_institutions.add(institution)
+        user_two.add_or_update_affiliated_institution(institution)
         user_two.save()
         return user_two
 

--- a/api_tests/sparse/test_sparse_node_list.py
+++ b/api_tests/sparse/test_sparse_node_list.py
@@ -304,7 +304,7 @@ class TestNodeCreate:
     @pytest.fixture()
     def user(self, institution):
         auth_user = AuthUserFactory()
-        auth_user.affiliated_institutions.add(institution)
+        auth_user.add_or_update_affiliated_institution(institution)
         return auth_user
 
     @pytest.fixture()

--- a/api_tests/users/serializers/test_serializers.py
+++ b/api_tests/users/serializers/test_serializers.py
@@ -20,7 +20,7 @@ from django.urls import resolve, reverse
 def user():
     user = UserFactory()
     inst = InstitutionFactory()
-    user.affiliated_institutions.add(inst)
+    user.add_or_update_affiliated_institution(inst)
     return user
 
 

--- a/api_tests/users/views/test_user_institutions.py
+++ b/api_tests/users/views/test_user_institutions.py
@@ -13,7 +13,7 @@ class TestUserInstitutions:
     def user(self, institutions):
         user = AuthUserFactory()
         for each in institutions:
-            user.affiliated_institutions.add(each)
+            user.add_or_update_affiliated_institution(each)
         return user
 
     @pytest.fixture()

--- a/api_tests/users/views/test_user_institutions.py
+++ b/api_tests/users/views/test_user_institutions.py
@@ -23,4 +23,4 @@ class TestUserInstitutions:
     def test_get_success(self, app, user, user_institutions_url):
         res = app.get(user_institutions_url)
         assert res.status_code == 200
-        assert len(res.json['data']) == user.affiliated_institutions.count()
+        assert len(res.json['data']) == user.get_affiliated_institutions().count()

--- a/api_tests/users/views/test_user_institutions_relationship.py
+++ b/api_tests/users/views/test_user_institutions_relationship.py
@@ -76,7 +76,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.affiliated_institutions.values_list('_id', flat=True))
+        ids = list(user.get_affiliated_institution__ids())
         assert institution_one._id not in ids
         assert institution_two._id in ids
 
@@ -95,7 +95,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.affiliated_institutions.values_list('_id', flat=True))
+        ids = list(user.get_affiliated_institution__ids())
         assert institution_one._id not in ids
         assert institution_two._id not in ids
 
@@ -113,7 +113,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.affiliated_institutions.values_list('_id', flat=True))
+        ids = list(user.get_affiliated_institution__ids())
         assert institution_one._id in ids
         assert institution_two._id in ids
 

--- a/api_tests/users/views/test_user_institutions_relationship.py
+++ b/api_tests/users/views/test_user_institutions_relationship.py
@@ -22,8 +22,8 @@ class TestUserInstititutionRelationship:
     @pytest.fixture()
     def user(self, institution_one, institution_two):
         user = AuthUserFactory()
-        user.affiliated_institutions.add(institution_one)
-        user.affiliated_institutions.add(institution_two)
+        user.add_or_update_affiliated_institution(institution_one)
+        user.add_or_update_affiliated_institution(institution_two)
         user.save()
         return user
 

--- a/api_tests/users/views/test_user_institutions_relationship.py
+++ b/api_tests/users/views/test_user_institutions_relationship.py
@@ -9,7 +9,7 @@ from osf_tests.factories import (
 
 
 @pytest.mark.django_db
-class TestUserInstititutionRelationship:
+class TestUserInstitutionRelationship:
 
     @pytest.fixture()
     def institution_one(self):
@@ -76,7 +76,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.get_affiliated_institution__ids())
+        ids = list(user.get_institution_affiliations().values_list('institution___id', flat=True))
         assert institution_one._id not in ids
         assert institution_two._id in ids
 
@@ -95,7 +95,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.get_affiliated_institution__ids())
+        ids = list(user.get_institution_affiliations().values_list('institution___id', flat=True))
         assert institution_one._id not in ids
         assert institution_two._id not in ids
 
@@ -113,7 +113,7 @@ class TestUserInstititutionRelationship:
 
         user.reload()
 
-        ids = list(user.get_affiliated_institution__ids())
+        ids = list(user.get_institution_affiliations().values_list('institution___id', flat=True))
         assert institution_one._id in ids
         assert institution_two._id in ids
 

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -46,7 +46,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     """This is an asynchronous task that runs during CONFIRMED ORCiD SSO logins and makes eligible
     institution affiliations.
     """
-    from osf.models import OSFUser, InstitutionAffiliation
+    from osf.models import OSFUser
     user = OSFUser.load(user_id)
     if not user or not verify_user_orcid_id(user, orcid_id):
         # This should not happen as long as this task is called at the right place at the right time.
@@ -58,8 +58,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     if institution:
         logger.info(f'Eligible institution affiliation has been found for ORCiD SSO user: '
                     f'institution=[{institution._id}], user=[{user_id}], orcid_id=[{orcid_id}]')
-        if not user.is_affiliated_with_institution(institution):
-            InstitutionAffiliation.create(user, institution)
+        user.add_one_affiliated_institution(institution=institution, sso_identity=orcid_id)
 
 
 def verify_user_orcid_id(user, orcid_id):

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -58,7 +58,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     if institution:
         logger.info(f'Eligible institution affiliation has been found for ORCiD SSO user: '
                     f'institution=[{institution._id}], user=[{user_id}], orcid_id=[{orcid_id}]')
-        user.add_one_affiliated_institution(institution=institution, sso_identity=orcid_id)
+        user.add_or_update_affiliated_institution(institution=institution, sso_identity=orcid_id)
 
 
 def verify_user_orcid_id(user, orcid_id):

--- a/framework/auth/tasks.py
+++ b/framework/auth/tasks.py
@@ -46,7 +46,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
     """This is an asynchronous task that runs during CONFIRMED ORCiD SSO logins and makes eligible
     institution affiliations.
     """
-    from osf.models import OSFUser
+    from osf.models import OSFUser, InstitutionAffiliation
     user = OSFUser.load(user_id)
     if not user or not verify_user_orcid_id(user, orcid_id):
         # This should not happen as long as this task is called at the right place at the right time.
@@ -59,7 +59,7 @@ def update_affiliation_for_orcid_sso_users(user_id, orcid_id):
         logger.info(f'Eligible institution affiliation has been found for ORCiD SSO user: '
                     f'institution=[{institution._id}], user=[{user_id}], orcid_id=[{orcid_id}]')
         if not user.is_affiliated_with_institution(institution):
-            user.affiliated_institutions.add(institution)
+            InstitutionAffiliation.create(user, institution)
 
 
 def verify_user_orcid_id(user, orcid_id):

--- a/osf/management/commands/migrate_user_institution_affiliation.py
+++ b/osf/management/commands/migrate_user_institution_affiliation.py
@@ -55,7 +55,12 @@ def migrate_user_institution_affiliation(dry_run=True):
             logger.info(f'\tMigrating affiliation for <{user._id}::{institution.name}> '
                         f'[{user_count_per_institution}/{user_total_per_institution}]')
             if not dry_run:
-                affiliation = InstitutionAffiliation.create(user, institution, is_migration=True)
+                affiliation = user.add_one_affiliated_institution(
+                    institution,
+                    sso_identity=InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE,
+                    sso_mail=None,
+                    sso_department=user.department,
+                )
                 logger.info(f'\tAffiliation=<{affiliation}> migrated for user=<{user._id}> @ institution=<{institution._id}>')
             else:
                 logger.warning(f'\tDry Run: Affiliation not migrated for {user._id} @ {institution._id}!')

--- a/osf/management/commands/migrate_user_institution_affiliation.py
+++ b/osf/management/commands/migrate_user_institution_affiliation.py
@@ -58,8 +58,7 @@ def migrate_user_institution_affiliation(dry_run=True):
                 affiliation = user.add_one_affiliated_institution(
                     institution,
                     sso_identity=InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE,
-                    sso_mail=None,
-                    sso_department=user.department,
+                    sso_department=user.department
                 )
                 logger.info(f'\tAffiliation=<{affiliation}> migrated for user=<{user._id}> @ institution=<{institution._id}>')
             else:

--- a/osf/management/commands/migrate_user_institution_affiliation.py
+++ b/osf/management/commands/migrate_user_institution_affiliation.py
@@ -55,7 +55,7 @@ def migrate_user_institution_affiliation(dry_run=True):
             logger.info(f'\tMigrating affiliation for <{user._id}::{institution.name}> '
                         f'[{user_count_per_institution}/{user_total_per_institution}]')
             if not dry_run:
-                affiliation = user.add_one_affiliated_institution(
+                affiliation = user.add_or_update_affiliated_institution(
                     institution,
                     sso_identity=InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE,
                     sso_department=user.department

--- a/osf/management/commands/update_institution_project_counts.py
+++ b/osf/management/commands/update_institution_project_counts.py
@@ -26,7 +26,7 @@ def update_institution_project_counts():
             timestamp=now
         )
 
-        for user in institution.osfuser_set.all():
+        for user in institution.get_institution_users():
             user_public_project_count = Node.objects.get_nodes_for_user(
                 user=user,
                 base_queryset=institution_public_projects_qs

--- a/osf/metadata/utils.py
+++ b/osf/metadata/utils.py
@@ -45,7 +45,7 @@ def datacite_format_name_identifiers(user):
 
 def datacite_format_affiliations(user):
     data = {'affiliation': []}
-    for affiliated_institution in user.affiliated_institutions.all():
+    for affiliated_institution in user.get_affiliated_institutions():
         data['affiliation'].append({
             'name': affiliated_institution.name,
         })
@@ -80,7 +80,7 @@ def datacite_format_creators(creators):
     creators_json = []
     for creator in creators:
         data = {}
-        if creator.affiliated_institutions.exists():
+        if creator.has_affiliated_institutions():
             data.update(datacite_format_affiliations(creator))
         data.update(datacite_format_name_identifiers(creator))
         data.update({
@@ -105,7 +105,7 @@ def datacite_format_contributors(contributors):
     contributors_json = []
     for contributor in contributors:
         data = {}
-        if contributor.affiliated_institutions.exists():
+        if contributor.has_affiliated_institutions():
             data.update(datacite_format_affiliations(contributor))
         data.update(datacite_format_name_identifiers(contributor))
         data.update({

--- a/osf/metrics/institution_metrics.py
+++ b/osf/metrics/institution_metrics.py
@@ -80,10 +80,11 @@ class UserInstitutionProjectCounts(MetricMixin, metrics.Metric):
 
     @classmethod
     def record_user_institution_project_counts(cls, user, institution, public_project_count, private_project_count, **kwargs):
+        affiliation = user.get_institution_affiliation(institution)
         return cls.record(
             user_id=user._id,
             institution_id=institution._id,
-            department=getattr(user, 'department', DEFAULT_ES_NULL_VALUE),
+            department=getattr(affiliation, 'department', DEFAULT_ES_NULL_VALUE),
             public_project_count=public_project_count,
             private_project_count=private_project_count,
             **kwargs

--- a/osf/metrics/institution_metrics.py
+++ b/osf/metrics/institution_metrics.py
@@ -84,7 +84,7 @@ class UserInstitutionProjectCounts(MetricMixin, metrics.Metric):
         return cls.record(
             user_id=user._id,
             institution_id=institution._id,
-            department=getattr(affiliation, 'department', DEFAULT_ES_NULL_VALUE),
+            department=getattr(affiliation, 'sso_department', DEFAULT_ES_NULL_VALUE),
             public_project_count=public_project_count,
             private_project_count=private_project_count,
             **kwargs

--- a/osf/metrics/institution_metrics.py
+++ b/osf/metrics/institution_metrics.py
@@ -80,7 +80,7 @@ class UserInstitutionProjectCounts(MetricMixin, metrics.Metric):
 
     @classmethod
     def record_user_institution_project_counts(cls, user, institution, public_project_count, private_project_count, **kwargs):
-        affiliation = user.get_institution_affiliation(institution)
+        affiliation = user.get_institution_affiliation(institution._id)
         return cls.record(
             user_id=user._id,
             institution_id=institution._id,

--- a/osf/metrics/institution_metrics.py
+++ b/osf/metrics/institution_metrics.py
@@ -135,7 +135,7 @@ class InstitutionProjectCounts(MetricMixin, metrics.Metric):
     def record_institution_project_counts(cls, institution, public_project_count, private_project_count, **kwargs):
         return cls.record(
             institution_id=institution._id,
-            user_count=institution.osfuser_set.count(),
+            user_count=institution.get_institution_users().count(),
             public_project_count=public_project_count,
             private_project_count=private_project_count,
             **kwargs

--- a/osf/metrics/reporters/institution_summary.py
+++ b/osf/metrics/reporters/institution_summary.py
@@ -45,8 +45,8 @@ class InstitutionSummaryReporter(DailyReporter):
                 institution_id=institution._id,
                 institution_name=institution.name,
                 users=RunningTotal(
-                    total=institution.osfuser_set.filter(is_active=True).count(),
-                    total_daily=institution.osfuser_set.filter(date_confirmed__date=date).count(),
+                    total=institution.get_institution_users().filter(is_active=True).count(),
+                    total_daily=institution.get_institution_users().filter(date_confirmed__date=date).count(),
                 ),
                 nodes=NodeRunningTotals(
                     total=node_qs.count(),

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -44,3 +44,9 @@ class InstitutionAffiliation(BaseModel):
         )
         affiliation.save()
         return affiliation
+
+    @classmethod
+    def add_multiple(cls, user, institutions):
+        for institution in institutions:
+            if not user.is_affiliated_with_institution(institution):
+                InstitutionAffiliation.create(user, institution)

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -8,7 +8,7 @@ from osf.utils.fields import LowercaseEmailField
 
 class InstitutionAffiliation(BaseModel):
 
-    DEFAULT_IDENTITY_VALUE_FROM_MIGRATION = 'NOT_AVAILABLE'
+    DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE = 'SSO_IDENTITY_NOT_AVAILABLE'
 
     user = models.ForeignKey('OSFUser', on_delete=models.CASCADE)
     institution = models.ForeignKey('Institution', on_delete=models.CASCADE)
@@ -28,25 +28,3 @@ class InstitutionAffiliation(BaseModel):
 
     def __str__(self):
         return f'{self.user._id}::{self.institution._id}::{self.sso_identity}'
-
-    @classmethod
-    def create(cls, user, institution, sso_identity=None, sso_mail=None, sso_department=None, is_migration=False):
-        if is_migration:
-            sso_identity = cls.DEFAULT_IDENTITY_VALUE_FROM_MIGRATION
-            sso_mail = None
-        affiliation = cls(
-            user=user,
-            institution=institution,
-            sso_identity=sso_identity,
-            sso_mail=sso_mail,
-            sso_department=sso_department,
-            sso_other_attributes={},
-        )
-        affiliation.save()
-        return affiliation
-
-    @classmethod
-    def add_multiple(cls, user, institutions):
-        for institution in institutions:
-            if not user.is_affiliated_with_institution(institution):
-                InstitutionAffiliation.create(user, institution)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1574,7 +1574,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     def add_affiliations(self, user, new):
         # add all of the user's affiliations to the forked or templated node
-        for affiliation in user.affiliated_institutions.all():
+        for affiliation in user.get_affiliated_institutions():
             new.affiliated_institutions.add(affiliation)
 
     # TODO: Optimize me (e.g. use bulk create)

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1701,9 +1701,9 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         qs = InstitutionAffiliation.objects.filter(user__id=self.id).values_list('institution', flat=True)
         return Institution.objects.filter(pk__in=qs)
 
-    def get_affiliated_institution__id_set(self):
-        """Return a set of ``_id`` of all affiliated institutions for the current user."""
-        return set(InstitutionAffiliation.objects.filter(user__id=self.id).values_list('institution___id', flat=True))
+    def get_affiliated_institution__ids(self):
+        """Return a queryset of ``_id`` of all affiliated institutions for the current user."""
+        return InstitutionAffiliation.objects.filter(user__id=self.id).values_list('institution___id', flat=True)
 
     def add_or_update_affiliated_institution(self, institution, sso_identity=None, sso_mail=None, sso_department=None):
         """Add one or update the existing institution affiliation between the current user and the given ``institution``

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -758,7 +758,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
                 self.email_verifications[k] = v
         user.email_verifications = {}
 
-        InstitutionAffiliation.add_multiple(self, user.get_affiliated_institutions())
+        self.copy_institution_affiliation_when_merging_user(user)
 
         for service in user.external_identity:
             for service_id in user.external_identity[service].keys():
@@ -1735,15 +1735,12 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             )
 
     def update_affiliated_institutions_by_email_domain(self):
-        """
-        Append affiliated_institutions by email domain.
-        :return:
-        """
+        """Append affiliated_institutions by email domain."""
         try:
             email_domains = [email.split('@')[1].lower() for email in self.emails.values_list('address', flat=True)]
             institutions = Institution.objects.filter(email_domains__overlap=email_domains)
             if institutions.exists():
-                InstitutionAffiliation.add_multiple(self, institutions)
+                self.add_multiple_institutions_non_sso(institutions)
         except IndexError:
             pass
 

--- a/osf_tests/test_draft_node.py
+++ b/osf_tests/test_draft_node.py
@@ -86,7 +86,7 @@ def make_complex_draft_registration(title, institution, description, category,
             data={},
             node=node if node else None
         )
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         draft_registration.set_title(title, Auth(user))
         draft_registration.set_description(description, Auth(user))
         draft_registration.category = category

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -205,7 +205,7 @@ class TestDraftRegistrations:
         write_contrib = factories.AuthUserFactory()
         subject = factories.SubjectFactory()
         institution = factories.InstitutionFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
 
         title = 'A Study of Elephants'
         description = 'Loxodonta africana'
@@ -610,7 +610,7 @@ class TestDraftRegistrationAffiliatedInstitutions:
     def test_affiliated_institutions(self, draft_registration):
         inst1, inst2 = factories.InstitutionFactory(), factories.InstitutionFactory()
         user = draft_registration.initiator
-        user.affiliated_institutions.add(inst1, inst2)
+        user.add_or_update_affiliated_institution(inst1, inst2)
         draft_registration.add_affiliated_institution(inst1, user=user)
 
         assert inst1 in draft_registration.affiliated_institutions.all()

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -610,7 +610,8 @@ class TestDraftRegistrationAffiliatedInstitutions:
     def test_affiliated_institutions(self, draft_registration):
         inst1, inst2 = factories.InstitutionFactory(), factories.InstitutionFactory()
         user = draft_registration.initiator
-        user.add_or_update_affiliated_institution(inst1, inst2)
+        user.add_or_update_affiliated_institution(inst1)
+        user.add_or_update_affiliated_institution(inst2)
         draft_registration.add_affiliated_institution(inst1, user=user)
 
         assert inst1 in draft_registration.affiliated_institutions.all()
@@ -621,7 +622,7 @@ class TestDraftRegistrationAffiliatedInstitutions:
         assert inst1 not in draft_registration.affiliated_institutions.all()
         assert inst2 not in draft_registration.affiliated_institutions.all()
 
-        user.affiliated_institutions.remove(inst1)
+        user.remove_affiliated_institution(inst1._id)
 
         with pytest.raises(UserNotAffiliatedError):
             draft_registration.add_affiliated_institution(inst1, user=user)

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -130,10 +130,10 @@ class TestInstitutionManager:
     def test_send_deactivation_email_call_count(self, mock_send_mail):
         institution = InstitutionFactory()
         user_1 = UserFactory()
-        user_1.affiliated_institutions.add(institution)
+        user_1.add_or_update_affiliated_institution(institution)
         user_1.save()
         user_2 = UserFactory()
-        user_2.affiliated_institutions.add(institution)
+        user_2.add_or_update_affiliated_institution(institution)
         user_2.save()
         institution._send_deactivation_email()
         assert mock_send_mail.call_count == 2
@@ -143,7 +143,7 @@ class TestInstitutionManager:
     def test_send_deactivation_email_call_args(self, mock_send_mail):
         institution = InstitutionFactory()
         user = UserFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
         institution._send_deactivation_email()
         forgot_password = 'forgotpassword' if settings.DOMAIN.endswith('/') else '/forgotpassword'

--- a/osf_tests/test_management_commands.py
+++ b/osf_tests/test_management_commands.py
@@ -279,8 +279,7 @@ class TestInstitutionMetricsUpdate:
     def user1(self, institution):
         # Private: 4, Public: 4 (+1 from user2 fixture)
         user = AuthUserFactory()
-        institution.osfuser_set.add(user)
-        institution.save()
+        user.add_or_update_affiliated_institution(institution)
 
         for i in range(5):
             project = ProjectFactory(creator=user, is_public=False)
@@ -303,8 +302,7 @@ class TestInstitutionMetricsUpdate:
     def user2(self, institution, user1):
         # Private: 10, Public: 1
         user = AuthUserFactory()
-        institution.osfuser_set.add(user)
-        institution.save()
+        user.add_or_update_affiliated_institution(institution)
 
         for i in range(10):
             project = ProjectFactory(creator=user, is_public=False)
@@ -322,8 +320,7 @@ class TestInstitutionMetricsUpdate:
     def user3(self, institution):
         # Private: 0, Public: 0
         user = AuthUserFactory()
-        institution.osfuser_set.add(user)
-        institution.save()
+        user.add_or_update_affiliated_institution(institution)
 
         return user
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -385,7 +385,7 @@ class TestParentNode:
 
     def test_fork_has_correct_affiliations(self, user, auth, project_with_affiliations):
         fork = project_with_affiliations.fork_node(auth=auth)
-        user_affiliations = user.affiliated_institutions.values_list('id', flat=True)
+        user_affiliations = user.get_affiliated_institution__ids()
         project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
         fork_affiliations = fork.affiliated_institutions.values_list('id', flat=True)
         assert set(project_affiliations) != set(user_affiliations)
@@ -419,7 +419,7 @@ class TestParentNode:
 
     def test_template_has_correct_affiliations(self, user, auth, project_with_affiliations):
         template = project_with_affiliations.use_as_template(auth=auth)
-        user_affiliations = user.affiliated_institutions.values_list('id', flat=True)
+        user_affiliations = user.get_affiliated_institution__ids()
         project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
         template_affiliations = template.affiliated_institutions.values_list('id', flat=True)
         assert set(project_affiliations) != set(user_affiliations)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -128,7 +128,7 @@ class TestParentNode:
     def project_with_affiliations(self, user):
         institution = InstitutionFactory()
         another_institution = InstitutionFactory()
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
         original = ProjectFactory(creator=user)
         original.affiliated_institutions.add(*[institution, another_institution])
@@ -2179,7 +2179,7 @@ def test_find_by_institutions():
     inst1, inst2 = InstitutionFactory(), InstitutionFactory()
     project = ProjectFactory(is_public=True)
     user = project.creator
-    user.affiliated_institutions.add(inst1, inst2)
+    user.add_or_update_affiliated_institution(inst1, inst2)
     project.add_affiliated_institution(inst1, user=user)
     project.save()
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -385,7 +385,7 @@ class TestParentNode:
 
     def test_fork_has_correct_affiliations(self, user, auth, project_with_affiliations):
         fork = project_with_affiliations.fork_node(auth=auth)
-        user_affiliations = user.get_affiliated_institution__ids()
+        user_affiliations = user.get_institution_affiliations().values_list('institution__id', flat=True)
         project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
         fork_affiliations = fork.affiliated_institutions.values_list('id', flat=True)
         assert set(project_affiliations) != set(user_affiliations)
@@ -419,7 +419,7 @@ class TestParentNode:
 
     def test_template_has_correct_affiliations(self, user, auth, project_with_affiliations):
         template = project_with_affiliations.use_as_template(auth=auth)
-        user_affiliations = user.get_affiliated_institution__ids()
+        user_affiliations = user.get_institution_affiliations().values_list('institution__id', flat=True)
         project_affiliations = project_with_affiliations.affiliated_institutions.values_list('id', flat=True)
         template_affiliations = template.affiliated_institutions.values_list('id', flat=True)
         assert set(project_affiliations) != set(user_affiliations)
@@ -2179,7 +2179,8 @@ def test_find_by_institutions():
     inst1, inst2 = InstitutionFactory(), InstitutionFactory()
     project = ProjectFactory(is_public=True)
     user = project.creator
-    user.add_or_update_affiliated_institution(inst1, inst2)
+    user.add_or_update_affiliated_institution(inst1)
+    user.add_or_update_affiliated_institution(inst2)
     project.add_affiliated_institution(inst1, user=user)
     project.save()
 

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -315,7 +315,7 @@ class TestRegisterNode:
         node = factories.NodeFactory()
         institution = factories.InstitutionFactory()
 
-        user.affiliated_institutions.add(institution)
+        user.add_or_update_affiliated_institution(institution)
         user.save()
 
         node.add_affiliated_institution(institution, user=user)

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -818,12 +818,12 @@ class TestOSFUser:
         user = UserFactory(username=user_email)
         user.update_affiliated_institutions_by_email_domain()
 
-        assert user.affiliated_institutions.count() == 1
+        assert user.get_affiliated_institutions().count() == 1
         assert user.is_affiliated_with_institution(institution) is True
 
         user.update_affiliated_institutions_by_email_domain()
 
-        assert user.affiliated_institutions.count() == 1
+        assert user.get_affiliated_institutions().count() == 1
 
     def test_is_affiliated_with_institution(self, user):
         institution1, institution2 = InstitutionFactory(), InstitutionFactory()

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -828,7 +828,7 @@ class TestOSFUser:
     def test_is_affiliated_with_institution(self, user):
         institution1, institution2 = InstitutionFactory(), InstitutionFactory()
 
-        user.affiliated_institutions.add(institution1)
+        user.add_or_update_affiliated_institution(institution1)
         user.save()
 
         assert user.is_affiliated_with_institution(institution1) is True

--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -292,7 +292,7 @@ class TestCrossRefClient:
         institution = InstitutionFactory()
         institution.ror_uri = 'http://ror.org/WHATisITgoodFOR/'
         institution.save()
-        preprint.creator.affiliated_institutions.add(institution)
+        preprint.creator.add_or_update_affiliated_institution(institution)
         preprint.creator.save()
 
         crossref_xml = crossref_client.build_metadata(preprint)

--- a/tests/test_institutions/test_affiliation_via_orcid.py
+++ b/tests/test_institutions/test_affiliation_via_orcid.py
@@ -103,9 +103,9 @@ class TestInstitutionAffiliationViaOrcidSso:
     ):
         mock_verify_user_orcid_id.return_value = True
         mock_check_institution_affiliation.return_value = eligible_institution
-        assert eligible_institution not in user_with_orcid_id_verified.affiliated_institutions.all()
+        assert eligible_institution not in user_with_orcid_id_verified.get_affiliated_institutions()
         tasks.update_affiliation_for_orcid_sso_users(user_with_orcid_id_verified._id, orcid_id_verified)
-        assert eligible_institution in user_with_orcid_id_verified.affiliated_institutions.all()
+        assert eligible_institution in user_with_orcid_id_verified.get_affiliated_institutions()
 
     @mock.patch('framework.auth.tasks.check_institution_affiliation')
     @mock.patch('framework.auth.tasks.verify_user_orcid_id')
@@ -119,9 +119,9 @@ class TestInstitutionAffiliationViaOrcidSso:
     ):
         mock_verify_user_orcid_id.return_value = True
         mock_check_institution_affiliation.return_value = eligible_institution
-        assert eligible_institution in user_verified_and_affiliated.affiliated_institutions.all()
+        assert eligible_institution in user_verified_and_affiliated.get_affiliated_institutions()
         tasks.update_affiliation_for_orcid_sso_users(user_verified_and_affiliated._id, orcid_id_verified)
-        assert eligible_institution in user_verified_and_affiliated.affiliated_institutions.all()
+        assert eligible_institution in user_verified_and_affiliated.get_affiliated_institutions()
 
     @mock.patch('framework.auth.tasks.check_institution_affiliation')
     @mock.patch('framework.auth.tasks.verify_user_orcid_id')
@@ -136,7 +136,7 @@ class TestInstitutionAffiliationViaOrcidSso:
         mock_verify_user_orcid_id.return_value = False
         tasks.update_affiliation_for_orcid_sso_users(user_with_orcid_id_link._id, orcid_id_link)
         mock_check_institution_affiliation.assert_not_called()
-        assert eligible_institution not in user_with_orcid_id_link.affiliated_institutions.all()
+        assert eligible_institution not in user_with_orcid_id_link.get_affiliated_institutions()
 
     @mock.patch('framework.auth.tasks.check_institution_affiliation')
     @mock.patch('framework.auth.tasks.verify_user_orcid_id')
@@ -150,9 +150,9 @@ class TestInstitutionAffiliationViaOrcidSso:
     ):
         mock_verify_user_orcid_id.return_value = True
         mock_check_institution_affiliation.return_value = None
-        assert eligible_institution not in user_with_orcid_id_verified.affiliated_institutions.all()
+        assert eligible_institution not in user_with_orcid_id_verified.get_affiliated_institutions()
         tasks.update_affiliation_for_orcid_sso_users(user_with_orcid_id_verified._id, orcid_id_verified)
-        assert eligible_institution not in user_with_orcid_id_verified.affiliated_institutions.all()
+        assert eligible_institution not in user_with_orcid_id_verified.get_affiliated_institutions()
 
     def test_verify_user_orcid_id_verified(self, user_with_orcid_id_verified, orcid_id_verified):
         assert tasks.verify_user_orcid_id(user_with_orcid_id_verified, orcid_id_verified)

--- a/tests/test_institutions/test_affiliation_via_orcid.py
+++ b/tests/test_institutions/test_affiliation_via_orcid.py
@@ -88,7 +88,7 @@ class TestInstitutionAffiliationViaOrcidSso:
     @pytest.fixture()
     def user_verified_and_affiliated(self, orcid_id_verified, eligible_institution):
         user = UserFactory(external_identity={'ORCID': {orcid_id_verified: 'VERIFIED'}})
-        user.affiliated_institutions.add(eligible_institution)
+        user.add_or_update_affiliated_institution(eligible_institution)
         return user
 
     @mock.patch('framework.auth.tasks.check_institution_affiliation')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -375,8 +375,8 @@ class TestProjectViews(OsfTestCase):
         # user is automatically affiliated with institutions
         # that matched email domains
         user.reload()
-        assert_in(inst1, user.affiliated_institutions.all())
-        assert_in(inst2, user.affiliated_institutions.all())
+        assert_in(inst1, user.get_affiliated_institutions())
+        assert_in(inst2, user.get_affiliated_institutions())
 
     def test_edit_title_empty(self):
         node = ProjectFactory(creator=self.user1)

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -192,7 +192,7 @@ class CrossRefClient(AbstractIdentifierClient):
                         institution.ror_uri,
                         type='ror'
                     ),
-                ) for institution in contributor.affiliated_institutions.all() if institution.ror_uri
+                ) for institution in contributor.get_affiliated_institutions() if institution.ror_uri
             ]
             if affiliations:
                 person.append(element.affiliations(*affiliations))

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -872,6 +872,7 @@ def _view_project(node, auth, primary=False,
 
 def get_affiliated_institutions(obj):
     ret = []
+    # TODO: check if the ``obj`` can be an ``OSFUser`` or not
     for institution in obj.affiliated_institutions.all():
         ret.append({
             'name': institution.name,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -19,6 +19,7 @@ from website.ember_osf_web.decorators import ember_flag_is_active
 from api.waffle.utils import flag_is_active, storage_i18n_flag_active, storage_usage_flag_active
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
+from osf.models.user import OSFUser
 from osf.utils.functional import rapply
 from osf.utils.registrations import strip_registered_meta_comments
 from osf.utils import sanitize
@@ -872,8 +873,11 @@ def _view_project(node, auth, primary=False,
 
 def get_affiliated_institutions(obj):
     ret = []
-    # TODO: check if the ``obj`` can be an ``OSFUser`` or not
-    for institution in obj.affiliated_institutions.all():
+    if isinstance(obj, OSFUser):
+        institutions = obj.get_affiliated_institutions()
+    else:
+        institutions = obj.affiliated_institutions.all()
+    for institution in institutions:
         ret.append({
             'name': institution.name,
             'logo_path': institution.logo_path,

--- a/website/routes.py
+++ b/website/routes.py
@@ -88,7 +88,7 @@ def get_globals():
     """
     user = _get_current_user()
     set_status_message(user)
-    user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.affiliated_institutions.all()] if user else []
+    user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.get_affiliated_institutions()] if user else []
     location = geolite2.reader().get(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:


### PR DESCRIPTION
## Purpose

Update user-institution affiliation references.

## TODO before Merge

- [x] Check `department` usages
- [x] Update factories, fixtures and unit tests to use the new affiliation model
- [x] Verify a couple of #TODO comments

## Changes

### Before

Calls `.affiliated_institutions` from `OSFUser` and `.osfuser_set` from `Institution`

### After

Use several helper methods in `OSFuser` and `Institution` to access user-institution affiliations from the `InstitutionAffiliation`

### Notes on Scope of Change

* `.affiliated_institution` on different models
  * After looking further into our code base, I learned that we don't need to worry about `.affiliated_institutions` on any of the `AbstractNode` models since we only changed the affiliation between `OSFUser` and `Institution`. Let's call them "nodes affiliations" hereafter.
  * Nodes affiliations are created/updated from user affiliations. How this is done is fully covered by the references/accesses in this PR.
  * In addition, nodes affiliations doesn't need anything other than the "affiliation" itself, and thus we don't need to turn these many-to-many fields into a separate "through" table with extra attributes.
* A similar case applies to both legacy (via `knockout` or `miltril`) and Ember (via API Serialized) FE.
  * As for legacy FE, there is no user affiliations being used anywhere at all.
  * As for ember FE, we covered all user affiliation references/accesses.

### Extra Note on non-standard SSO

* Non-SSO email domain whitelist affiliations use `'NOT_AVAILABLE'` for `sso_identity`
* ORCiD-SSO affiliations use the user's ORCiD ID as `sso_identity`
* Both Non-SSO and ORCiD-SSO has empty `sso_mail`

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

* https://openscience.atlassian.net/browse/ENG-4199
* https://openscience.atlassian.net/browse/ENG-4200
