### PR TITLE
[fix] send utf8 to shtrove

### DIFF
--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -11,6 +11,7 @@ import requests
 
 from framework.celery_tasks import app as celery_app
 from framework.celery_tasks.handlers import enqueue_task
+from framework.encryption import ensure_bytes
 from framework.sentry import log_exception
 from osf.metadata.osf_gathering import osf_iri
 from osf.metadata.tools import pls_gather_metadata_file
@@ -102,7 +103,7 @@ def pls_send_trove_indexcard(osf_item):
             'Content-Type': _metadata_record.mediatype,
             **_shtrove_auth_headers(osf_item),
         },
-        data=_metadata_record.serialized_metadata,
+        data=ensure_bytes(_metadata_record.serialized_metadata),
     )
 
 

--- a/api_tests/share/_utils.py
+++ b/api_tests/share/_utils.py
@@ -55,7 +55,9 @@ def assert_ingest_request(request, expected_osfguid, *, token=None, delete=False
         assert request.method == 'DELETE'
     else:
         assert request.method == 'POST'
-        assert _querydict['focus_iri'] == f'{website_settings.DOMAIN}{expected_osfguid}'
+        _focus_iri = _querydict['focus_iri']
+        assert _focus_iri == f'{website_settings.DOMAIN}{expected_osfguid}'
+        assert _focus_iri in request.body.decode('utf-8')
     _token = token or website_settings.SHARE_API_TOKEN
     assert request.headers['Authorization'] == f'Bearer {_token}'
 

--- a/api_tests/share/test_share_node.py
+++ b/api_tests/share/test_share_node.py
@@ -63,7 +63,7 @@ class TestNodeShare:
 
     @pytest.fixture()
     def registration(self, node):
-        reg = RegistrationFactory(is_public=True)
+        reg = RegistrationFactory(is_public=True, title='〠')
         IdentifierFactory(referent=reg, category='doi')
         reg.archive_jobs.clear()  # if reg.archiving is True it will skip updating SHARE
         return reg

--- a/osf/metadata/serializers/turtle.py
+++ b/osf/metadata/serializers/turtle.py
@@ -36,7 +36,7 @@ def _get_turtleblock_sortkey(focus_iri: str):
 
 
 class TurtleMetadataSerializer(_base.MetadataSerializer):
-    mediatype = 'text/turtle'
+    mediatype = 'text/turtle; charset=utf-8'
 
     def filename_for_itemid(self, itemid: str):
         return f'{itemid}-metadata.ttl'

--- a/osf/metadata/tools.py
+++ b/osf/metadata/tools.py
@@ -10,7 +10,7 @@ from osf.metadata.serializers import get_metadata_serializer
 class SerializedMetadataFile(typing.NamedTuple):
     mediatype: str
     filename: str
-    serialized_metadata: str
+    serialized_metadata: typing.Union[str, bytes]
 
 
 def pls_gather_metadata_as_dict(osf_item, format_key, serializer_config=None):

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -70,7 +70,7 @@ FULL_METADATA_SCENARIO = {
 }
 
 EXPECTED_MEDIATYPE = {
-    'turtle': 'text/turtle',
+    'turtle': 'text/turtle; charset=utf-8',
     'datacite-xml': 'application/xml',
     'datacite-json': 'application/json',
 }
@@ -246,7 +246,7 @@ class TestSerializers(OsfTestCase):
                     resp = self.app.get(f'/{osfguid}/metadata/?format={format_key}')
                     assert resp.status_code == 200
                     self.assertEqual(resp.status_code, 200)
-                    self.assertEqual(resp.content_type, EXPECTED_MEDIATYPE[format_key])
+                    self.assertEqual(resp.headers['Content-Type'], EXPECTED_MEDIATYPE[format_key])
                     self.assertEqual(
                         resp.content_disposition,
                         f'attachment; filename={gathered_file.filename}',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
support non-ascii characters in metadata pushed to share/trove (oops)
<!-- Describe the purpose of your changes -->

## Changes
- pass pre-encoded `bytes` to `requests.post` (instead of `str`)
- also add `charset=utf-8` to mimetype (more correct, tho it doesn't actually change anything)
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify non-ascii unicode characters get all the way thru to render in search results
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
