### PR TITLE
[hotifx] fix spam metrics filter for monthly reports

### DIFF
--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -43,7 +43,6 @@ from api.metrics.serializers import (
 from api.metrics.utils import (
     parse_datetimes,
     parse_date_range,
-    parse_yearmonth_range,
 )
 from api.nodes.permissions import MustBePublic
 
@@ -338,14 +337,12 @@ class RecentReportList(JSONAPIBaseView):
         if is_daily:
             serializer_class = DailyReportSerializer
             range_field_name = 'report_date'
-            range_parser = parse_date_range
         elif is_monthly:
             serializer_class = MonthlyReportSerializer
             range_field_name = 'report_yearmonth'
-            range_parser = parse_yearmonth_range
         else:
             raise ValueError(f'report class must subclass DailyReport or MonthlyReport: {report_class}')
-        range_filter = range_parser(request.GET)
+        range_filter = parse_date_range(request.GET)
         search_recent = (
             report_class.search()
             .filter('range', **{range_field_name: range_filter})


### PR DESCRIPTION
## Purpose

Currently the monthly elasticsearch filter only shows a single item regardless of filtering this PR allow the user to filter the date properly using the `start_date` and `end_date` query params.

## Changes

- filters on typical date object, not monthYear

## Notes

Not sure exactly how the yearmonth date type could have been properly implemented, but since day specifying datetime formats still work as expected we can use them instead. Arguably it's just better to have consistently formatted date value query params on these filters, I feel that's what I'd expect if I was an external integrator. 