### PR TITLE
[ENG-4617] Send File Metadata to SHARE

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -255,6 +255,41 @@ class OsfStorageFile(OsfStorageFileNode, File):
             'last_seen': self.modified
         }
 
+    @property
+    def should_update_search(self):
+        target = self.target
+        qa_tags = set(website_settings.DO_NOT_INDEX_LIST['tags'])
+        if qa_tags.intersection(self.tags.all().values_list('name', flat=True)):
+            return False
+        if qa_tags.intersection(target.tags.all().values_list('name', flat=True)):
+            return False
+        if any(qa_substring in target.title for qa_substring in website_settings.DO_NOT_INDEX_LIST['titles']):
+            return False
+
+        if not self.name or self.is_deleted:
+            return False
+
+        spam_check_field = (
+            'is_spammy'
+            if website_settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH
+            else 'is_spam'
+        )
+        target_check_fields = [
+            ('is_public', True),
+            ('deleted', None),
+            ('is_deleted', False),
+            ('is_retracted', False),
+            (spam_check_field, False),
+            ('archiving', False),
+            ('verified_publishable', True),
+            ('primary_file', self)
+        ]
+        for field_name, expected_value in target_check_fields:
+            if hasattr(target, field_name) and getattr(target, field_name, expected_value) != expected_value:
+                return False
+
+        return True
+
     def touch(self, bearer, version=None, revision=None, **kwargs):
         try:
             return self.get_version(revision or version)
@@ -392,17 +427,14 @@ class OsfStorageFile(OsfStorageFileNode, File):
             self.remove_tag(tag, auth, save)
 
     def delete(self, user=None, **kwargs):
-        from website.search import search
-
-        search.update_file(self, delete=True)
-        return super().delete(user, **kwargs)
+        ret = super().delete(user, **kwargs)
+        self.update_search()
+        return ret
 
     def save(self, skip_search=False, *args, **kwargs):
-        from website.search import search
-
         ret = super(OsfStorageFile, self).save()
         if not skip_search:
-            search.update_file(self)
+            self.update_search()
         return ret
 
 

--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -154,7 +154,7 @@ def _should_delete_indexcard(osf_item):
     # if it quacks like BaseFileNode, look at .target instead
     _containing_item = getattr(osf_item, 'target', None)
     if _containing_item:
-        return _should_delete_indexcard(_containing_item)
+        return not osf_item.should_update_search or _should_delete_indexcard(_containing_item)
     return (
         not _is_item_public(osf_item)
         or getattr(osf_item, 'is_spam', False)

--- a/osf/management/commands/recatalog_metadata.py
+++ b/osf/management/commands/recatalog_metadata.py
@@ -3,7 +3,8 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from osf.models import AbstractProvider, Registration, Preprint, Node
+from addons.osfstorage.models import OsfStorageFile
+from osf.models import AbstractProvider, Registration, Preprint, Node, OSFUser
 from api.share.utils import update_share
 
 logger = logging.getLogger(__name__)
@@ -80,11 +81,16 @@ class Command(BaseCommand):
             action='store_true',
             help='recatalog metadata for non-registration projects (and components)',
         )
-        # type_group.add_argument(
-        #     '--files',
-        #     action='store_true',
-        #     help='recatalog metadata for files',
-        # )
+        type_group.add_argument(
+            '--files',
+            action='store_true',
+            help='recatalog metadata for files',
+        )
+        type_group.add_argument(
+            '--users',
+            action='store_true',
+            help='recatalog metadata for users',
+        )
 
         parser.add_argument(
             '--start-id',
@@ -111,6 +117,8 @@ class Command(BaseCommand):
         pls_recatalog_preprints = options['preprints']
         pls_recatalog_registrations = options['registrations']
         pls_recatalog_projects = options['projects']
+        pls_recatalog_files = options['files']
+        pls_recatalog_users = options['users']
         start_id = options['start_id']
         chunk_size = options['chunk_size']
         chunk_count = options['chunk_count']
@@ -123,7 +131,7 @@ class Command(BaseCommand):
 
         if pls_all_types:
             assert not start_id, 'choose a specific type to resume with --start-id'
-            provided_models = [Preprint, Registration, Node]
+            provided_models = [Preprint, Registration, Node, OSFUser, OsfStorageFile]
         else:
             if pls_recatalog_preprints:
                 provided_models = [Preprint]
@@ -131,6 +139,10 @@ class Command(BaseCommand):
                 provided_models = [Registration]
             if pls_recatalog_projects:
                 provided_models = [Node]
+            if pls_recatalog_files:
+                provided_models = [OsfStorageFile]
+            if pls_recatalog_users:
+                provided_models = [OSFUser]
 
         for provided_model in provided_models:
             recatalog(provided_model, providers, start_id, chunk_count, chunk_size)

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -14,6 +14,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from typedmodels.models import TypedModel, TypedModelManager
 
+from api.share.utils import update_share
 from framework.analytics import get_basic_counters
 from framework import sentry
 from osf.models.base import BaseModel, OptionalGuidMixin, ObjectIDMixin
@@ -23,7 +24,6 @@ from osf.models.validators import validate_location
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import NonNaiveDateTimeField
 from api.base.utils import waterbutler_api_url_for
-from api.share.utils import update_share
 from website.files import utils
 from website.files.exceptions import VersionNotFoundError
 from website.util import api_v2_url, web_url_for, api_url_for
@@ -442,6 +442,11 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
             self.save()
 
         return self
+
+    @property
+    def should_update_search(self):
+        # Only OsfStorageFile expected to actually update_search
+        return False
 
     def update_search(self):
         update_share(self)

--- a/osf_tests/management_commands/test_recatalog_metadata.py
+++ b/osf_tests/management_commands/test_recatalog_metadata.py
@@ -55,7 +55,27 @@ class TestRecatalogMetadata:
             for registration in registrations
         ])
 
