### PR TITLE
[ENG-4435] Update selective SSO config due to institution preferred ID change

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -61,7 +61,7 @@ INSTITUTION_SELECTIVE_SSO_MAP = {
         'criteria_action': SsoFilterCriteriaAction.EQUALS_TO.value,
         'criteria_value': 'http://directory.manchester.ac.uk/epe/3rdparty/osf',
     },
-    'yalelaw': {
+    'yls': {
         'criteria_action': SsoFilterCriteriaAction.IN.value,
         'criteria_value': ['Yes', 'yes', 'y'],
     },

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -120,7 +120,7 @@ def institution_selective_type_1():
 @pytest.fixture()
 def institution_selective_type_2():
     institution = InstitutionFactory()
-    institution._id = 'yalelaw'
+    institution._id = 'yls'
     institution.save()
     return institution
 


### PR DESCRIPTION
## Purpose

Update selective SSO configuration for Yale Law School due to institution preferred ID change

## Changes

`yalelaw` -> `yls`

## QA Notes

N/A

## Documentation

N/A

## Side Effects

Selective SSO for test server Yale Law School will be disabled until we update the institution ID. 

## Ticket

https://openscience.atlassian.net/browse/ENG-4435
