### PR TITLE
[ENG-4566] S3 Subfolder Selection Feature

### DIFF
--- a/addons/s3/models.py
+++ b/addons/s3/models.py
@@ -8,11 +8,18 @@ from osf.models.files import File, Folder, BaseFileNode
 from addons.base import exceptions
 from addons.s3.provider import S3Provider
 from addons.s3.serializer import S3Serializer
-from addons.s3.settings import (BUCKET_LOCATIONS,
-                                        ENCRYPT_UPLOADS_DEFAULT)
-from addons.s3.utils import (bucket_exists,
-                                     get_bucket_location_or_error,
-                                     get_bucket_names)
+from addons.s3.settings import (
+    BUCKET_LOCATIONS,
+    ENCRYPT_UPLOADS_DEFAULT
+)
+from addons.s3.utils import (
+    bucket_exists,
+    get_bucket_location_or_error,
+    get_bucket_names,
+    get_bucket_prefixes
+)
+from website.util import api_v2_url
+
 
 class S3FileNode(BaseFileNode):
     _provider = 's3'
@@ -55,8 +62,8 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def display_name(self):
         return u'{0}: {1}'.format(self.config.full_name, self.folder_id)
 
-    def set_folder(self, folder_id, auth):
-        if not bucket_exists(self.external_account.oauth_key, self.external_account.oauth_secret, folder_id):
+    def set_folder(self, folder_id, auth, bucket_name=None):
+        if not bucket_exists(self.external_account.oauth_key, self.external_account.oauth_secret, bucket_name):
             error_message = ('We are having trouble connecting to that bucket. '
                              'Try a different one.')
             raise exceptions.InvalidFolderError(error_message)
@@ -66,7 +73,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         bucket_location = get_bucket_location_or_error(
             self.external_account.oauth_key,
             self.external_account.oauth_secret,
-            folder_id
+            bucket_name
         )
         try:
             bucket_location = BUCKET_LOCATIONS[bucket_location]
@@ -78,29 +85,45 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.folder_name = '{} ({})'.format(folder_id, bucket_location)
         self.save()
 
-        self.nodelogger.log(action='bucket_linked', extra={'bucket': str(folder_id)}, save=True)
+        self.nodelogger.log(action='bucket_linked', extra={'bucket': bucket_name, 'path': self.folder_id}, save=True)
 
     def get_folders(self, **kwargs):
-        # This really gets only buckets, not subfolders,
-        # as that's all we want to be linkable on a node.
-        try:
-            buckets = get_bucket_names(self)
-        except Exception:
-            raise exceptions.InvalidAuthError()
+        """
+        Our S3 implementation allows for folder_id to be a bucket's root, or a subfolder in that bucket.
+        """
+        path = kwargs.get('path')
+        bucket_name = kwargs.get('bucket_name')
 
-        return [
-            {
+        # This is the root, so list all buckets.
+        if not bucket_name:
+            buckets = get_bucket_names(self)
+
+            return [{
                 'addon': 's3',
                 'kind': 'folder',
                 'id': bucket,
                 'name': bucket,
-                'path': bucket,
+                'bucket_name': bucket,
+                'path': '/',
                 'urls': {
-                    'folders': ''
+                    'folders': api_v2_url(
+                        f'nodes/{self.owner._id}/addons/s3/folders/',
+                        params={
+                            'id': bucket,
+                            'bucket_name': bucket,
+                        }
+                    ),
                 }
-            }
-            for bucket in buckets
-        ]
+            } for bucket in buckets]
+        # This is for a directory for a specific bucket, folders (Prefixes), but not files (Keys) returned, because
+        # these we can only set folders as our base folder_id
+        else:
+            return get_bucket_prefixes(
+                self.external_account.oauth_key,
+                self.external_account.oauth_secret,
+                prefix=path,
+                bucket_name=bucket_name
+            )
 
     @property
     def complete(self):
@@ -135,10 +158,16 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         }
 
     def serialize_waterbutler_settings(self):
+        """
+        We use the folder id to hold the bucket location
+        """
         if not self.folder_id:
             raise exceptions.AddonError('Cannot serialize settings for S3 addon')
+
+        bucket_name, _, folder_id = self.folder_id.partition('/')
         return {
-            'bucket': self.folder_id,
+            'bucket': bucket_name,  # fool wb
+            'id': folder_id,
             'encrypt_uploads': self.encrypt_uploads
         }
 

--- a/addons/s3/static/s3NodeConfig.js
+++ b/addons/s3/static/s3NodeConfig.js
@@ -28,7 +28,7 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
             {   // TreeBeard Options
                 columnTitles: function() {
                     return [{
-                        title: 'Buckets',
+                        title: 'Buckets/Folders',
                         width: '75%',
                         sort: false
                     }, {
@@ -36,12 +36,6 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
                         width: '25%',
                         sort: false
                     }];
-                },
-                resolveToggle: function(item) {
-                    return '';
-                },
-                resolveIcon: function(item) {
-                    return m('i.fa.fa-folder-o', ' ');
                 },
             },
             tbOpts

--- a/addons/s3/tests/test_model.py
+++ b/addons/s3/tests/test_model.py
@@ -38,6 +38,14 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     NodeSettingsClass = NodeSettings
     UserSettingsFactory = S3UserSettingsFactory
 
