### PR TITLE
[ENG-4239] Add Cancel Behaviors for Collection Submissions

### DIFF
--- a/api/collection_submission_actions/serializers.py
+++ b/api/collection_submission_actions/serializers.py
@@ -88,6 +88,8 @@ class CollectionSubmissionActionSerializer(JSONAPISerializer):
                 collection_submission.remove(user=user, comment=comment)
             elif trigger == CollectionSubmissionsTriggers.RESUBMIT:
                 collection_submission.resubmit(user=user, comment=comment)
+            elif trigger == CollectionSubmissionsTriggers.CANCEL:
+                collection_submission.cancel(user=user, comment=comment)
             else:
                 raise JSONAPIAttributeException(attribute='trigger', detail='Invalid trigger.')
         except PermissionsError as exc:

--- a/osf/models/collection.py
+++ b/osf/models/collection.py
@@ -230,10 +230,13 @@ class Collection(DirtyFieldsMixin, GuidMixin, BaseModel, GuardianMixin):
         collection_submission = self.collectionsubmission_set.filter(guid=obj.guids.first())
         if collection_submission:
             collection_submission = collection_submission.get()
-            try:
-                collection_submission.resubmit(user=collector, comment='Resubmitted via collect_object')
-            except MachineError:
-                raise ValidationError('Object already exists in collection.')
+            if collection_submission.state == CollectionSubmissionStates.IN_PROGRESS:
+                collection_submission.submit(user=collector, comment='Submitted via collect_object')
+            else:
+                try:
+                    collection_submission.resubmit(user=collector, comment='Resubmitted via collect_object')
+                except MachineError:
+                    raise ValidationError('Object already exists in collection.')
             return collection_submission
         else:
             collection_submission = self.collectionsubmission_set.create(guid=obj.guids.first(), creator=collector)

--- a/osf/models/collection.py
+++ b/osf/models/collection.py
@@ -230,6 +230,7 @@ class Collection(DirtyFieldsMixin, GuidMixin, BaseModel, GuardianMixin):
         collection_submission = self.collectionsubmission_set.filter(guid=obj.guids.first())
         if collection_submission:
             collection_submission = collection_submission.get()
+            # IN_PROGRESS is "pre-submission", before the first save or after a submission cancellation.
             if collection_submission.state == CollectionSubmissionStates.IN_PROGRESS:
                 collection_submission.submit(user=collector, comment='Submitted via collect_object')
             else:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2418,10 +2418,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     removed_due_to_privacy=True
                 )
             elif submission.state == CollectionSubmissionStates.PENDING and user:
-                submission.reject(
+                submission.cancel(
                     user=user,
-                    comment='Rejected from collection due to implicit removal due to privacy changes.',
-                    force=True
+                    comment='Request to review this submission was canceled due to privacy changes.',
                 )
             elif force and submission.state == CollectionSubmissionStates.ACCEPTED:
                 request, user_id = get_request_and_user_id()
@@ -2432,7 +2431,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 )
             elif force and submission.state == CollectionSubmissionStates.PENDING:
                 request, user_id = get_request_and_user_id()
