### PR TITLE
[ENG-4246] Add Specific Subscription Provider Endpoints for dupe ids

### DIFF
--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -116,6 +116,10 @@ class CollectionProviderSerializer(ProviderSerializer):
     )
     reviews_workflow = ser.ChoiceField(choices=Workflows.choices(), read_only=True)
 
+    subscriptions = RelationshipField(
+        related_view='providers:collection-providers:notification-subscription-list',
+        related_view_kwargs={'provider_id': '<_id>'},
+    )
     filterable_fields = frozenset([
         'allow_submissions',
         'allow_commenting',
@@ -171,6 +175,11 @@ class RegistrationProviderSerializer(ProviderSerializer):
         related_view_kwargs={'provider_id': '<_id>'},
     )
 
+    subscriptions = RelationshipField(
+        related_view='providers:registration-providers:notification-subscription-list',
+        related_view_kwargs={'provider_id': '<_id>'},
+    )
+
     links = LinksField({
         'self': 'get_absolute_url',
         'external_url': 'get_external_url',
@@ -220,6 +229,11 @@ class PreprintProviderSerializer(MetricsSerializerMixin, ProviderSerializer):
 
     moderators = RelationshipField(
         related_view='providers:preprint-providers:provider-moderator-list',
+        related_view_kwargs={'provider_id': '<_id>'},
+    )
+
+    subscriptions = RelationshipField(
+        related_view='providers:preprint-providers:notification-subscription-list',
         related_view_kwargs={'provider_id': '<_id>'},
     )
 

--- a/api/providers/urls.py
+++ b/api/providers/urls.py
@@ -1,6 +1,14 @@
 from django.conf.urls import include, re_path
 
 from api.providers import views
+from api.subscriptions.views import (
+    PreprintProviderSubscriptionDetail,
+    RegistrationProviderSubscriptionDetail,
+    CollectionProviderSubscriptionDetail,
+    PreprintProviderSubscriptionList,
+    RegistrationProviderSubscriptionList,
+    CollectionProviderSubscriptionList,
+)
 
 app_name = 'osf'
 
@@ -20,6 +28,16 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/withdraw_requests/$', views.PreprintProviderWithdrawRequestList.as_view(), name=views.PreprintProviderWithdrawRequestList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.PreprintProviderModeratorsList.as_view(), name=views.PreprintProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.PreprintProviderModeratorsDetail.as_view(), name=views.PreprintProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        PreprintProviderSubscriptionDetail.as_view(),
+                        name=PreprintProviderSubscriptionDetail.view_name,
+                    ),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/$',
+                        PreprintProviderSubscriptionList.as_view(),
+                        name=PreprintProviderSubscriptionList.view_name,
+                    ),
                 ], 'preprints',
             ),
             namespace='preprint-providers',
@@ -40,6 +58,16 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/taxonomies/highlighted/$', views.CollectionProviderHighlightedTaxonomyList.as_view(), name=views.CollectionProviderHighlightedTaxonomyList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.CollectionProviderModeratorsList.as_view(), name=views.CollectionProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.CollectionProviderModeratorsDetail.as_view(), name=views.CollectionProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        CollectionProviderSubscriptionDetail.as_view(),
+                        name=CollectionProviderSubscriptionDetail.view_name,
+                    ),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/$',
+                        CollectionProviderSubscriptionList.as_view(),
+                        name=CollectionProviderSubscriptionList.view_name,
+                    ),
                 ], 'collections',
             ),
             namespace='collection-providers',
@@ -64,6 +92,16 @@ urlpatterns = [
                     re_path(r'^(?P<provider_id>\w+)/actions/$', views.RegistrationProviderActionList.as_view(), name=views.RegistrationProviderActionList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/$', views.RegistrationProviderModeratorsList.as_view(), name=views.RegistrationProviderModeratorsList.view_name),
                     re_path(r'^(?P<provider_id>\w+)/moderators/(?P<moderator_id>\w+)/$', views.RegistrationProviderModeratorsDetail.as_view(), name=views.RegistrationProviderModeratorsDetail.view_name),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/(?P<subscription_id>\w+)/$',
+                        RegistrationProviderSubscriptionDetail.as_view(),
+                        name=RegistrationProviderSubscriptionDetail.view_name,
+                    ),
+                    re_path(
+                        r'^(?P<provider_id>\w+)/subscriptions/$',
+                        RegistrationProviderSubscriptionList.as_view(),
+                        name=RegistrationProviderSubscriptionList.view_name,
+                    ),
                 ], 'registrations',
             ),
             namespace='registration-providers',

