### PR TITLE
[ENG-4881] Provide parent folder info to use for the upload URL

### DIFF
--- a/addons/boa/tasks.py
+++ b/addons/boa/tasks.py
@@ -137,7 +137,6 @@ async def submit_to_boa_async(host, username, password, user_guid, project_guid,
 
     logger.debug(f'Uploading Boa query output to OSF: name=[{output_file_name}], upload_url=[{output_upload_url}] ...')
     try:
-        # TODO: either let the caller v1 view provide the full upload URL w/ all query params
         upload_request = request.Request(f'{output_upload_url}&name={output_file_name}')
         upload_request.method = 'PUT'
         upload_request.data = ensure_bytes(boa_job_output)

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1362,19 +1362,18 @@ function _submitToBoaEvent (event, item, col) {
         tb.modal.dismiss();
     }
     function runSubmitToBoa(item, dataset) {
-        console.error('@@@ Submitting item to Boa!', item);
         return $osf.postJSON(
             item.data.nodeApiUrl + 'boa/submit-job/',
             {
                 data: item.data,
+                parent: item.parent().data,
                 dataset: dataset,
             }
         ).done(function(xhr) {
-            console.error('@@@   BOA SUCCESS!', item);
             $osf.growl(
                 'Success',
                 'File submitted to Boa. You will be notified by email when the job is done.',
-                'success',
+                'success'
             );
             tb.modal.dismiss();
             // if (showError) {


### PR DESCRIPTION
## Purpose

Current upload URL in the Boa submission view only uploads file to the root folder.
The view needs to provide the parent folder’s upload URL to task.

## Changes

* Update `fangorn` to submit parent data to Boa submission view in addition to file data
* Update submission view to obtain the upload URL

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4881
