### PR TITLE
fix: serialize json-ld as json

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -61,7 +61,7 @@ from addons.wiki.utils import serialize_wiki_widget
 from addons.wiki.models import WikiVersion
 from addons.dataverse.utils import serialize_dataverse_widget
 from addons.forward.utils import serialize_forward_widget
-from osf.metadata.tools import pls_gather_metadata_as_primitive
+from osf.metadata.tools import pls_gather_metadata_file
 
 r_strip_html = lambda collection: rapply(collection, strip_html)
 logger = logging.getLogger(__name__)
@@ -837,7 +837,10 @@ def _view_project(node, auth, primary=False,
         'addon_widgets': widgets,
         'addon_widget_js': js,
         'addon_widget_css': css,
-        'google_dataset_tags': pls_gather_metadata_as_primitive(node, 'google-dataset-json-ld'),
+        'google_dataset_tags': pls_gather_metadata_file(
+            osf_item=node,
+            format_key='google-dataset-json-ld',
+        ).serialized_metadata,
         'node_categories': [
             {'value': key, 'display_name': value}
             for key, value in list(settings.NODE_CATEGORY_MAP.items())


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fix json-ld osfnode metadata -- serialize as double-quoted json (rather than single-quoted python dict)
<!-- Describe the purpose of your changes -->

## Changes
use the correct osf.metadata tool
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify the html of the node dashboard page (`https://osf.example/blarg`) includes a `<script type="application/ld+json">` tag that contains valid json -- in particular: `"` (double quotes) around strings, not `'` (single quote)
- Verify with a glance that the contents of said json are coherent with the info on the web page

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
