### PR TITLE
[Refactor Sessions] [ENG-4393] Unit Tests - Part 1: Fix add-on tests

### DIFF
--- a/addons/osfstorage/tests/test_utils.py
+++ b/addons/osfstorage/tests/test_utils.py
@@ -2,8 +2,9 @@
 # encoding: utf-8
 import pytest
 from nose.tools import *  # noqa
+from importlib import import_module
 
-
+from django.conf import settings as django_conf_settings
 from framework import sessions
 from framework.flask import request
 
@@ -14,6 +15,7 @@ from addons.osfstorage import utils
 from addons.osfstorage.tests.utils import StorageTestCase
 from website.files.utils import attach_versions
 
+SessionStore = import_module(django_conf_settings.SESSION_ENGINE).SessionStore
 
 @pytest.mark.django_db
 class TestSerializeRevision(StorageTestCase):
@@ -30,11 +32,11 @@ class TestSerializeRevision(StorageTestCase):
         self.record.save()
 
     def test_serialize_revision(self):
-        mock_session = Session()
-        sessions.sessions[request._get_current_object()] = mock_session
-        utils.update_analytics(self.project, self.record, 0, mock_session)
-        utils.update_analytics(self.project, self.record, 0, mock_session)
-        utils.update_analytics(self.project, self.record, 2, mock_session)
+        s = SessionStore()
+        s.create()
+        utils.update_analytics(self.project, self.record, 0, s.session_key)
+        utils.update_analytics(self.project, self.record, 0, s.session_key)
+        utils.update_analytics(self.project, self.record, 2, s.session_key)
         expected = {
             'index': 1,
             'user': {
@@ -58,11 +60,11 @@ class TestSerializeRevision(StorageTestCase):
         assert_equal(self.record.get_download_count(version=0), 2)
 
     def test_anon_revisions(self):
-        mock_session = Session()
-        sessions.sessions[request._get_current_object()] = mock_session
-        utils.update_analytics(self.project, self.record, 0, mock_session)
-        utils.update_analytics(self.project, self.record, 0, mock_session)
-        utils.update_analytics(self.project, self.record, 2, mock_session)
+        s = SessionStore()
+        s.create()
+        utils.update_analytics(self.project, self.record, 0, s.session_key)
+        utils.update_analytics(self.project, self.record, 0, s.session_key)
+        utils.update_analytics(self.project, self.record, 2, s.session_key)
         expected = {
             'index': 2,
             'user': None,

--- a/api/base/settings/local-travis.py
+++ b/api/base/settings/local-travis.py
@@ -7,6 +7,7 @@ ENABLE_ESI = False
 
 OSF_DB_PASSWORD = 'postgres'
 
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'user': '1000000/second',

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -230,4 +230,8 @@ def after_request(response):
         from framework.sessions.utils import remove_session
         remove_session(session)
         response.delete_cookie(settings.COOKIE_NAME, domain=settings.OSF_COOKIE_DOMAIN)
+    # Usually, the flask app context "g" has the same lifetime of a request
+    # However this is not the case for unit tests
+    # Therefore, we need to clear g.current_session manually here for tests to run
+    g.current_session = None
     return response

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -125,6 +125,7 @@ def create_session(response, data=None):
     updated session and the set-cookie response as a tuple.
     """
     user_session = get_session()
+    user_session.create()
     if not user_session:
         response.delete_cookie(settings.COOKIE_NAME, domain=settings.OSF_COOKIE_DOMAIN)
         return None, response
@@ -171,6 +172,7 @@ def before_request():
         )
         # Create an empty session
         user_session = get_session(ignore_cookie=True)
+        user_session.create()
         # Although the if check is not necessary based on current ``get_session()`` implementation. However, we
         # keep it here in case ``get_session()`` was changed. It may be removed after we have unit tests for this.
         if not user_session:


### PR DESCRIPTION
## Purpose

* Use DB backend when running unit tests on GitHub Actions.
* Fix add-on tests
* Properly create new session by calling `.create()` instead of or in addition to `.save()` to avoid key conflict
* Fix a discrepancy on Flask `g` between code and test.

## Changes

See **Purpose**

## QA Notes

N/A

## Side Effects

N/A

## Ticket

Part of https://openscience.atlassian.net/browse/ENG-4393
