### PR TITLE
[ENG-4560] Remove 'Untitled' as the default entry from the Title entry field for the draft registration

### DIFF
--- a/api_tests/draft_nodes/views/test_draft_node_detail.py
+++ b/api_tests/draft_nodes/views/test_draft_node_detail.py
@@ -55,6 +55,7 @@ class TestDraftNodeDetail:
         assert res.status_code == 404
 
         # cannot access draft node after it's been registered (it's now a node!)
+        draft_reg.title = 'test user generated title.'
         draft_reg.register(Auth(user))
         url = '/{}draft_nodes/{}/'.format(API_BASE, draft_node._id)
         res = app.get(url, auth=user_two.auth, expect_errors=True)

--- a/api_tests/draft_registrations/views/test_draft_registration_detail.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_detail.py
@@ -95,7 +95,7 @@ class TestDraftRegistrationDetailEndpoint(TestDraftRegistrationDetail):
         res = app.get(url, auth=user.auth, expect_errors=True)
         attributes = res.json['data']['attributes']
 
-        assert attributes['title'] == 'Untitled'
+        assert attributes['title'] == ''
         assert attributes['description'] == ''
         assert attributes['category'] == ''
         assert attributes['node_license'] is None

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -394,7 +394,7 @@ class TestDraftRegistrationCreateWithoutNode(TestDraftRegistrationCreate):
         res = app.post_json_api(url_draft_registrations, payload, auth=user.auth)
         assert res.status_code == 201
         attributes = res.json['data']['attributes']
-        assert attributes['title'] == 'Untitled'
+        assert attributes['title'] == ''
         assert attributes['description'] != project_public.description
         assert attributes['category'] != project_public.category
         assert set(attributes['tags']) != set([tag.name for tag in project_public.tags.all()])

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1570,6 +1570,9 @@ class TestRegistrationCreate(TestNodeRegistrationCreate):
         payload_ver['data']['attributes']['draft_registration_id'] = draft_registration._id
         assert draft_registration.branched_from.is_admin_contributor(user) is False
         assert draft_registration.has_permission(user, permissions.ADMIN) is True
+        assert draft_registration.title is ''
+        draft_registration.title = 'test user generated title required'
+        draft_registration.save()
         res = app.post_json_api(url_registrations_ver, payload_ver, auth=user.auth)
         assert res.status_code == 201
 
@@ -1578,6 +1581,9 @@ class TestRegistrationCreate(TestNodeRegistrationCreate):
         assert draft_registration.branched_from.is_admin_contributor(user) is True
         assert draft_registration.has_permission(user, permissions.ADMIN) is True
         payload_ver['data']['attributes']['draft_registration_id'] = draft_registration._id
+        assert draft_registration.title is ''
+        draft_registration.title = 'test user generated title required'
+        draft_registration.save()
         res = app.post_json_api(url_registrations_ver, payload_ver, auth=user.auth)
         assert res.status_code == 201
 

--- a/osf/models/draft_node.py
+++ b/osf/models/draft_node.py
@@ -66,7 +66,7 @@ class DraftNode(AbstractNode):
         """
         self.convert_draft_node_to_node(auth)
         # Copies editable fields from the DraftRegistration back to the Node
-        self.copy_editable_fields(draft_registration, auth=auth, save=True)
+        self.copy_editable_fields(draft_registration, save=True)
 
         # Calls super on Node, since self is no longer a DraftNode
         return super(Node, self).register_node(schema, auth, draft_registration, parent, child_ids, provider)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2263,12 +2263,17 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
 
     def copy_editable_fields(self, resource, alternative_resource=None, include_contributors=True, save=True, excluded_attributes=None):
         """
-        Copy various editable fields from the 'resource' object to the current object.
-        Includes, title, description, category, contributors, node_license, tags, subjects, and affiliated_institutions
-        The field on the resource will always supersede the field on the alternative_resource. For example,
-        copying fields from the draft_registration to the registration.  resource will be a DraftRegistration object,
-        but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
-        TODO, add optional logging parameter
+        This method copies various editable fields from the 'resource' object to the current object. Includes, title,
+        description, category, contributors, node_license, tags, subjects, and affiliated_institutions.
+        The field on the resource will always supersede the field on the alternative_resource. For example, copying
+        fields from the draft_registration to the registration.  resource will be a DraftRegistration object, but the
+        alternative_resource will be a Node. DraftRegistration fields will trump Node fields.
+
+        :param Object resource: Primary resource where you want to copy attributes
+        :param Object alternative_resource: Backup resource for copying attributes
+        :param Boolean include_contributors: represents whether to also copy the resource's contributors
+        :param Boolean save: represents whether to save the resources changes immediately
+        :param List: a list of strings representing attributes to exclude from copying
         """
         if not excluded_attributes:
             excluded_attributes = []

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2261,7 +2261,7 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         else:
             return []
 
-    def copy_editable_fields(self, resource, auth=None, alternative_resource=None, include_contributors=True, save=True):
+    def copy_editable_fields(self, resource, alternative_resource=None, include_contributors=True, save=True, excluded_attributes=None):
         """
         Copy various editable fields from the 'resource' object to the current object.
         Includes, title, description, category, contributors, node_license, tags, subjects, and affiliated_institutions
