### PR TITLE
[Institution Rework] [ENG-4229] Add unit tests to cover reworked SSO flow with identity and affiliation

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -132,6 +132,8 @@ class InstitutionAuthentication(BaseAuthentication):
             raise PermissionDenied(detail='InstitutionSsoInvalidInstitution')
 
         sso_identity = provider['user'].get('ssoIdentity')
+        sso_identity = sso_identity.strip() if sso_identity else None
+
         sso_email = provider['user'].get('ssoEmail')
         fullname = provider['user'].get('fullname')
         given_name = provider['user'].get('givenName')

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -117,11 +117,12 @@ def register_unconfirmed(username, password, fullname, campaign=None, accepted_t
 def get_or_create_institutional_user(fullname, sso_email, sso_identity, primary_institution):
     """
     Get or create an institutional user by fullname, email address and sso identity and institution.
-    Returns a tuple of four objects ``(user, is_created, duplicate_user, email_to_add)``:
+    Returns a tuple of five objects ``(user, is_created, duplicate_user, email_to_add, identity_to_add)``:
         1. the user to authenticate
         2. whether the user is newly created or not
         3. whether a potential duplicate user is found or not
         4. the extra email to add to the user account
+        5. the sso identity to add to the affiliation
     Note: secondary institution always have a primary institution which shares its email and identity
     :param str fullname: user's full name
     :param str sso_email: user's email, which comes from the email attribute during SSO
@@ -136,7 +137,10 @@ def get_or_create_institutional_user(fullname, sso_email, sso_identity, primary_
     user_by_email = get_user(email=sso_email)
     # ``InstitutionAffiliationStateError`` can be raised by ``get_user_by_institution_identity()``, the caller of
     # ``get_or_create_institutional_user()`` must handle it properly
-    user_by_identity = get_user_by_institution_identity(primary_institution, sso_identity)
+    user_by_identity, is_identity_eligible = get_user_by_institution_identity(primary_institution, sso_identity)
+    # Avoid adding an sso identity that is not eligible
+    if not is_identity_eligible:
+        sso_identity = None
 
     if user_by_identity:
         # CASE 1/5: the user is only found by identity but not by email, return the user and the sso email to add

--- a/osf/management/commands/migrate_user_institution_affiliation.py
+++ b/osf/management/commands/migrate_user_institution_affiliation.py
@@ -50,7 +50,7 @@ def migrate_user_institution_affiliation(dry_run=True):
         skipped_user_count_per_institution = 0
         users = institution.osfuser_set.all()
         user_total_per_institution = users.count()
-        sso_identity = ''
+        sso_identity = None
         if not institution.delegation_protocol:
             sso_identity = InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE
         logger.info(f'Migrating affiliation for <{institution.name}> [{institution_count}/{institution_total}]')

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -44,7 +44,7 @@ def get_user_by_institution_identity(institution, sso_identity):
     determines whether the sso_identity is an eligible identity.
     """
     if not institution or not sso_identity:
-        return None, True
+        return None, False
     # Skip the default identity that is used only for institutions that don't have SSO
     if sso_identity == InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE:
         return None, False

--- a/osf/models/institution_affiliation.py
+++ b/osf/models/institution_affiliation.py
@@ -40,20 +40,21 @@ class InstitutionAffiliation(BaseModel):
 
 def get_user_by_institution_identity(institution, sso_identity):
     """Return the user with the given sso_identity for the given institution if found. Return ``None`` if missing
-    inputs or if user not found. Raise exception if multiple users found.
+    inputs or if user not found. Raise exception if multiple users found. In addition, returns a second value which
+    determines whether the sso_identity is an eligible identity.
     """
     if not institution or not sso_identity:
-        return None
+        return None, True
     # Skip the default identity that is used only for institutions that don't have SSO
     if sso_identity == InstitutionAffiliation.DEFAULT_VALUE_FOR_SSO_IDENTITY_NOT_AVAILABLE:
-        return None
+        return None, False
     try:
         affiliation = InstitutionAffiliation.objects.get(institution___id=institution._id, sso_identity=sso_identity)
     except InstitutionAffiliation.DoesNotExist:
-        return None
+        return None, True
     except InstitutionAffiliation.MultipleObjectsReturned as err:
         message = f'Duplicate SSO Identity: institution={institution._id}, sso_identity={sso_identity}, err={str(err)}'
         logger.error(message)
         sentry.log_message(message)
         raise InstitutionAffiliationStateError(message)
-    return affiliation.user
+    return affiliation.user, True

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1749,7 +1749,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         if not self.is_affiliated_with_institution(institution):
             return None
         affiliation = InstitutionAffiliation.objects.get(user__id=self.id, institution__id=institution.id)
-        affiliation.sso_identity = ''
+        affiliation.sso_identity = None
         affiliation.save()
         return affiliation
 


### PR DESCRIPTION
## Purpose

Add unit tests to cover reworked SSO flow with identity and affiliation

## Changes

* Always use `None` (instead of `''`) when SSO identity is not provided
  * When migrating existing SSO affiliations
  * When removing identity from affiliations in the "duplicate account" case
  * During institution authentication when identity is provided as empty or blank from CAS
  * When calling `add_or_update` without the identity param

* Handle a corner case where SSO identity is not eligible
  
* Add unit tests to cover updated  SSO flow with identity and affiliation

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4229
