### PR TITLE
[ENG-4398] `get_session` should return empty session object when there is no cookie

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -79,8 +79,9 @@ def prepare_private_key():
 def get_session():
     """
     Get existing session from request context or create a new blank Django Session.
-    Case 0: If cookie does not exist, create a new session and return it.
-            Note, the newly created session is not "authenticated" until session data is updated.
+    Case 0: If cookie does not exist, return a new SessionStore().
+            Note: this SessionStore object is empty, it is not saved to the backend (DB or Cache),  and it doesn't
+            have a `session_key`. It is the caller that takes care of the `.save()` if the session is updated.
     Case 1: If cookie exists but is not valid, return None
     Case 2: If cookie exists and is valid but its session is not found, return None
     Case 3: If cookie exists, is valid and its session is found, return the session

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -88,9 +88,7 @@ def get_session():
     secret = settings.SECRET_KEY
     cookie = request.cookies.get(settings.COOKIE_NAME)
     if not cookie:
-        s = SessionStore()
-        s.create()
-        return s
+        return SessionStore()
     try:
         session_key = ensure_str(itsdangerous.Signer(secret).unsign(cookie))
         return SessionStore(session_key=session_key) if SessionStore().exists(session_key=session_key) else None


### PR DESCRIPTION
## Purpose

`get_session` should return empty session object when there is no cookie

## Changes

Do not call `s.create()` in `get_session()` when there is no OSF cookie.

## QA Notes

N/A

## Documentation

N/a

## Side Effects

N/A

## Ticket

[ENG-4398](https://openscience.atlassian.net/browse/ENG-4398)


[ENG-4398]: https://openscience.atlassian.net/browse/ENG-4398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