### PR TITLE
[ENG-4897] Unit tests for Boa add-on + improve Boa add-on

### DIFF
--- a/addons/base/exceptions.py
+++ b/addons/base/exceptions.py
@@ -1,21 +1,27 @@
-"""
-Custom exceptions for add-ons.
-"""
-
 class AddonError(Exception):
     pass
+
 
 class InvalidFolderError(AddonError):
     pass
 
+
 class InvalidAuthError(AddonError):
     pass
+
 
 class HookError(AddonError):
     pass
 
+
 class QueryError(AddonError):
     pass
 
+
 class DoesNotExist(AddonError):
+    pass
+
+
+class NotApplicableError(AddonError):
+    """This exception is used by non-storage and/or non-oauth add-ons when they don't need or have certain features."""
     pass

--- a/addons/base/serializer.py
+++ b/addons/base/serializer.py
@@ -141,7 +141,7 @@ class StorageAddonSerializer(OAuthAddonSerializer):
     REQUIRED_URLS = ('auth', 'importAuth', 'folders', 'files', 'config', 'deauthorize', 'accounts')
 
     @abc.abstractmethod
-    def credentials_are_valid(self, user_settings):
+    def credentials_are_valid(self, user_settings, client=None):
         pass
 
     @abc.abstractmethod
@@ -154,7 +154,7 @@ class StorageAddonSerializer(OAuthAddonSerializer):
         current_user_settings = current_user.get_addon(self.addon_short_name)
         user_is_owner = user_settings is not None and user_settings.owner == current_user
 
