### PR TITLE
Make GUID Metadata Logs actually display the name of the resource

### DIFF
--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -48,7 +48,7 @@
     "file_removed":     "${user} removed ${path_type} ${path} from ${node}",
     "file_restored":    "${user} restored file ${path} from ${node}",
     "file_metadata_updated": "${user} updated file metadata for ${path}",
-    "guid_metadata_updated": "${user} updated metadata for ${title}",
+    "guid_metadata_updated": "${user} updated metadata for ${guid}",
     "checked_out":  "${user} checked out ${kind} ${path} from ${node}",
     "checked_in":   "${user} checked in ${kind} ${path} to ${node}",
     "comment_added":    "${user} added a comment ${comment_location} in ${node}",

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -771,8 +771,13 @@ var LogPieces = {
     guid: {
         view: function (ctrl, logObject) {
             var guid = logObject.attributes.params.guid;
+			var useTitle = false;
+			var title = logObject.attributes.params.title;
+			if(title){
+				useTitle = true;
+			}
             if (paramIsReturned(guid, logObject)){
-                return m('a', {href: '/' + guid}, guid);
+                return m('a', {href: '/' + guid}, useTitle ? title : guid);
             }
             return m('span', 'an object');
         }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -771,13 +771,9 @@ var LogPieces = {
     guid: {
         view: function (ctrl, logObject) {
             var guid = logObject.attributes.params.guid;
-			var useTitle = false;
-			var title = logObject.attributes.params.title;
-			if(title){
-				useTitle = true;
-			}
+            var title = logObject.attributes.params.title;
             if (paramIsReturned(guid, logObject)){
-                return m('a', {href: '/' + guid}, useTitle ? title : guid);
+                return m('a', {href: '/' + guid}, title || guid);
             }
             return m('span', 'an object');
         }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
https://staging-sentry.cos.io/cos/osf-front-end-r3/issues/16212/

## Changes
Hack `logTextParser` to use a provided Title instead of just the guid when showing metadata updates.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
