### PR TITLE
[ENG-4642] Cleanups for Boa's legacy front-end

### DIFF
--- a/addons/boa/README.md
+++ b/addons/boa/README.md
@@ -1,7 +1,9 @@
-OSF Boa Addon
+# OSF Boa Addon
 
+Via https://boa.cs.iastate.edu/:
+
+> Boa is a domain-specific language and infrastructure that eases mining software repositories. Boa's infrastructure leverages distributed computing techniques to execute queries against hundreds of thousands of software projects very efficiently.
 
 ## Setup:
-1. Copy settings/local-dist.py to settings/local.py and change the necessary settings.
-2. The setting `DEFAULT_HOSTS` can be set to a list of known hosts that satisfies [OCS1.7](https://www.freedesktop.org/wiki/Specifications/open-collaboration-services-1.7/). While this is not necessary, a default list can be used to provide users with suggested hosts.
-3. Make sure GnuPG is enabled as below:
+
+1. No local server configuration is required for the Boa addon to work.  Users will need to [request an account](https://boa.cs.iastate.edu/request/) from Boa to connect and enable the addon.

--- a/addons/boa/apps.py
+++ b/addons/boa/apps.py
@@ -1,7 +1,6 @@
 import os
 
 from addons.base.apps import BaseAddonAppConfig
-from addons.boa.settings import MAX_UPLOAD_SIZE
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(HERE, 'templates')

--- a/addons/boa/apps.py
+++ b/addons/boa/apps.py
@@ -19,7 +19,6 @@ class BoaAddonAppConfig(BaseAddonAppConfig):
     has_hgrid_files = False
     node_settings_template = os.path.join(TEMPLATE_PATH, 'boa_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'boa_user_settings.mako')
-    max_file_size = MAX_UPLOAD_SIZE
 
     actions = ()
 

--- a/addons/boa/apps.py
+++ b/addons/boa/apps.py
@@ -15,7 +15,7 @@ class BoaAddonAppConfig(BaseAddonAppConfig):
     short_name = 'boa'
     owners = ['user', 'node']
     configs = ['accounts', 'node']
-    categories = ['Remote computing']
+    categories = ['remote-computing']
     has_hgrid_files = False
     node_settings_template = os.path.join(TEMPLATE_PATH, 'boa_node_settings.mako')
     user_settings_template = os.path.join(TEMPLATE_PATH, 'boa_user_settings.mako')

--- a/addons/boa/settings/defaults.py
+++ b/addons/boa/settings/defaults.py
@@ -1,3 +1,4 @@
+# Not used currently, but may be expanded to accommodate other Boa databases in the future
 DEFAULT_HOSTS = []
 
 # Max file size allowed for submission

--- a/addons/boa/settings/defaults.py
+++ b/addons/boa/settings/defaults.py
@@ -1,8 +1,4 @@
 DEFAULT_HOSTS = []
-USE_SSL = True
-
-# Note: not applicable to the Boa addon
-MAX_UPLOAD_SIZE = 512  # 512 MB
 
 # Max file size allowed for submission
 MAX_SUBMISSION_SIZE = 512 * 1024  # 512 KB

--- a/addons/boa/settings/local-dist.py
+++ b/addons/boa/settings/local-dist.py
@@ -1,2 +1,1 @@
 DEFAULT_HOSTS = ['https://localhost/boa']
-USE_SSL = True

--- a/addons/boa/settings/local-dist.py
+++ b/addons/boa/settings/local-dist.py
@@ -1,1 +1,2 @@
-DEFAULT_HOSTS = ['https://localhost/boa']
+# Not used currently, but may be expanded to accommodate other Boa databases in the future
+DEFAULT_HOSTS = []

--- a/addons/boa/static/boaUserConfig.js
+++ b/addons/boa/static/boaUserConfig.js
@@ -20,7 +20,7 @@ var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
         self.password = ko.observable();
         self.loaded = ko.observable(false);
     },
-    fetch :function(){
+    fetch: function(){
         var self = this;
         $.ajax({
             url: self.url,
@@ -38,10 +38,10 @@ var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
             });
         });
     },
-    clearModal : function() {
+    clearModal: function() {
         var self = this;
     },
-    connectAccount : function() {
+    connectAccount: function() {
         var self = this;
         if ( !(self.username() && self.password()) ){
             self.setMessage('Please enter a username and password.', 'text-danger');

--- a/framework/addons/data/addons.json
+++ b/framework/addons/data/addons.json
@@ -273,7 +273,7 @@
         "Boa": {
             "Permissions": {
                 "status": "partial",
-                "text": "Making an OSF project public or private is independent of Boa privacy."
+                "text": "An OSF project's privacy is independent of Boa privacy."
             },
             "View / download file versions": {
                 "status": "NA"
@@ -287,11 +287,11 @@
             },
             "Logs": {
                 "status": "partial",
-                "text": "The OSF keeps track of Boa-generated results that have been copied to OSF Storage."
+                "text": "The OSF tracks Boa-generated results that were copied to OSF Storage."
             },
             "Forking": {
                 "status": "partial",
-                "text": "Forking a project or component does not copy Boa authorization unless the user forking the project is the same user who authorized the Boa add-on in the source project being forked."
+                "text": "Boa authorization will only copy to a forked project/component if the contributor that authorized the add-on is the same contributor that forked the project/component."
             },
             "Registering": {
                 "status": "partial",

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -332,7 +332,7 @@ def node_addons(auth, node, **kwargs):
     ret['addon_settings'] = [addon for addon in addon_settings]
 
     # Addons can have multiple categories, but we only want a set of unique ones being used.
-    ret['addon_categories'] = set([item for addon in addon_settings for item in addon['categories']])
+    ret['addon_categories'] = sorted(set([item for addon in addon_settings for item in addon['categories']]))
 
     # The page only needs to load enabled addons and it refreshes when a new addon is being enabled.
     ret['addon_js'] = collect_node_config_js([addon for addon in addon_settings if addon['enabled']])


### PR DESCRIPTION
## Purpose

Cleanups for Boa's legacy front-end (discovered during QA) + response to some of the CR items in https://github.com/CenterForOpenScience/osf.io/pull/10469

## Changes

* Update Boa TOS to be Product-compliant
* Stably sort addon category names (and rename "Remote computing" to "remote-computing")
* make legacy submit-to-boa modal look and behave more like ember's. 
* make the README.md about Boa
* remove unused setting vars

## QA Notes

N/A

## Documentation
N/A

## Side Effects

N/A

## Ticket

N/A
