### PR TITLE
Add provider moderator endpoints

### DIFF
--- a/api/providers/urls.py
+++ b/api/providers/urls.py
@@ -1,6 +1,11 @@
 from django.conf.urls import include, re_path
 
 from api.providers import views
+from api.subscriptions.views import (
+    PreprintProviderSubscriptionDetail,
+    RegistrationProviderSubscriptionDetail,
+    CollectionProviderSubscriptionDetail,
+)
 
 app_name = 'osf'
 
@@ -20,6 +25,11 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/withdraw_requests/$', views.PreprintProviderWithdrawRequestList.as_view(), name=views.PreprintProviderWithdrawRequestList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.PreprintProviderModeratorsList.as_view(), name=views.PreprintProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.PreprintProviderModeratorsDetail.as_view(), name=views.PreprintProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        PreprintProviderSubscriptionDetail.as_view(),
+                        name=PreprintProviderSubscriptionDetail.view_name,
+                    ),
                 ], 'preprints',
             ),
             namespace='preprint-providers',
@@ -40,6 +50,11 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/taxonomies/highlighted/$', views.CollectionProviderHighlightedTaxonomyList.as_view(), name=views.CollectionProviderHighlightedTaxonomyList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.CollectionProviderModeratorsList.as_view(), name=views.CollectionProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.CollectionProviderModeratorsDetail.as_view(), name=views.CollectionProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        CollectionProviderSubscriptionDetail.as_view(),
+                        name=CollectionProviderSubscriptionDetail.view_name,
+                    ),
                 ], 'collections',
             ),
             namespace='collection-providers',
@@ -64,6 +79,11 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/actions/$', views.RegistrationProviderActionList.as_view(), name=views.RegistrationProviderActionList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.RegistrationProviderModeratorsList.as_view(), name=views.RegistrationProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.RegistrationProviderModeratorsDetail.as_view(), name=views.RegistrationProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        RegistrationProviderSubscriptionDetail.as_view(),
+                        name=RegistrationProviderSubscriptionDetail.view_name,
+                    ),
                 ], 'registrations',
             ),
             namespace='registration-providers',

