### PR TITLE
[Hotfix][ENG-4565] Remove deprecated support links

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -212,7 +212,7 @@ INSTITUTIONS = {
                 'name': 'Carnegie Mellon University',
                 'description': 'A Project Management Tool for the CMU Community: <a href="https://l'
                                'ibrary.cmu.edu/OSF">Get Help at CMU</a> | <a href="https://cos.io/o'
-                               'ur-products/osf/">About OSF</a> | <a href="https://osf.io/support/"'
+                               'ur-products/osf/">About OSF</a> | <a href="https://help.osf.io/"'
                                '>OSF Support</a> | <a href="https://library.cmu.edu/OSF/terms-of-us'
                                'e">Terms of Use</a>',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://login.cmu.edu/idp/shibboleth')),
@@ -1151,7 +1151,7 @@ INSTITUTIONS = {
                 'name': 'Carnegie Mellon University [Test]',
                 'description': 'A Project Management Tool for the CMU Community: <a href="https://l'
                                'ibrary.cmu.edu/OSF">Get Help at CMU</a> | <a href="https://cos.io/o'
-                               'ur-products/osf/">About OSF</a> | <a href="https://osf.io/support/"'
+                               'ur-products/osf/">About OSF</a> | <a href="https://help.osf.io/"'
                                '>OSF Support</a> | <a href="https://library.cmu.edu/OSF/terms-of-us'
                                'e">Terms of Use</a>',
                 'login_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('https://login.cmu.edu/idp/shibboleth')),

--- a/website/ember_osf_web/views.py
+++ b/website/ember_osf_web/views.py
@@ -12,7 +12,6 @@ routes = [
     '/quickfiles/',
     '/<uid>/quickfiles/',
     '/institutions/',
-    '/support/',
 ]
 
 def use_ember_app(**kwargs):

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -288,7 +288,7 @@
 
 <%def name="nav()">
     <%namespace name="nav_helper" file="nav.mako" />
-    ${nav_helper.nav(service_name='HOME', service_url=domain, service_support_url='/support/')}
+    ${nav_helper.nav(service_name='HOME', service_url=domain, service_support_url='https://help.osf.io/')}
 </%def>
 
 <%def name="title()">

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -63,7 +63,7 @@
 
                 <ul class="dropdown-menu auth-dropdown" role="menu">
                     <li><a data-bind="click: trackClick.bind($data, 'MyProfile')" href="${domain}profile/"><i class="fa fa-user fa-lg p-r-xs"></i> My Profile</a></li>
-                    <li><a data-bind="click: trackClick.bind($data, 'Support')" href="${domain}support/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> OSF Support</a></li>
+                    <li><a data-bind="click: trackClick.bind($data, 'Support')" href="https://help.osf.io/" ><i class="fa fa-life-ring fa-lg p-r-xs"></i> OSF Support</a></li>
                     <li><a data-bind="click: trackClick.bind($data, 'Settings')" href="${web_url_for('user_profile')}"><i class="fa fa-cog fa-lg p-r-xs"></i> Settings</a></li>
                     <li><a data-bind="click: trackClick.bind($data, 'Logout')" href="${web_url_for('auth_logout')}"><i class="fa fa-sign-out fa-lg p-r-xs"></i> Log out</a></li>
                 </ul>


### PR DESCRIPTION
## Purpose
`osf.io/support` is being replaced by `help.osf.io`. Remove old links.

## Changes
- Support links updated in the legacy top-nav and logged-in user drop-nav
- Updated in `populate_institutions.py`.
- Removed `/support` ember route.
- Also updated affected institution in the database.

## Side Effects
None expected. 

## Ticket
https://openscience.atlassian.net/browse/ENG-4565
