### PR TITLE
Fix an old bug for view-only link on legacy projects

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -59,7 +59,6 @@ def prepare_private_key():
     NOTE: In order to ensure the execution order of the before_request callbacks,
     this is attached in website.app.init_app rather than using @app.before_request.
     """
-    current_session = get_session()
     # Done if not GET request
     if request.method != 'GET':
         return
@@ -80,7 +79,7 @@ def prepare_private_key():
         key = None
 
     # Update URL and redirect
-    if key and not current_session.get('auth_user_id', None):
+    if key:
         new_url = add_key_to_url(request.url, scheme, key)
         return redirect(new_url, code=http_status.HTTP_307_TEMPORARY_REDIRECT)
 

--- a/website/app.py
+++ b/website/app.py
@@ -66,8 +66,6 @@ def attach_handlers(app, settings):
     # has been created
     add_handlers(app, {'before_request': framework.sessions.set_current_session})
     add_handlers(app, {'before_request': framework.sessions.prepare_private_key})
-    # framework.session's before_request handler must go after
-    # prepare_private_key, else view-only links won't work
     add_handlers(app, {'before_request': framework.sessions.before_request,
                        'after_request': framework.sessions.after_request})
 


### PR DESCRIPTION
## Purpose

Fix an old bug for view-only link on legacy projects

## Changes

* Remove the was-noop authentication check when processing view only link
* Remove deprecated order or handler notes

## QA Notes

TBD

## Documentation

N/A

## Side Effects

`prepare_private_key()` no longer have to be added before `before_request()`

## Ticket

N/A
