### PR TITLE
[ENG-4961] make Boa configurable via API v2

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -302,8 +302,8 @@ ENABLE_ESI = osf_settings.ENABLE_ESI
 VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
-ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
+ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive', 'boa']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward']
 
 BYPASS_THROTTLE_TOKEN = 'test-token'
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1107,7 +1107,11 @@ class BoaNodeAddonSettingsSerializer(NodeAddonSettingsSerializer):
         user = self.context['request'].user
         if username and password:
             boa_client = BoaClient(endpoint=BOA_API_ENDPOINT)
-            boa_client.login(username, password)
+
+            try:
+                boa_client.login(username, password)
+            except BoaException:
+                raise exceptions.PermissionDenied('Raised login error')
             boa_client.close()
 
             provider = BoaProvider(

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1096,25 +1096,19 @@ class NodeAddonSettingsSerializer(NodeAddonSettingsSerializerBase):
 
 
 class BoaNodeAddonSettingsSerializer(NodeAddonSettingsSerializer):
-    SHORT_NAME = 'boa'
-    FULL_NAME = 'Boa'
 
-    oauth_secret = ser.CharField(required=False, allow_null=True, write_only=True)
-    oauth_key = ser.CharField(required=False, allow_null=True, write_only=True)
+    username = ser.CharField(required=False, allow_null=True, write_only=True)
+    password = ser.CharField(required=False, allow_null=True, write_only=True)
 
     def update(self, instance, validated_data):
         instance = super().update(instance, validated_data)
         username = validated_data.get('username')
         password = validated_data.get('password')
         user = self.context['request'].user
-
         if username and password:
-            try:
-                boa_client = BoaClient(endpoint=BOA_API_ENDPOINT)
-                boa_client.login(username, password)
-                boa_client.close()
-            except BoaException:
-                raise exceptions.PermissionDenied('You do not have access to this addon')
+            boa_client = BoaClient(endpoint=BOA_API_ENDPOINT)
+            boa_client.login(username, password)
+            boa_client.close()
 
             provider = BoaProvider(
                 account=None,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -93,6 +93,7 @@ from api.nodes.permissions import (
 from api.nodes.serializers import (
     NodeSerializer,
     ForwardNodeAddonSettingsSerializer,
+    BoaNodeAddonSettingsSerializer,
     NodeAddonSettingsSerializer,
     NodeLinksSerializer,
     NodeForksSerializer,
@@ -1419,8 +1420,12 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
         """
         Use NodeDetailSerializer which requires 'id'
         """
-        if 'provider' in self.kwargs and self.kwargs['provider'] == 'forward':
+        provider = self.kwargs.get('provider')
+
+        if provider == 'forward':
             return ForwardNodeAddonSettingsSerializer
+        elif provider == 'boa':
+            return BoaNodeAddonSettingsSerializer
         else:
             return NodeAddonSettingsSerializer
 

--- a/api_tests/addons_tests/boa/test_configure_boa.py
+++ b/api_tests/addons_tests/boa/test_configure_boa.py
@@ -4,7 +4,12 @@ from framework.auth.core import Auth
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
 
-mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+_mock = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+def mock_boa_client():
+    return _mock({
+        'login': False
+    })
 
 
 @pytest.mark.django_db

--- a/api_tests/addons_tests/boa/test_configure_boa.py
+++ b/api_tests/addons_tests/boa/test_configure_boa.py
@@ -1,0 +1,66 @@
+import mock
+import pytest
+from framework.auth.core import Auth
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
+
+mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+
+@pytest.mark.django_db
+class TestBoaConfig:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, user):
+        return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def enabled_addon(self, node, user):
+        addon = node.get_or_add_addon('boa', auth=Auth(user))
+        addon.save()
+        return addon
+
+    @pytest.fixture()
+    def node_with_authorized_addon(self, user, node, enabled_addon):
+        external_account = ExternalAccountFactory(provider='boa')
+        enabled_addon.external_account = external_account
+        user_settings = user.get_or_add_addon('boa')
+        user_settings.save()
+        enabled_addon.user_settings = user_settings
+        user.external_accounts.add(external_account)
+        user.save()
+        enabled_addon.save()
+        return node
+
+    def test_addon_folders_PATCH(self, app, node_with_authorized_addon, user):
+
+        payload = {'data': {'attributes': {'folder_path': 'john.e.tordoff/test-project', 'folder_id': '52343250'}}}
+
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node_with_authorized_addon._id}/addons/boa/',
+            payload,
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['folder_id'] == 'john.e.tordoff/test-project'
+        assert resp.json['data']['attributes']['folder_path'] == 'john.e.tordoff/test-project'
+
+    def test_addon_credentials_PATCH(self, app, node, user, enabled_addon):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node._id}/addons/boa/',
+            {
+                'data': {
+                    'attributes': {
+                        'username': 'johntordoff',
+                        'password': 'Quez_Watkins',
+                    }
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['external_account_id']


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow users to configure their account details entirely via the V2 api.

## Changes

- override the serializer to allow credentials to be updated
- add tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4961