### PR TITLE
[Institution Rework] Remove user from institution metrics admin when affiliation is removed

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1765,6 +1765,10 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         if not affiliation:
             return False
         affiliation.delete()
+        if self.has_perm('view_institutional_metrics', affiliation.institution):
+            group = affiliation.institution.get_group('institutional_admins')
+            group.user_set.remove(self)
+            group.save()
         return True
 
     def get_activity_points(self):


### PR DESCRIPTION
###

Remove user from institution metrics admin when affiliation is removed

For details, see: https://www.notion.so/cos/Remove-Institution-Admin-Access-if-a-User-Deletes-their-Institution-Affiliation-3d9d240cd90245338c91ce42bec3ddb8