### PR TITLE
Use colon delineation for s3 buckets

### DIFF
--- a/addons/s3/tests/test_model.py
+++ b/addons/s3/tests/test_model.py
@@ -41,7 +41,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def _node_settings_class_kwargs(self, node, user_settings):
         return {
             'user_settings': self.user_settings,
-            'folder_id': 'bucket_name/path_goes_here/with_folder_id',
+            'folder_id': 'bucket_name:/path_goes_here/with_folder_id',
             'owner': self.node
         }
 
@@ -107,6 +107,6 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         expected = {
             'bucket': 'bucket_name',
             'encrypt_uploads': self.node_settings.encrypt_uploads,
-            'id': 'path_goes_here/with_folder_id'
+            'id': 'bucket_name:/path_goes_here/with_folder_id'
         }
         assert_equal(settings, expected)

--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -124,7 +124,7 @@ def get_bucket_location_or_error(access_key, secret_key, bucket_name):
         raise InvalidFolderError()
 
 
-def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
+def get_bucket_prefixes(access_key, secret_key, prefix, bucket_name):
     bucket = connect_s3(access_key, secret_key).get_bucket(bucket_name)
 
     folders = []
@@ -133,7 +133,7 @@ def get_bucket_prefixes(access_key, secret_key, prefix=None, bucket_name=None):
             folders.append(
                 {
                     'path': key.name,
-                    'id': f'{bucket_name}/{key.name}',
+                    'id': f'{bucket_name}:/{key.name}',
                     'folder_id': key.name,
                     'kind': 'folder',
                     'bucket_name': bucket_name,

--- a/addons/s3/views.py
+++ b/addons/s3/views.py
@@ -41,12 +41,7 @@ s3_get_config = generic_views.get_config(
 
 def _set_folder(node_addon, folder, auth):
     folder_id = folder['id']
-    if folder['path'] == '/':
-        node_addon.set_folder(folder_id, auth=auth, bucket_name=folder_id)
-    else:
-        bucket_name = folder_id.split('/')[0]
-        node_addon.set_folder(folder_id, auth=auth, bucket_name=bucket_name)
-
+    node_addon.set_folder(folder_id, auth=auth)
     node_addon.save()
 
 s3_set_config = generic_views.set_config(
@@ -62,9 +57,8 @@ def s3_folder_list(node_addon, **kwargs):
     """ Returns all the subsequent folders under the folder id passed.
     """
     path = request.args.get('path', '')
-    id = request.args.get('id', '')
-    bucket_name = request.args.get('bucket_name', '')
-    return node_addon.get_folders(path=path, folder_id=id, bucket_name=bucket_name)
+    folder_id = request.args.get('id', '')
+    return node_addon.get_folders(path=path, folder_id=folder_id)
 
 @must_be_logged_in
 def s3_add_user_account(auth, **kwargs):

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -12,7 +12,7 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
     id = ser.CharField(read_only=True)
     kind = ser.CharField(default='folder', read_only=True)
     name = ser.CharField(read_only=True)
-    folder_id = ser.SerializerMethodField(read_only=True)
+    folder_id = ser.CharField(source='id', read_only=True)
     path = ser.CharField(read_only=True)
     provider = ser.CharField(source='addon', read_only=True)
 
@@ -44,12 +44,6 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
             kwargs=self.context['request'].parser_context['kwargs'],
         )
 
-    def get_folder_id(self, obj):
-        if obj['addon'] == 's3':
-            # Addons with special top level directories such as a bucket with subfolders get a `:` delineator.
-            return f'{obj["bucket_name"]}:{obj["path"]}'
-        else:
-            return obj['id']
 
 class AddonSerializer(JSONAPISerializer):
     filterable_fields = frozenset([

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -44,7 +44,6 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
             kwargs=self.context['request'].parser_context['kwargs'],
         )
 
-
 class AddonSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'categories',

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1454,14 +1454,13 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
 
         path = self.request.query_params.get('path')
         folder_id = self.request.query_params.get('id')
-        bucket_name = self.request.query_params.get('bucket_name')
 
         if not hasattr(node_addon, 'get_folders'):
             raise EndpointNotImplementedError('Endpoint not yet implemented for this addon')
 
         #  Convert v1 errors to v2 as much as possible.
         try:
-            return node_addon.get_folders(path=path, folder_id=folder_id, bucket_name=bucket_name)
+            return node_addon.get_folders(path=path, folder_id=folder_id)
         except InvalidAuthError:
             raise NotAuthenticated('This add-on could not be authenticated.')
         except HTTPError as exc:

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -805,7 +805,7 @@ class TestNodeZoteroAddon(
                 'fileEditing': 'members',
                 'libraryEditing': 'members',
                 'type': 'Private',
-                'id': 18497322,
+                'id': '18497322',
                 'name': 'Group Library I'
             },
             'version': 1,

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1014,7 +1014,7 @@ class TestNodeS3Addon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
         return {
             'name': 'a.bucket',
             'path': '/',
-            'id': 'a.bucket'
+            'id': 'a.bucket:/'
         }
 
     @mock.patch('addons.s3.models.get_bucket_names')


### PR DESCRIPTION
## Purpose

We decided to move away from using parent directory names as bucket identifiers to delineating them with a colon. This is for two reasons:
- It looks better
- It allows the folder_id received to always be the same as the one sent.

## Changes

- removes query param special casing and embraces the colon case.

## Side effects

None that I know of.

## QA Notes

- was discovered by QA test: https://github.com/CenterForOpenScience/osf-selenium-tests/blob/f9089d5b3db7673cf961e2874e955ddd93631936/api/osf_api.py#L406
- here's a script I ran to replicate that test locally:
```python
attributes = requests.get(
    f'http://0.0.0.0:8000/v2/nodes/{node_id}/addons/s3/folders/',
    headers={'Authorization': f'Bearer {token}'}
).json()['data'][0]['attributes']

raw_payload = {
    'data': {
        'type': 'node_addons',
        'id': 's3',
        'attributes': {
            'folder_id': attributes['folder_id'],
        },
    },
}

print(
    requests.patch(
        url=f'http://0.0.0.0:8000/v2/nodes/{node_id}/addons/s3/',
        json=raw_payload,
        headers={'Authorization': f'Bearer {token}'}
    ).json()
)
```


## Deployment Notes

WB side: https://github.com/CenterForOpenScience/waterbutler/pull/404
