### PR TITLE
[Refactor Sessions] Redis performance improvement

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -27,11 +27,11 @@ SessionStore = import_module(api_settings.SESSION_ENGINE).SessionStore
 
 def drf_get_session_from_cookie(cookie_val):
     """
-    Given a cookie value, return the Django native `Session` object or `None`, using the SessionStore.
+    Given a cookie value, return the Django native `SessionStore` object.
 
-    When using DB backend, for expired sessions, SessionStore().exists(session_key=session_key) returns
-    true while SessionStore(session_key=session_key) doesn't load the session data. Thus, when using the
-    returned session object from this method, must check ``session.get('auth_user_id', None)``.
+    For expired/nonexistent sessions,
+    SessionStore(session_key=session_key) doesn't load the session data.
+    Thus, when using the returned session object from this method, must check ``session.get('auth_user_id', None)``.
 
     :param cookie_val: the cookie
     :return: the Django native `Session` object or None
@@ -40,7 +40,7 @@ def drf_get_session_from_cookie(cookie_val):
         session_key = ensure_str(itsdangerous.Signer(settings.SECRET_KEY).unsign(cookie_val))
     except itsdangerous.BadSignature:
         return None
-    return SessionStore(session_key=session_key) if SessionStore().exists(session_key=session_key) else None
+    return SessionStore(session_key=session_key)
 
 
 def check_user(user):

--- a/osf_tests/test_session.py
+++ b/osf_tests/test_session.py
@@ -340,7 +340,7 @@ class TestSessions(AppTestCase):
             flask_get_session_from_cookie(self.cookie_session_removed)
 
     @pytest.mark.skipif(SKIP_NON_DB_BACKEND_TESTS, reason='Django Session DB Backend Required for This Test')
-    def test_get_session_from_cookie_with_session_expired(self):
+    def test_flask_get_session_from_cookie_with_session_expired(self):
         # Expired Session (yet to be cleared)
         session_expired = SessionStore()
         session_expired['auth_user_id'] = self.user._primary_key
@@ -355,7 +355,7 @@ class TestSessions(AppTestCase):
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie(cookie_session_expired)
 
-    def test_get_session_from_cookie_with_authenticated_session(self):
+    def test_flask_get_session_from_cookie_with_authenticated_session(self):
         session = flask_get_session_from_cookie(self.cookie)
         assert session is not None
         assert session.session_key == self.session.session_key

--- a/osf_tests/test_session.py
+++ b/osf_tests/test_session.py
@@ -9,6 +9,7 @@ import itsdangerous
 import pytest
 from unittest import mock
 
+from api.base.authentication.drf import drf_get_session_from_cookie
 from framework.sessions import set_current_session, flask_get_session_from_cookie, get_session, create_session
 from framework.sessions.utils import remove_session, remove_sessions_for_user
 from osf.management.commands.clear_expired_sessions import clear_expired_sessions
@@ -307,21 +308,34 @@ class TestSessions(AppTestCase):
         assert self.context.g.current_session is not None
         assert self.context.g.current_session.get('auth_user_id', None) == self.user._primary_key
 
-    def test_get_session_from_cookie_without_cookie(self):
+    def test_drf_get_session_from_cookie_with_cookie_not_signed_by_server_secret(self):
+        ret_val = drf_get_session_from_cookie(self.cookie_invalid)
+        assert ret_val is None
+
+    def test_drf_get_session_from_cookie_with_session_removed(self):
+        ret_val = drf_get_session_from_cookie(self.cookie_session_removed)
+        assert ret_val.session_key == itsdangerous.Signer(osf_settings.SECRET_KEY).unsign(self.cookie_session_removed).decode()
+        assert ret_val.load() == {}
+
+    def test_drf_get_session_from_cookie_with_valid_session(self):
+        ret_val = drf_get_session_from_cookie(self.cookie)
+        assert ret_val.session_key == self.session.session_key
+
+    def test_flask_get_session_from_cookie_without_cookie(self):
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie(None)
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie('')
 
-    def test_get_session_from_cookie_with_invalid_cookie(self):
+    def test_flask_get_session_from_cookie_with_invalid_cookie(self):
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie(self.cookie_invalid)
 
-    def test_get_session_from_cookie_with_invalid_session(self):
+    def test_flask_get_session_from_cookie_with_invalid_session(self):
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie(self.cookie_session_invalid)
 
-    def test_get_session_from_cookie_with_session_gone(self):
+    def test_flask_get_session_from_cookie_with_session_gone(self):
         with pytest.raises(InvalidCookieOrSessionError):
             flask_get_session_from_cookie(self.cookie_session_removed)
 


### PR DESCRIPTION
## Purpose

Currently, we do `SessionStore().exists(session_key=session_key)` every time we want to get the session with a key. However, this is redundant, because if the `session_key` itself is not in redis/db, `SessionStore(session_key=session_key)` would not load the data at all, becasue the redis `GET` operation just returns nothing.

Therefore, simply removing the `SessionStore().exists(session_key=session_key)` in `drf_get_session_from_cookie` has the potential of reducing most of the `EXISTS` queries to Redis, potentially boosting performance because now the app does not have to do an extra query, and Redis has ~50% less queries to handle.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
