### PR TITLE
[ENG-4946] Standardize Addon Serialization

### DIFF
--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -181,12 +181,10 @@ class BaseOAuthUserSettings(BaseUserSettings):
     @property
     def external_accounts(self):
         """The user's list of ``ExternalAccount`` instances for this provider"""
-        from django.db.models import Value
-
         return self.owner.external_accounts.filter(
             provider=self.oauth_provider.short_name
         ).annotate(
-            user_id=Value(self.owner._id),
+            user_id=models.Value(self.owner._id),
         )
 
     def delete(self, save=True):

--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -181,7 +181,13 @@ class BaseOAuthUserSettings(BaseUserSettings):
     @property
     def external_accounts(self):
         """The user's list of ``ExternalAccount`` instances for this provider"""
-        return self.owner.external_accounts.filter(provider=self.oauth_provider.short_name)
+        from django.db.models import Value
+
+        return self.owner.external_accounts.filter(
+            provider=self.oauth_provider.short_name
+        ).annotate(
+            user_id=Value(self.owner._id),
+        )
 
     def delete(self, save=True):
         for account in self.external_accounts.filter(provider=self.config.short_name):

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -48,7 +48,7 @@ class AddonSerializer(JSONAPISerializer):
     ])
 
     class Meta:
-        type_ = 'addon'
+        type_ = 'addons'
 
     id = ser.CharField(source='short_name', read_only=True)
     name = ser.CharField(source='full_name', read_only=True)

--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -47,6 +47,10 @@ class AddonSerializer(JSONAPISerializer):
         'categories',
     ])
 
+    links = LinksField({
+        'self': 'get_absolute_url',
+    })
+
     class Meta:
         type_ = 'addons'
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1685,9 +1685,16 @@ def relationship_diff(current_items, new_items):
 
 class AddonAccountSerializer(JSONAPISerializer):
     id = ser.CharField(source='_id', read_only=True)
-    provider = ser.CharField(read_only=True)
     profile_url = ser.CharField(required=False, read_only=True)
     display_name = ser.CharField(required=False, read_only=True)
+
+    provider = RelationshipField(
+        related_view='users:user-addon-detail',
+        related_view_kwargs={
+            'provider': '<provider>',
+            'user_id': '<user_id>',
+        },
+    )
 
     links = links = LinksField({
         'self': 'get_absolute_url',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -908,6 +908,12 @@ class NodeAddonSettingsSerializerBase(JSONAPISerializer):
     external_account_id = ser.CharField(source='external_account._id', required=False, allow_null=True)
     folder_id = ser.CharField(required=False, allow_null=True)
     folder_path = ser.CharField(required=False, allow_null=True)
+    node = RelationshipField(
+        related_view='nodes:node-detail',
+        related_view_kwargs={
+            'node_id': '<owner._id>',
+        },
+    )
 
     # Forward-specific
     label = ser.CharField(required=False, allow_blank=True)

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -267,8 +267,20 @@ class UserAddonSettingsSerializer(JSONAPISerializer):
 
     links = LinksField({
         'self': 'get_absolute_url',
-        'accounts': 'account_links',
     })
+    accounts = RelationshipField(
+        related_view='users:user-external_accounts',
+        related_view_kwargs={
+            'user_id': '<owner._id>',
+            'provider': '<short_name>',
+        },
+    )
+    user = RelationshipField(
+        related_view='users:user-detail',
+        related_view_kwargs={
+            'user_id': '<owner._id>',
+        },
+    )
 
     class Meta:
         @staticmethod
@@ -285,24 +297,6 @@ class UserAddonSettingsSerializer(JSONAPISerializer):
             },
         )
 
