### PR TITLE
api: add `iris` and `assets.banner` to institutions

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -83,6 +83,7 @@ class InstitutionSerializer(JSONAPISerializer):
         return {
             'logo': obj.logo_path,
             'logo_rounded': obj.logo_path_rounded_corners,
+            'banner': obj.banner_path,
         }
 
     class Meta:

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -33,6 +33,7 @@ class InstitutionSerializer(JSONAPISerializer):
     auth_url = ser.CharField(read_only=True)
     iri = ser.CharField(read_only=True, source='identifier_domain')
     ror_iri = ser.CharField(read_only=True, source='ror_uri')
+    iris = ser.SerializerMethodField(read_only=True)
     assets = ser.SerializerMethodField(read_only=True)
     links = LinksField({
         'self': 'get_api_url',
@@ -74,6 +75,9 @@ class InstitutionSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return obj.absolute_api_v2_url
+
+    def get_iris(self, obj):
+        return list(obj.get_semantic_iris())
 
     def get_assets(self, obj):
         return {

--- a/api_tests/institutions/views/test_institution_detail.py
+++ b/api_tests/institutions/views/test_institution_detail.py
@@ -34,13 +34,19 @@ class TestInstitutionDetail:
 
         res = app.get(url)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['name'] == institution.name
-        assert res.json['data']['attributes']['iri'] == institution.identifier_domain
-        assert res.json['data']['attributes']['ror_iri'] == institution.ror_uri
-        assert 'logo_path' in res.json['data']['attributes']
-        assert 'assets' in res.json['data']['attributes']
-        assert 'logo' in res.json['data']['attributes']['assets']
-        assert 'logo_rounded' in res.json['data']['attributes']['assets']
+        attrs = res.json['data']['attributes']
+        assert attrs['name'] == institution.name
+        assert attrs['iri'] == institution.identifier_domain
+        assert attrs['ror_iri'] == institution.ror_uri
+        assert set(attrs['iris']) == {
+            institution.ror_uri,
+            institution.identifier_domain,
+            institution.absolute_url,
+        }
+        assert 'logo_path' in attrs
+        assert 'assets' in attrs
+        assert 'logo' in attrs['assets']
+        assert 'logo_rounded' in attrs['assets']
         assert res.json['data']['links']['self'].endswith(url)
 
         relationships = res.json['data']['relationships']

--- a/api_tests/institutions/views/test_institution_detail.py
+++ b/api_tests/institutions/views/test_institution_detail.py
@@ -44,9 +44,7 @@ class TestInstitutionDetail:
             institution.absolute_url,
         }
         assert 'logo_path' in attrs
-        assert 'assets' in attrs
-        assert 'logo' in attrs['assets']
-        assert 'logo_rounded' in attrs['assets']
+        assert set(attrs['assets'].keys()) == {'logo', 'logo_rounded', 'banner'}
         assert res.json['data']['links']['self'].endswith(url)
 
         relationships = res.json['data']['relationships']


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
provide the institutions search frontend with all it needs
<!-- Describe the purpose of your changes -->

## Changes
- add `iris` attribute to `InstitutionSerializer` with a list from the institution's `get_semantic_iris()` (to filter for an institution that may or may not have a ror id or non-osf iri)
- add `banner` to the `assets` attribute (to display the same banner image as the old institutions dashboard)
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
