### PR TITLE
 [ENG-4961] Allow Gitlab full configuration via V2 API 

### DIFF
--- a/addons/gitlab/models.py
+++ b/addons/gitlab/models.py
@@ -447,3 +447,22 @@ class NodeSettings(BaseOAuthNodeSettings, BaseStorageAddon):
                     self.save()
                 return True
         return False
+
+    def get_folders(self, *args, **kwargs):
+        connection = GitLabClient(external_account=self.external_account)
+        return [
+            {
+                'addon': 'gitlab',
+                'path': '/',
+                'kind': 'folder',
+                'id': repo.id,
+                'name': repo.path_with_namespace,
+            } for repo in connection.repos(all=True)
+        ]
+
+    def set_folder(self, folder_data, auth):
+        if folder_data.get('folder_path') != self.repo or folder_data.get('folder_id') != self.repo_id:
+            self.repo = folder_data['folder_path']
+            self.repo_id = folder_data['folder_id']
+            self.nodelogger.log(action='folder_selected', save=True)
+            self.save()

--- a/addons/gitlab/static/gitlabNodeConfig.js
+++ b/addons/gitlab/static/gitlabNodeConfig.js
@@ -173,7 +173,7 @@ var ViewModel = oop.extend(UserViewModel,{
             return Boolean(self.selectedHost());
         });
         self.tokenUrl = ko.pureComputed(function() {
-            return self.host() ? self.host() + '/profile/personal_access_tokens' : null;
+            return self.host() ? self.host() + '/-/profile/personal_access_tokens' : null;
         });
     },
     authSuccessCallback: function() {

--- a/addons/gitlab/static/gitlabUserConfig.js
+++ b/addons/gitlab/static/gitlabUserConfig.js
@@ -56,7 +56,7 @@ var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
             return Boolean(self.selectedHost());
         });
         self.tokenUrl = ko.pureComputed(function() {
-            return self.host() ? self.host() + '/profile/personal_access_tokens' : null;
+            return self.host() ? self.host() + '/-/profile/personal_access_tokens/' : null;
         });
     },
     clearModal: function() {

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -302,8 +302,8 @@ ENABLE_ESI = osf_settings.ENABLE_ESI
 VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
-ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'gitlab', 'mendeley', 'zotero', 'forward', 'boa']
+ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive', 'figshare', 'owncloud', 'onedrive', 'gitlab']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'bitbucket', 'mendeley', 'zotero', 'forward', 'boa']
 
 BYPASS_THROTTLE_TOKEN = 'test-token'
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1,3 +1,5 @@
+import gitlab
+
 from django.db import connection
 from distutils.version import StrictVersion
 
