### PR TITLE
[ENG-4395] Add Collection Submission Metadata

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -374,6 +374,32 @@
                                         Type: <i>${collection['type']}</i>
                                     </div>
                                 % endif
+                                % if collection['status'] and collection['issue']:
+                                    <div  style="padding-left: 30px;">
+                                        Status: <i>${collection['status']}</i> |&nbsp; Issue: <i>${collection['issue']}</i>
+                                    </div>
+                                % elif collection['status']:
+                                    <div  style="padding-left: 30px;">
+                                        Status: <i>${collection['status']}</i>
+                                    </div>
+                                % elif collection['issue']:
+                                    <div  style="padding-left: 30px;">
+                                        Issue: <i>${collection['issue']}</i>
+                                    </div>
+                                % endif
+                                % if collection['volume'] and collection['program_area']:
+                                    <div  style="padding-left: 30px;">
+                                        Volume: <i>${collection['volume']}</i> |&nbsp; Program Area: <i>${collection['program_area']}</i>
+                                    </div>
+                                % elif collection['volume']:
+                                    <div  style="padding-left: 30px;">
+                                        Volume: <i>${collection['volume']}</i>
+                                    </div>
+                                % elif collection['program_area']:
+                                    <div  style="padding-left: 30px;">
+                                        Program Area: <i>${collection['program_area']}</i>
+                                    </div>
+                                % endif
                                 <hr>
                             % elif collection['state'] == 'pending' and user['is_contributor_or_group_member']:
                                 % if user['is_admin']:
@@ -394,6 +420,32 @@
                                 % elif collection['type']:
                                     <div  style="padding-left: 30px;">
                                         Type: <i>${collection['type']}</i>
+                                    </div>
+                                % endif
+                                % if collection['status'] and collection['issue']:
+                                    <div  style="padding-left: 30px;">
+                                        Status: <i>${collection['status']}</i> |&nbsp; Issue: <i>${collection['issue']}</i>
+                                    </div>
+                                % elif collection['status']:
+                                    <div  style="padding-left: 30px;">
+                                        Status: <i>${collection['status']}</i>
+                                    </div>
+                                % elif collection['issue']:
+                                    <div  style="padding-left: 30px;">
+                                        Issue: <i>${collection['issue']}</i>
+                                    </div>
+                                % endif
+                                % if collection['volume'] and collection['program_area']:
+                                    <div  style="padding-left: 30px;">
+                                        Volume: <i>${collection['volume']}</i> |&nbsp; Program Area: <i>${collection['program_area']}</i>
+                                    </div>
+                                % elif collection['volume']:
+                                    <div  style="padding-left: 30px;">
+                                        Volume: <i>${collection['volume']}</i>
+                                    </div>
+                                % elif collection['program_area']:
+                                    <div  style="padding-left: 30px;">
+                                        Program Area: <i>${collection['program_area']}</i>
                                     </div>
                                 % endif
                                 <hr>


### PR DESCRIPTION
## Purpose

Make all collection submission metadata fields appear on the project overview page.

## Changes

- HTML template changes

## Notes

Duplicating a lot of code here, but trying to keep it simple and declarative.

![Screen Shot 2023-03-09 at 4 37 23 PM](https://user-images.githubusercontent.com/9688518/224165979-e3f7d4e8-c987-4156-b571-9bef5c8e63ef.png)

*currently only type (collected_type) and study_design appear here*

## Ticket
https://openscience.atlassian.net/browse/ENG-4395