### PR TITLE
[ENG-4411] Add title to NodeLogParams serializer

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -88,6 +88,7 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     tags = ser.CharField(read_only=True)
     target = NodeLogFileParamsSerializer(read_only=True)
     template_node = ser.DictField(read_only=True)
+    title = ser.CharField(read_only=True)
     title_new = ser.CharField(read_only=True)
     title_original = ser.CharField(read_only=True)
     updated_fields = ser.DictField(read_only=True)


### PR DESCRIPTION
## Purpose
In a feat of surprisingly good separation of powers, the NodeLog widget on the Legacy FE actually pulls from the API. The NodeLog API, meanwhile, limits which NodeLog `params` are surfaced in order to ensure that some internal-only information remains internal-only. As such, the NodeLog widget had no access to the `title` param that was added to improve the readability of guid_metadata_updated NodeLogs. This PR surfaces that param.

## Changes
Add `title` to the NodeLogParamsSerializer.

## Ticket
https://openscience.atlassian.net/browse/ENG-4411
