### PR TITLE
Update query-params when clicking tags

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -2071,7 +2071,7 @@ var Information = {
                             m('p.m-t-md', [
                                 m('p', 'Tags'),
                                 item.attributes.tags.map(function(tag){
-                                    return m('a.tag', { href : '/search/?q=(tags:' + tag + ')', onclick: function(){
+                                    return m('a.tag', { href : '/search/?q="' + tag + '"', onclick: function(){
                                         $osf.trackClick('myProjects', 'information-panel', 'navigate-to-search-by-tag');
                                     }}, tag);
                                 })

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -261,7 +261,7 @@ $(document).ready(function() {
 
     $('body').on('click', '.tagsinput .tag > span', function(e) {
       if(e){
-        window.location = '/search/?q=(tags:"' + $(e.target).text().toString().trim()+ '")';
+        window.location = '/search/?q="' + $(e.target).text().toString().trim()+ '"';
       }
     });
 


### PR DESCRIPTION
## Purpose
- Pass correct query-params when clicking tags on legacy pages [Notion Card](https://www.notion.so/cos/Access-to-Search-Page-from-other-OSF-Legacy-Pages-a99905a7196d426fbb027e1158daf686?pvs=4)

## Changes
- Update tag click behavior on My Projects page
- Update tag click behavior on Project Overview page
- Did not update [website/static/js/search.js](https://github.com/CenterForOpenScience/osf.io/blob/develop/website/static/js/search.js#L274) or [website/templates/search_bar_help_modal.mako](https://github.com/CenterForOpenScience/osf.io/blob/develop/website/templates/search_bar_help_modal.mako#L14) as we should no longer be using these pages, and also it uses Lucene search syntax and this isn't Lucene

## QA Notes
Project Overview page
![Screen Shot 2023-10-05 at 1 55 05 PM](https://github.com/CenterForOpenScience/osf.io/assets/51409893/fe38e4b3-10d9-4ad7-ba92-067404f3293d)

My Projects page
![Screen Shot 2023-10-05 at 1 58 46 PM](https://github.com/CenterForOpenScience/osf.io/assets/51409893/74d38260-acb9-4e6f-9419-00a843e9eaf4)


What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
