### PR TITLE
[ENG-5038] New template version is set to inactive when fetched

### DIFF
--- a/osf/management/commands/fetch_cedar_metadata_templates.py
+++ b/osf/management/commands/fetch_cedar_metadata_templates.py
@@ -19,15 +19,16 @@ class Command(BaseCommand):
             if existing_versions:
                 latest_version = existing_versions.order_by('-template_version').first()
                 if pav_last_updated_on != latest_version.template['pav:lastUpdatedOn']:
+                    # New version should be inactive
                     CedarMetadataTemplate.objects.create(
                         schema_name=schema_name,
                         template=template,
                         cedar_id=cedar_id,
+                        active=False,
                         template_version=latest_version.template_version + 1
                     )
-                    latest_version.active = False
-                    latest_version.save()
             else:
+                # Initial version should be active
                 CedarMetadataTemplate.objects.create(
                     schema_name=schema_name,
                     template=template,


### PR DESCRIPTION
## Purpose

New template version is set to inactive when fetched

## Changes

* If a template is fetched for the first time, set status to active
* If a template is fetched as a new version, set status to inactive

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5038
