### PR TITLE
[ENG-4376][WIP] Add Check for User Notable Domains to Spam Check

### DIFF
--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -211,6 +211,11 @@ class SpamMixin(models.Model):
             content,
         )
 
+        from osf.models import OSFUser
+        user = OSFUser.objects.get(username=author_email)
+        if user.is_assumed_ham:
+            return
+
         if settings.SPAM_SERVICES_ENABLED:
             for key, value in request_kwargs.items():
                 request_kwargs[key] = ensure_str(value)

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -102,9 +102,7 @@ class SpamMixin(models.Model):
 
     @property
     def is_hammy(self):
-        return self.is_ham or (
-            self.spam_status == SpamStatus.UNKNOWN and self.is_assumed_ham
-        )
+        return self.is_assumed_ham or self.spam_status == SpamStatus.UNKNOWN
 
     @property
     def is_assumed_ham(self):
@@ -210,11 +208,6 @@ class SpamMixin(models.Model):
             self.guids.first()._id,
             content,
         )
-
-        from osf.models import OSFUser
-        user = OSFUser.objects.get(username=author_email)
-        if user.is_assumed_ham:
-            return
 
         if settings.SPAM_SERVICES_ENABLED:
             for key, value in request_kwargs.items():

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -102,7 +102,7 @@ class SpamMixin(models.Model):
 
     @property
     def is_hammy(self):
-        return self.is_assumed_ham or self.spam_status == SpamStatus.UNKNOWN
+        return self.is_ham or self.is_assumed_ham or self.spam_status == SpamStatus.UNKNOWN
 
     @property
     def is_assumed_ham(self):


### PR DESCRIPTION
## Purpose

Currently users this hammed notable domains were still getting there nodes flagged during routine spam checks, that resolves that by skipping the check for verified users.

## Changes

- changes evaluation order of conditional to ensure it runs correctly
- adds test to ensure correct behavior

## QA Notes

- Verify a user whose's domain is hammed can't have a resource flagged as spam.
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4376