### PR TITLE
[Refactor Sessions] [ENG-4431] Fix status message

### DIFF
--- a/framework/status/__init__.py
+++ b/framework/status/__init__.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 
-from framework.sessions import session
+from framework.sessions import get_session
 
 Status = namedtuple('Status', ['message', 'jumbotron', 'css_class', 'dismissible', 'trust', 'id', 'extra'])  # trust=True displays msg as raw HTML
 
@@ -30,8 +30,9 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
     :param jumbotron: Should this be in a jumbotron element rather than an alert
     """
     # TODO: Change the default to trust=False once conversion to markupsafe rendering is complete
+    current_session = get_session()
     try:
-        statuses = session.get('status', None)
+        statuses = current_session.get('status', None)
     except RuntimeError as e:
         exception_message = str(e)
         if 'Working outside of request context.' in exception_message:
@@ -57,25 +58,27 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
                            id=id,
                            extra=extra,
                            trust=trust))
-    session['status'] = statuses
-    session.save()
+    current_session['status'] = statuses
+    current_session.save()
 
 
 def pop_status_messages(level=0):
-    messages = session.get('status', None)
+    current_session = get_session()
+    messages = current_session.get('status', None)
     for message in messages or []:
         if len(message) == 5:
             message += [None, None]  # Make sure all status's have enough arguments
-    session['status_prev'] = messages
-    if 'status' in session:
-        session.pop('status', None)
-        session.save()
+    current_session['status_prev'] = messages
+    if 'status' in current_session:
+        current_session.pop('status', None)
+        current_session.save()
     return messages
 
 
 def pop_previous_status_messages(level=0):
-    messages = session.get('status_prev', None)
-    if 'status_prev' in session:
-        session.pop('status_prev', None)
-        session.save()
+    current_session = get_session()
+    messages = current_session.get('status_prev', None)
+    if 'status_prev' in current_session:
+        current_session.pop('status_prev', None)
+        current_session.save()
     return messages

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1805,7 +1805,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         """
         secret = secret or website_settings.SECRET_KEY
 
-        user_session_map = UserSessionMap.objects.filter(user__id=self.id).order_by('-expired_date').first()
+        user_session_map = UserSessionMap.objects.filter(user__id=self.id).order_by('-expire_date').first()
 
         if not SessionStore().exists(session_key=user_session_map.session_key):
             user_session = SessionStore()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Since `session` is a `LocalProxy` of `get_session()`, everything we refer to `session` it is actually creating a new `SessionStore` object. Hence, doing `session['status'] = statuses` before `session.save()` is actually setting the `status` field of one `SessionStore` object and calling `save()` on another, therefore not updating the underlying session data in db/redis, even though the two `SessionStore` obects loads the same session data with the same `session_key`.

The fix is to directly call `get_session()` and store the `SessionStore` object in `current_session` and invoke `current_session.save()` after updating.

## Changes

TBD

## QA Notes

N/A

Any concerns/considerations/questions that development raised?

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4431
