### PR TITLE
Fix non-default regions for s3

### DIFF
--- a/addons/s3/utils.py
+++ b/addons/s3/utils.py
@@ -18,7 +18,7 @@ def connect_s3(access_key=None, secret_key=None, node_settings=None):
     if node_settings is not None:
         if node_settings.external_account is not None:
             access_key, secret_key = node_settings.external_account.oauth_key, node_settings.external_account.oauth_secret
-    connection = S3Connection(access_key, secret_key, calling_format=OrdinaryCallingFormat())
+    connection = S3Connection(access_key, secret_key)
     return connection
 
 


### PR DESCRIPTION
## Purpose

Because we are using an older version of boto we are subject to s3 region weirdness, this fixes that.

## Changes

- remove old special casing that makes everything not work

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

relvent code from WB side:
```
    async def _check_region(self):
        """Lookup the region via bucket name, then update the host to match.

        Manually constructing the connection hostname allows us to use OrdinaryCallingFormat
        instead of SubdomainCallingFormat, which can break on buckets with periods in their name.
        The default region, US East (N. Virginia), is represented by the empty string and does not
        require changing the host.  Ireland is represented by the string 'EU', with the host
        parameter 'eu-west-1'.  All other regions return the host parameter as the region name.

        Region Naming: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
        """
        if self.region is None:
            self.region = await self._get_bucket_region()
            if self.region == 'EU':
                self.region = 'eu-west-1'

            if self.region != '':
                self.connection.host = self.connection.host.replace('s3.', 's3-' + self.region + '.', 1)
                self.connection._auth_handler = get_auth_handler(
                    self.connection.host, boto_config, self.connection.provider, self.connection._required_auth_capability())

        self.metrics.add('region', self.region)
```
This explains why only certain names were affected.


## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
