### PR TITLE
[Hotfix] Avoid KeyError on force-remove

### DIFF
--- a/osf/models/collection_submission.py
+++ b/osf/models/collection_submission.py
@@ -210,7 +210,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
             )
 
     def _validate_remove(self, event_data):
-        user = event_data.kwargs['user']
+        user = event_data.kwargs.get('user')
         force = event_data.kwargs.get('force')
         if force:
             return


### PR DESCRIPTION
## Purpose
Avoid KeyError on force-remove from collection

## Changes
- Use `.get`

## Side Effects
None expected

## Ticket
None