### PR TITLE
[Hotfix][ENG-4557]Use provided name for unregistered contributors' csl_name

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -541,14 +541,15 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         else:
             name = self.get_unclaimed_record(node_id)['name']
 
-        if self.family_name and self.given_name:
-            """If the user has a family and given name, use those"""
+        # Unregistered contributors' names may vary across unclaimed records
+        if self.is_registered and self.family_name and self.given_name:
+            """If a registered user has a family and given name, use those"""
             return {
                 'family': self.family_name,
                 'given': self.csl_given_name,
             }
         else:
-            """ If the user doesn't autofill his family and given name """
+            """ If the user is unregistered or doesn't autofill his family and given name """
             parsed = utils.impute_names(name)
             given_name = parsed['given']
             middle_names = parsed['middle']

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1419,7 +1419,7 @@ class TestCitationProperties:
                 }
             )
 
-    def test_unregistered_user_csl(self, unreg_user, project):
+    def test_unregistered_user_csl(self, unreg_user, project, referrer):
         # Tests the csl name for an unregistered user
         name = unreg_user.unclaimed_records[project._primary_key]['name'].split(' ')
         family_name = name[-1]
@@ -1429,6 +1429,21 @@ class TestCitationProperties:
             {
                 'given': given_name,
                 'family': family_name,
+            }
+        )
+        # Tests the csl name for a user with different names across unclaimed_records
+        project_2 = NodeFactory(creator=referrer)
+        unreg_user.add_unclaimed_record(
+            project_2,
+            given_name='Bob Bobson',
+            referrer=referrer,
+            email=unreg_user.username
+        )
+        assert bool(
+            unreg_user.csl_name(project_2._id) ==
+            {
+                'given': 'Bob',
+                'family': 'Bobson'
             }
         )
 


### PR DESCRIPTION
## Purpose
Cite unregistered contributors with the name provided when they were added

## Changes
* Change `csl_name` logic to use `unclaimed_records` for unregistered contributors
* Update test

## QA Notes
See Ticket

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/ENG-4557