### PR TITLE
[fix] filterable "resourceNature"

### DIFF
--- a/osf/metadata/rdfutils.py
+++ b/osf/metadata/rdfutils.py
@@ -21,6 +21,8 @@ FOAF = rdflib.Namespace('http://xmlns.com/foaf/0.1/')                   # "frien
 OWL = rdflib.Namespace('http://www.w3.org/2002/07/owl#')                # "web ontology language"
 RDF = rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')   # "resource description framework"
 SKOS = rdflib.Namespace('http://www.w3.org/2004/02/skos/core#')         # "simple knowledge organization system"
+# non-standard namespace for datacite terms (resolves to datacite docs)
+DATACITE = rdflib.Namespace('https://schema.datacite.org/meta/kernel-4.4/#')
 
 
 # namespace prefixes that will be shortened by default

--- a/osf/metadata/serializers/datacite/datacite_tree_walker.py
+++ b/osf/metadata/serializers/datacite/datacite_tree_walker.py
@@ -17,6 +17,7 @@ from osf.metadata.rdfutils import (
     OSF,
     ROR,
     SKOS,
+    DATACITE,
     without_namespace,
 )
 
@@ -63,36 +64,6 @@ CONTRIBUTOR_TYPE_MAP = {
     # TODO: contributor roles
     # DCTERMS.contributor: 'ProjectMember',
     OSF.HostingInstitution: 'HostingInstitution',
-}
-RESOURCE_TYPES_GENERAL = {
-    'Audiovisual',
-    'Book',
-    'BookChapter',
-    'Collection',
-    'ComputationalNotebook',
-    'ConferencePaper',
-    'ConferenceProceeding',
-    'DataPaper',
-    'Dataset',
-    'Dissertation',
-    'Event',
-    'Image',
-    'InteractiveResource',
-    'Journal',
-    'JournalArticle',
-    'Model',
-    'OutputManagementPlan',
-    'PeerReview',
-    'PhysicalObject',
-    'Preprint',
-    'Report',
-    'Service',
-    'Software',
-    'Sound',
-    'Standard',
-    'Text',
-    'Workflow',
-    'Other',
 }
 
 
@@ -436,12 +407,6 @@ class DataciteTreeWalker:
             self.basket[focus_iri:RDF.type],
         )
         for type_term in type_terms:
-            if isinstance(type_term, rdflib.Literal):
-                general_type = type_term.toPython()
-                if general_type in RESOURCE_TYPES_GENERAL:
-                    return general_type
-            elif isinstance(type_term, rdflib.URIRef) and type_term.startswith(OSF):
-                general_type = without_namespace(type_term, OSF)
-                if general_type in RESOURCE_TYPES_GENERAL:
-                    return general_type
+            if isinstance(type_term, rdflib.URIRef) and type_term.startswith(DATACITE):
+                return without_namespace(type_term, DATACITE)
         return 'Text'

--- a/osf_tests/metadata/expected_metadata_files/file_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/file_full.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://localhost:5000/w3ibb> a osf:File ;
     dcterms:created "2123-05-04" ;
@@ -23,7 +24,7 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!"@en ;
-    dcterms:type "Dataset" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
     osf:funder <https://doi.org/10.$$$$> ;
     osf:hasFunding <https://moneypockets.example/millions> .
@@ -60,3 +61,5 @@
         foaf:Organization ;
     dcterms:identifier "http://localhost:5000" ;
     foaf:name "OSF" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Dataset> rdfs:label "Dataset"@en .

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 <http://localhost:5000/w4ibb> a osf:Preprint ;
@@ -16,6 +17,7 @@
     dcterms:subject <http://localhost:8000/v2/subjects/subjwibbb/>,
         <http://localhost:8000/v2/subjects/subjwobbb/> ;
     dcterms:title "this is a preprint title!" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Preprint> ;
     owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> ;
     osf:isSupplementedBy <http://localhost:5000/w2ibb> ;
     osf:statedConflictOfInterest osf:no-conflict-of-interest .
@@ -61,3 +63,5 @@
 <https://bepress.com/reference_guide_dc/disciplines/> dcterms:title "bepress Digital Commons Three-Tiered Taxonomy" .
 
 <https://doi.org/11.111/something-or-other> dcterms:identifier "https://doi.org/11.111/something-or-other" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Preprint> rdfs:label "Preprint"@en .

