### PR TITLE
[Hotfix] Async Domain Extraction

### DIFF
--- a/osf/management/commands/backfill_domain_references.py
+++ b/osf/management/commands/backfill_domain_references.py
@@ -55,7 +55,7 @@ def backfill_domain_references(model_name, dry_run=False, batch_size=None):
         logger.info(f'{item}, queued')
         spam_content = item._get_spam_content(include_tags=False)
         if not dry_run:
-            spam_tasks.check_resource_for_domains.apply_async(
+            spam_tasks.check_resource_for_domains_async.apply_async(
                 kwargs={'guid': item._id, 'content': spam_content}
             )
     return spam_check_count

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -5,14 +5,10 @@ from django.db import models
 from django.utils import timezone
 
 from osf.exceptions import ValidationValueError, ValidationTypeError
-from osf.external.spam.tasks import check_resource_for_domains
-from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
-from osf.utils.fields import NonNaiveDateTimeField
-
-from osf.external.spam.tasks import check_resource_with_spam_services
 from osf.external.askismet import tasks as akismet_tasks
-from osf.utils.fields import ensure_str
-
+from osf.external.spam.tasks import check_resource_for_domains_postcommit, check_resource_with_spam_services
+from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
+from osf.utils.fields import ensure_str, NonNaiveDateTimeField
 from website import settings
 
 logger = logging.getLogger(__name__)
@@ -206,7 +202,7 @@ class SpamMixin(models.Model):
         }
         request_kwargs.update(request_headers)
 
-        check_resource_for_domains(
+        check_resource_for_domains_postcommit(
             self.guids.first()._id,
             content,
         )

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -155,16 +155,13 @@ class TestNotableDomain:
             note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT,
         )
 
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_check_resource_for_domains_moderation_queue(self, spam_domain, factory):
         obj = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj.guids.first()._id,
-                    content=spam_domain.geturl(),
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj.guids.first()._id,
+                content=spam_domain.geturl(),
             )
 
         obj.reload()
@@ -175,16 +172,13 @@ class TestNotableDomain:
         obj.reload()
         assert obj.spam_status == SpamStatus.UNKNOWN
 
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_check_resource_for_domains_spam(self, spam_domain, marked_as_spam_domain, factory):
         obj = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj.guids.first()._id,
-                    content=spam_domain.geturl(),
-                )
+            spam_tasks.check_resource_for_domains(
+                guid=obj.guids.first()._id,
+                content=spam_domain.geturl(),
             )
 
         obj.reload()
@@ -241,18 +235,15 @@ class TestNotableDomain:
         obj.reload()
         assert obj.spam_status == SpamStatus.SPAM
 
-    @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_check_resource_for_duplicate_spam_domains(self, factory, spam_domain, marked_as_spam_domain):
         obj = factory()
         obj.spam_data['domains'] = [spam_domain.netloc]
         obj.save()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj.guids.first()._id,
-                    content=f'{spam_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj.guids.first()._id,
+                content=f'{spam_domain.geturl()}',
             )
 
         obj.reload()
@@ -343,11 +334,9 @@ class TestNotableDomainReclassification:
     def test_from_spam_to_unknown_one_spam_domain(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_one.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_one.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_one.reload()
@@ -363,11 +352,9 @@ class TestNotableDomainReclassification:
     def test_from_spam_to_unknown_two_spam_domains(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_two.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_two.reload()
@@ -385,11 +372,9 @@ class TestNotableDomainReclassification:
         obj_three.spam_data['who_flagged'] = 'some external spam checker'
         obj_three.save()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_three.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_three.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_three.reload()
@@ -405,11 +390,9 @@ class TestNotableDomainReclassification:
     def test_from_spam_to_ignored_one_spam_domain(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_one.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_one.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_one.reload()
@@ -425,11 +408,9 @@ class TestNotableDomainReclassification:
     def test_from_spam_to_ignored_two_spam_domains(self, factory, spam_notable_domain_one, spam_notable_domain_two, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_two.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.spam_domain_two.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_two.reload()
@@ -447,11 +428,9 @@ class TestNotableDomainReclassification:
         obj_three.spam_data['who_flagged'] = 'some external spam checker'
         obj_three.save()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_three.guids.first()._id,
-                    content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_three.guids.first()._id,
+                content=f'{self.spam_domain_one.geturl()} {self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_three.reload()
@@ -467,11 +446,9 @@ class TestNotableDomainReclassification:
     def test_from_unknown_to_spam_unknown_plus_ignored(self, factory, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_one.guids.first()._id,
-                    content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_one.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_one.reload()
@@ -487,11 +464,9 @@ class TestNotableDomainReclassification:
     def test_from_unknown_to_spam_unknown_only(self, factory, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_two.guids.first()._id,
-                    content=f'{self.unknown_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()}',
             )
 
         obj_two.reload()
@@ -507,11 +482,9 @@ class TestNotableDomainReclassification:
     def test_from_ignored_to_spam_unknown_plus_ignored(self, factory, unknown_notable_domain, ignored_notable_domain):
         obj_one = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_one.guids.first()._id,
-                    content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_one.guids.first()._id,
+                content=f'{self.unknown_domain.geturl()} {self.ignored_domain.geturl()}',
             )
 
         obj_one.reload()
@@ -527,11 +500,9 @@ class TestNotableDomainReclassification:
     def test_from_ignored_to_spam_ignored_only(self, factory, unknown_notable_domain, ignored_notable_domain):
         obj_two = factory()
         with mock.patch.object(spam_tasks.requests, 'head'):
-            spam_tasks.check_resource_for_domains.apply_async(
-                kwargs=dict(
-                    guid=obj_two.guids.first()._id,
-                    content=f'{self.ignored_domain.geturl()}',
-                )
+            spam_tasks._check_resource_for_domains(
+                guid=obj_two.guids.first()._id,
+                content=f'{self.ignored_domain.geturl()}',
             )
 
         obj_two.reload()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Combining the `@run_postcommit` decorator with the `@task` decorator prevented us from actively running the `backfill_spam_domains` management command in non-local environments. Create separate functions for standard async execution and post-commit execution.

## Changes
* Extract `check_resources_for_domains` functionality into a "protected", synchronous function.
* Create explicit `check_resources_for_domains_postcommit` and `check_resources_for_domains_async` functions and use them appropriately
* Fix tests that reference the old function to simply use the synchronous version

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