@@ -43,6 +45,7 @@ from osf.models import (
 from website.project import new_private_link
 from website.project.model import NodeUpdateError
 from osf.utils import permissions as osf_permissions
+from addons.gitlab.api import GitLabClient
 
 
 class RegistrationProviderRelationshipField(RelationshipField):
@@ -2038,3 +2041,54 @@ class NodeGroupsDetailSerializer(NodeGroupsSerializer):
             # permission is in writeable_method_fields, so validation happens on OSF Group model
             raise exceptions.ValidationError(detail=str(e))
         return obj
+
+
+class GitlabNodeAddonSettingsSerializer(NodeAddonSettingsSerializer):
+    """
+    This overrides the serializer to provide specific behavior for Gitlab addons, it adds the ability to add Gitlab
+    credential entirely via the v2 API.
+    """
+
+    host = ser.CharField(required=False, allow_null=True, write_only=True)
+    access_token = ser.CharField(required=False, allow_null=True, write_only=True)
+
+    def update(self, instance, validated_data):
+        instance = super().update(instance, validated_data)
+
+        host = validated_data.get('host')
+        access_token = validated_data.get('access_token')
+        # Validate host and access_token
+        if host and access_token:
+            client = GitLabClient(access_token=access_token, host=host)
+            try:
+                client.gitlab.auth()
+                user = client.gitlab.user
+            except ConnectionError:
+                raise exceptions.PermissionDenied('Gitlab host is invalid')
+            except gitlab.exceptions.GitlabAuthenticationError:
+                raise exceptions.PermissionDenied('Gitlab credentials were invalid')
+            except gitlab.exceptions.GitlabGetError:
+                raise exceptions.PermissionDenied('Gitlab credentials were invalid')
+
+            # When user's add credentials via API, make sure it's also saved to their user settings as well
+            account, created = ExternalAccount.objects.update_or_create(
+                provider='gitlab',
+                provider_id=user.web_url,  # unique for host/username
+                defaults={
+                    'display_name': user.username,
+                    'oauth_key': access_token,
+                    'oauth_secret': host,
+                },
+            )
+            instance.external_account_id = account.id
+            user = self.context['request'].user
+            if not user.external_accounts.filter(id=account.id).exists():
+                user.external_accounts.add(account)
+                user.save()
+
+        return instance
+
+    def get_folder_info(self, data, addon_name):
+        if data.get('folder_id') and data.get('folder_path'):
+            return True, data
+        return False, None

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -114,6 +114,7 @@ from api.nodes.serializers import (
     NodeGroupsSerializer,
     NodeGroupsCreateSerializer,
     NodeGroupsDetailSerializer,
+    GitlabNodeAddonSettingsSerializer,
 )
 from api.nodes.utils import NodeOptimizationMixin, enforce_no_children
 from api.osf_groups.views import OSFGroupMixin
@@ -1419,8 +1420,11 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
         """
         Use NodeDetailSerializer which requires 'id'
         """
-        if 'provider' in self.kwargs and self.kwargs['provider'] == 'forward':
+        provider = self.kwargs.get('provider')
+        if provider == 'forward':
             return ForwardNodeAddonSettingsSerializer
+        elif provider == 'gitlab':
+            return GitlabNodeAddonSettingsSerializer
         else:
             return NodeAddonSettingsSerializer
 

--- a/api_tests/addons_tests/gitlab/test_configure_gitlab.py
+++ b/api_tests/addons_tests/gitlab/test_configure_gitlab.py
@@ -1,0 +1,84 @@
+import mock
+import pytest
+from framework.auth.core import Auth
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
+
+_mock = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+
+def mock_gitlab_client():
+    return _mock({
+        'gitlab': _mock({
+            'auth': lambda *args, **kwargs: True,
+            'user': _mock({
+                'username': 'WeaponX',
+                'web_url': 'https://BrianDawkins@eagles.bird'
+            })
+        })
+    })
+
+
+@pytest.mark.django_db
+class TestGitlabConfig:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, user):
+        return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def enabled_addon(self, node, user):
+        addon = node.get_or_add_addon('gitlab', auth=Auth(user))
+        addon.save()
+        return addon
+
+    @pytest.fixture()
+    def node_with_authorized_addon(self, user, node, enabled_addon):
+        external_account = ExternalAccountFactory(provider='gitlab')
+        enabled_addon.external_account = external_account
+        user_settings = user.get_or_add_addon('gitlab')
+        user_settings.save()
+        enabled_addon.user_settings = user_settings
+        user.external_accounts.add(external_account)
+        user.save()
+        enabled_addon.save()
+        return node
+
+    @mock.patch('api.nodes.serializers.GitLabClient', return_value=mock_gitlab_client())
+    def test_addon_folders_PATCH(self, mock_client, app, node_with_authorized_addon, user):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node_with_authorized_addon._id}/addons/gitlab/',
+            {
+                'data': {
+                    'attributes': {
+                        'folder_path': 'john.e.tordoff/test-project',
+                        'folder_id': '52343250'
+                    }
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['folder_id'] == 'john.e.tordoff/test-project'
+        assert resp.json['data']['attributes']['folder_path'] == 'john.e.tordoff/test-project'
+
+    @mock.patch('api.nodes.serializers.GitLabClient', return_value=mock_gitlab_client())
+    def test_addon_credentials_PATCH(self, mock_client, app, node, user, enabled_addon):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node._id}/addons/gitlab/',
+            {
+                'data': {
+                    'attributes': {
+                        'host': 'https://hasanreddick@eagles.bird',
+                        'access_token': 'JoshSweat'
+                    }
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['external_account_id']


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow API users the ability to configure their Gitlab addon node directly via the API.

## Changes

- add get and set methods for Gitlab models

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4961