--- a/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 <http://localhost:5000/w4ibb> a osf:Preprint ;
@@ -16,6 +17,7 @@
     dcterms:subject <http://localhost:8000/v2/subjects/subjwibbb/>,
         <http://localhost:8000/v2/subjects/subjwobbb/> ;
     dcterms:title "this is a preprint title!" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Preprint> ;
     owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> ;
     osf:isSupplementedBy <http://localhost:5000/w2ibb> ;
     osf:statedConflictOfInterest osf:no-conflict-of-interest .
@@ -31,7 +33,7 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!"@en ;
-    dcterms:type "Dataset" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
     osf:funder <https://doi.org/10.$$$$> ;
     osf:hasFunding <https://moneypockets.example/millions> .
@@ -78,3 +80,7 @@
 <https://bepress.com/reference_guide_dc/disciplines/> dcterms:title "bepress Digital Commons Three-Tiered Taxonomy" .
 
 <https://doi.org/11.111/something-or-other> dcterms:identifier "https://doi.org/11.111/something-or-other" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Preprint> rdfs:label "Preprint"@en .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Dataset> rdfs:label "Dataset"@en .

--- a/osf_tests/metadata/expected_metadata_files/project_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://localhost:5000/w2ibb> a osf:Project ;
     dcterms:created "2123-05-04" ;
@@ -21,6 +22,16 @@
     osf:contains <http://localhost:5000/w3ibb> ;
     osf:supplements <http://localhost:5000/w4ibb> .
 
+<http://localhost:5000/w4ibb> a osf:Preprint ;
+    dcterms:created "2123-05-04" ;
+    dcterms:creator <http://localhost:5000/w1ibb> ;
+    dcterms:identifier "http://localhost:5000/w4ibb",
+        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+    dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
+    dcterms:title "this is a preprint title!" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Preprint> ;
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
+
 <http://localhost:5000/w5ibb> a osf:Registration ;
     dcterms:created "2123-05-04" ;
     dcterms:creator <http://localhost:5000/w1ibb> ;
@@ -31,15 +42,6 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!" .
-
-<http://localhost:5000/w4ibb> a osf:Preprint ;
-    dcterms:created "2123-05-04" ;
-    dcterms:creator <http://localhost:5000/w1ibb> ;
-    dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
-    dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
-    dcterms:title "this is a preprint title!" ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
 
 <http://localhost:5000/w3ibb> a osf:File ;
     dcterms:created "2123-05-04" ;
@@ -68,3 +70,5 @@
         foaf:Organization ;
     dcterms:identifier "http://localhost:5000" ;
     foaf:name "OSF" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Preprint> rdfs:label "Preprint"@en .

--- a/osf_tests/metadata/expected_metadata_files/project_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_full.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://localhost:5000/w2ibb> a osf:Project ;
     dcterms:created "2123-05-04" ;
@@ -18,12 +19,22 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!"@en ;
-    dcterms:type "Dataset" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
     osf:contains <http://localhost:5000/w3ibb> ;
     osf:funder <https://doi.org/10.$$$$> ;
     osf:hasFunding <https://moneypockets.example/millions> ;
     osf:supplements <http://localhost:5000/w4ibb> .
+
+<http://localhost:5000/w4ibb> a osf:Preprint ;
+    dcterms:created "2123-05-04" ;
+    dcterms:creator <http://localhost:5000/w1ibb> ;
+    dcterms:identifier "http://localhost:5000/w4ibb",
+        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+    dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
+    dcterms:title "this is a preprint title!" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Preprint> ;
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
 
 <http://localhost:5000/w5ibb> a osf:Registration ;
     dcterms:created "2123-05-04" ;
@@ -35,15 +46,6 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!" .
-
-<http://localhost:5000/w4ibb> a osf:Preprint ;
-    dcterms:created "2123-05-04" ;
-    dcterms:creator <http://localhost:5000/w1ibb> ;
-    dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
-    dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
-    dcterms:title "this is a preprint title!" ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
 
 <http://localhost:5000/w3ibb> a osf:File ;
     dcterms:created "2123-05-04" ;
