### PR TITLE
[ENG-4412][fix] update user-count reporter to institution remodel

### DIFF
--- a/osf/metrics/reporters/user_count.py
+++ b/osf/metrics/reporters/user_count.py
@@ -13,7 +13,7 @@ class UserCountReporter(DailyReporter):
             deactivated=OSFUser.objects.filter(date_disabled__isnull=False, date_disabled__date__lte=report_date).count(),
             merged=OSFUser.objects.filter(date_registered__date__lte=report_date, merged_by__isnull=False).count(),
             new_users_daily=OSFUser.objects.filter(is_active=True, date_confirmed__date=report_date).count(),
-            new_users_with_institution_daily=OSFUser.objects.filter(is_active=True, date_confirmed__date=report_date, affiliated_institutions__isnull=False).count(),
+            new_users_with_institution_daily=OSFUser.objects.filter(is_active=True, date_confirmed__date=report_date, institutionaffiliation__isnull=False).count(),
             unconfirmed=OSFUser.objects.filter(date_registered__date__lte=report_date, date_confirmed__isnull=True).count(),
         )
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
the "user count" nightly metrics report is failing on `develop`
<!-- Describe the purpose of your changes -->

## Changes
update `OSFUser.objects.filter(affiliated_institutions__isnull...` to `OSFUser.objects.filter(institutionaffiliation__isnull...`
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the `user_summary` metrics report (`osfapi:/_/metrics/reports/user_summary/recent/`) runs successfully each night
- Verify specifically the `new_users_with_institution_daily` field is correct-seeming (maybe add user with affiliation and check for increase the next day?)

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-4412]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-4412]: https://openscience.atlassian.net/browse/ENG-4412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