### PR TITLE
 [ENG-4961] Allow Dataverse full configuration via V2 API 

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -13,6 +13,8 @@ from addons.base import exceptions
 from addons.dataverse.client import connect_from_settings_or_401
 from addons.dataverse.serializer import DataverseSerializer
 from addons.dataverse.utils import DataverseNodeLogger
+from addons.dataverse import client
+
 
 class DataverseFileNode(BaseFileNode):
     _provider = 'dataverse'
@@ -93,6 +95,15 @@ class UserSettings(BaseOAuthUserSettings):
     oauth_provider = DataverseProvider
     serializer = DataverseSerializer
 
+    @property
+    def has_auth(self):
+        return self.external_accounts.exists()
+
+    @property
+    def external_accounts(self):
+        """The user's list of ``ExternalAccount`` instances for this provider"""
+        return self.owner.external_accounts.filter(provider=self.oauth_provider.short_name)
+
 
 class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     oauth_provider = DataverseProvider
@@ -104,6 +115,11 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     _dataset_id = models.TextField(blank=True, null=True)
     dataset = models.TextField(blank=True, null=True)
     user_settings = models.ForeignKey(UserSettings, null=True, blank=True, on_delete=models.CASCADE)
+
+    @property
+    def has_auth(self):
+        """Instance has an external account and *active* permission to use it"""
+        return bool(self.user_settings and self.user_settings.has_auth and self.external_account)
 
     @property
     def folder_name(self):
@@ -142,24 +158,30 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
             auth=auth
         )
 
-    def set_folder(self, dataverse, dataset, auth=None):
+    def set_folder(self, folder_id, auth=None, dataset=None):
+        connection = client.connect_from_settings(self)
+        dataverse = client.get_dataverse(connection, folder_id)
+
         self.dataverse_alias = dataverse.alias
         self.dataverse = dataverse.title
 
-        self.dataset_doi = dataset.doi
-        self._dataset_id = dataset.id
-        self.dataset = dataset.title
+        if dataset:
+            self.dataset_doi = dataset.doi
+            self._dataset_id = dataset.id
+            self.dataset = dataset.title
 
         self.save()
 
         if auth:
+            log_params = {
+                'project': self.owner.parent_id,
+                'node': self.owner._id,
+            }
+            if dataset:
+                log_params['dataset'] = dataset.title
             self.owner.add_log(
                 action='dataverse_dataset_linked',
-                params={
-                    'project': self.owner.parent_id,
-                    'node': self.owner._id,
-                    'dataset': dataset.title,
-                },
+                params=log_params,
                 auth=auth,
             )
 
@@ -238,3 +260,15 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
     def on_delete(self):
         self.deauthorize(add_log=False)
         self.save()
+
+    def get_folders(self, path, folder_id):
+        # Update with Dataverse specific fields
+        if self.has_auth:
+            connection = client.connect_from_settings(self)
+            dataverses = client.get_dataverses(connection)
+            return [
+                {
+                    'path': dataverse.alias,
+                    'id': dataverse.title,
+                    'addon': 'dataverse'
+                } for dataverse in dataverses]

--- a/addons/dataverse/tests/test_model.py
+++ b/addons/dataverse/tests/test_model.py
@@ -16,6 +16,7 @@ from addons.dataverse.tests.factories import (
 )
 from addons.dataverse.tests import utils
 from osf_tests.factories import DraftRegistrationFactory
+from api_tests.addons_tests.dataverse.test_configure_dataverse import mock_dataverse_client
 
 pytestmark = pytest.mark.django_db
 
@@ -69,22 +70,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             filename
         )
 
-    @mock.patch('addons.dataverse.client.Connection')
+    @mock.patch('addons.dataverse.client.Connection', return_value=mock_dataverse_client())
     def test_set_folder(self, mock_client):
-        mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
         dataset = utils.create_mock_dataset()
         dataverse = utils.create_mock_dataverse()
 
-        mock_client.return_value = mock_return({
-            'get_service_document': mock_return({}),
-            'get_dataverse': lambda alias: mock_return(
-                {
-                    'title': 'FastBatman',
-                    'alias': alias,
-                    'id': 'SwoleBatman'
-                }
-            )
-        })
         self.node_settings.set_folder(dataverse, dataset=dataset, auth=Auth(self.user))
         # Folder was set
         assert_equal(self.node_settings.folder_id, dataset.id)

--- a/addons/dataverse/tests/test_model.py
+++ b/addons/dataverse/tests/test_model.py
@@ -69,10 +69,23 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             filename
         )
 
-    def test_set_folder(self):
-        dataverse = utils.create_mock_dataverse()
+    @mock.patch('addons.dataverse.client.Connection')
+    def test_set_folder(self, mock_client):
+        mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
         dataset = utils.create_mock_dataset()
-        self.node_settings.set_folder(dataverse, dataset, auth=Auth(self.user))
+        dataverse = utils.create_mock_dataverse()
+
+        mock_client.return_value = mock_return({
+            'get_service_document': mock_return({}),
+            'get_dataverse': lambda alias: mock_return(
+                {
+                    'title': 'FastBatman',
+                    'alias': alias,
+                    'id': 'SwoleBatman'
+                }
+            )
+        })
+        self.node_settings.set_folder(dataverse, dataset=dataset, auth=Auth(self.user))
         # Folder was set
         assert_equal(self.node_settings.folder_id, dataset.id)
         # Log was saved

--- a/addons/dataverse/views.py
+++ b/addons/dataverse/views.py
@@ -141,7 +141,25 @@ def dataverse_set_config(node_addon, auth, **kwargs):
     dataverse = client.get_dataverse(connection, alias)
     dataset = client.get_dataset(dataverse, doi)
 
