### PR TITLE
[fix][ENG-4392] datacite:publicationYear is stricter than dcterms:dateCopyrighted

### DIFF
--- a/osf/metadata/serializers/datacite_json.py
+++ b/osf/metadata/serializers/datacite_json.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 import json
 
 from datacite import schema43 as datacite_schema43
@@ -238,9 +239,11 @@ def _format_funding_references(basket):
 
 
 def _format_publication_year(basket):
-    year_copyrighted = next(basket[DCT.dateCopyrighted], None)
-    if year_copyrighted:
-        return year_copyrighted
+    date_copyrighted = next(basket[DCT.dateCopyrighted], None)
+    # dct:dateCopyrighted could contain a date range or other descriptive text;
+    # if not datacite's required YYYY, use a stricter date
+    if date_copyrighted and re.fullmatch(r'\d{4}', date_copyrighted):
+        return date_copyrighted
     for date_predicate in (DCT.available, DCT.dateAccepted, DCT.created, DCT.modified):
         date_str = next(basket[date_predicate], None)
         if date_str:

--- a/osf_tests/metadata/test_metadata_download.py
+++ b/osf_tests/metadata/test_metadata_download.py
@@ -33,6 +33,7 @@ class TestMetadataDownload(OsfTestCase):
             'project_id': project._id,
             'user_id': user._id,
             'date': str(today),
+            'project_created_year': project.created.year,
         }
 
         resp = self.app.get(f'/{project._id}/metadata/?format=turtle', auth=user.auth)
@@ -71,6 +72,7 @@ class TestMetadataDownload(OsfTestCase):
         project.node_license.node_license = NodeLicense.objects.get(
             name='CC-By Attribution-NonCommercial-NoDerivatives 4.0 International',
         )
+        project.node_license.year = '2250-2254'
         project.node_license.save()
 
         file = create_test_file(
@@ -104,7 +106,7 @@ class TestMetadataDownload(OsfTestCase):
         assert resp.unicode_body == COMPLICATED_DATACITE_XML.format(**format_kwargs)
 
         ### now check that file
-        format_kwargs['year'] = str(today.year)
+        format_kwargs['file_created_year'] = file.created.year
         resp = self.app.get(f'/{file_guid}/metadata/?format=turtle', auth=user.auth)
         assert resp.status_code == 200
         assert resp.content_type == 'text/turtle'
@@ -345,7 +347,7 @@ COMPLICATED_DATACITE_JSON = '''{{
     }}
   ],
   "language": "es",
-  "publicationYear": "2252",
+  "publicationYear": "{project_created_year}",
   "publisher": "Open Science Framework",
   "relatedIdentifiers": [],
   "rightsList": [
@@ -384,7 +386,7 @@ COMPLICATED_DATACITE_XML = '''<?xml version='1.0' encoding='utf-8'?>
     <title>this is a project title!</title>
   </titles>
   <publisher>Open Science Framework</publisher>
-  <publicationYear>2252</publicationYear>
+  <publicationYear>{project_created_year}</publicationYear>
   <contributors>
     <contributor contributorType="HostingInstitution">
       <contributorName nameType="Organizational">Open Science Framework</contributorName>
@@ -423,7 +425,7 @@ COMPLICATED_TURTLE = '''@prefix dct: <http://purl.org/dc/terms/> .
 <http://localhost:5000/{project_id}> a osf:Project ;
     dct:created "{date}" ;
     dct:creator <http://localhost:5000/{user_id}> ;
-    dct:dateCopyrighted "2252" ;
+    dct:dateCopyrighted "2250-2254" ;
     dct:description "this is a project description!" ;
     dct:hasPart <http://localhost:5000/{file_id}> ;
     dct:identifier "http://localhost:5000/{project_id}",
@@ -480,7 +482,7 @@ FILE_TURTLE = '''@prefix dct: <http://purl.org/dc/terms/> .
 <http://localhost:5000/{project_id}> a osf:Project ;
     dct:created "{date}" ;
     dct:creator <http://localhost:5000/{user_id}> ;
-    dct:dateCopyrighted "2252" ;
+    dct:dateCopyrighted "2250-2254" ;
     dct:description "this is a project description!" ;
     dct:identifier "http://localhost:5000/{project_id}",
         "https://doi.org/10.70102/FK2osf.io/{project_id}" ;
@@ -576,7 +578,7 @@ FILE_DATACITE_JSON = '''{{
       "identifierType": "URL"
     }}
   ],
-  "publicationYear": "{year}",
+  "publicationYear": "{file_created_year}",
   "publisher": "Open Science Framework",
   "relatedIdentifiers": [
     {{
@@ -616,7 +618,7 @@ FILE_DATACITE_XML = '''<?xml version='1.0' encoding='utf-8'?>
     <title>my-file.blarg</title>
   </titles>
   <publisher>Open Science Framework</publisher>
-  <publicationYear>{year}</publicationYear>
+  <publicationYear>{file_created_year}</publicationYear>
   <contributors>
     <contributor contributorType="HostingInstitution">
       <contributorName nameType="Organizational">Open Science Framework</contributorName>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fix doi-minting for projects with non-YYYY license years
<!-- Describe the purpose of your changes -->

## Changes
fix: in datacite serializer, check the format of dcterms:dateCopyrighted and fall back to date fields on the model if it does not match YYYY
<!-- Briefly describe or list your changes  -->

## QA Notes
Please make verification statements inspired by your code and what your code touches.
- Verify projects with license year values that aren't just 4 digits can still get a doi
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-4392]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-4392]: https://openscience.atlassian.net/browse/ENG-4392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