### PR TITLE
[ENG-4961] Allow Bitbucket full configuration via V2 API

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -302,8 +302,8 @@ ENABLE_ESI = osf_settings.ENABLE_ESI
 VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
-ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
+ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive', 'bitbucket']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
 
 BYPASS_THROTTLE_TOKEN = 'test-token'
 

--- a/api_tests/addons_tests/bitbucket/test_bitbucket_configure.py
+++ b/api_tests/addons_tests/bitbucket/test_bitbucket_configure.py
@@ -1,0 +1,73 @@
+import mock
+import pytest
+from framework.auth.core import Auth
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
+from addons.bitbucket.tests.factories import BitbucketUserSettingsFactory
+
+_mock = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+
+def mock_bitbucket_client():
+    return _mock({
+        'repos': lambda *args, **kwargs: [
+            {
+                'full_name': 'bitbucket-user-name/test-folder'
+            }
+        ],
+        'repo': _mock({})
+    })
+
+
+@pytest.mark.django_db
+class TestBitbucketConfig:
+    """
+    This class tests features added for our POSE grant which will enable us to access of Bitbucket Addon entirely via
+    osf.io's v2 REST API. This requires giving the user the ability to configure the base folder for their bitbucket
+    storage via the API.
+
+    """
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, user):
+        return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def enabled_addon(self, node, user):
+        addon = node.get_or_add_addon('bitbucket', auth=Auth(user))
+        addon.user_settings = BitbucketUserSettingsFactory(owner=user)
+        addon.save()
+        return addon
+
+    @pytest.fixture()
+    def node_with_authorized_addon(self, user, node, enabled_addon):
+        external_account = ExternalAccountFactory(provider='bitbucket')
+        enabled_addon.external_account = external_account
+        user_settings = enabled_addon.user_settings
+        user_settings.oauth_grants[node._id] = {enabled_addon.external_account._id: []}
+        user_settings.save()
+        user.external_accounts.add(external_account)
+        user.save()
+        enabled_addon.save()
+        return node
+
+    @mock.patch('addons.bitbucket.models.BitbucketClient', return_value=mock_bitbucket_client())
+    def test_addon_folders_PATCH(self, mock_bitbucket, app, node_with_authorized_addon, user):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node_with_authorized_addon._id}/addons/bitbucket/',
+            {
+                'data': {
+                    'attributes': {
+                        'folder_id': 'bitbucket-user-name/test-folder'
+                    }
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['folder_id'] == 'test-folder'
+        assert resp.json['data']['attributes']['folder_path'] == 'test-folder'

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -21,6 +21,7 @@ from addons.figshare.tests.factories import FigshareAccountFactory, FigshareNode
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import AuthUserFactory
 from tests.base import ApiAddonTestCase
+from api_tests.addons_tests.bitbucket.test_bitbucket_configure import mock_bitbucket_client
 
 from addons.mendeley.tests.factories import (
     MendeleyAccountFactory, MendeleyNodeSettingsFactory
@@ -680,10 +681,14 @@ class TestNodeWikiAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
 
 # OAUTH
 
-class TestNodeBitbucketAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
+class TestNodeBitbucketAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'bitbucket'
     AccountFactory = BitbucketAccountFactory
     NodeSettingsFactory = BitbucketNodeSettingsFactory
+
+    @property
+    def _mock_folder_info(self):
+        return {'folder_id': 'jasonkelece/0987654321'}
 
     def _settings_kwargs(self, node, user_settings):
         return {
@@ -691,6 +696,22 @@ class TestNodeBitbucketAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             'repo': 'mock',
             'user': 'abc',
             'owner': self.node
+        }
+
+    def test_folder_list_GET_expected_behavior(self):
+        with mock.patch('addons.bitbucket.models.BitbucketClient', return_value=mock_bitbucket_client()):
+            super(TestNodeBitbucketAddon, self).test_folder_list_GET_expected_behavior()
+
+    def test_settings_detail_PUT_all_sets_settings(self):
+        with mock.patch('addons.bitbucket.models.BitbucketClient', return_value=mock_bitbucket_client()):
+            super(TestNodeBitbucketAddon, self).test_settings_detail_PUT_all_sets_settings()
+
+    @property
+    def _mock_folder_result(self):
+        return {
+            'name': 'bitbucket-user-name/test-folder',
+            'path': '/',
+            'id': 'bitbucket-user-name/test-folder',
         }
 
 


### PR DESCRIPTION
## Purpose

Allow configuration of Bitbucket node addon via our v2 API.

## Changes

- adds new serializer with custom bitbucket behavior
- adds tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

instructions for setting up things locally at: addons/bitbucket/README.md

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
