### PR TITLE
fix ordering for collections moderation

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -54,7 +54,7 @@ class OSFOrderingFilter(OrderingFilter):
         ordering = self.get_ordering(request, queryset, view)
         if isinstance(queryset, DjangoQuerySet):
             if queryset.ordered:
-                return queryset
+                return super().filter_queryset(request, queryset, view)
             elif ordering and getattr(queryset.query, 'distinct_fields', None):
                 order_fields = tuple([field.lstrip('-') for field in ordering])
                 distinct_fields = queryset.query.distinct_fields

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -52,20 +52,20 @@ class OSFOrderingFilter(OrderingFilter):
     # override
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view)
+        if not ordering:
+            return queryset
+
         if isinstance(queryset, DjangoQuerySet):
-            if queryset.ordered:
-                return super().filter_queryset(request, queryset, view)
-            elif ordering and getattr(queryset.query, 'distinct_fields', None):
+            if getattr(queryset.query, 'distinct_fields', None):
                 order_fields = tuple([field.lstrip('-') for field in ordering])
                 distinct_fields = queryset.query.distinct_fields
                 queryset.query.distinct_fields = tuple(set(distinct_fields + order_fields))
-            return super(OSFOrderingFilter, self).filter_queryset(request, queryset, view)
-        if ordering:
-            if isinstance(ordering, (list, tuple)):
-                sorted_list = sorted(queryset, key=cmp_to_key(sort_multiple(ordering)))
-                return sorted_list
-            return queryset.sort(*ordering)
-        return queryset
+            return super().filter_queryset(request, queryset, view)
+        elif isinstance(ordering, (list, tuple)):
+            sorted_list = sorted(queryset, key=cmp_to_key(sort_multiple(ordering)))
+            return sorted_list
+        else:
+            raise NotImplementedError()
 
     def get_serializer_source_field(self, view, request):
         """

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -505,7 +505,7 @@ class BaseContributorDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
 class BaseContributorList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
-    ordering = ('-modified',)
+    ordering = ('-node__modified',)
 
     def get_default_queryset(self):
         node = self.get_node()

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -763,7 +763,7 @@ class NodeLinksList(JSONAPIBaseView, bulk_views.BulkDestroyJSONAPIView, bulk_vie
     view_name = 'node-pointers'
     model_class = CollectionSubmission
 
-    ordering = ('-modified',)
+    ordering = ('_order', '-modified',)
 
     def get_queryset(self):
         return self.get_collection().collectionsubmission_set.filter(

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -551,7 +551,7 @@ class NodeImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView, ListFi
     serializer_class = UserSerializer
     view_category = 'nodes'
     view_name = 'node-implicit-contributors'
-    ordering = ('_order',)  # default ordering
+    ordering = ('contributor___order',)  # default ordering
 
     def get_default_queryset(self):
         node = self.get_node()

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -249,14 +249,14 @@ class GenericProviderTaxonomies(JSONAPIBaseView, generics.ListAPIView):
     pagination_class = IncreasedPageSizePagination
     view_name = 'taxonomy-list'
 
-    ordering = ('_order', '-id')
+    ordering = ('_order', 'text')
 
     def get_queryset(self):
         parent = self.request.query_params.get('filter[parents]', None) or self.request.query_params.get('filter[parent]', None)
         provider = get_object_or_error(self.provider_class, self.kwargs['provider_id'], self.request, display_name=self.provider_class.__name__)
         if parent:
             if parent == 'null':
-                return provider.top_level_subjects
+                return optimize_subject_query(provider.top_level_subjects)
             return optimize_subject_query(provider.all_subjects.filter(parent___id=parent))
         return optimize_subject_query(provider.all_subjects)
 
@@ -298,7 +298,7 @@ class BaseProviderSubjects(SubjectList):
         provider = get_object_or_error(self.provider_class, self.kwargs['provider_id'], self.request, display_name=self.provider_class.__name__)
         if parent:
             if parent == 'null':
-                return provider.top_level_subjects
+                return optimize_subject_query(provider.top_level_subjects)
             return optimize_subject_query(provider.all_subjects.filter(parent___id=parent))
         return optimize_subject_query(provider.all_subjects)
 
@@ -319,6 +319,7 @@ class PreprintProviderSubjects(BaseProviderSubjects):
     view_category = 'preprint-providers'
     provider_class = PreprintProvider  # Not actually the model being serialized, privatize to avoid issues
 
+    ordering = ('_order', 'text',)
 
 class GenericProviderHighlightedTaxonomyList(JSONAPIBaseView, generics.ListAPIView):
     permission_classes = (
@@ -332,6 +333,8 @@ class GenericProviderHighlightedTaxonomyList(JSONAPIBaseView, generics.ListAPIVi
     required_write_scopes = [CoreScopes.NULL]
 
     serializer_class = TaxonomySerializer
+
+    ordering = ('_order', 'text',)
 
     def get_queryset(self):
         provider = get_object_or_error(self.provider_class, self.kwargs['provider_id'], self.request, display_name=self.provider_class.__name__)

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -249,7 +249,7 @@ class GenericProviderTaxonomies(JSONAPIBaseView, generics.ListAPIView):
     pagination_class = IncreasedPageSizePagination
     view_name = 'taxonomy-list'
 
-    ordering = ('_order', 'text')
+    ordering = ('is_other', 'text')
 
     def get_queryset(self):
         parent = self.request.query_params.get('filter[parents]', None) or self.request.query_params.get('filter[parent]', None)

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -249,7 +249,7 @@ class GenericProviderTaxonomies(JSONAPIBaseView, generics.ListAPIView):
     pagination_class = IncreasedPageSizePagination
     view_name = 'taxonomy-list'
 
-    ordering = ('-id',)
+    ordering = ('_order', '-id')
 
     def get_queryset(self):
         parent = self.request.query_params.get('filter[parents]', None) or self.request.query_params.get('filter[parent]', None)

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -319,7 +319,7 @@ class PreprintProviderSubjects(BaseProviderSubjects):
     view_category = 'preprint-providers'
     provider_class = PreprintProvider  # Not actually the model being serialized, privatize to avoid issues
 
-    ordering = ('_order', 'text',)
+    ordering = ('is_other', 'text',)
 
 class GenericProviderHighlightedTaxonomyList(JSONAPIBaseView, generics.ListAPIView):
     permission_classes = (
@@ -334,7 +334,7 @@ class GenericProviderHighlightedTaxonomyList(JSONAPIBaseView, generics.ListAPIVi
 
     serializer_class = TaxonomySerializer
 
-    ordering = ('_order', 'text',)
+    ordering = ('is_other', 'text',)
 
     def get_queryset(self):
         provider = get_object_or_error(self.provider_class, self.kwargs['provider_id'], self.request, display_name=self.provider_class.__name__)

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -331,7 +331,7 @@ class RegistrationImplicitContributorsList(JSONAPIBaseView, generics.ListAPIView
     serializer_class = UserSerializer
     view_category = 'registrations'
     view_name = 'registration-implicit-contributors'
-    ordering = ('_order',)  # default ordering
+    ordering = ('contributor___order',)  # default ordering
 
     def get_default_queryset(self):
         node = self.get_node()

--- a/api/subjects/views.py
+++ b/api/subjects/views.py
@@ -105,7 +105,7 @@ class SubjectList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
     view_category = 'subjects'
     view_name = 'subject-list'
 
-    ordering = ('-id',)
+    ordering = ('_order', '-id',)
 
     def get_default_queryset(self):
         return optimize_subject_query(Subject.objects.all())

--- a/api/subjects/views.py
+++ b/api/subjects/views.py
@@ -105,7 +105,7 @@ class SubjectList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
     view_category = 'subjects'
     view_name = 'subject-list'
 
-    ordering = ('_order', '-id',)
+    ordering = ('is_other', '-id',)
 
     def get_default_queryset(self):
         return optimize_subject_query(Subject.objects.all())

--- a/api/taxonomies/utils.py
+++ b/api/taxonomies/utils.py
@@ -6,7 +6,7 @@ def optimize_subject_query(subject_queryset):
     """
     return subject_queryset.prefetch_related('parent', 'provider').annotate(
         children_count=Count('children'),
-        _order=Case(
+        is_other=Case(
             When(text__startswith='Other', then=True),
             default=False,
             output_field=BooleanField(),

--- a/api/taxonomies/utils.py
+++ b/api/taxonomies/utils.py
@@ -6,9 +6,9 @@ def optimize_subject_query(subject_queryset):
     """
     return subject_queryset.prefetch_related('parent', 'provider').annotate(
         children_count=Count('children'),
-        is_other=Case(
+        _order=Case(
             When(text__startswith='Other', then=True),
             default=False,
             output_field=BooleanField(),
         ),
-    ).order_by('is_other', 'text')
+    )

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -28,7 +28,7 @@ class TaxonomyList(DeprecatedView, JSONAPIBaseView, generics.ListAPIView, ListFi
     view_name = 'taxonomy-list'
     max_version = '2.5'
 
-    ordering = ('-id',)
+    ordering = ('_order', 'text',)
 
     def get_default_queryset(self):
         return optimize_subject_query(Subject.objects.all())

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -28,7 +28,7 @@ class TaxonomyList(DeprecatedView, JSONAPIBaseView, generics.ListAPIView, ListFi
     view_name = 'taxonomy-list'
     max_version = '2.5'
 
-    ordering = ('_order', 'text',)
+    ordering = ('is_other', 'text',)
 
     def get_default_queryset(self):
         return optimize_subject_query(Subject.objects.all())

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -406,7 +406,7 @@ class TestRegistrationForkCreate:
             API_BASE, new_registration._id, '?embed=node_links')
 
         res = app.post_json_api(url, fork_data, auth=user.auth)
-        assert res.json['data']['embeds']['node_links']['data'][1]['embeds']['target_node']['data']['id'] == pointer._id
+        assert res.json['data']['embeds']['node_links']['data'][0]['embeds']['target_node']['data']['id'] == pointer._id
         assert res.json['data']['embeds']['node_links']['links']['meta']['total'] == 2
 
     def test_cannot_fork_retractions(

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -397,7 +397,7 @@ class PreprintProvider(AbstractProvider):
             if len(self.subjects_acceptable) == 0:
                 return optimize_subject_query(Subject.objects.filter(parent__isnull=True, provider___id='osf'))
             tops = set([sub[0][0] for sub in self.subjects_acceptable])
-            return [Subject.load(sub) for sub in tops]
+            return Subject.objects.filter(_id__in=tops)
 
     @property
     def landing_url(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently querysets that are ordered by a default ordering automatically override user provided sort parameters, this fix allows us to use both the view level default sorting and use the `sort` param to do a custom sort. Generally we wanted to stick to always sorting on DB fields or queryset annotations, even for default sorts even if just for consistency, 

## Changes

- now querysets with `ordered==True`, are filterted on user params in `OSFOrderingFilter`
- logic that sorted subjects `is_other` ordering is now done using `_order` annotations.
- certain views whose default sorting was being ignored must get correct default odering parameters

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