--- a/api/subscriptions/serializers.py
+++ b/api/subscriptions/serializers.py
@@ -49,3 +49,18 @@ class SubscriptionSerializer(JSONAPISerializer):
         notification_type = validated_data.get('notification_type')
         instance.add_user_to_subscription(user, notification_type, save=True)
         return instance
+
+
+class RegistrationSubscriptionSerializer(SubscriptionSerializer):
+    class Meta:
+        type_ = 'registration-subscription'
+
+
+class CollectionSubscriptionSerializer(SubscriptionSerializer):
+    class Meta:
+        type_ = 'collection-subscription'
+
+
+class PreprintSubscriptionSerializer(SubscriptionSerializer):
+    class Meta:
+        type_ = 'preprint-subscription'

--- a/api/subscriptions/views.py
+++ b/api/subscriptions/views.py
@@ -8,9 +8,20 @@ from framework.auth.oauth_scopes import CoreScopes
 from api.base.views import JSONAPIBaseView
 from api.base.filters import ListFilterMixin
 from api.base import permissions as base_permissions
-from api.subscriptions.serializers import SubscriptionSerializer
+from api.subscriptions.serializers import (
+    SubscriptionSerializer,
+    CollectionSubscriptionSerializer,
+    PreprintSubscriptionSerializer,
+    RegistrationSubscriptionSerializer,
+)
 from api.subscriptions.permissions import IsSubscriptionOwner
-from osf.models import NotificationSubscription
+from osf.models import (
+    NotificationSubscription,
+    CollectionProvider,
+    PreprintProvider,
+    RegistrationProvider,
+    AbstractProvider,
+)
 
 
 class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
@@ -61,3 +72,61 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
             raise NotFound
         self.check_object_permissions(self.request, obj)
         return obj
+
+
+class AbstractProviderSubscriptionDetail(SubscriptionDetail):
+    view_name = 'provider-notification-subscription-detail'
+    view_category = 'notification-subscriptions'
+    permission_classes = (
+        drf_permissions.IsAuthenticated,
+        base_permissions.TokenHasScope,
+        IsSubscriptionOwner,
+    )
+
+    required_read_scopes = [CoreScopes.SUBSCRIPTIONS_READ]
+    required_write_scopes = [CoreScopes.SUBSCRIPTIONS_WRITE]
+    provider_class = None
+
+    def __init__(self, *args, **kwargs):
+        assert issubclass(self.provider_class, AbstractProvider), 'Class must be subclass of AbstractProvider'
+        super().__init__(*args, **kwargs)
+
+    def get_object(self):
+        subscription_id = self.kwargs['subscription_id']
+        provider = self.provider_class.objects.get(_id=self.kwargs['provider_id'])
+        try:
+            obj = NotificationSubscription.objects.get(
+                _id=subscription_id,
+                provider_id=provider.id,
+            )
+        except ObjectDoesNotExist:
+            raise NotFound
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+
+class CollectionProviderSubscriptionDetail(AbstractProviderSubscriptionDetail):
+    provider_class = CollectionProvider
+    serializer_class = CollectionSubscriptionSerializer
+
+
+class PreprintProviderSubscriptionDetail(AbstractProviderSubscriptionDetail):
+    provider_class = PreprintProvider
+    serializer_class = PreprintSubscriptionSerializer
+
+
+class RegistrationProviderSubscriptionDetail(AbstractProviderSubscriptionDetail):
+    provider_class = RegistrationProvider
+    serializer_class = RegistrationSubscriptionSerializer
+
+
+class CollectionProviderSubscriptionList(SubscriptionList):
+    serializer_class = CollectionSubscriptionSerializer
+
+
+class PreprintProviderSubscriptionList(SubscriptionList):
+    serializer_class = PreprintSubscriptionSerializer
+
+
+class RegistrationProviderSubscriptionList(SubscriptionList):
+    serializer_class = RegistrationSubscriptionSerializer


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently the subscription endpoint doesn't distingish a subscriptions provider type, that causes problems with duplicate `_id`s this fixes that.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4246