### PR TITLE
fix: upgrade pyyaml to 6.0.1 to avoid build error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ citeproc-py==0.4.0
 boto3==1.4.7
 django-waffle==2.4.1
 pymongo==3.7.1
-PyYAML==6.0
+PyYAML==6.0.1
 tqdm==4.28.1
 # Python markdown extensions for comment emails
 git+https://github.com/Johnetordoff/mdx_del_ins.git@django-3


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
avoid a build error (`pip install` fails [because pyyaml](https://github.com/yaml/pyyaml/issues/601), [clever loop swallows the error](https://github.com/CenterForOpenScience/osf.io/blob/f8606b060b81b6c8750951bcbdaff4186df4dc42/Dockerfile#L72-L78), docker build breaks only later saying `invoke: not found`)
see https://github.com/yaml/pyyaml/issues/601
and https://github.com/yaml/pyyaml/pull/702 
<!-- Describe the purpose of your changes -->

## Changes
lowest-effort fix: upgrade pyyaml from 6.0 to 6.0.1
<!-- Briefly describe or list your changes  -->
