### PR TITLE
[ENG-4448] Port contributor search to SQL from the old elasticsearch

### DIFF
--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1075,7 +1075,7 @@ class TestAddContributor(OsfTestCase):
     def setUp(self):
         self.name1 = 'Roger1 Taylor1'
         self.name2 = 'John2 Deacon2'
-        self.name3 = u'j\xc3\xb3ebert3 Smith3'
+        self.name3 = u'jã3ebert Smith3'
         self.name4 = u'B\xc3\xb3bbert4 Jones4'
 
         with run_celery_tasks():

--- a/website/search/search.py
+++ b/website/search/search.py
@@ -162,8 +162,11 @@ def create_index(index=None):
 
 
 @requires_search
-def search_contributor(query, page=0, size=10, exclude=None, current_user=None):
-    exclude = exclude or []
-    result = search_engine.search_contributor(query=query, page=page, size=size,
-                                              exclude=exclude, current_user=current_user)
+def search_contributor(query, page=0, size=5, current_user=None):
+    result = search_engine.search_contributor(
+        query=query,
+        page=page,
+        size=size,
+        current_user=current_user
+    )
     return result

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -1,22 +1,17 @@
-# -*- coding: utf-8 -*-
 import functools
 from rest_framework import status as http_status
 import logging
 import time
 
 import bleach
-from django.db.models import Q
 from flask import request
 
 from framework.auth.decorators import collect_auth
-from framework.auth.decorators import must_be_logged_in
 from framework.exceptions import HTTPError
 from framework import sentry
 from website import language
 from osf import features
-from osf.models import OSFUser, AbstractNode
 from website import settings
-from website.project.views.contributor import get_node_contributors_abbrev
 from website.ember_osf_web.decorators import ember_flag_is_active
 from website.search import exceptions
 import website.search.search as search
@@ -196,11 +191,27 @@ def process_project_search_results(results, **kwargs):
 @collect_auth
 def search_contributor(auth):
     user = auth.user if auth else None
-    nid = request.args.get('excludeNode')
-    exclude = AbstractNode.load(nid).contributors if nid else []
-    # TODO: Determine whether bleach is appropriate for ES payload. Also, inconsistent with website.sanitize.util.strip_html
-    query = bleach.clean(request.args.get('query', ''), tags=[], strip=True)
-    page = int(bleach.clean(request.args.get('page', '0'), tags=[], strip=True))
-    size = int(bleach.clean(request.args.get('size', '5'), tags=[], strip=True))
-    return search.search_contributor(query=query, page=page, size=size,
-                                     exclude=exclude, current_user=user)
+    query = bleach.clean(
+        request.args.get('query', ''),
+        tags=[],
+        strip=True
+    )
+    page = int(
+        bleach.clean(
+            request.args.get('page', '0'),
+            tags=[],
+            strip=True)
+    )
+    size = int(
+        bleach.clean(
+            request.args.get('size', '5'),
+            tags=[],
+            strip=True
+        )
+    )
+    return search.search_contributor(
+        query=query,
+        page=page,
+        size=size,
+        current_user=user
+    )


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This converts the contributor searches elasticsearch backend to SQL so the old search back-end can be depreciated.

## Changes

- logical changes to Flask's search_contributor view
- Moves  '/api/v1/search/user/', the legacy contributor search away from ES to django ORM SQL.
- adds tests for jobs and schools filtering and splits up existing tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify search contributor feature doesn't change significantly 
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation
![Screen Shot 2023-03-23 at 1 34 50 PM](https://user-images.githubusercontent.com/9688518/228608113-e3f1caa2-23dc-4349-8120-219acda3814e.png)

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4448