-    def test_recatalog_metadata(self, mock_update_share, preprint_provider, preprints, registration_provider, registrations, projects):
+    @pytest.fixture
+    def files(self, preprints):
+        return sorted_by_id([
+            preprint.primary_file
+            for preprint in preprints
+        ])
+
+    @pytest.fixture
+    def users(self, preprints, registrations, projects):
+        return sorted_by_id(list(set([
+            project.creator
+            for project in projects
+        ] + [
+            registration.creator
+            for registration in registrations
+        ] + [
+            preprint.creator
+            for preprint in preprints
+        ])))
+
+    def test_recatalog_metadata(self, mock_update_share, preprint_provider, preprints, registration_provider, registrations, projects, files, users):
         mock_update_share.reset_mock()
         # test preprints
         call_command(
@@ -96,6 +116,34 @@ class TestRecatalogMetadata:
         expected_update_share_calls = [
             mock.call(project)
             for project in projects  # already ordered by id
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # test files
+        call_command(
+            'recatalog_metadata',
+            '--files',
+            '--all-providers',
+        )
+        expected_update_share_calls = [
+            mock.call(file)
+            for file in files  # already ordered by id
+        ]
+        assert mock_update_share.mock_calls == expected_update_share_calls
+
+        mock_update_share.reset_mock()
+
+        # test users
+        call_command(
+            'recatalog_metadata',
+            '--users',
+            '--all-providers',
+        )
+        expected_update_share_calls = [
+            mock.call(user)
+            for user in users  # already ordered by id
         ]
         assert mock_update_share.mock_calls == expected_update_share_calls
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -517,7 +517,7 @@ def update_node(node, index=None, bulk=False, async_update=False):
     from addons.osfstorage.models import OsfStorageFile
     index = index or INDEX
     for file_ in paginated(OsfStorageFile, Q(target_content_type=ContentType.objects.get_for_model(type(node)), target_object_id=node.id)):
-        update_file(file_, index=index)
+        file_.update_search()
 
     is_qa_node = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(node.tags.all().values_list('name', flat=True))) or any(substring in node.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
     if node.is_deleted or not node.is_public or node.archiving or node.is_spam or (node.spam_status == SpamStatus.FLAGGED and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH) or node.is_quickfiles or is_qa_node:
@@ -535,7 +535,7 @@ def update_preprint(preprint, index=None, bulk=False, async_update=False):
     from addons.osfstorage.models import OsfStorageFile
     index = index or INDEX
     for file_ in paginated(OsfStorageFile, Q(target_content_type=ContentType.objects.get_for_model(type(preprint)), target_object_id=preprint.id)):
-        update_file(file_, index=index)
+        file_.update_search()
 
     is_qa_preprint = bool(set(settings.DO_NOT_INDEX_LIST['tags']).intersection(preprint.tags.all().values_list('name', flat=True))) or any(substring in preprint.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
     if not preprint.verified_publishable or preprint.is_spam or (preprint.spam_status == SpamStatus.FLAGGED and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH) or is_qa_preprint:
@@ -732,14 +732,7 @@ def update_file(file_, index=None, delete=False):
     index = index or INDEX
     target = file_.target
 
-    # TODO: Can remove 'not file_.name' if we remove all base file nodes with name=None
-    file_node_is_qa = bool(
-        set(settings.DO_NOT_INDEX_LIST['tags']).intersection(file_.tags.all().values_list('name', flat=True))
-    ) or bool(
-        set(settings.DO_NOT_INDEX_LIST['tags']).intersection(target.tags.all().values_list('name', flat=True))
-    ) or any(substring in target.title for substring in settings.DO_NOT_INDEX_LIST['titles'])
-    if not file_.name or not target.is_public or delete or file_node_is_qa or getattr(target, 'is_deleted', False) or getattr(target, 'archiving', False) or target.is_spam or (
-            target.spam_status == SpamStatus.FLAGGED and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH):
+    if not file_.should_update_search or delete:
         client().delete(
             index=index,
             doc_type='file',
@@ -748,18 +741,6 @@ def update_file(file_, index=None, delete=False):
             ignore=[404]
         )
         return
-
-    if isinstance(target, Preprint):
-        if not getattr(target, 'verified_publishable', False) or target.primary_file != file_ or target.is_spam or (
-                target.spam_status == SpamStatus.FLAGGED and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH):
-            client().delete(
-                index=index,
-                doc_type='file',
-                id=file_._id,
-                refresh=True,
-                ignore=[404]
-            )
-            return
 
     # We build URLs manually here so that this function can be
     # run outside of a Flask request context (e.g. in a celery task)


### PR DESCRIPTION
## Purpose
Send file metadata to SHARE when files get updated, or the target it is contained within is updated

## Changes
- Prefer `BaseFileNode.update_search` over older methods
- Extract, update `should_update_search` logic from `elastic_search.py` for reuse
- Ensure files `update_share` when appropriate
- Update `recatalog` command

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/ENG-4617
