### PR TITLE
[ENG-4519] Remove institution affiliations from merged user during merge

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1799,12 +1799,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     def remove_all_affiliated_institutions(self):
         """Remove all institution affiliations for the current user."""
-        for affiliation in self.get_institution_affiliations():
-            affiliation.delete()
-            if self.has_perm('view_institutional_metrics', affiliation.institution):
-                group = affiliation.institution.get_group('institutional_admins')
-                group.user_set.remove(self)
-                group.save()
+        for institution in self.get_affiliated_institutions():
+            self.remove_affiliated_institution(institution._id)
 
     def get_activity_points(self):
         return analytics.get_total_activity_count(self._id)

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -38,13 +38,14 @@ from osf.models import (
     PreprintContributor,
     DraftRegistrationContributor,
 )
+from osf.models.institution_affiliation import get_user_by_institution_identity
 from addons.github.tests.factories import GitHubAccountFactory
 from addons.osfstorage.models import Region
 from addons.osfstorage.settings import DEFAULT_REGION_ID
 from framework.auth.core import Auth
 from osf.utils.names import impute_names_model
 from osf.utils import permissions
-from osf.exceptions import ValidationError, BlockedEmailError, UserStateError
+from osf.exceptions import ValidationError, BlockedEmailError, UserStateError, InstitutionAffiliationStateError
 
 from .utils import capture_signals
 from .factories import (
@@ -1580,26 +1581,32 @@ class TestMergingUsers:
     def test_merging_user_moves_all_institution_affiliations(self):
         user_1 = UserFactory()
         institution_1 = InstitutionFactory()
-        user_1.add_or_update_affiliated_institution(institution_1, sso_identity=user_1._id, sso_mail=user_1.username)
+        user_1.add_or_update_affiliated_institution(institution_1, sso_identity=f'{user_1._id}@{institution_1._id}', sso_mail=user_1.username)
         user_2 = UserFactory()
         institution_2 = InstitutionFactory()
         institution_3 = InstitutionFactory()
-        user_2.add_or_update_affiliated_institution(institution_2, sso_identity=user_2._id, sso_mail=user_2.username)
-        user_2.add_or_update_affiliated_institution(institution_3, sso_identity=user_2._id, sso_mail=user_2.username)
+        user_2.add_or_update_affiliated_institution(institution_2, sso_identity=f'{user_2._id}@{institution_2._id}', sso_mail=user_2.username)
+        user_2.add_or_update_affiliated_institution(institution_3, sso_identity=None, sso_mail=user_2.username)
         user_1.merge_user(user_2)
         user_1.reload()
+        # Verify that the main user has the dupe user's institution affiliations
         assert user_1.is_affiliated_with_institution(institution_2)
         assert user_1.is_affiliated_with_institution(institution_3)
         user_2.reload()
+        # Verify that the dupe user no longer has any institution affiliations
         assert not user_2.is_affiliated_with_institution(institution_2)
         assert not user_2.is_affiliated_with_institution(institution_3)
-        from osf.models.institution_affiliation import get_user_by_institution_identity
-        from osf.exceptions import InstitutionAffiliationStateError
+        # Verify that only one user is found when identity is present
         try:
-            user = get_user_by_institution_identity(institution_2, user_2._id)
-            assert user == user_1
+            user_by_identity, is_identity_eligible = get_user_by_institution_identity(institution_2, f'{user_2._id}@{institution_2._id}')
+            assert user_by_identity == user_1
+            assert is_identity_eligible is True
         except InstitutionAffiliationStateError:
             pytest.fail('get_user_by_institution_identity() failed with InstitutionAffiliationStateError')
+        # Verify that user is not found when identity is empty
+        user_by_identity, is_identity_eligible = get_user_by_institution_identity(institution_2, None)
+        assert user_by_identity is None
+        assert is_identity_eligible is False
 
 
 class TestDisablingUsers(OsfTestCase):
@@ -1854,6 +1861,15 @@ class TestUser(OsfTestCase):
         ProjectFactory(creator=self.user)
         projects_created_by_user = AbstractNode.objects.filter(creator=self.user)
         assert list(self.user.nodes_created.all()) == list(projects_created_by_user)
+
+    def test_remove_all_affiliated_institutions(self):
+        user = UserFactory()
+        for institution in [InstitutionFactory(), InstitutionFactory(), InstitutionFactory()]:
+            user.add_or_update_affiliated_institution(institution, sso_identity=f'{user._id}@{institution._id}', sso_mail=user.username)
+        assert user.get_affiliated_institutions().count() == 3
+        user.remove_all_affiliated_institutions()
+        user.reload()
+        assert user.get_affiliated_institutions().count() == 0
 
 
 # Copied from tests/models/test_user.py


### PR DESCRIPTION
## Purpose

Remove institution affiliations from merged user during merge

## Changes

* Added a new helper method in `OSFUser` to remove all affiliated institutions
* Call this helper after affiliations have been copied when merging user
- [x] Unit tests: add a unit test for checking 1) affiliations are successfully copied to the target user and 2) affiliation are successfully removed from the merged user.

## QA Notes

This is a hotfix that only needs post-release verification. However, this can’t be verified by QA via our website or the badmin app since the merged user is no longer active. What we need to do is to check that affiliations have been removed from a merged user via shell.

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4519