-    def account_links(self, obj):
-        # TODO: [OSF-4933] remove this after refactoring Figshare
-        if hasattr(obj, 'external_accounts'):
-            return {
-                account._id: {
-                    'account': absolute_reverse(
-                        'users:user-external_account-detail', kwargs={
-                            'user_id': obj.owner._id,
-                            'provider': obj.config.short_name,
-                            'account_id': account._id,
-                            'version': self.context['request'].parser_context['kwargs']['version'],
-                        },
-                    ),
-                    'nodes_connected': [n.absolute_api_v2_url for n in obj.get_attached_nodes(account)],
-                }
-                for account in obj.external_accounts.all()
-            }
-        return {}
 
 class UserDetailSerializer(UserSerializer):
     """

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -74,7 +74,6 @@ from rest_framework.response import Response
 from rest_framework.exceptions import NotAuthenticated, NotFound, ValidationError, Throttled
 from osf.models import (
     Contributor,
-    ExternalAccount,
     Guid,
     AbstractNode,
     Preprint,
@@ -290,13 +289,9 @@ class UserAddonAccountDetail(JSONAPIBaseView, generics.RetrieveAPIView, UserMixi
     def get_object(self):
         user_settings = self.get_addon_settings(check_object_permissions=False)
         account_id = self.kwargs['account_id']
-        from django.db.models import Value
 
-        account = ExternalAccount.objects.filter(
-            _id=account_id,
-        ).annotate(
-            user_id=Value(user_settings.owner._id),
-        ).get()
+        account = user_settings.external_accounts.get(_id=account_id)
+
         if not (account and user_settings.external_accounts.filter(id=account.id).exists()):
             raise NotFound('Requested addon unavailable')
         return account

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -270,6 +270,7 @@ class UserAddonAccountList(JSONAPIBaseView, generics.ListAPIView, UserMixin, Add
     def get_queryset(self):
         return self.get_addon_settings(check_object_permissions=False).external_accounts
 
+
 class UserAddonAccountDetail(JSONAPIBaseView, generics.RetrieveAPIView, UserMixin, AddonSettingsMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/Users_addon_accounts_read).
     """
@@ -289,8 +290,13 @@ class UserAddonAccountDetail(JSONAPIBaseView, generics.RetrieveAPIView, UserMixi
     def get_object(self):
         user_settings = self.get_addon_settings(check_object_permissions=False)
         account_id = self.kwargs['account_id']
+        from django.db.models import Value
 
-        account = ExternalAccount.load(account_id)
+        account = ExternalAccount.objects.filter(
+            _id=account_id,
+        ).annotate(
+            user_id=Value(user_settings.owner._id),
+        ).get()
         if not (account and user_settings.external_accounts.filter(id=account.id).exists()):
             raise NotFound('Requested addon unavailable')
         return account

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -203,11 +203,10 @@ class UserAddonAccountListMixin(object):
                 addon_data['attributes']['display_name'],
                 self.account.display_name)
             assert_equal(
-                addon_data['attributes']['provider'],
-                self.account.provider)
-            assert_equal(
                 addon_data['attributes']['profile_url'],
                 self.account.profile_url)
+            addon_relationship_link = addon_data['relationships']['provider']['links']['related']['href']
+            assert addon_relationship_link.endswith(f'/addons/{self.account.provider}/')
         if wrong_type:
             assert_equal(res.status_code, 404)
 
@@ -294,11 +293,11 @@ class UserAddonAccountDetailMixin(object):
                 addon_data['attributes']['display_name'],
                 self.account.display_name)
             assert_equal(
-                addon_data['attributes']['provider'],
-                self.account.provider)
-            assert_equal(
                 addon_data['attributes']['profile_url'],
                 self.account.profile_url)
+            addon_relationship_link = addon_data['relationships']['provider']['links']['related']['href']
+            assert addon_relationship_link.endswith(f'/addons/{self.account.provider}/')
+
         if wrong_type:
             assert_equal(res.status_code, 404)
 

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -36,8 +36,7 @@ class UserAddonListMixin(object):
         if not wrong_type:
             addon_data = res.json['data'][0]
             assert_true(addon_data['attributes']['user_has_auth'])
-            assert_in(
-                self.node._id, addon_data['links']['accounts'][self.account_id]['nodes_connected'][0])
+            assert addon_data['relationships']['accounts']
         if wrong_type:
             assert_equal(res.status_code, 200)
             assert_equal(res.json['data'], [])
@@ -117,10 +116,7 @@ class UserAddonDetailMixin(object):
         if not wrong_type:
             addon_data = res.json['data']
             assert_true(addon_data['attributes']['user_has_auth'])
-            assert_in(
-                self.node._id,
-                addon_data['links']['accounts'][self.account_id]['nodes_connected'][0]
-            )
+            assert addon_data['relationships']['accounts']
         if wrong_type:
             assert_equal(res.status_code, 404)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

A catch all PR for minor tweaks to addon resources in API to accommodate new POSE based addons and FE/JSON-API best practices.

## Changes

- remove figshare TODO: https://github.com/CenterForOpenScience/osf.io/blob/a3e0a0b9ddda5dd75fc8248d58f3bcdeece0323e/api/users/serializers.py#L289
- Add `user` relationship to UserAddons
- Add `accounts` relationship to UserAddons
- Add `node`  relationship to NodeAddons
- Fix top-level Addon type to addons from addon
- Add `self` link to top-level addons view


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4946