### PR TITLE
[ENG-4369] [ENG-4370] Update `framework` and `website` to use Django Session

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -9,8 +9,8 @@ from django.db.models import Q
 from django.db.models import Subquery
 from django.core.validators import URLValidator
 from flask import request
-from framework.sessions import session
 
+from framework.sessions import get_session
 from osf.exceptions import ValidationValueError, ValidationError
 from osf.utils.requests import check_select_for_update
 from website import security, settings
@@ -74,7 +74,10 @@ def validate_social(value):
 
 
 def get_current_user_id():
-    return session._get_current_object() and session.data.get('auth_user_id')
+    current_session = get_session()
+    session_data = current_session.get_decoded()
+    return session_data.get('auth_user_id', None)
+
 
 # TODO - rename to _get_current_user_from_session /HRYBACKI
 def _get_current_user():

--- a/framework/routing/__init__.py
+++ b/framework/routing/__init__.py
@@ -17,7 +17,7 @@ import werkzeug.wrappers
 from framework import sentry
 from framework.exceptions import HTTPError
 from framework.flask import app, redirect
-from framework.sessions import session
+from framework.sessions import get_session
 
 from website import settings
 
@@ -102,10 +102,9 @@ def wrap_with_renderer(fn, renderer, renderer_kwargs=None, debug_mode=True):
     """
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):
-        if session:
-            session_error_code = session.data.get('auth_error_code')
-        else:
-            session_error_code = None
+        current_session = get_session()
+        session_data = current_session.get_decoded()
+        session_error_code = session_data.get('auth_error_code', None)
         if session_error_code:
             return renderer(
                 HTTPError(session_error_code),

--- a/framework/status/__init__.py
+++ b/framework/status/__init__.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 
-from framework.sessions import session
+from framework.sessions import get_session
 
 Status = namedtuple('Status', ['message', 'jumbotron', 'css_class', 'dismissible', 'trust', 'id', 'extra'])  # trust=True displays msg as raw HTML
 
@@ -17,6 +17,7 @@ TYPE_MAP = {
     'default': 'default',
 }
 
+
 def push_status_message(message, kind='warning', dismissible=True, trust=True, jumbotron=False, id=None, extra=None):
     """
     Push a status message that will be displayed as a banner on the next page loaded by the user.
@@ -30,7 +31,9 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
     """
     # TODO: Change the default to trust=False once conversion to markupsafe rendering is complete
     try:
-        statuses = session.data.get('status')
+        current_session = get_session()
+        session_data = current_session.get_decoded()
+        statuses = session_data.get('status', None)
     except RuntimeError as e:
         exception_message = str(e)
         if 'Working outside of request context.' in exception_message:
@@ -56,23 +59,29 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
                            id=id,
                            extra=extra,
                            trust=trust))
-    session.data['status'] = statuses
-    session.save()
+    current_session['status'] = statuses
+    current_session.save()
+
 
 def pop_status_messages(level=0):
-    messages = session.data.get('status')
+    current_session = get_session()
+    session_data = current_session.get_decoded()
+    messages = session_data.get('status', None)
     for message in messages or []:
         if len(message) == 5:
             message += [None, None]  # Make sure all status's have enough arguments
-    session.status_prev = messages
-    if 'status' in session.data:
-        del session.data['status']
-        session.save()
+    current_session['status_prev'] = messages
+    if messages:
+        current_session['status'] = None
+        current_session.save()
     return messages
 
+
 def pop_previous_status_messages(level=0):
-    messages = session.data.get('status_prev')
-    if 'status_prev' in session.data:
-        del session.data['status_prev']
-        session.save()
+    current_session = get_session()
+    session_data = current_session.get_decoded()
+    messages = session_data.get('status_prev', None)
+    if messages:
+        current_session['status_prev'] = None
+        current_session.save()
     return messages


### PR DESCRIPTION
## Purpose

Update part of OSF to use Django Session

## Changes

* In `framework/auth/core.py`, use Django session when retrieving current user id
  
* In `framework/rounting/__init__.py`, use Django session when retrieving `auth_error_code`
  
* In `framework/status/__init__.py`, use Django session for status push and pop
  * In addition, set value to None instead of removing keys from dictionary when status and previous status is popped.
  
* In `website/project/views/contributor.py`, use Django session when a registered user claims a contributor

### Notes for CR

* For all above cases, no session key is available; thus must call `get_session()` to retrieve session from request context (instead of using `SessionStore` directly.

* We had expected many more legacy views affected under `framework\` and `website\` but discovered that most of them are handled via the `@collect_auth` decorator, in which our `get_current_user_id()` update in `framework/auth/core.py` takes care of getting current user from session.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4369
https://openscience.atlassian.net/browse/ENG-4370

