### PR TITLE
[ENG-4961] Make Owncloud configurable via api v2

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1,5 +1,8 @@
 from django.db import connection
 from distutils.version import StrictVersion
+import owncloud
+import requests
+from owncloud import Client as OwnCloudClient
 
 from api.base.exceptions import (
     Conflict, EndpointNotImplementedError,
@@ -43,6 +46,7 @@ from osf.models import (
 from website.project import new_private_link
 from website.project.model import NodeUpdateError
 from osf.utils import permissions as osf_permissions
+from addons.owncloud.settings import USE_SSL
 
 
 class RegistrationProviderRelationshipField(RelationshipField):
@@ -2038,3 +2042,53 @@ class NodeGroupsDetailSerializer(NodeGroupsSerializer):
             # permission is in writeable_method_fields, so validation happens on OSF Group model
             raise exceptions.ValidationError(detail=str(e))
         return obj
+
+
+class OwncloudNodeAddonSettingsSerializer(NodeAddonSettingsSerializer):
+    """
+    This serializer adds specific behavior for the OwnCloud addon. It enables a user to add and update their owncloud
+    credentials to their node settings via the API.
+    """
+
+    host = ser.CharField(required=False, allow_null=True, write_only=True)
+    username = ser.CharField(required=False, allow_null=True, write_only=True)
+    password = ser.CharField(required=False, allow_null=True, write_only=True)
+
+    def update(self, instance, validated_data):
+        instance = super().update(instance, validated_data)
+        username = validated_data.get('username')
+        password = validated_data.get('password')
+        host = validated_data.get('host')
+
+        if username and password and host:
+            # Validate credentials before adding them to NodeSettings
+            try:
+                client = OwnCloudClient(host, verify_certs=USE_SSL)
+            except requests.exceptions.ConnectionError:
+                raise exceptions.ValidationError('Invalid ownCloud server.')
+
+            try:
+                client.login(username, password)
+                client.logout()
+            except owncloud.owncloud.HTTPResponseError:
+                raise exceptions.PermissionDenied('ownCloud Login failed.')
+
+            # Add credentials to user settings if user makes them via the v2 API,
+            account, created = ExternalAccount.objects.get_or_create(
+                provider='owncloud',
+                provider_id=f'{host}:{username}'.lower(),
+            )
+            account.display_name = username
+            account.oauth_key = password
+            account.oauth_secret = host
+            account.save()
+
+            instance.external_account = account
+            instance.save()
+
+            user = self.context['request'].user
+            if not user.external_accounts.filter(id=account.id).exists():
+                user.external_accounts.add(account)
+                user.save()
+
+        return instance

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -114,6 +114,7 @@ from api.nodes.serializers import (
     NodeGroupsSerializer,
     NodeGroupsCreateSerializer,
     NodeGroupsDetailSerializer,
+    OwncloudNodeAddonSettingsSerializer,
 )
 from api.nodes.utils import NodeOptimizationMixin, enforce_no_children
 from api.osf_groups.views import OSFGroupMixin
@@ -1419,8 +1420,11 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
         """
         Use NodeDetailSerializer which requires 'id'
         """
-        if 'provider' in self.kwargs and self.kwargs['provider'] == 'forward':
+        provider = self.kwargs.get('provider')
+        if provider == 'forward':
             return ForwardNodeAddonSettingsSerializer
+        elif provider == 'owncloud':
+            return OwncloudNodeAddonSettingsSerializer
         else:
             return NodeAddonSettingsSerializer
 

--- a/api_tests/addons_tests/owncloud/test_configure_owncloud.py
+++ b/api_tests/addons_tests/owncloud/test_configure_owncloud.py
@@ -1,0 +1,92 @@
+import mock
+import pytest
+from framework.auth.core import Auth
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import ProjectFactory, AuthUserFactory, ExternalAccountFactory
+
+_mock = lambda attributes: type('MockObject', (mock.Mock,), attributes)
+
+def mock_owncloud_client():
+    return _mock({
+        'login': lambda username, password: None,
+        'logout': lambda: None,
+        'list': lambda folder: [folder]
+    })
+
+
+@pytest.mark.django_db
+class TestOwnCloudConfig:
+    """
+    This class tests for new Owncloud Addon behavior created by the POSE grant. This new behavior allows a user access
+    two additional features via the API.
+
+    1. Adds ability to add credentials via v2 API tested in `test_addon_credentials_PATCH`
+    2. Adds ability to set owncloud base folders via v2 API tested in `test_addon_credentials_PATCH`
+
+    This also adds validation for setting owncloud folder_id's checking them againest the owncloud server.
+    """
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def node(self, user):
+        return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def enabled_addon(self, node, user):
+        addon = node.get_or_add_addon('owncloud', auth=Auth(user))
+        addon.save()
+        return addon
+
+    @pytest.fixture()
+    def node_with_authorized_addon(self, user, node, enabled_addon):
+        external_account = ExternalAccountFactory(
+            provider='owncloud',
+            display_name='test_username',
+            oauth_key='test_password',
+            oauth_secret='http://test_host.com',
+        )
+        enabled_addon.external_account = external_account
+        user_settings = user.get_or_add_addon('owncloud')
+        enabled_addon.user_settings = user_settings
+        user.external_accounts.add(external_account)
+        user.save()
+        user_settings.save()
+        enabled_addon.save()
+        return node
+
+    @mock.patch('addons.owncloud.models.OwnCloudClient', return_value=mock_owncloud_client())
+    def test_addon_folders_PATCH(self, mock_client, app, node_with_authorized_addon, user):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node_with_authorized_addon._id}/addons/owncloud/',
+            {
+                'data': {
+                    'attributes': {
+                        'folder_id': '/'}
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['folder_id'] == '/'
+        assert resp.json['data']['attributes']['folder_path'] == '/'
+
+    @mock.patch('api.nodes.serializers.OwnCloudClient', return_value=mock_owncloud_client())
+    def test_addon_credentials_PATCH(self, mock_client, app, node, user, enabled_addon):
+        resp = app.patch_json_api(
+            f'/{API_BASE}nodes/{node._id}/addons/owncloud/',
+            {
+                'data': {
+                    'attributes': {
+                        'username': 'FastBatman',
+                        'password': 'Quez_Watkins',
+                        'host': 'https://sirianni@eagles.bird',
+                    }
+                }
+            },
+            auth=user.auth
+        )
+        assert resp.status_code == 200
+        assert resp.json['data']['attributes']['external_account_id']

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -21,6 +21,7 @@ from addons.figshare.tests.factories import FigshareAccountFactory, FigshareNode
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import AuthUserFactory
 from tests.base import ApiAddonTestCase
+from api_tests.addons_tests.owncloud.test_configure_owncloud import mock_owncloud_client
 
 from addons.mendeley.tests.factories import (
     MendeleyAccountFactory, MendeleyNodeSettingsFactory
@@ -996,6 +997,10 @@ class TestNodeOwnCloudAddon(
             'path': '/',
             'id': '/'
         }
+
+    def test_settings_detail_PUT_all_sets_settings(self):
+        with mock.patch('addons.owncloud.models.OwnCloudClient', return_value=mock_owncloud_client()):
+            return super().test_settings_detail_PUT_all_sets_settings()
 
 
 class TestNodeS3Addon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTestCase):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make Owncloud fully configurable via the API v2. 

## Changes

- override the serializer to allow users to update the owncloud credentials addons/owncloud/README.md

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4961