@@ -86,3 +88,7 @@
         foaf:Organization ;
     dcterms:identifier "http://localhost:5000" ;
     foaf:name "OSF" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Preprint> rdfs:label "Preprint"@en .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Dataset> rdfs:label "Dataset"@en .

--- a/osf_tests/metadata/expected_metadata_files/registration_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/registration_full.turtle
@@ -2,6 +2,7 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 <http://localhost:5000/w5ibb> a osf:Registration ;
     dcterms:conformsTo <http://fake.example/schema/for/test> ;
@@ -29,7 +30,7 @@
     dcterms:rightsHolder "Me",
         "You" ;
     dcterms:title "this is a project title!"@en ;
-    dcterms:type "Dataset" ;
+    dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
     osf:funder <https://doi.org/10.$$$$> ;
     osf:hasFunding <https://moneypockets.example/millions> .
@@ -62,5 +63,7 @@
         foaf:Organization ;
     dcterms:identifier "http://localhost:5000" ;
     foaf:name "OSF" .
+
+<https://schema.datacite.org/meta/kernel-4.4/#Dataset> rdfs:label "Dataset"@en .
 
 <http://fake.example/schema/for/test> dcterms:title "Open-Ended Registration" .

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -141,21 +141,27 @@ class TestOsfGathering(TestCase):
         _assert_triples(osf_gathering.gather_flexible_types(self.projectfocus), {
         })
         self.projectfocus.guid_metadata_record.resource_type_general = 'Book'
+        _datacite_book_ref = URIRef('https://schema.datacite.org/meta/kernel-4.4/#Book')
         _assert_triples(osf_gathering.gather_flexible_types(self.projectfocus), {
-            (self.projectfocus.iri, DCTERMS.type, Literal('Book')),
+            (self.projectfocus.iri, DCTERMS.type, _datacite_book_ref),
+            (_datacite_book_ref, rdflib.RDFS.label, Literal('Book', lang='en')),
         })
         # focus: registration
         _assert_triples(osf_gathering.gather_flexible_types(self.registrationfocus), {
         })
         self.registrationfocus.guid_metadata_record.resource_type_general = 'Preprint'
+        _datacite_preprint_ref = URIRef('https://schema.datacite.org/meta/kernel-4.4/#Preprint')
         _assert_triples(osf_gathering.gather_flexible_types(self.registrationfocus), {
-            (self.registrationfocus.iri, DCTERMS.type, Literal('Preprint')),
+            (self.registrationfocus.iri, DCTERMS.type, _datacite_preprint_ref),
+            (_datacite_preprint_ref, rdflib.RDFS.label, Literal('Preprint', lang='en')),
         })
         # focus: file
         _assert_triples(osf_gathering.gather_flexible_types(self.filefocus), set())
         self.filefocus.guid_metadata_record.resource_type_general = 'Dataset'
+        _datacite_dataset_ref = URIRef('https://schema.datacite.org/meta/kernel-4.4/#Dataset')
         _assert_triples(osf_gathering.gather_flexible_types(self.filefocus), {
-            (self.filefocus.iri, DCTERMS.type, Literal('Dataset')),
+            (self.filefocus.iri, DCTERMS.type, _datacite_dataset_ref),
+            (_datacite_dataset_ref, rdflib.RDFS.label, Literal('Dataset', lang='en')),
         })
 
     def test_gather_created(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
when building a metadata record, use an iri value for `dcterms:type` (aka `resourceNature`) to make it filterable in the new iri-centric search api
<!-- Describe the purpose of your changes -->

## Changes
- introduce a namespace for terms defined in datacite 4.4: `https://schema.datacite.org/meta/kernel-4.4/#`
  - datacite does not provide iris for each term, but that's ok -- for anyone curious how the term is defined, the iri leads to documentation
- use an iri in that namespace for each datacite resourceTypeGeneral value (in `dcterms:type`)
  - before:
    ```
    :my-item
        dcterms:type "BookChapter" .
    ```
  - after:
    ```
    :my-item
        dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#BookChapter> .

    <https://schema.datacite.org/meta/kernel-4.4/#BookChapter>
        rdfs:label "BookChapter"@en .
    ```


<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
