### PR TITLE
make month year datetime work correctly for spam metrics

### DIFF
--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -342,7 +342,7 @@ class RecentReportList(JSONAPIBaseView):
             range_field_name = 'report_yearmonth'
         else:
             raise ValueError(f'report class must subclass DailyReport or MonthlyReport: {report_class}')
-        range_filter = parse_date_range(request.GET)
+        range_filter = parse_date_range(request.GET, is_monthly=is_monthly)
         search_recent = (
             report_class.search()
             .filter('range', **{range_field_name: range_filter})


### PR DESCRIPTION
## Purpose

Make MonthYear datetime work as expected for spam metrics filter.

## Changes

- simple changes to date formatter, passes `is_monthly` format

## QA Notes

There seemed to be some clashing with the `strict_date`/`strict_yearmonth` formatting with different environments, this preserves those fields without changing them and allows that YYYY-MM-DD format to be consistently used. 

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