-    node_addon.set_folder(dataverse, dataset, auth)
+    node_addon.dataverse_alias = dataverse.alias
+    node_addon.dataverse = dataverse.title
+
+    node_addon.dataset_doi = dataset.doi
+    node_addon._dataset_id = dataset.id
+    node_addon.dataset = dataset.title
+
+    node_addon.save()
+
+    if auth:
+        node_addon.owner.add_log(
+            action='dataverse_dataset_linked',
+            params={
+                'project': node_addon.owner.parent_id,
+                'node': node_addon.owner._id,
+                'dataset': dataset.title,
+            },
+            auth=auth,
+        )
 
     return {'dataverse': dataverse.title, 'dataset': dataset.title}, http_status.HTTP_200_OK
 

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -302,8 +302,8 @@ ENABLE_ESI = osf_settings.ENABLE_ESI
 VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
-ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
+ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive', 'dataverse']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
 
 BYPASS_THROTTLE_TOKEN = 'test-token'
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -114,6 +114,7 @@ from api.nodes.serializers import (
     NodeGroupsSerializer,
     NodeGroupsCreateSerializer,
     NodeGroupsDetailSerializer,
+    DataverseNodeAddonSettingsSerializer,
 )
 from api.nodes.utils import NodeOptimizationMixin, enforce_no_children
 from api.osf_groups.views import OSFGroupMixin
@@ -1419,8 +1420,11 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
         """
         Use NodeDetailSerializer which requires 'id'
         """
-        if 'provider' in self.kwargs and self.kwargs['provider'] == 'forward':
+        provider = self.kwargs.get('provider')
+        if provider == 'forward':
             return ForwardNodeAddonSettingsSerializer
+        elif provider == 'dataverse':
+            return DataverseNodeAddonSettingsSerializer
         else:
             return NodeAddonSettingsSerializer
 

--- a/api_tests/addons_tests/dataverse/test_configure_dataverse.py
+++ b/api_tests/addons_tests/dataverse/test_configure_dataverse.py
@@ -1,0 +1,83 @@
+
+import mock
+import pytest
+from framework.auth.core import Auth
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
+from addons.dataverse.tests.factories import DataverseUserSettingsFactory
+
+mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+
+@pytest.mark.django_db
+class TestDataverseConfig:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, user):
+        return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def enabled_addon(self, node, user):
+        addon = node.get_or_add_addon('dataverse', auth=Auth(user))
+        addon.user_settings = DataverseUserSettingsFactory(owner=user)
+        addon.save()
+        return addon
+
+    @pytest.fixture()
+    def node_with_authorized_addon(self, user, node, enabled_addon):
+        external_account = ExternalAccountFactory(provider='dataverse')
+        enabled_addon.external_account = external_account
+        user_settings = enabled_addon.user_settings
+        user_settings.save()
+        user.external_accounts.add(external_account)
+        user.save()
+        enabled_addon.save()
+        return node
+
+    @mock.patch('addons.dataverse.client.Connection')
+    def test_addon_folders_PATCH(self, mock_client, app, node_with_authorized_addon, user):
+        mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+        mock_client.return_value = mock_return({
+            'get_service_document': mock_return({}),
+            'get_dataverse': lambda alias: mock_return(
+                {
+                    'title': 'FastBatman',
+                    'alias': alias,
+                    'id': 'SwoleBatman'
+                }
+            )
+        })
+
+        payload = {'data': {'attributes': {'folder_id': 'test_123'}}}
+
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node_with_authorized_addon._id}/addons/dataverse/',
+            payload,
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['folder_id'] == 'test-folder'
+        assert resp.json['data']['attributes']['folder_path'] == 'test-folder'
+
+    @mock.patch('addons.dataverse.client.Connection')
+    def test_addon_credentials_PATCH(self, mock_client, app, node, user, enabled_addon):
+        mock_return = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+        mock_client.return_value = mock_return({
+            'get_service_document': mock_return({})
+        })
+
+        payload = {'data': {'attributes': {'host': 'jakeelliot@eagles.bird', 'access_token': 'access_token'}}}
+
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node._id}/addons/dataverse/',
+            payload,
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['external_account_id']

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -29,6 +29,7 @@ from addons.zotero.tests.factories import (
     ZoteroAccountFactory, ZoteroNodeSettingsFactory
 )
 from osf.utils.permissions import WRITE, READ, ADMIN
+from api_tests.addons_tests.dataverse.test_configure_dataverse import mock_dataverse_client
 
 pytestmark = pytest.mark.django_db
 # Varies between addons. Some need to make a call to get the root,
@@ -694,7 +695,7 @@ class TestNodeBitbucketAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
         }
 
 
-class TestNodeDataverseAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
+class TestNodeDataverseAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'dataverse'
     AccountFactory = DataverseAccountFactory
     NodeSettingsFactory = DataverseNodeSettingsFactory
@@ -705,6 +706,22 @@ class TestNodeDataverseAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             '_dataset_id': '1234567890',
             'owner': self.node
         }
+
+    @property
+    def _mock_folder_result(self):
+        return {
+            'name': 'Dataverse Test Title',
+            'path': 'Dataverse Test Alias',
+            'id': 'Dataverse Test Title'
+        }
+
+    def test_folder_list_GET_expected_behavior(self):
+        with mock.patch('addons.dataverse.client.Connection', return_value=mock_dataverse_client()):
+            super().test_folder_list_GET_expected_behavior()
+
+    def test_settings_detail_PUT_all_sets_settings(self):
+        with mock.patch('addons.dataverse.client.Connection', return_value=mock_dataverse_client()):
+            super().test_settings_detail_PUT_all_sets_settings()
 
 
 class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allows API users to configure Dataverse entirely via the V2 API

## Changes

- adds new serializer that overrides current update behavior
- adds tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4961