-        valid_credentials = self.credentials_are_valid(user_settings, client)
+        valid_credentials = self.credentials_are_valid(user_settings, client=client)
 
         result = {
             'userIsOwner': user_is_owner,

--- a/addons/base/tests/views.py
+++ b/addons/base/tests/views.py
@@ -1,19 +1,26 @@
-from rest_framework import status as http_status
-from future.moves.urllib.parse import urlparse, urljoin, parse_qs
-
+from future.moves.urllib.parse import urlparse, parse_qs
 import mock
+from nose.tools import *  # noqa
 import responses
+from rest_framework import status as http_status
+
 from addons.base.tests.base import OAuthAddonTestCaseMixin
 from framework.auth import Auth
 from framework.exceptions import HTTPError
-from nose.tools import (assert_equal, assert_false, assert_in, assert_is_none,
-                        assert_not_equal, assert_raises, assert_true)
 from osf_tests.factories import AuthUserFactory, ProjectFactory
 from osf.utils import permissions
 from website.util import api_url_for, web_url_for
 
 
 class OAuthAddonAuthViewsTestCaseMixin(OAuthAddonTestCaseMixin):
+
+    @property
+    def ADDON_SHORT_NAME(self):
+        raise NotImplementedError()
+
+    @property
+    def ExternalAccountFactory(self):
+        raise NotImplementedError()
 
     @property
     def Provider(self):
@@ -68,7 +75,20 @@ class OAuthAddonAuthViewsTestCaseMixin(OAuthAddonTestCaseMixin):
         res = self.app.delete(url, auth=other_user.auth, expect_errors=True)
         assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
 
+
 class OAuthAddonConfigViewsTestCaseMixin(OAuthAddonTestCaseMixin):
+
+    def __init__(self, *args, **kwargs):
+        super(OAuthAddonConfigViewsTestCaseMixin,self).__init__(*args, **kwargs)
+        self.node_settings = None
+
+    @property
+    def ADDON_SHORT_NAME(self):
+        raise NotImplementedError()
+
+    @property
+    def ExternalAccountFactory(self):
+        raise NotImplementedError()
 
     @property
     def folder(self):
@@ -218,7 +238,34 @@ class OAuthAddonConfigViewsTestCaseMixin(OAuthAddonTestCaseMixin):
         last_log = self.project.logs.latest()
         assert_equal(last_log.action, '{0}_node_deauthorized'.format(self.ADDON_SHORT_NAME))
 
+
 class OAuthCitationAddonConfigViewsTestCaseMixin(OAuthAddonConfigViewsTestCaseMixin):
+
+    def __init__(self, *args, **kwargs):
+        super(OAuthAddonConfigViewsTestCaseMixin,self).__init__(*args, **kwargs)
+        self.mock_verify = None
+        self.node_settings = None
+        self.provider = None
+
+    @property
+    def ADDON_SHORT_NAME(self):
+        raise NotImplementedError()
+
+    @property
+    def ExternalAccountFactory(self):
+        raise NotImplementedError()
+
+    @property
+    def folder(self):
+        raise NotImplementedError()
+
+    @property
+    def Serializer(self):
+        raise NotImplementedError()
+
+    @property
+    def client(self):
+        raise NotImplementedError()
 
     @property
     def citationsProvider(self):

--- a/addons/boa/apps.py
+++ b/addons/boa/apps.py
@@ -1,12 +1,11 @@
 import os
+
 from addons.base.apps import BaseAddonAppConfig
 from addons.boa.settings import MAX_UPLOAD_SIZE
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-TEMPLATE_PATH = os.path.join(
-    HERE,
-    'templates'
-)
+TEMPLATE_PATH = os.path.join(HERE, 'templates')
+
 
 class BoaAddonAppConfig(BaseAddonAppConfig):
 

--- a/addons/boa/models.py
+++ b/addons/boa/models.py
@@ -1,19 +1,15 @@
-# -*- coding: utf-8 -*-
-import logging
-
-from addons.base.models import (BaseOAuthNodeSettings, BaseOAuthUserSettings,
-                                BaseStorageAddon)
 from django.db import models
-from framework.auth import Auth
+
+from addons.base.exceptions import NotApplicableError
+from addons.base.models import BaseOAuthNodeSettings, BaseOAuthUserSettings, BaseStorageAddon
 from addons.boa.serializer import BoaSerializer
 from addons.boa.settings import DEFAULT_HOSTS
+from framework.auth import Auth
 from osf.models.external import BasicAuthProviderMixin
-# from website.util import api_v2_url
-logger = logging.getLogger(__name__)
 
 
 class BoaProvider(BasicAuthProviderMixin):
-    """An alternative to `ExternalProvider` not tied to OAuth"""
+    """Boa provider, an alternative to `ExternalProvider` which is not tied to OAuth"""
 
     name = 'Boa'
     short_name = 'boa'
@@ -21,9 +17,7 @@ class BoaProvider(BasicAuthProviderMixin):
     def __init__(self, account=None, host=None, username=None, password=None):
         if username:
             username = username.lower()
-        return super(BoaProvider, self).__init__(
-            account=account, host=host, username=username, password=password
-        )
+        super(BoaProvider, self).__init__(account=account, host=host, username=username, password=password)
 
     def __repr__(self):
         return '<{name}: {status}>'.format(
@@ -33,6 +27,7 @@ class BoaProvider(BasicAuthProviderMixin):
 
 
 class UserSettings(BaseOAuthUserSettings):
+
     oauth_provider = BoaProvider
     serializer = BoaSerializer
 
@@ -43,13 +38,12 @@ class UserSettings(BaseOAuthUserSettings):
 
 
 class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
+
     oauth_provider = BoaProvider
     serializer = BoaSerializer
 
     folder_id = models.TextField(blank=True, null=True)
-    user_settings = models.ForeignKey(
-        UserSettings, null=True, blank=True, on_delete=models.CASCADE
-    )
+    user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
 
     _api = None
 
@@ -67,7 +61,9 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def folder_name(self):
         return self.folder_id
 
-    # def set_folder(self, folder, auth=None):  # NOTE: no for Boa
+    def set_folder(self, folder, auth=None):
+        """Not applicable to cloud computing add-on."""
+        raise NotApplicableError
 
     def fetch_folder_name(self):
         if self.folder_id == '/':
@@ -85,16 +81,16 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.clear_auth()  # Also performs a .save()
 
     def serialize_waterbutler_credentials(self):
-        # required by superclass, not actually used
-        pass
+        """Not applicable to cloud computing add-on."""
+        raise NotApplicableError
 
     def serialize_waterbutler_settings(self):
-        # required by superclass, not actually used
-        pass
+        """Not applicable to cloud computing add-on."""
+        raise NotApplicableError
 
     def create_waterbutler_log(self, *args, **kwargs):
-        # required by superclass, not actually used
-        pass
+        """Not applicable to cloud computing add-on."""
+        raise NotApplicableError
 
     def after_delete(self, user):
         self.deauthorize(Auth(user=user), add_log=True)
@@ -104,4 +100,6 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.deauthorize(add_log=False)
         self.save()
 
-    # def get_folders(self, **kwargs):  # NOTE: no for boa
+    def get_folders(self, **kwargs):
+        """Not applicable to cloud computing add-on."""
+        raise NotApplicableError

--- a/addons/boa/models.py
+++ b/addons/boa/models.py
@@ -62,7 +62,7 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         return self.folder_id
 
     def set_folder(self, folder, auth=None):
-        """Not applicable to cloud computing add-on."""
+        """Not applicable to remote computing add-on."""
         raise NotApplicableError
 
     def fetch_folder_name(self):
@@ -81,15 +81,15 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.clear_auth()  # Also performs a .save()
 
     def serialize_waterbutler_credentials(self):
-        """Not applicable to cloud computing add-on."""
+        """Not applicable to remote computing add-on."""
         raise NotApplicableError
 
     def serialize_waterbutler_settings(self):
-        """Not applicable to cloud computing add-on."""
+        """Not applicable to remote computing add-on."""
         raise NotApplicableError
 
     def create_waterbutler_log(self, *args, **kwargs):
-        """Not applicable to cloud computing add-on."""
+        """Not applicable to remote computing add-on."""
         raise NotApplicableError
 
     def after_delete(self, user):
@@ -101,5 +101,5 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
         self.save()
 
     def get_folders(self, **kwargs):
-        """Not applicable to cloud computing add-on."""
+        """Not applicable to remote computing add-on."""
         raise NotApplicableError

--- a/addons/boa/routes.py
+++ b/addons/boa/routes.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
+from addons.boa import views
 from framework.routing import Rule, json_renderer
 
-from addons.boa import views
-
-# JSON endpoints
 api_routes = {
     'rules': [
         Rule(
@@ -22,21 +19,18 @@ api_routes = {
             json_renderer,
         ),
         Rule(
-            ['/project/<pid>/boa/settings/',
-             '/project/<pid>/node/<nid>/boa/settings/'],
-            'put',
-            views.boa_set_config,
-            json_renderer
-        ),
-        Rule(
-            ['/project/<pid>/boa/settings/',
-             '/project/<pid>/node/<nid>/boa/settings/'],
+            [
+                '/project/<pid>/boa/settings/',
+                '/project/<pid>/node/<nid>/boa/settings/'
+            ],
             'get',
             views.boa_get_config,
             json_renderer
         ),
         Rule(
-            ['/settings/boa/accounts/'],
+            [
+                '/settings/boa/accounts/'
+            ],
             'post',
             views.boa_add_user_account,
             json_renderer
@@ -50,14 +44,6 @@ api_routes = {
             views.boa_import_auth,
             json_renderer
         ),
-        # NOTE: not for Boa
-        # Rule(
-        #     ['/project/<pid>/boa/folders/',
-        #      '/project/<pid>/node/<nid>/boa/folders/'],
-        #     'get',
-        #     views.boa_folder_list,
-        #     json_renderer
-        # ),
         Rule(
             [
                 '/project/<pid>/boa/submit-job/',

--- a/addons/boa/serializer.py
+++ b/addons/boa/serializer.py
@@ -1,9 +1,8 @@
+from boaapi.boa_client import BoaClient, BOA_API_ENDPOINT, BoaException
+
 from addons.base.serializer import StorageAddonSerializer
 from addons.boa.settings import DEFAULT_HOSTS
 from website.util import web_url_for
-
-from boaapi.boa_client import BoaClient, BOA_API_ENDPOINT
-from boaapi.util import BoaException
 
 
 class BoaSerializer(StorageAddonSerializer):
@@ -22,15 +21,16 @@ class BoaSerializer(StorageAddonSerializer):
         provider = self.node_settings.oauth_provider(external_account)
 
         try:
-            boa = BoaClient(endpoint=BOA_API_ENDPOINT)
-            boa.login(provider.username, provider.password)
-            boa.close()
+            boa_client = BoaClient(endpoint=BOA_API_ENDPOINT)
+            boa_client.login(provider.username, provider.password)
+            boa_client.close()
             return True
         except BoaException:
             return False
 
     @property
     def addon_serialized_urls(self):
+
         node = self.node_settings.owner
         user_settings = self.node_settings.user_settings or self.user_settings
 
@@ -39,15 +39,12 @@ class BoaSerializer(StorageAddonSerializer):
             'accounts': node.api_url_for('boa_account_list'),
             'importAuth': node.api_url_for('boa_import_auth'),
             'deauthorize': node.api_url_for('boa_deauthorize_node'),
-            # 'folders': node.api_url_for('boa_folder_list'),
             'folders': None,
-            # 'files': node.web_url_for('collect_file_trees'),
             'files': None,
-            'config': node.api_url_for('boa_set_config'),
+            'config': None,
         }
         if user_settings:
-            result['owner'] = web_url_for('profile_view_id',
-                                          uid=user_settings.owner._id)
+            result['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
         return result
 
     @property

--- a/addons/boa/serializer.py
+++ b/addons/boa/serializer.py
@@ -12,7 +12,7 @@ class BoaSerializer(StorageAddonSerializer):
     addon_short_name = 'boa'
 
     def serialized_folder(self, node_settings):
-        """Not applicable to cloud-computing add-ons"""
+        """Not applicable to remote computing add-ons"""
         raise NotApplicableError
 
     def credentials_are_valid(self, user_settings, client=None):

--- a/addons/boa/tests/async_mock.py
+++ b/addons/boa/tests/async_mock.py
@@ -1,6 +1,0 @@
-from unittest.mock import MagicMock
-
-
-class AsyncMock(MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)

--- a/addons/boa/tests/factories.py
+++ b/addons/boa/tests/factories.py
@@ -3,15 +3,19 @@ from factory import DjangoModelFactory, Sequence, SubFactory
 from addons.boa.models import UserSettings, NodeSettings
 from osf_tests.factories import UserFactory, ProjectFactory, ExternalAccountFactory
 
+BOA_HOST = 'http://localhost:9999/boa/?q=boa/api'
+BOA_USERNAME = 'fake-boa-username'
+BOA_PASSWORD = 'fake-boa-password'
+
 
 class BoaAccountFactory(ExternalAccountFactory):
 
     provider = 'boa'
     provider_name = 'Fake Boa Provider'
-    provider_id = Sequence(lambda n: 'id-{0}'.format(n))
-    profile_url = Sequence(lambda n: 'https://localhost:9999/{0}/boa'.format(n))
+    provider_id = f'{BOA_HOST}:{BOA_USERNAME}'
+    profile_url = Sequence(lambda n: 'http://localhost:9999/{0}/boa'.format(n))
     oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
-    oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
+    oauth_key = BOA_PASSWORD
     display_name = 'Fake Boa'
 
 

--- a/addons/boa/tests/factories.py
+++ b/addons/boa/tests/factories.py
@@ -12,7 +12,7 @@ class BoaAccountFactory(ExternalAccountFactory):
 
     provider = 'boa'
     provider_name = 'Fake Boa Provider'
-    provider_id = f'{BOA_HOST}:{BOA_USERNAME}'
+    provider_id = Sequence(lambda n: '{0}:{1}-{2}'.format(BOA_HOST, BOA_USERNAME, n))
     profile_url = Sequence(lambda n: 'http://localhost:9999/{0}/boa'.format(n))
     oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
     oauth_key = BOA_PASSWORD

--- a/addons/boa/tests/factories.py
+++ b/addons/boa/tests/factories.py
@@ -1,31 +1,32 @@
-# -*- coding: utf-8 -*-
-import factory
-from factory.django import DjangoModelFactory
-from osf_tests.factories import UserFactory, ProjectFactory, ExternalAccountFactory
+from factory import DjangoModelFactory, Sequence, SubFactory
 
 from addons.boa.models import UserSettings, NodeSettings
+from osf_tests.factories import UserFactory, ProjectFactory, ExternalAccountFactory
 
 
 class BoaAccountFactory(ExternalAccountFactory):
+
     provider = 'boa'
-    provider_id = factory.Sequence(lambda n: 'id-{0}'.format(n))
-    profile_url = factory.Sequence(lambda n: 'https://localhost/{0}/boa'.format(n))
-    oauth_secret = factory.Sequence(lambda n: 'https://localhost/{0}/boa'.format(n))
-    display_name = 'catname'
-    oauth_key = 'meoword'
+    provider_name = 'Fake Boa Provider'
+    provider_id = Sequence(lambda n: 'id-{0}'.format(n))
+    profile_url = Sequence(lambda n: 'https://localhost:9999/{0}/boa'.format(n))
+    oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
+    oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
+    display_name = 'Fake Boa'
 
 
 class BoaUserSettingsFactory(DjangoModelFactory):
+
     class Meta:
         model = UserSettings
 
-    owner = factory.SubFactory(UserFactory)
+    owner = SubFactory(UserFactory)
 
 
 class BoaNodeSettingsFactory(DjangoModelFactory):
+
     class Meta:
         model = NodeSettings
 
-    owner = factory.SubFactory(ProjectFactory)
-    user_settings = factory.SubFactory(BoaUserSettingsFactory)
-    folder_id = '/Documents/'
+    owner = SubFactory(ProjectFactory)
+    user_settings = SubFactory(BoaUserSettingsFactory)

--- a/addons/boa/tests/test_models.py
+++ b/addons/boa/tests/test_models.py
@@ -1,59 +1,41 @@
-from nose.tools import assert_is_not_none, assert_equal
 import pytest
 import unittest
 
-from addons.base.tests.models import (OAuthAddonNodeSettingsTestSuiteMixin,
-                                      OAuthAddonUserSettingTestSuiteMixin)
-
-from addons.boa.models import NodeSettings
-from addons.boa.tests.factories import (
-    BoaAccountFactory, BoaNodeSettingsFactory,
-    BoaUserSettingsFactory
-)
-from addons.boa.settings import USE_SSL
+from addons.base.exceptions import NotApplicableError
+from addons.base.tests.models import OAuthAddonNodeSettingsTestSuiteMixin, OAuthAddonUserSettingTestSuiteMixin
+from addons.boa.tests.utils import BoaAddonTestCaseBaseMixin
+from framework.auth import Auth
+from osf.models import NodeLog
 
 pytestmark = pytest.mark.django_db
 
-class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
 
-    short_name = 'boa'
-    full_name = 'boa'
-    UserSettingsFactory = BoaUserSettingsFactory
-    ExternalAccountFactory = BoaAccountFactory
+class TestUserSettings(BoaAddonTestCaseBaseMixin, OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
+
+    pass
 
 
-class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
+class TestNodeSettings(BoaAddonTestCaseBaseMixin, OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
-    short_name = 'boa'
-    full_name = 'boa'
-    ExternalAccountFactory = BoaAccountFactory
-    NodeSettingsFactory = BoaNodeSettingsFactory
-    NodeSettingsClass = NodeSettings
-    UserSettingsFactory = BoaUserSettingsFactory
+    def test_set_folder(self):
+        with pytest.raises(NotApplicableError):
+            self.node_settings.set_folder('fake_folder_id', auth=Auth(self.user))
 
-    def _node_settings_class_kwargs(self, node, user_settings):
-        return {
-            'user_settings': self.user_settings,
-            'folder_id': '/Documents',
-            'owner': self.node
-        }
+    def test_create_log(self):
+        with pytest.raises(NotApplicableError):
+            self.node_settings.create_waterbutler_log(
+                auth=Auth(user=self.user),
+                action=NodeLog.FILE_ADDED,
+                metadata={
+                    'path': 'fake_path',
+                    'materialized': 'fake_materialized_path',
+                }
+            )
 
     def test_serialize_credentials(self):
-        credentials = self.node_settings.serialize_waterbutler_credentials()
-
-        assert_is_not_none(self.node_settings.external_account.oauth_secret)
-        expected = {
-            'host': self.node_settings.external_account.oauth_secret,
-            'password': 'meoword',
-            'username': 'catname'
-        }
-
-        assert_equal(credentials, expected)
+        with pytest.raises(NotApplicableError):
+            _ = self.node_settings.serialize_waterbutler_credentials()
 
     def test_serialize_settings(self):
-        settings = self.node_settings.serialize_waterbutler_settings()
-        expected = {
-            'folder': self.node_settings.folder_id,
-            'verify_ssl': USE_SSL
-        }
-        assert_equal(settings, expected)
+        with pytest.raises(NotApplicableError):
+            _ = self.node_settings.serialize_waterbutler_settings()

--- a/addons/boa/tests/test_serializer.py
+++ b/addons/boa/tests/test_serializer.py
@@ -2,16 +2,17 @@ import mock
 import pytest
 
 from tests.base import OsfTestCase
-from addons.base.tests.serializers import OAuthAddonSerializerTestSuiteMixin
-from addons.boa.tests.factories import BoaAccountFactory
-from addons.boa.serializer import BoaSerializer
+from addons.base.exceptions import NotApplicableError
+from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin
+from addons.boa.tests.utils import BoaAddonTestCaseBaseMixin
 
 pytestmark = pytest.mark.django_db
 
-class TestBoaSerializer(OAuthAddonSerializerTestSuiteMixin, OsfTestCase):
-    addon_short_name = 'boa'
-    Serializer = BoaSerializer
-    ExternalAccountFactory = BoaAccountFactory
+
+class TestBoaSerializer(BoaAddonTestCaseBaseMixin, StorageAddonSerializerTestSuiteMixin, OsfTestCase):
+
+    def set_provider_id(self, pid=None):
+        self.node_settings.folder_id = pid
 
     def setUp(self):
         self.mock_credentials = mock.patch('addons.boa.serializer.BoaSerializer.credentials_are_valid')
@@ -22,3 +23,9 @@ class TestBoaSerializer(OAuthAddonSerializerTestSuiteMixin, OsfTestCase):
     def tearDown(self):
         self.mock_credentials.stop()
         super(TestBoaSerializer, self).tearDown()
+
+    def test_serialize_settings_authorized_folder_is_set(self):
+        self.set_provider_id(pid='foo')
+        with pytest.raises(NotApplicableError):
+            with mock.patch.object(type(self.node_settings), 'has_auth', return_value=True):
+                _ = self.ser.serialize_settings(self.node_settings, self.user, self.client)

--- a/addons/boa/tests/test_tasks.py
+++ b/addons/boa/tests/test_tasks.py
@@ -4,17 +4,21 @@ from boaapi.status import CompilerStatus, ExecutionStatus
 from http.client import HTTPMessage
 import mock
 import pytest
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 from urllib.error import HTTPError
 
 from addons.boa import settings as boa_settings
 from addons.boa.boa_error_code import BoaErrorCode
 from addons.boa.tasks import submit_to_boa, submit_to_boa_async, handle_boa_error
-from addons.boa.tests.async_mock import AsyncMock
 from osf_tests.factories import AuthUserFactory, ProjectFactory
 from tests.base import OsfTestCase
 from website import settings as osf_settings
 from website.mails import ADDONS_BOA_JOB_COMPLETE, ADDONS_BOA_JOB_FAILURE
+
+
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
 class TestBoaErrorHandling(OsfTestCase):

--- a/addons/boa/tests/test_views.py
+++ b/addons/boa/tests/test_views.py
@@ -1,66 +1,190 @@
-# -*- coding: utf-8 -*-
-from nose.tools import assert_in, assert_equal
 import mock
 import pytest
-
 from rest_framework import status as http_status
 
-from addons.base.tests.views import (
-    OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
-)
-from addons.boa.models import BoaProvider
+from addons.base.tests.views import OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
+from addons.boa.tests.utils import BoaBasicAuthAddonTestCase
+from osf_tests.factories import AuthUserFactory
+from osf.utils import permissions
 from tests.base import OsfTestCase
-from addons.boa.serializer import BoaSerializer
-from addons.boa.tests.utils import BoaAddonTestCase
 
 pytestmark = pytest.mark.django_db
 
-class TestAuthViews(OAuthAddonAuthViewsTestCaseMixin, BoaAddonTestCase, OsfTestCase):
 
-    @property
-    def Provider(self):
-        return BoaProvider
+class TestAuthViews(BoaBasicAuthAddonTestCase, OAuthAddonAuthViewsTestCaseMixin, OsfTestCase):
 
     def test_oauth_start(self):
+        """Not applicable to non-oauth add-ons."""
         pass
 
     def test_oauth_finish(self):
+        """Not applicable to non-oauth add-ons."""
         pass
 
 
-class TestConfigViews(BoaAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
-    Serializer = BoaSerializer
-    client = BoaProvider
-
-    @property
-    def folder(self):
-        return {'name': '/Documents/', 'path': '/Documents/'}
+class TestConfigViews(BoaBasicAuthAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
 
     def setUp(self):
         super(TestConfigViews, self).setUp()
-        self.mock_ser_api = mock.patch('boa.Client.login')
-        self.mock_ser_api.start()
-        self.set_node_settings(self.node_settings)
+        self.mock_boa_client_login = mock.patch('boaapi.boa_client.BoaClient.login')
+        self.mock_boa_client_close = mock.patch('boaapi.boa_client.BoaClient.close')
+        self.mock_boa_client_login.start()
+        self.mock_boa_client_close.start()
 
     def tearDown(self):
-        self.mock_ser_api.stop()
+        self.mock_boa_client_close.stop()
+        self.mock_boa_client_login.stop()
         super(TestConfigViews, self).tearDown()
 
-    @mock.patch('addons.boa.models.NodeSettings.get_folders')
-    def test_folder_list(self, mock_connection):
-        #test_get_datasets
-        mock_connection.return_value = ['/Documents/', '/Pictures/', '/Videos/']
+    def test_folder_list(self):
+        """Not applicable to remote computing add-ons."""
+        pass
 
-        super(TestConfigViews, self).test_folder_list()
+    def test_set_config(self):
+        """Not applicable to remote computing add-ons."""
+        pass
 
     def test_get_config(self):
-        url = self.project.api_url_for(
-            '{0}_get_config'.format(self.ADDON_SHORT_NAME))
-        res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
-        assert_in('result', res.json)
+        """Lacking coverage for remote computing add-ons and thus replaced by:
+            * ``test_get_config_owner_with_external_account()``
+            * ``test_get_config_owner_without_external_account()``
+            * ``test_get_config_write_contrib_with_external_account()``
+            * ``test_get_config_write_contrib_without_external_account()``
+            * ``test_get_config_admin_contrib_with_external_account()``
+            * ``test_get_config_admin_contrib_without_external_account()``
+        """
+        pass
+
+    def test_get_config_unauthorized(self):
+        """Lacking coverage for remote computing add-ons and thus replaced by:
+            * ``test_get_config_read_contrib_with_valid_credentials()``
+            * ``test_get_config_read_contrib_without_valid_credentials()``
+        """
+        pass
+
+    def test_get_config_owner_with_external_account(self):
+
+        self.node_settings.set_auth(self.external_account, self.user)
         serialized = self.Serializer().serialize_settings(
             self.node_settings,
             self.user,
+            self.client
         )
-        assert_equal(serialized, res.json['result'])
+        assert self.node_settings.external_account is not None
+        assert serialized['validCredentials'] is True
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=self.user.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_owner_without_external_account(self):
+
+        serialized = self.Serializer().serialize_settings(
+            self.node_settings,
+            self.user,
+            self.client
+        )
+        assert self.node_settings.external_account is None
+        assert serialized['validCredentials'] is False
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=self.user.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_write_contrib_with_external_account(self):
+
+        user_write = AuthUserFactory()
+        self.node_settings.set_auth(self.external_account, self.user)
+        self.project.add_contributor(user_write, permissions=permissions.WRITE, auth=self.auth, save=True)
+        serialized = self.Serializer().serialize_settings(
+            self.node_settings,
+            user_write,
+            self.client
+        )
+        assert self.node_settings.external_account is not None
+        assert serialized['validCredentials'] is True
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=user_write.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_write_contrib_without_external_account(self):
+
+        user_write = AuthUserFactory()
+        self.project.add_contributor(user_write, permissions=permissions.WRITE, auth=self.auth, save=True)
+        serialized = self.Serializer().serialize_settings(
+            self.node_settings,
+            user_write,
+            self.client
+        )
+        assert self.node_settings.external_account is None
+        assert serialized['validCredentials'] is False
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=user_write.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_admin_contrib_with_external_account(self):
+
+        user_admin = AuthUserFactory()
+        self.node_settings.set_auth(self.external_account, self.user)
+        self.project.add_contributor(user_admin, permissions=permissions.ADMIN, auth=self.auth, save=True)
+        serialized = self.Serializer().serialize_settings(
+            self.node_settings,
+            user_admin,
+            self.client
+        )
+        assert self.node_settings.external_account is not None
+        assert serialized['validCredentials'] is True
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=user_admin.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_admin_contrib_without_external_account(self):
+
+        user_admin = AuthUserFactory()
+        self.project.add_contributor(user_admin, permissions=permissions.ADMIN, auth=self.auth, save=True)
+        serialized = self.Serializer().serialize_settings(
+            self.node_settings,
+            user_admin,
+            self.client
+        )
+        assert self.node_settings.external_account is None
+        assert serialized['validCredentials'] is False
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=user_admin.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_read_contrib_with_valid_credentials(self):
+
+        user_read_only = AuthUserFactory()
+        self.project.add_contributor(user_read_only, permissions=permissions.READ, auth=self.auth, save=True)
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        with mock.patch.object(type(self.Serializer()), 'credentials_are_valid', return_value=True):
+            res = self.app.get(url, auth=user_read_only.auth, expect_errors=True)
+            assert res.status_code == http_status.HTTP_403_FORBIDDEN
+
+    def test_get_config_read_contrib_without_valid_credentials(self):
+
+        user_read_only = AuthUserFactory()
+        self.project.add_contributor(user_read_only, permissions=permissions.READ, auth=self.auth, save=True)
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        with mock.patch.object(type(self.Serializer()), 'credentials_are_valid', return_value=False):
+            res = self.app.get(url, auth=user_read_only.auth, expect_errors=True)
+            assert res.status_code == http_status.HTTP_403_FORBIDDEN

--- a/addons/boa/tests/test_views.py
+++ b/addons/boa/tests/test_views.py
@@ -3,7 +3,7 @@ import pytest
 from rest_framework import status as http_status
 
 from addons.base.tests.views import OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
-from addons.boa.tests.factories import BOA_HOST, BOA_USERNAME, BOA_PASSWORD
+from addons.boa.tests.factories import BOA_HOST, BOA_PASSWORD
 from addons.boa.tests.utils import BoaBasicAuthAddonTestCase
 from addons.boa.boa_error_code import BoaErrorCode
 from api.base.utils import waterbutler_api_url_for
@@ -248,7 +248,7 @@ class TestBoaSubmitViews(BoaBasicAuthAddonTestCase, OsfTestCase):
             assert res.status_code == http_status.HTTP_200_OK
             mock_submit_s.assert_called_with(
                 BOA_HOST,
-                BOA_USERNAME,
+                mock.ANY,
                 BOA_PASSWORD,
                 self.user._id,
                 self.project._id,
@@ -267,7 +267,7 @@ class TestBoaSubmitViews(BoaBasicAuthAddonTestCase, OsfTestCase):
             assert res.status_code == http_status.HTTP_200_OK
             mock_submit_s.assert_called_with(
                 BOA_HOST,
-                BOA_USERNAME,
+                mock.ANY,
                 BOA_PASSWORD,
                 self.user._id,
                 self.project._id,

--- a/addons/boa/tests/utils.py
+++ b/addons/boa/tests/utils.py
@@ -1,9 +1,8 @@
 from abc import ABC
 
-from addons.base.tests.base import AddonTestCase
+from addons.base.tests.base import AddonTestCase, OAuthAddonTestCaseMixin
 from addons.boa.models import BoaProvider, BoaSerializer, NodeSettings
 from addons.boa.tests.factories import BoaAccountFactory, BoaNodeSettingsFactory, BoaUserSettingsFactory
-from framework.auth import Auth
 
 
 class BoaAddonTestCaseBaseMixin(ABC):
@@ -22,7 +21,7 @@ class BoaAddonTestCaseBaseMixin(ABC):
     UserSettingsFactory = BoaUserSettingsFactory
 
 
-class BoaBasicAuthAddonTestCase(BoaAddonTestCaseBaseMixin, AddonTestCase):
+class BoaBasicAuthAddonTestCase(BoaAddonTestCaseBaseMixin, OAuthAddonTestCaseMixin, AddonTestCase):
 
     def __init__(self, *args, **kwargs):
         super(BoaBasicAuthAddonTestCase, self).__init__(*args, **kwargs)
@@ -30,11 +29,7 @@ class BoaBasicAuthAddonTestCase(BoaAddonTestCaseBaseMixin, AddonTestCase):
         self.external_account = None
 
     def set_user_settings(self, settings):
-        self.external_account = self.ExternalAccountFactory()
-        self.external_account.save()
-        self.user.external_accounts.add(self.external_account)
-        self.user.save()
-        self.auth = Auth(self.user)
+        super(BoaBasicAuthAddonTestCase, self).set_user_settings(settings)
 
     def set_node_settings(self, settings):
-        self.user_settings.grant_oauth_access(self.project, self.external_account)
+        super(BoaBasicAuthAddonTestCase, self).set_node_settings(settings)

--- a/addons/boa/tests/utils.py
+++ b/addons/boa/tests/utils.py
@@ -1,11 +1,9 @@
-from abc import ABC
-
 from addons.base.tests.base import AddonTestCase, OAuthAddonTestCaseMixin
 from addons.boa.models import BoaProvider, BoaSerializer, NodeSettings
 from addons.boa.tests.factories import BoaAccountFactory, BoaNodeSettingsFactory, BoaUserSettingsFactory
 
 
-class BoaAddonTestCaseBaseMixin(ABC):
+class BoaAddonTestCaseBaseMixin(object):
 
     short_name = 'boa'
     full_name = 'Boa'

--- a/addons/boa/tests/utils.py
+++ b/addons/boa/tests/utils.py
@@ -1,22 +1,40 @@
-from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
-from addons.boa.models import BoaProvider, NodeSettings
-from addons.boa.tests.factories import (
-    BoaAccountFactory, BoaNodeSettingsFactory,
-    BoaUserSettingsFactory
-)
+from abc import ABC
 
-class BoaAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
+from addons.base.tests.base import AddonTestCase
+from addons.boa.models import BoaProvider, BoaSerializer, NodeSettings
+from addons.boa.tests.factories import BoaAccountFactory, BoaNodeSettingsFactory, BoaUserSettingsFactory
+from framework.auth import Auth
+
+
+class BoaAddonTestCaseBaseMixin(ABC):
 
     short_name = 'boa'
     full_name = 'Boa'
+    client = None  # Non-oauth add-on does not have client
+    folder = None  # Remote computing add-on does not have folder
+    addon_short_name = 'boa'
     ADDON_SHORT_NAME = 'boa'
-    ExternalAccountFactory = BoaAccountFactory
     Provider = BoaProvider
+    Serializer = BoaSerializer
+    ExternalAccountFactory = BoaAccountFactory
     NodeSettingsFactory = BoaNodeSettingsFactory
     NodeSettingsClass = NodeSettings
     UserSettingsFactory = BoaUserSettingsFactory
-    # folder = {
-    #     'path': '/Documents/',
-    #     'name': '/Documents',
-    #     'id': '/Documents/'
-    # }
+
+
+class BoaBasicAuthAddonTestCase(BoaAddonTestCaseBaseMixin, AddonTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(BoaBasicAuthAddonTestCase, self).__init__(*args, **kwargs)
+        self.auth = None
+        self.external_account = None
+
+    def set_user_settings(self, settings):
+        self.external_account = self.ExternalAccountFactory()
+        self.external_account.save()
+        self.user.external_accounts.add(self.external_account)
+        self.user.save()
+        self.auth = Auth(self.user)
+
+    def set_node_settings(self, settings):
+        self.user_settings.grant_oauth_access(self.project, self.external_account)

--- a/addons/boa/views.py
+++ b/addons/boa/views.py
@@ -22,48 +22,31 @@ logger = logging.getLogger(__name__)
 SHORT_NAME = 'boa'
 FULL_NAME = 'Boa'
 
-boa_account_list = generic_views.account_list(
-    SHORT_NAME,
-    BoaSerializer
-)
-
-boa_import_auth = generic_views.import_auth(
-    SHORT_NAME,
-    BoaSerializer
-)
-
-boa_deauthorize_node = generic_views.deauthorize_node(
-    SHORT_NAME
-)
+boa_account_list = generic_views.account_list(SHORT_NAME, BoaSerializer)
+boa_import_auth = generic_views.import_auth(SHORT_NAME, BoaSerializer)
+boa_deauthorize_node = generic_views.deauthorize_node(SHORT_NAME)
+boa_get_config = generic_views.get_config(SHORT_NAME, BoaSerializer)
 
 
 @must_be_logged_in
 def boa_add_user_account(auth, **kwargs):
-    """
-        Verifies new external account credentials and adds to user's list
-
-        This view expects `username` and `password` fields in the JSON
-        body of the request.
+    """Verifies new external account credentials and adds to user's list.
+    This view expects `username` and `password` fields in the JSON body of the request.
     """
 
     username = request.json.get('username')
     password = request.json.get('password')
     try:
-        b = BoaClient(endpoint=BOA_API_ENDPOINT)
-        b.login(username, password)
-        b.close()
+        boa_client = BoaClient(endpoint=BOA_API_ENDPOINT)
+        boa_client.login(username, password)
+        boa_client.close()
     except BoaException:
-        return {
-            'message': 'Boa Login failed.'
-        }, http_status.HTTP_401_UNAUTHORIZED
+        return {'message': 'Boa Login failed.'}, http_status.HTTP_401_UNAUTHORIZED
 
-    provider = BoaProvider(
-        account=None, host=BOA_API_ENDPOINT, username=username, password=password
-    )
+    provider = BoaProvider(account=None, host=BOA_API_ENDPOINT, username=username, password=password)
     try:
         provider.account.save()
-    except ValidationError:  # as vexc:
-        # ... or get the old one
+    except ValidationError:
         provider.account = ExternalAccount.objects.get(
             provider=provider.short_name,
             provider_id='{}:{}'.format(BOA_API_ENDPOINT, username).lower()
@@ -71,7 +54,7 @@ def boa_add_user_account(auth, **kwargs):
         if provider.account.oauth_key != password:
             provider.account.oauth_key = password
             provider.account.save()
-    except Exception:  # as exc:
+    except Exception:
         return {}
 
     user = auth.user
@@ -80,35 +63,7 @@ def boa_add_user_account(auth, **kwargs):
 
     user.get_or_add_addon('boa', auth=auth)
     user.save()
-
     return {}
-
-# @must_have_addon(SHORT_NAME, 'user')
-# @must_have_addon(SHORT_NAME, 'node')
-# def boa_folder_list(node_addon, user_addon, **kwargs):
-#     """ Returns all the subsequent folders under the folder id passed.
-#         Not easily generalizable due to `path` kwarg.
-#     """
-#     path = request.args.get('path')
-#     return node_addon.get_folders(path=path)
-
-
-def _set_folder(node_addon, folder, auth):
-    node_addon.set_folder(folder['path'], auth=auth)
-    node_addon.save()
-
-
-boa_set_config = generic_views.set_config(
-    SHORT_NAME,
-    FULL_NAME,
-    BoaSerializer,
-    _set_folder
-)
-
-boa_get_config = generic_views.get_config(
-    SHORT_NAME,
-    BoaSerializer
-)
 
 
 @must_be_logged_in

--- a/addons/boa/views.py
+++ b/addons/boa/views.py
@@ -96,7 +96,7 @@ def boa_submit_job(node_addon, user_addon, **kwargs):
     if is_addon_root:
         base_url = project_node.osfstorage_region.waterbutler_url
         parent_wb_url = waterbutler_api_url_for(project_guid, 'osfstorage', _internal=True, base_url=base_url)
-        output_upload_url = f'{parent_wb_url}?kind=file&name='
+        output_upload_url = f'{parent_wb_url}?kind=file'
     else:
         output_upload_url = req_params['parent']['links']['upload'].replace(osf_settings.WATERBUTLER_URL,
                                                                             osf_settings.WATERBUTLER_INTERNAL_URL)

--- a/addons/owncloud/serializer.py
+++ b/addons/owncloud/serializer.py
@@ -17,6 +17,8 @@ class OwnCloudSerializer(StorageAddonSerializer):
     def credentials_are_valid(self, user_settings, client=None):
         node = self.node_settings
         external_account = node.external_account
+        if external_account is None:
+            return False
         provider = self.node_settings.oauth_provider(external_account)
 
         try:

--- a/addons/owncloud/tests/test_models.py
+++ b/addons/owncloud/tests/test_models.py
@@ -1,35 +1,18 @@
-from nose.tools import assert_is_not_none, assert_equal
 import pytest
 import unittest
 
-from addons.base.tests.models import (OAuthAddonNodeSettingsTestSuiteMixin,
-                                      OAuthAddonUserSettingTestSuiteMixin)
-
-from addons.owncloud.models import NodeSettings
-from addons.owncloud.tests.factories import (
-    OwnCloudAccountFactory, OwnCloudNodeSettingsFactory,
-    OwnCloudUserSettingsFactory
-)
+from addons.base.tests.models import OAuthAddonNodeSettingsTestSuiteMixin, OAuthAddonUserSettingTestSuiteMixin
 from addons.owncloud.settings import USE_SSL
+from addons.owncloud.tests.utils import OwnCloudAddonTestCaseBaseMixin
 
 pytestmark = pytest.mark.django_db
 
-class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
 
-    short_name = 'owncloud'
-    full_name = 'ownCloud'
-    UserSettingsFactory = OwnCloudUserSettingsFactory
-    ExternalAccountFactory = OwnCloudAccountFactory
+class TestUserSettings(OwnCloudAddonTestCaseBaseMixin, OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
+    pass
 
 
-class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
-
-    short_name = 'owncloud'
-    full_name = 'ownCloud'
-    ExternalAccountFactory = OwnCloudAccountFactory
-    NodeSettingsFactory = OwnCloudNodeSettingsFactory
-    NodeSettingsClass = NodeSettings
-    UserSettingsFactory = OwnCloudUserSettingsFactory
+class TestNodeSettings(OwnCloudAddonTestCaseBaseMixin, OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
 
     def _node_settings_class_kwargs(self, node, user_settings):
         return {
@@ -41,14 +24,14 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def test_serialize_credentials(self):
         credentials = self.node_settings.serialize_waterbutler_credentials()
 
-        assert_is_not_none(self.node_settings.external_account.oauth_secret)
+        assert self.node_settings.external_account.oauth_secret is not None
         expected = {
             'host': self.node_settings.external_account.oauth_secret,
             'password': 'meoword',
             'username': 'catname'
         }
 
-        assert_equal(credentials, expected)
+        assert credentials == expected
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
@@ -56,4 +39,4 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
             'folder': self.node_settings.folder_id,
             'verify_ssl': USE_SSL
         }
-        assert_equal(settings, expected)
+        assert settings == expected

--- a/addons/owncloud/tests/test_serializer.py
+++ b/addons/owncloud/tests/test_serializer.py
@@ -3,18 +3,14 @@ import pytest
 
 from tests.base import OsfTestCase
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin
-from addons.owncloud.tests.factories import OwnCloudAccountFactory
-from addons.owncloud.serializer import OwnCloudSerializer
+from addons.owncloud.tests.utils import OwnCloudAddonTestCaseBaseMixin
 
 pytestmark = pytest.mark.django_db
 
-class TestOwnCloudSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCase):
-    addon_short_name = 'owncloud'
-    Serializer = OwnCloudSerializer
-    ExternalAccountFactory = OwnCloudAccountFactory
-    client = None
 
-    def set_provider_id(self, pid):
+class TestOwnCloudSerializer(OwnCloudAddonTestCaseBaseMixin, StorageAddonSerializerTestSuiteMixin, OsfTestCase):
+
+    def set_provider_id(self, pid=None):
         self.node_settings.folder_id = pid
 
     def setUp(self):

--- a/addons/owncloud/tests/test_views.py
+++ b/addons/owncloud/tests/test_views.py
@@ -1,25 +1,15 @@
-# -*- coding: utf-8 -*-
-from nose.tools import assert_in, assert_equal
 import mock
 import pytest
-
 from rest_framework import status as http_status
 
-from addons.base.tests.views import (
-    OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
-)
-from addons.owncloud.models import OwnCloudProvider
+from addons.base.tests.views import OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
+from addons.owncloud.tests.utils import OwnCloudBasicAuthAddonTestCase
 from tests.base import OsfTestCase
-from addons.owncloud.serializer import OwnCloudSerializer
-from addons.owncloud.tests.utils import OwnCloudAddonTestCase
 
 pytestmark = pytest.mark.django_db
 
-class TestAuthViews(OwnCloudAddonTestCase, OAuthAddonAuthViewsTestCaseMixin, OsfTestCase):
 
-    @property
-    def Provider(self):
-        return OwnCloudProvider
+class TestAuthViews(OwnCloudBasicAuthAddonTestCase, OAuthAddonAuthViewsTestCaseMixin, OsfTestCase):
 
     def test_oauth_start(self):
         pass
@@ -28,39 +18,53 @@ class TestAuthViews(OwnCloudAddonTestCase, OAuthAddonAuthViewsTestCaseMixin, Osf
         pass
 
 
-class TestConfigViews(OwnCloudAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
-    Serializer = OwnCloudSerializer
-    client = OwnCloudProvider
-
-    @property
-    def folder(self):
-        return {'name': '/Documents/', 'path': '/Documents/'}
+class TestConfigViews(OwnCloudBasicAuthAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
 
     def setUp(self):
         super(TestConfigViews, self).setUp()
-        self.mock_ser_api = mock.patch('owncloud.Client.login')
-        self.mock_ser_api.start()
-        self.set_node_settings(self.node_settings)
+        self.mock_owncloud_login = mock.patch('owncloud.Client.login')
+        self.mock_owncloud_logout = mock.patch('owncloud.Client.logout')
+        self.mock_owncloud_login.start()
+        self.mock_owncloud_logout.start()
 
     def tearDown(self):
-        self.mock_ser_api.stop()
+        self.mock_owncloud_logout.stop()
+        self.mock_owncloud_login.stop()
         super(TestConfigViews, self).tearDown()
 
     @mock.patch('addons.owncloud.models.NodeSettings.get_folders')
-    def test_folder_list(self, mock_connection):
-        #test_get_datasets
-        mock_connection.return_value = ['/Documents/', '/Pictures/', '/Videos/']
-
+    def test_folder_list(self, mock_get_folders):
+        mock_get_folders.return_value = ['/Documents/', '/Pictures/', '/Videos/']
         super(TestConfigViews, self).test_folder_list()
 
     def test_get_config(self):
-        url = self.project.api_url_for(
-            '{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        """Lacking coverage for non-oauth add-ons and thus replaced by:
+            * ``test_get_config_with_external_account()``
+            * ``test_get_config_without_external_account()``
+        """
+        pass
+
+    def test_get_config_with_external_account(self):
+
+        self.node_settings.set_auth(self.external_account, self.user)
+        serialized = self.Serializer().serialize_settings(self.node_settings, self.user)
+        assert self.node_settings.external_account is not None
+        assert serialized['validCredentials'] is True
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
-        assert_in('result', res.json)
-        serialized = self.Serializer().serialize_settings(
-            self.node_settings,
-            self.user,
-        )
-        assert_equal(serialized, res.json['result'])
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']
+
+    def test_get_config_without_external_account(self):
+
+        serialized = self.Serializer().serialize_settings(self.node_settings, self.user)
+        assert self.node_settings.external_account is None
+        assert serialized['validCredentials'] is False
+
+        url = self.project.api_url_for('{0}_get_config'.format(self.ADDON_SHORT_NAME))
+        res = self.app.get(url, auth=self.user.auth)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
+        assert serialized == res.json['result']

--- a/addons/owncloud/tests/test_views.py
+++ b/addons/owncloud/tests/test_views.py
@@ -15,7 +15,7 @@ from addons.owncloud.tests.utils import OwnCloudAddonTestCase
 
 pytestmark = pytest.mark.django_db
 
-class TestAuthViews(OAuthAddonAuthViewsTestCaseMixin, OwnCloudAddonTestCase, OsfTestCase):
+class TestAuthViews(OwnCloudAddonTestCase, OAuthAddonAuthViewsTestCaseMixin, OsfTestCase):
 
     @property
     def Provider(self):

--- a/addons/owncloud/tests/utils.py
+++ b/addons/owncloud/tests/utils.py
@@ -1,22 +1,37 @@
-from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
-from addons.owncloud.models import OwnCloudProvider, NodeSettings
+from addons.base.tests.base import AddonTestCase, OAuthAddonTestCaseMixin
+from addons.owncloud.models import NodeSettings, OwnCloudProvider, OwnCloudSerializer
 from addons.owncloud.tests.factories import (
-    OwnCloudAccountFactory, OwnCloudNodeSettingsFactory,
-    OwnCloudUserSettingsFactory
+    OwnCloudAccountFactory,
+    OwnCloudNodeSettingsFactory,
+    OwnCloudUserSettingsFactory,
 )
 
-class OwnCloudAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
+
+class OwnCloudAddonTestCaseBaseMixin(object):
 
     short_name = 'owncloud'
     full_name = 'OwnCloud'
+    client = None  # Non-oauth add-on does not have client
+    folder = {'path': '/Documents/', 'name': '/Documents', 'id': '/Documents/'}
+    addon_short_name = 'owncloud'
     ADDON_SHORT_NAME = 'owncloud'
-    ExternalAccountFactory = OwnCloudAccountFactory
     Provider = OwnCloudProvider
+    Serializer = OwnCloudSerializer
+    ExternalAccountFactory = OwnCloudAccountFactory
     NodeSettingsFactory = OwnCloudNodeSettingsFactory
     NodeSettingsClass = NodeSettings
     UserSettingsFactory = OwnCloudUserSettingsFactory
-    folder = {
-        'path': '/Documents/',
-        'name': '/Documents',
-        'id': '/Documents/'
-    }
+
+
+class OwnCloudBasicAuthAddonTestCase(OwnCloudAddonTestCaseBaseMixin, OAuthAddonTestCaseMixin, AddonTestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(OwnCloudBasicAuthAddonTestCase, self).__init__(*args, **kwargs)
+        self.auth = None
+        self.external_account = None
+
+    def set_user_settings(self, settings):
+        super(OwnCloudBasicAuthAddonTestCase, self).set_user_settings(settings)
+
+    def set_node_settings(self, settings):
+        super(OwnCloudBasicAuthAddonTestCase, self).set_node_settings(settings)

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -11,6 +11,7 @@ from framework.auth import Auth
 from website.util import rubeus
 from website.util.rubeus import sort_by_name
 
+
 class TestRubeus(OsfTestCase):
 
     def setUp(self):
@@ -316,8 +317,9 @@ class TestSerializingNodeWithAddon(OsfTestCase):
         self.serializer = rubeus.NodeFileCollector(node=self.project, auth=self.auth)
 
     def test_collect_addons(self):
-        ret = self.serializer._collect_addons(self.project)
-        assert_equal(ret, [serialized])
+        return_value, active_addons = self.serializer._collect_addons(self.project)
+        assert_equal(return_value, [serialized])
+        assert_equal(len(active_addons), 1)
 
     def test_sort_by_name(self):
         files = [

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -241,6 +241,7 @@ class NodeFileCollector(object):
 
     def _get_nodes(self, node, grid_root=None):
         data = []
+        active_addons = []
         if node.can_view(auth=self.auth):
             serialized_addons, active_addons = self._collect_addons(node)
             serialized_children = [
@@ -251,18 +252,17 @@ class NodeFileCollector(object):
         return self._serialize_node(node, children=data, active_addons=active_addons)
 
     def _collect_addons(self, node):
-        rv = []
+        return_value = []
         active_addons = []
         for addon in node.get_addons():
             if addon.has_auth:
                 active_addons.append(addon.config.short_name)
-
             if addon.config.has_hgrid_files:
                 # WARNING: get_hgrid_data can return None if the addon is added but has no credentials.
                 try:
                     temp = addon.config.get_hgrid_data(addon, self.auth, **self.extra)
                 except Exception as e:
-                    logger.warn(
+                    logger.warning(
                         getattr(
                             e,
                             'data',
@@ -270,7 +270,7 @@ class NodeFileCollector(object):
                         )
                     )
                     sentry.log_exception()
-                    rv.append({
+                    return_value.append({
                         KIND: FOLDER,
                         'unavailable': True,
                         'iconUrl': addon.config.icon_url,
@@ -280,8 +280,8 @@ class NodeFileCollector(object):
                         'name': '{} is currently unavailable'.format(addon.config.full_name),
                     })
                     continue
-                rv.extend(sort_by_name(temp) or [])
-        return rv, active_addons
+                return_value.extend(sort_by_name(temp) or [])
+        return return_value, active_addons
 
 
 # TODO: these might belong in addons module


### PR DESCRIPTION
## Purpose

* Fix/update unit tests for Boa add-on
* Improve add-on code

Note: refer to diff in https://github.com/cslzchen/osf.io/pull/17 before https://github.com/CenterForOpenScience/osf.io/pull/10474 is merged

## Changes

### Code

* Add-on base
  * Added a new exception: `NotApplicableError`
  * Fixed signature for `credentials_are_valid()` and its usage
* Boa
  * Removed unused routes, views and methods
  * Raise ``NonApplicableError()`` in stead of `return None` , `pass` or being commented out
  * Added sentry logs
  * Fixed a no-effect bug in `boa_submit_job()` where output URL was built with and extra parameter `&name=`
  * Updated code style, comments and `docstr`
* Owncloud
  * `credentials_are_valid()` returns False earlier if `external_account` is None
* Website
  * Fixed an issue in `_collect_addons()` where `active_addons` is accessed before definition

### Tests

* Addon-on base tests
  * Fixed class inheritance initialization issue
* Boa tests
  * Rewrote `BoaAddonTestCase` into `BoaAddonTestCaseBaseMixin` and `BoaBasicAuthAddonTestCase`
  * Refactored factories
  * Rewrote view test classes to inherit from `BoaBasicAuthAddonTestCase`; rewrote model and serializer test classes to inherit from `BoaAddonTestCaseBaseMixin`.
  * Fixed and expanded view/model/serializer tests
  * Added new view tests for `boa_sumbit_job()`
  * Move `AsyncMock` into test utils.

* Owncloud tests
  * Similar to Boa, refactored

* Website tests
  * Fixed `test_collect_addons()`

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-4897