@@ -2270,10 +2270,12 @@ class EditableFieldsMixin(TitleMixin, DescriptionMixin, CategoryMixin, Contribut
         but the alternative_resource will be a Node.  DraftRegistration fields will trump Node fields.
         TODO, add optional logging parameter
         """
-        self.set_editable_attribute('title', resource, alternative_resource)
-        self.set_editable_attribute('description', resource, alternative_resource)
-        self.set_editable_attribute('category', resource, alternative_resource)
-        self.set_editable_attribute('node_license', resource, alternative_resource)
+        if not excluded_attributes:
+            excluded_attributes = []
+
+        for attribute in ['title', 'description', 'category', 'node_license']:
+            if attribute not in excluded_attributes:
+                self.set_editable_attribute(attribute, resource, alternative_resource)
 
         if include_contributors:
             # Contributors will always come from "resource", as contributor constraints

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1488,7 +1488,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             resource = self
             alternative_resource = None
 
-        registered.copy_editable_fields(resource, auth=auth, alternative_resource=alternative_resource)
+        registered.copy_editable_fields(resource, alternative_resource=alternative_resource)
         registered.copy_registration_responses_into_schema_response(draft_registration)
 
         if settings.ENABLE_ARCHIVER:

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1261,9 +1261,12 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         else:
             provider.validate_schema(schema)
 
+        excluded_attributes = []
         if not node:
             # If no node provided, a DraftNode is created for you
             node = DraftNode.objects.create(creator=user, title=settings.DEFAULT_DRAFT_NODE_TITLE)
+            # Force the user to add their own title for no-project
+            excluded_attributes.append('title')
 
         if not (isinstance(node, Node) or isinstance(node, DraftNode)):
             raise DraftRegistrationStateError()
@@ -1279,7 +1282,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
         draft.copy_editable_fields(
             node,
             save=True,
-            excluded_attributes=['title']  # Force the user to add their own title for no-project
+            excluded_attributes=excluded_attributes
         )
         draft.update(data, auth=Auth(user))
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -1263,7 +1263,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
 
         if not node:
             # If no node provided, a DraftNode is created for you
-            node = DraftNode.objects.create(creator=user, title='Untitled')
+            node = DraftNode.objects.create(creator=user, title=settings.DEFAULT_DRAFT_NODE_TITLE)
 
         if not (isinstance(node, Node) or isinstance(node, DraftNode)):
             raise DraftRegistrationStateError()
@@ -1276,7 +1276,11 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             provider=provider,
         )
         draft.save()
-        draft.copy_editable_fields(node, Auth(user), save=True)
+        draft.copy_editable_fields(
+            node,
+            save=True,
+            excluded_attributes=['title']  # Force the user to add their own title for no-project
+        )
         draft.update(data, auth=Auth(user))
 
         if node.type == 'osf.draftnode':

--- a/osf_tests/test_draft_node.py
+++ b/osf_tests/test_draft_node.py
@@ -22,6 +22,7 @@ from osf_tests.factories import (
     get_default_metaschema,
 )
 from website.project.signals import after_create_registration
+from website import settings
 
 pytestmark = pytest.mark.django_db
 
@@ -123,8 +124,8 @@ class TestDraftNode:
             schema=get_default_metaschema(),
             data=data,
         )
-        assert draft.title == 'Untitled'
-        assert draft.branched_from.title == 'Untitled'
+        assert draft.title == ''
+        assert draft.branched_from.title == settings.DEFAULT_DRAFT_NODE_TITLE
         assert draft.branched_from.type == 'osf.draftnode'
         assert draft.branched_from.creator == user
         assert len(draft.logs.all()) == 0

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -269,7 +269,7 @@ class TestDraftRegistrations:
             schema=factories.get_default_metaschema(),
         )
 
-        assert draft.title == 'Untitled'
+        assert draft.title == ''
         assert draft.description == ''
         assert draft.category == ''
         assert user in draft.contributors.all()

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -2129,3 +2129,4 @@ CAS_LOG_LEVEL = 3  # ERROR
 PREPRINT_METRICS_START_DATE = datetime.datetime(2019, 1, 1)
 
 WAFFLE_VALUES_YAML = 'osf/features.yaml'
+DEFAULT_DRAFT_NODE_TITLE = 'Untitled'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Some users are forgetting to update the title of their "no-project-registration", so this PR sets the no-project registration's title to an empty string so it must be updated to validate the form. This PR simply doesn't copy over the default DraftNode title if the DraftRegistration uses a DraftNode instead of a Node.

## Changes

- Changes `copy_editable_fields` logic to exclude the default title of draftnodes 
- Changes to tests
- refactor `Untitled` to `DEFAULT_DRAFT_NODE_TITLE`
- **Removed unused param auth**


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4560