### PR TITLE
[Hotfix][ENG-4192] Allow DraftRegistrations to register when attached files have '&' in the name

### DIFF
--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -587,7 +587,7 @@ class TestArchiverTasks(ArchiverTestCase):
     def test_archive_success_escaped_file_names(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
-        fake_file_name = strip_html(fake_file['name'])
+        fake_file_name = strip_html(fake_file['name']).replace('&amp;', '&')
         file_tree['children'] = [fake_file]
 
         node = factories.NodeFactory(creator=self.user)

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -322,7 +322,7 @@ def _make_file_response(file_info, parent_guid):
     archived_file_id = file_info['path'].lstrip('/')
     return {
         'file_id': archived_file_id,
-        'file_name': bleach.clean(file_info['name']),
+        'file_name': bleach.clean(file_info['name']).replace('&amp;', '&'),
         'file_urls': {
             'html':
                 FILE_HTML_LINK_TEMPLATE.format(


### PR DESCRIPTION
## Purpose
Improve special character handling 

## Changes
- un-`bleach` `&amp;`'s

## QA Notes
- For RegistrationSchemas that allow file uploads in response to questions, a file named `&.txt` should no longer break.

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/ENG-4192