+    def _node_settings_class_kwargs(self, node, user_settings):
+        return {
+            'user_settings': self.user_settings,
+            'folder_id': 'bucket_name/path_goes_here/with_folder_id',
+            'owner': self.node
+        }
+
+
     def test_registration_settings(self):
         registration = ProjectFactory()
         clone, message = self.node_settings.after_register(
@@ -96,6 +104,9 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
-        expected = {'bucket': self.node_settings.folder_id,
-                    'encrypt_uploads': self.node_settings.encrypt_uploads}
+        expected = {
+            'bucket': 'bucket_name',
+            'encrypt_uploads': self.node_settings.encrypt_uploads,
+            'id': 'path_goes_here/with_folder_id'
+        }
         assert_equal(settings, expected)

--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -122,3 +122,24 @@ def get_bucket_location_or_error(access_key, secret_key, bucket_name):
         return connect_s3(access_key, secret_key).get_bucket(bucket_name, validate=False).get_location()
     except exception.S3ResponseError:
         raise InvalidFolderError()
+
+
+def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
+    bucket = connect_s3(access_key, secret_key).get_bucket(bucket_name)
+
+    folders = []
+    for key in bucket.list(delimiter='/', prefix=prefix):
+        if key.name.endswith('/') and key.name != prefix:
+            folders.append(
+                {
+                    'path': key.name,
+                    'id': f'{bucket_name}/{key.name}',
+                    'folder_id': key.name,
+                    'kind': 'folder',
+                    'bucket_name': bucket_name,
+                    'name': key.name.split('/')[-2],
+                    'addon': 's3',
+                }
+            )
+
+    return folders

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -41,7 +41,12 @@ s3_get_config = generic_views.get_config(
 
 def _set_folder(node_addon, folder, auth):
     folder_id = folder['id']
-    node_addon.set_folder(folder_id, auth=auth)
+    if folder['path'] == '/':
+        node_addon.set_folder(folder_id, auth=auth, bucket_name=folder_id)
+    else:
+        bucket_name = folder_id.split('/')[0]
+        node_addon.set_folder(folder_id, auth=auth, bucket_name=bucket_name)
+
     node_addon.save()
 
 s3_set_config = generic_views.set_config(
@@ -56,7 +61,10 @@ s3_set_config = generic_views.set_config(
 def s3_folder_list(node_addon, **kwargs):
     """ Returns all the subsequent folders under the folder id passed.
     """
-    return node_addon.get_folders()
+    path = request.args.get('path', '')
+    id = request.args.get('id', '')
+    bucket_name = request.args.get('bucket_name', '')
+    return node_addon.get_folders(path=path, folder_id=id, bucket_name=bucket_name)
 
 @must_be_logged_in
 def s3_add_user_account(auth, **kwargs):

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -22,18 +22,23 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
     })
 
     def get_absolute_url(self, obj):
-        if obj['addon'] in ('s3', 'figshare', 'github', 'mendeley'):
+        if obj['addon'] in ('figshare', 'github', 'mendeley'):
             # These addons don't currently support linking anything other
             # than top-level objects.
             return
 
+        query_kwargs = {
+            'path': obj['path'],
+            'id': obj['id'],
+        }
+
+        if obj['addon'] == 's3' and obj['kind'] == 'folder':  # Send S3 bucket name
+            query_kwargs['bucket_name'] = obj.get('bucket_name', '')
+
         return absolute_reverse(
             'nodes:node-addon-folders',
             kwargs=self.context['request'].parser_context['kwargs'],
-            query_kwargs={
-                'path': obj['path'],
-                'id': obj['id'],
-            },
+            query_kwargs=query_kwargs,
         )
 
     def get_root_folder(self, obj):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1454,13 +1454,14 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
 
         path = self.request.query_params.get('path')
         folder_id = self.request.query_params.get('id')
+        bucket_name = self.request.query_params.get('bucket_name')
 
         if not hasattr(node_addon, 'get_folders'):
             raise EndpointNotImplementedError('Endpoint not yet implemented for this addon')
 
         #  Convert v1 errors to v2 as much as possible.
         try:
-            return node_addon.get_folders(path=path, folder_id=folder_id)
+            return node_addon.get_folders(path=path, folder_id=folder_id, bucket_name=bucket_name)
         except InvalidAuthError:
             raise NotAuthenticated('This add-on could not be authenticated.')
         except HTTPError as exc:

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1013,7 +1013,7 @@ class TestNodeS3Addon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
     def _mock_folder_result(self):
         return {
             'name': 'a.bucket',
-            'path': 'a.bucket',
+            'path': '/',
             'id': 'a.bucket'
         }
 


### PR DESCRIPTION
## Purpose

A system to allow a holder of S3 IAM credentials to link a CommonPrefix of their bucket to a project. This will allow project and their registrations to contain only a subset of the items inside a bucket.

## Changes

- A bucket's root level path is now `/` instead of that buckets name.
- S3 special casing replaced in the NodeAddonFolderSerializer, S3 now passes a `bucket_name` query param to it's child buckets.
- Similar special casing for `bucket_name` in NodeAddonFolderList

## QA Plan

https://docs.google.com/document/d/1glfVQLc5LNaqERcFE4vvsEoaVEveVjrtFERapq9TNxg/edit

Hypothetical behavior
![S3-improvement](https://github.com/Johnetordoff/osf.io/assets/9688518/d7bd7ef2-cf69-4f52-9226-23525a517281)


Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

Waterbutler-side fix
https://github.com/CenterForOpenScience/waterbutler/pull/403

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4566