--- a/api_tests/subscriptions/views/test_provider_subscription_detail.py
+++ b/api_tests/subscriptions/views/test_provider_subscription_detail.py
@@ -1,0 +1,152 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import AuthUserFactory
+from osf_tests.factories import (
+    CollectionProviderFactory,
+    RegistrationProviderFactory,
+    PreprintProviderFactory
+)
+from api_tests.utils import UserRoles
+
+from osf.models import AbstractProvider
+
+
+def configure_test_auth(user_role, provider):
+    if user_role is UserRoles.UNAUTHENTICATED:
+        return None
+
+    user = AuthUserFactory()
+    if user_role is UserRoles.MODERATOR:
+        provider.add_to_group(user, 'moderator')
+        provider.save()
+
+    return user.auth
+
+
+def get_provider_by_type(provider_type):
+    return AbstractProvider.objects.get(_id='EAGLES', type=provider_type)
+
+
+@pytest.mark.django_db
+class TestGETPermissionsProviderSubscriptionDetail:
+    """
+    Autouse=True providers and ensure they have all identical `_id`s to test for bug where this causes errors.
+    """
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture(autouse=True)
+    def collections_provider(self):
+        return CollectionProviderFactory(_id='EAGLES')
+
+    @pytest.fixture(autouse=True)
+    def registrations_provider(self):
+        return RegistrationProviderFactory(_id='EAGLES')
+
+    @pytest.fixture(autouse=True)
+    def preprints_provider(self):
+        return PreprintProviderFactory(_id='EAGLES')
+
+    @pytest.fixture()
+    def url(self, provider):
+        provider = get_provider_by_type(provider)
+        provider_type = provider.type.lstrip('osf.').rstrip('provider') + 's'
+        return f'/{API_BASE}providers/{provider_type}/' \
+               f'{provider._id}/subscriptions/{provider._id}_new_pending_submissions/'
+
+    @pytest.mark.parametrize('user_role', [UserRoles.NONCONTRIB, UserRoles.UNAUTHENTICATED])
+    @pytest.mark.parametrize('provider', ['osf.preprintprovider', 'osf.collectionprovider', 'osf.registrationprovider'])
+    def test_status_code_no_auth_non_contrib(self, app, url, user_role, provider):
+        provider = get_provider_by_type(provider)
+        test_auth = configure_test_auth(user_role, provider)
+        resp = app.get(
+            url,
+            auth=test_auth,
+            expect_errors=True
+        )
+        expected_code = 403 if user_role is not UserRoles.UNAUTHENTICATED else 401
+        assert resp.status_code == expected_code
+
+    @pytest.mark.parametrize('user_role', [UserRoles.MODERATOR])
+    @pytest.mark.parametrize('provider', ['osf.preprintprovider', 'osf.collectionprovider', 'osf.registrationprovider'])
+    def test_status_code_moderator(self, app, url, provider, user_role):
+        provider = get_provider_by_type(provider)
+        test_auth = configure_test_auth(user_role, provider)
+        resp = app.get(
+            url,
+            auth=test_auth,
+            expect_errors=True
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+class TestPATCHPermissionsProviderSubscriptionDetail:
+    """
+    Autouse=True providers and ensure they have all identical `_id`s to test for bug where this causes errors.
+    """
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture(autouse=True)
+    def collections_provider(self):
+        return CollectionProviderFactory(_id='EAGLES')
+
+    @pytest.fixture(autouse=True)
+    def registrations_provider(self):
+        return RegistrationProviderFactory(_id='EAGLES')
+
+    @pytest.fixture(autouse=True)
+    def preprints_provider(self):
+        return PreprintProviderFactory(_id='EAGLES')
+
+    @pytest.fixture()
+    def url(self, provider):
+        provider = get_provider_by_type(provider)
+        provider_type = provider.type.lstrip('osf.').rstrip('provider') + 's'
+        return f'/{API_BASE}providers/{provider_type}/' \
+               f'{provider._id}/subscriptions/{provider._id}_new_pending_submissions/'
+
+    @pytest.fixture()
+    def payload(self, frequecy):
+        return {
+            'data': {
+                'type': 'user-provider-subscription',
+                'attributes': {
+                    'frequency': frequecy
+                }
+            }
+        }
+
+    @pytest.mark.parametrize('user_role', [UserRoles.NONCONTRIB, UserRoles.UNAUTHENTICATED])
+    @pytest.mark.parametrize('provider', ['osf.preprintprovider', 'osf.collectionprovider', 'osf.registrationprovider'])
+    def test_status_code_no_auth_non_contrib(self, app, url, user_role, provider):
+        provider = get_provider_by_type(provider)
+        test_auth = configure_test_auth(user_role, provider)
+        resp = app.patch_json_api(
+            url,
+            auth=test_auth,
+            expect_errors=True
+        )
+        expected_code = 403 if user_role is not UserRoles.UNAUTHENTICATED else 401
+        assert resp.status_code == expected_code
+
+    @pytest.mark.parametrize('user_role', [UserRoles.MODERATOR])
+    @pytest.mark.parametrize('provider', ['osf.preprintprovider', 'osf.collectionprovider', 'osf.registrationprovider'])
+    @pytest.mark.parametrize('frequecy', ['none', 'daily', 'instant'])
+    def test_status_code_moderator(self, app, url, provider, user_role, payload, frequecy):
+        provider = get_provider_by_type(provider)
+        test_auth = configure_test_auth(user_role, provider)
+        resp = app.patch_json_api(
+            url,
+            payload,
+            auth=test_auth,
+            expect_errors=True
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['frequency'] == frequecy

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -311,7 +311,10 @@ class CollectionFactory(DjangoModelFactory):
     @classmethod
     def _create(cls, *args, **kwargs):
         collected_types = kwargs.pop('collected_types', ContentType.objects.filter(app_label='osf', model__in=['abstractnode', 'basefilenode', 'collection', 'preprint']))
+        _id = kwargs.pop('_id', None)
         obj = cls._build(*args, **kwargs)
+        if _id and _id != 'osf':
+            obj._id = _id
         obj.save()
         # M2M, requires initial save
         obj.collected_types.add(*collected_types)
@@ -332,8 +335,11 @@ class CollectionProviderFactory(DjangoModelFactory):
     @classmethod
     def _create(cls, *args, **kwargs):
         user = kwargs.pop('creator', None)
+        _id = kwargs.pop('_id', None)
         obj = cls._build(*args, **kwargs)
         obj._creator = user or UserFactory()  # Generates primary_collection
+        if _id and _id != 'osf':
+            obj._id = _id
         obj.save()
         return obj
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -320,7 +320,7 @@
     <div class="row">
         <div class="collections-container col-12">
             <div class="collections-box" style="font-size: 15px;">
-                <div class="clearfix" id="collections-header" data-toggle="collapse" href="#collectionList" role="button" style="margin: 10px;">
+                <div class="clearfix" id="collections-header" data-toggle="collapse" href="#collectionList" style="margin: 10px;">
                     <div class="pull-left" style="margin-top: 5px">
                         <img src="${ node['collections'][0]['logo']}" style="display: inline; height: 25px; width: 25px; margin-left: 5px;"/>
                         % if 'accepted' in [x['state'] for x in node['collections']]:
@@ -349,15 +349,15 @@
                         <button id='collections-caret-down' class="btn btn-link" aria-label="Toggle Collections" ><i class="fa fa-angle-down"></i></button>
                     </div>
                 </div>
-                <div id="collectionList" class="collapse">
+                <div id="collectionList" class="collapse" aria-expanded="true">
                      <div class="panel-body" style="text-align: left;">
                         % for collection in node['collections']:
 
                             % if collection['state'] == 'accepted':
                                 % if user['is_admin']:
-                                    <a class="fa fa-pencil pull-right collection-pencil" href="${collection['url']}${node['id']}/edit"></a>
+                                    <a class="fa fa-pencil pull-right collection-pencil" href="${collection['url']}${node['id']}/edit" aria-label="Edit Collection Button"></a>
                                 % endif
-                                <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;"/>
+                                <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;" alt="collection logo" />
                                 <div style="display: inline;">
                                     Included in <a href="${collection['url']}" >${collection['collection_title']}</a>
                                 </div>
@@ -376,7 +376,7 @@
                                 % endif
                                 <hr>
                             % elif collection['state'] == 'pending' and user['is_contributor_or_group_member']:
-                                <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;"/>
+                                <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;" alt="collection logo" />
                                 <div style="display: inline;">
                                     Pending entry into <a href="${collection['url']}" >${collection['collection_title']}</a>
                                 </div>
@@ -396,7 +396,7 @@
                                 <hr>
                             % elif collection['state'] == 'rejected' and user['is_contributor_or_group_member']:
                                 % if user['is_admin']:
-                                    <a class="fa fa-repeat collections-retry-icon pull-right" collection_id=${collection['collection_id']} node_id=${collection['node_id']} ></a>
+                                    <a class="fa fa-repeat collections-retry-icon pull-right" collection_id=${collection['collection_id']} node_id=${collection['node_id']} aria-label="Edit Collection Button"></a>
                                 % endif
                                 <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;"/>
                                 <div style="display: inline;">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fixes duplicate `_id` issue for email subscriptions.

## Changes

Adds API endpoints for  `preprints/<provider_id>/subscriptions/<subscription_id>/`, `registrations/<provider_id>/subscriptions/<subscription_id>/`, `collections/<provider_id>/subscriptions/<subscription_id>/`


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
