### PR TITLE
[Institution Rework] [ENG-4202] [ENG-4204] Rework Institution SSO flow with identity and affiliation - API Part

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -219,13 +219,15 @@ class InstitutionAuthentication(BaseAuthentication):
         except InstitutionAffiliationStateError:
             message = f'Institution SSO Error: duplicate SSO identity {sso_identity} found for institution ' \
                       f'[{institution._id}]. More info: SSO email is [{sso_email}]'
+            sentry.log_message(message)
             logger.error(message)
-            raise PermissionDenied(detail='DuplicateSSOIdentityPerInstitution')
+            raise PermissionDenied(detail='InstitutionSsoDuplicateIdentity')
 
         # Existing but inactive users need to be either "activated" or failed the auth
         activation_required = False
         new_password_required = False
         if not is_created:
+            # TODO: fix the case when user is found by identity only and the ``sso_email`` needs to be added
             try:
                 drf.check_user(user)
                 logger.info(f'Institution SSO: active user [sso_email={sso_email}]')

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -13,7 +13,7 @@ from api.base.authentication import drf
 from api.base import exceptions, settings
 
 from framework import sentry
-from framework.auth import get_or_create_user
+from framework.auth import get_or_create_institutional_user
 
 from osf import features
 from osf.models import Institution
@@ -75,29 +75,34 @@ class InstitutionAuthentication(BaseAuthentication):
         """
         Handle CAS institution authentication request.
 
-        The JWT `data` payload is expected in the following structure:
-        {
-            "provider": {
-                "idp": "",
-                "id": "",
-                "user": {
-                    "username": "",
-                    "fullname": "",
-                    "familyName": "",
-                    "givenName": "",
-                    "middleNames": "",
-                    "suffix": "",
-                    "department": "",
-                    "isMemberOf": "",  # Shared SSO
-                    "selectiveSsoFilter": "",  # Selective SSO
+        Note: If authentication fails, HTTP 403 Forbidden is returned no matter what type of the
+        exception is raised. In this method, we use ``AuthenticationFailed`` when the payload is
+        not correctly encrypted or encoded since it is the "authentication" between CAS and this
+        endpoint. We use `PermissionDenied` for all other exceptions that happens afterwards.
+
+        Expected JWT ``data`` payload format in JSON:
+
+        .. highlight:: json
+        .. code-block:: python
+
+            {
+                "provider": {
+                    "idp": "",
+                    "id": "",
+                    "user": {
+                        "eppn": "",
+                        "username": "",
+                        "fullname": "",
+                        "familyName": "",
+                        "givenName": "",
+                        "middleNames": "",
+                        "suffix": "",
+                        "department": "",
+                        "isMemberOf": "",
+                        "selectiveSsoFilter": "",
+                    }
                 }
             }
-        }
-
-        Note that if authentication failed, HTTP 403 Forbidden is returned no matter what type of
-        exception is raised. In this method, we use `AuthenticationFailed` when the payload is not
-        correctly encrypted/encoded since it is the "authentication" between CAS and this endpoint.
-        We use `PermissionDenied` for all other exceptions that happened afterwards.
 
         :param request: the POST request
         :return: user, None if authentication succeed
@@ -124,6 +129,7 @@ class InstitutionAuthentication(BaseAuthentication):
             logger.error(message)
             sentry.log_message(message)
             raise PermissionDenied(detail='InstitutionSsoInvalidInstitution')
+        eppn = provider['user'].get('eppn')
         username = provider['user'].get('username')
         fullname = provider['user'].get('fullname')
         given_name = provider['user'].get('givenName')
@@ -199,16 +205,12 @@ class InstitutionAuthentication(BaseAuthentication):
             sentry.log_message(message)
             raise PermissionDenied(detail='InstitutionSsoMissingUserNames')
 
-        # Get an existing user or create a new one. If a new user is created, the user object is
-        # confirmed but not registered,which is temporarily of an inactive status. If an existing
-        # user is found, it is also possible that the user is inactive (e.g. unclaimed, disabled,
-        # unconfirmed, etc.).
-        user, created = get_or_create_user(fullname, username, reset_password=False)
+        user, is_created, email_to_add = get_or_create_institutional_user(fullname, username, eppn=eppn)
 
         # Existing but inactive users need to be either "activated" or failed the auth
         activation_required = False
         new_password_required = False
-        if not created:
+        if not is_created:
             try:
                 drf.check_user(user)
                 logger.info('Institution SSO: active user [{}]'.format(username))
@@ -272,7 +274,7 @@ class InstitutionAuthentication(BaseAuthentication):
                         'inst=[{}]'.format(user_guid, username, institution._id))
 
         # Both created and activated accounts need to be updated and registered
-        if created or activation_required:
+        if is_created or activation_required:
 
             if given_name:
                 user.given_name = given_name
@@ -303,6 +305,10 @@ class InstitutionAuthentication(BaseAuthentication):
                 osf_support_email=OSF_SUPPORT_EMAIL,
                 storage_flag_is_active=waffle.flag_is_active(request, features.STORAGE_I18N),
             )
+
+        # Add the email to the user's account if it is identified by the eppn
+        if not is_created and email_to_add:
+            user.emails.add(email_to_add)
 
         # Affiliate the user to the primary institution if not previously affiliated
         user.add_or_update_affiliated_institution(institution, sso_mail=username, sso_department=department)

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -26,10 +26,13 @@ def make_user(username, fullname):
 
 def make_payload(
         institution,
-        username,
+        sso_email,
         fullname='Fake User',
         given_name='',
         family_name='',
+        middle_names='',
+        suffix='',
+        sso_identity='',
         department='',
         is_member_of='',
         user_roles='',
@@ -40,12 +43,13 @@ def make_payload(
         'provider': {
             'id': institution._id,
             'user': {
-                'middleNames': '',
+                'ssoIdentity': sso_identity,
+                'ssoEmail': sso_email,
+                'fullname': fullname,
                 'familyName': family_name,
                 'givenName': given_name,
-                'fullname': fullname,
-                'suffix': '',
-                'username': username,
+                'middleNames': middle_names,
+                'suffix': suffix,
                 'department': department,
                 'isMemberOf': is_member_of,
                 'userRoles': user_roles,
@@ -57,7 +61,7 @@ def make_payload(
     return jwe.encrypt(
         jwt.encode(
             {
-                'sub': username,
+                'sub': sso_email,
                 'data': json.dumps(data)
             },
             settings.JWT_SECRET,

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -122,6 +122,7 @@ def get_or_create_institutional_user(fullname, sso_email, sso_identity, primary_
         2. whether the user is newly created or not
         3. whether a potential duplicate user is found or not
         4. the extra email to add to the user account
+    Note: secondary institution always have a primary institution which shares its email and identity
     :param str fullname: user's full name
     :param str sso_email: user's email, which comes from the email attribute during SSO
     :param str sso_identity: user's institutional identity, which comes from the identity attribute during SSO

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -114,6 +114,43 @@ def register_unconfirmed(username, password, fullname, campaign=None, accepted_t
     return user
 
 
+def get_or_create_institutional_user(fullname, email, eppn=None):
+    """
+    Get or create an institutional user by fullname, email address and eppn (optional). Returns a tuple of three
+    objects ``(user, is_created, email_to_add)``: the user to authenticate, whether the user is newly created or
+    not, and an extra email to add to the user later (after the user passes status check).
+
+    :param str fullname: user's full name
+    :param str email: user's email, which comes from the email attribute during SSO
+    :param str eppn: user's eppn, which comes from the identity attribute during SSO
+    """
+
+    from osf.models import OSFUser
+    email_user = get_user(email=email)
+    # If eppn is provided by CAS, check if an account already exists using eppn as email.
+    if eppn:
+        eppn_user = get_user(email=eppn)
+        if eppn_user:
+            if not email_user:
+                # CASE 1: If the email doesn't belong to any user, return both the eppn_user and the email
+                return eppn_user, False, email
+            if email_user == eppn_user:
+                # CASE 2: Return the user only since email already belongs to the same user
+                return email_user, False, None
+            # TODO: log warning and inform sentry since this indicates potential duplicate users exist
+            # CASE 3: When eppn and email point to different users, the email takes priority
+            return email_user, False, None
+    # If eppn is empty, use email_user if found.
+    if email_user:
+        # CASE 4: user only found via email
+        return email_user, False, None
+    # CASE 5/5: existing user not found
+    # Institution users are created as confirmed with a strong and random password. Users don't need the password
+    # since they sign in via institution SSO. They can still reset their password to enable email/password login.
+    user = OSFUser.create_confirmed(email, str(uuid.uuid4()), fullname)
+    return user, True, None
+
+
 def get_or_create_user(fullname, address, reset_password=True, is_spam=False):
     """
     Get or create user by fullname and email address.

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -114,40 +114,39 @@ def register_unconfirmed(username, password, fullname, campaign=None, accepted_t
     return user
 
 
-def get_or_create_institutional_user(fullname, email, eppn=None):
+def get_or_create_institutional_user(fullname, sso_email, eppn=None):
     """
     Get or create an institutional user by fullname, email address and eppn (optional). Returns a tuple of three
     objects ``(user, is_created, email_to_add)``: the user to authenticate, whether the user is newly created or
     not, and an extra email to add to the user later (after the user passes status check).
 
     :param str fullname: user's full name
-    :param str email: user's email, which comes from the email attribute during SSO
+    :param str sso_email: user's email, which comes from the email attribute during SSO
     :param str eppn: user's eppn, which comes from the identity attribute during SSO
     """
 
     from osf.models import OSFUser
-    email_user = get_user(email=email)
+    email_user = get_user(email=sso_email)
     # If eppn is provided by CAS, check if an account already exists using eppn as email.
     if eppn:
         eppn_user = get_user(email=eppn)
         if eppn_user:
             if not email_user:
-                # CASE 1: If the email doesn't belong to any user, return both the eppn_user and the email
-                return eppn_user, False, email
+                # CASE 1/5: If the email doesn't belong to any user, return both the eppn_user and the sso_email.
+                return eppn_user, False, sso_email
             if email_user == eppn_user:
-                # CASE 2: Return the user only since email already belongs to the same user
+                # CASE 2/5: Return the user only since sso_email already belongs to the same user
                 return email_user, False, None
-            # TODO: log warning and inform sentry since this indicates potential duplicate users exist
-            # CASE 3: When eppn and email point to different users, the email takes priority
+            # CASE 3/5: When eppn and sso_email point to different users, the sso_email takes priority
             return email_user, False, None
-    # If eppn is empty, use email_user if found.
+    # If eppn is not provided, use email_user if found.
     if email_user:
-        # CASE 4: user only found via email
+        # CASE 4/5: user only found via email
         return email_user, False, None
-    # CASE 5/5: existing user not found
+    # CASE 5/5: If no user is found, create a confirmed user and return it.
     # Institution users are created as confirmed with a strong and random password. Users don't need the password
-    # since they sign in via institution SSO. They can still reset their password to enable email/password login.
-    user = OSFUser.create_confirmed(email, str(uuid.uuid4()), fullname)
+    # since they sign in via institution SSO. They can reset their password to enable email/password login.
+    user = OSFUser.create_confirmed(sso_email, str(uuid.uuid4()), fullname)
     return user, True, None
 
 

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -41,11 +41,16 @@ class NodeStateError(NodeError):
     """
     pass
 
+
 class UserStateError(OSFError):
     """Raised when the user's state is not suitable for the requested action
 
     Example: user.gdpr_delete() is called, but the user has resources that cannot be deleted.
     """
+    pass
+
+
+class InstitutionAffiliationStateError(OSFError):
     pass
 
 

--- a/osf/management/commands/migrate_user_institution_affiliation.py
+++ b/osf/management/commands/migrate_user_institution_affiliation.py
@@ -50,6 +50,9 @@ def migrate_user_institution_affiliation(dry_run=True):
         skipped_user_count_per_institution = 0
         users = institution.osfuser_set.all()
         user_total_per_institution = users.count()
+        sso_identity = ''
+        if not institution.delegation_protocol:
+            sso_identity = InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE
         logger.info(f'Migrating affiliation for <{institution.name}> [{institution_count}/{institution_total}]')
         for user in institution.osfuser_set.all():
             user_count_per_institution += 1
@@ -59,7 +62,7 @@ def migrate_user_institution_affiliation(dry_run=True):
             if not dry_run:
                 affiliation = user.add_or_update_affiliated_institution(
                     institution,
-                    sso_identity=InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE,
+                    sso_identity=sso_identity,
                     sso_department=user.department
                 )
                 if affiliation:

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -28,3 +28,20 @@ class InstitutionAffiliation(BaseModel):
 
     def __str__(self):
         return f'{self.user._id}::{self.institution._id}::{self.sso_identity}'
+
+
+def get_user_by_institution_identity(institution, sso_identity):
+    """Return the user with the given sso_identity for the given institution.
+    """
+    if not institution or not sso_identity:
+        return None
+    if sso_identity == InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE:
+        return None
+    try:
+        affiliation = InstitutionAffiliation.objects.get(institution___id=institution._id, sso_identity=sso_identity)
+    except InstitutionAffiliation.DoesNotExist:
+        return None
+    except InstitutionAffiliation.MultipleObjectsReturned:
+        # TODO: add exception handling
+        return None
+    return affiliation.user

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -4,6 +4,7 @@ from osf.models.base import BaseModel
 from osf.models.validators import validate_email
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import LowercaseEmailField
+from osf.exceptions import InstitutionAffiliationStateError
 
 
 class InstitutionAffiliation(BaseModel):
@@ -42,6 +43,7 @@ def get_user_by_institution_identity(institution, sso_identity):
     except InstitutionAffiliation.DoesNotExist:
         return None
     except InstitutionAffiliation.MultipleObjectsReturned:
-        # TODO: add exception handling
-        return None
+        raise InstitutionAffiliationStateError(
+            f'Duplicate SSO Identity: institution={institution._id}, sso_identity={sso_identity}'
+        )
     return affiliation.user

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1712,29 +1712,37 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     def add_or_update_affiliated_institution(self, institution, sso_identity=None, sso_mail=None, sso_department=None):
         """Add one or update the existing institution affiliation between the current user and the given ``institution``
-        with attributes. ``sso_department`` is the only attribute that needs to be updated for now. Returns the
-        affiliation if added or updated; returns ``None`` if affiliation exists and there is nothing to update.
+        with attributes. Returns the affiliation if created or updated; returns ``None`` if affiliation exists and
+        there is nothing to update.
         """
-        if self.is_affiliated_with_institution(institution):
-            if not sso_identity and not sso_department and not sso_mail:
-                return None
-            affiliation = InstitutionAffiliation.objects.get(user__id=self.id, institution__id=institution.id)
-            if sso_department and affiliation.sso_department != sso_department:
-                affiliation.sso_department = sso_department
-            if sso_mail and affiliation.sso_mail != sso_mail:
-                affiliation.sso_mail = sso_mail
-            if sso_identity and affiliation.sso_identity != sso_identity:
-                affiliation.sso_identity = sso_identity
-            affiliation.save()
+        # CASE 1: affiliation not found -> create and return the affiliation
+        if not self.is_affiliated_with_institution(institution):
+            affiliation = InstitutionAffiliation.objects.create(
+                user=self,
+                institution=institution,
+                sso_identity=sso_identity,
+                sso_mail=sso_mail,
+                sso_department=sso_department,
+                sso_other_attributes={}
+            )
             return affiliation
-        affiliation = InstitutionAffiliation.objects.create(
-            user=self,
-            institution=institution,
-            sso_identity=sso_identity,
-            sso_mail=sso_mail,
-            sso_department=sso_department,
-            sso_other_attributes={}
-        )
+        # CASE 2: affiliation exists
+        updated = False
+        affiliation = InstitutionAffiliation.objects.get(user__id=self.id, institution__id=institution.id)
+        if sso_department and affiliation.sso_department != sso_department:
+            affiliation.sso_department = sso_department
+            updated = True
+        if sso_mail and affiliation.sso_mail != sso_mail:
+            affiliation.sso_mail = sso_mail
+            updated = True
+        if sso_identity and affiliation.sso_identity != sso_identity:
+            affiliation.sso_identity = sso_identity
+            updated = True
+        # CASE 1.1: nothing to update -> return None
+        if not updated:
+            return None
+        # CASE 1.3: at least one attribute is updated -> return the affiliation
+        affiliation.save()
         return affiliation
 
     def remove_sso_identity_from_affiliation(self, institution):

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -435,6 +435,18 @@ WELCOME_OSF4I = Mail(
     engagement=True
 )
 
+# TODO: need email details from the Product Team
+DUPLICATE_ACCOUNTS_OSF4I = Mail(
+    'duplicate_accounts_sso_osf4i',
+    subject='Potential duplicate account found'
+)
+
+# TODO: need email details from the Product Team
+ADD_SSO_EMAIL_OSF4I = Mail(
+    'add_sso_email_osf4i',
+    subject='Your institutional email has been added to your account'
+)
+
 EMPTY = Mail('empty', subject='${subject}')
 
 REVIEWS_SUBMISSION_CONFIRMATION = Mail(


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-4202
https://openscience.atlassian.net/browse/ENG-4204

## Purpose

Rework Institution SSO flow with identity and affiliation - API Part

CAS Part: https://github.com/CenterForOpenScience/osf-cas/pull/75

## Changes

* Retrieve and parse the identity field from CAS

* Disambiguate the following attributes/properties
  * SSO Identity (do not rely solely on `eppn` since institutions could use other attributes)
  * SSO Email (an email provided by SSO, this may or may not be the same as user’s `username`)
  * `username`
  * User found by identity
  * User found by SSO email

* Handle different cases of matching/mismatching identity and email (See code for details)
  * CASE 1: new user: similar to the old flow's new user
  * CASE 2: existing user by identity → add email and notify
  * CASE 3: existing user by email → add identity
  * CASE 4: existing user by identity and email (match): similar to old flow's existing user
  * CASE 5: existing user by identity and email (mismatch) → use the user found by identity and send email about potential duplicate account (i.e. user found by email)

* Added a new exception to handle the corner case where two different users have the same SSO identity for the same institution.

* Other
  * Use Python 3 `f` string
  * Create a dedicated `get_or_create()` method for institutions
  * Fix the migration script
  * Improved affiliation check/update/create
  * Improved SSO logging

## TODO

- [x] Unit tests
- [x] Sentry
- [ ] Email template