-                submission.reject(
+                submission.cancel(
                     user=request.user,
                     comment='Rejected from collection via system command.',  # typically spam
                     force=True

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2411,13 +2411,13 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
             user = getattr(auth, 'user', None)
 
-            if submission.state == CollectionSubmissionStates.ACCEPTED:
+            if submission.state == CollectionSubmissionStates.ACCEPTED and not force:
                 submission.remove(
                     user=user,
                     comment='Removed from collection due to implicit removal due to privacy changes.',
                     removed_due_to_privacy=True
                 )
-            elif submission.state == CollectionSubmissionStates.PENDING and user:
+            elif submission.state == CollectionSubmissionStates.PENDING and user and not force:
                 submission.cancel(
                     user=user,
                     comment='Request to review this submission was canceled due to privacy changes.',

--- a/osf/utils/workflows.py
+++ b/osf/utils/workflows.py
@@ -186,6 +186,7 @@ class CollectionSubmissionsTriggers(ModerationEnum):
     REJECT = 2
     REMOVE = 3
     RESUBMIT = 4
+    CANCEL = 5
 
 
 @unique
@@ -501,6 +502,15 @@ COLLECTION_SUBMISSION_TRANSITIONS = [
         'after': ['_make_public', '_notify_contributors_pending', '_notify_moderators_pending'],
         'conditions': ['is_hybrid_moderated'],
         'unless': ['is_submitted_by_moderator_contributor']
+    },
+    {
+        'trigger': 'cancel',
+        'source': [CollectionSubmissionStates.PENDING],
+        'dest': CollectionSubmissionStates.IN_PROGRESS,
+        'before': ['_validate_cancel'],
+        'after': ['_notify_cancel'],
+        'conditions': [],
+        'unless': []
     },
 ]
 

--- a/osf_tests/test_collection_submission.py
+++ b/osf_tests/test_collection_submission.py
@@ -322,6 +322,22 @@ class TestModeratedCollectionSubmission:
             moderated_collection_submission.resubmit(user=user, comment='Test Comment')
         assert moderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 
+    @pytest.mark.parametrize('user_role', UserRoles.excluding(UserRoles.ADMIN_USER))
+    def test_cancel_fails(self, node, user_role, moderated_collection_submission):
+        user = configure_test_auth(node, user_role)
+        moderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        moderated_collection_submission.save()
+        with pytest.raises(PermissionsError):
+            moderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert moderated_collection_submission.state == CollectionSubmissionStates.PENDING
+
+    def test_cancel_succeeds(self, node, moderated_collection_submission):
+        user = configure_test_auth(node, UserRoles.ADMIN_USER)
+        moderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        moderated_collection_submission.save()
+        moderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert moderated_collection_submission.state == CollectionSubmissionStates.IN_PROGRESS
+
 
 @pytest.mark.django_db
 class TestUnmoderatedCollectionSubmission:
@@ -392,6 +408,22 @@ class TestUnmoderatedCollectionSubmission:
         with pytest.raises(PermissionsError):
             unmoderated_collection_submission.resubmit(user=user, comment='Test Comment')
         assert unmoderated_collection_submission.state == CollectionSubmissionStates.REMOVED
+
+    @pytest.mark.parametrize('user_role', UserRoles.excluding(UserRoles.ADMIN_USER))
+    def test_cancel_fails(self, node, user_role, unmoderated_collection_submission):
+        user = configure_test_auth(node, user_role)
+        unmoderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        unmoderated_collection_submission.save()
+        with pytest.raises(PermissionsError):
+            unmoderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert unmoderated_collection_submission.state == CollectionSubmissionStates.PENDING
+
+    def test_cancel_succeeds(self, node, unmoderated_collection_submission):
+        user = configure_test_auth(node, UserRoles.ADMIN_USER)
+        unmoderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        unmoderated_collection_submission.save()
+        unmoderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert unmoderated_collection_submission.state == CollectionSubmissionStates.IN_PROGRESS
 
 
 @pytest.mark.django_db
@@ -577,3 +609,19 @@ class TestHybridModeratedCollectionSubmission:
         hybrid_moderated_collection_submission.save()
         hybrid_moderated_collection_submission.resubmit(user=user, comment='Test Comment')
         assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.ACCEPTED
+
+    @pytest.mark.parametrize('user_role', UserRoles.excluding(UserRoles.ADMIN_USER))
+    def test_cancel_fails(self, node, user_role, hybrid_moderated_collection_submission):
+        user = configure_test_auth(node, user_role)
+        hybrid_moderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        hybrid_moderated_collection_submission.save()
+        with pytest.raises(PermissionsError):
+            hybrid_moderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.PENDING
+
+    def test_cancel_succeeds(self, node, hybrid_moderated_collection_submission):
+        user = configure_test_auth(node, UserRoles.ADMIN_USER)
+        hybrid_moderated_collection_submission.state_machine.set_state(CollectionSubmissionStates.PENDING)
+        hybrid_moderated_collection_submission.save()
+        hybrid_moderated_collection_submission.cancel(user=user, comment='Test Comment')
+        assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.IN_PROGRESS

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -227,6 +227,10 @@ COLLECTION_SUBMISSION_REMOVED_PRIVATE = lambda collection, node: Mail(
     'collection_submission_removed_private',
     subject=f'{node.title} was removed from {collection.title}'
 )
+COLLECTION_SUBMISSION_CANCEL = lambda collection, node: Mail(
+    'collection_submission_cancel',
+    subject=f'Request to add {node.title} to {collection.title} was canceled'
+)
 
 PRIMARY_EMAIL_CHANGED = Mail('primary_email_changed', subject='Primary email changed')
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -836,11 +836,7 @@ def update_collection_submission_async(self, node_id, collection_id=None, op='up
                 continue
             if collection_submission.guid.referent.deleted:
                 continue
-            if collection_submission.state in [
-                CollectionSubmissionStates.REMOVED,
-                CollectionSubmissionStates.REJECTED,
-                CollectionSubmissionStates.PENDING
-            ]:
+            if collection_submission.state is not CollectionSubmissionStates.ACCEPTED:
                 continue
         try:
             update_collection_submission(collection_submission, op=op, index=index)

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -111,6 +111,8 @@ $(document).ready(function () {
         // If the clicked element has .keep-open, don't allow the event to propagate
         return !(target.hasClass('keep-open') || target.parents('.keep-open').length);
     });
+    var collectionsActionsURL = $osf.apiV2Url('collection_submission_actions/');
+
     $('.collections-retry-icon').on('click', function (evt) {
         var target = $(evt.target);
         var payload = {
@@ -130,7 +132,38 @@ $(document).ready(function () {
                 }
             }
         };
-        var collectionsActionsURL = $osf.apiV2Url('collection_submission_actions/');
+
+        var request = $osf.ajaxJSON(
+            'POST',
+            collectionsActionsURL,
+            {
+                data: payload,
+                isCors: true
+            }
+        );
+        request.done(function(resp) {
+            location.reload();
+        });
+    });
+    $('.collections-cancel-icon').on('click', function (evt) {
+        var target = $(evt.target);
+        var payload = {
+            data: {
+                type: 'collection-submission-actions',
+                attributes: {
+                    comment: 'Canceled via project overview page',
+                    trigger: 'cancel',
+                },
+                relationships: {
+                    target: {
+                        data: {
+                            id: evt.target.getAttribute('node_id') + '-' + evt.target.getAttribute('collection_id'),
+                            type: 'collection-submission',
+                        }
+                    }
+                }
+            }
+        };
 
         var request = $osf.ajaxJSON(
             'POST',

--- a/website/templates/emails/collection_submission_cancel.html.mako
+++ b/website/templates/emails/collection_submission_cancel.html.mako
@@ -9,23 +9,23 @@
     <br>
     <p>
         % if is_admin:
-            You have changed the privacy of <a href="${node.absolute_url}">${node.title}</a> and it has therefore been
-            removed from
-            % if collection.provider:
+             The request to add <a href="${node.absolute_url}">${node.title}</a> to
+             % if collection.provider:
                 <a href="${settings.DOMAIN + 'collections/' + collection.provider._id}">${collection.provider.name}</a>
             % else:
                 <a href="${settings.DOMAIN + 'myprojects/'}">${collection.provider.name}</a>
             % endif
-            . If you wish to be associated with the collection, you will need to request addition to the collection again.
+
+            was canceled. If you wish to be associated with the collection, you will need to request to be added again.
         % else:
-            <a href="${remover.absolute_url}">${remover.fullname}</a> has changed the privacy settings for
-            <a href="${node.absolute_url}">${node.title}</a> it has therefore been removed from
+            <a href="${remover.absolute_url}">${remover.fullname}</a> canceled the request to add
+            <a href="${node.absolute_url}">${node.title}</a>to
             % if collection.provider:
                 <a href="${settings.DOMAIN + 'collections/' + collection.provider._id}">${collection.provider.name}</a>
             % else:
                 <a href="${settings.DOMAIN + 'myprojects/'}">${collection.provider.name}</a>
             % endif
-            It will need to be re-submitteds to be included in the collection again.
+            If you wish to be associated with the collection, an admin will need to request addition again.
         % endif
     </p>
     <p>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -376,6 +376,9 @@
                                 % endif
                                 <hr>
                             % elif collection['state'] == 'pending' and user['is_contributor_or_group_member']:
+                                % if user['is_admin']:
+                                    <a class="fa fa-close collections-cancel-icon pull-right" collection_id=${collection['collection_id']} node_id=${collection['node_id']} aria-label="Cancel Submission Request Button"></a>
+                                % endif
                                 <img src="${collection['logo']}" style="display: inline; height: 25px; margin-top: -2px;" alt="collection logo" />
                                 <div style="display: inline;">
                                     Pending entry into <a href="${collection['url']}" >${collection['collection_title']}</a>


### PR DESCRIPTION
## Purpose

Pending collection submissions can't be withdrawn from consideration voluntarily by a project admin without some general bad UX, this adds a direct way for the user to cancel a pending collection submission without changing the privacy state of the project. 

## Changes

- adds new trigger `cancel`  and new transition to the transitions list
- adds changes adding a cancel button to project overview page
- adds tests and serializer logic for canceling a collection submission
- Accessibility changes

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4239
