### PR TITLE
[ENG-4959] Fix wiki spam checking

### DIFF
--- a/addons/wiki/models.py
+++ b/addons/wiki/models.py
@@ -203,11 +203,7 @@ class WikiVersion(ObjectIDMixin, BaseModel):
         )
 
     def _get_spam_content(self, node):
-        content = []
-        content.append(self.raw_text(node))
-        if not content:
-            return None
-        return ' '.join(content)
+        return self.content or None
 
     def clone_version(self, wiki_page, user):
         """Clone a node wiki page.

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -268,7 +268,7 @@ class TestNotableDomain:
         project = wiki_version.wiki_page.node
         project.is_public = True
         project.save()
-        wiki_version.content = 'This has a domain: https://cos.io'
+        wiki_version.content = '[EXTREME VIDEO] <b><a href="https://cos.io/JAkeEloit">WATCH VIDEO</a></b>'
 
         request_context.g.current_session = {'auth_user_id': project.creator._id}
         with mock.patch.object(spam_tasks.requests, 'head'):


### PR DESCRIPTION

## Purpose

Fix the Notable Domain feature so it sanitizes wikis properly.  We were sanitizing everything that was displayed in the wiki, so effectively it only was checking the "WATCH VIDEO" label.

## Changes

- uses `content` instead of `raw_text`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4959