### PR TITLE
[Hotfix][ENG-4919] Update sitemap for preprint routes, downloads

### DIFF
--- a/osf_tests/test_generate_sitemap.py
+++ b/osf_tests/test_generate_sitemap.py
@@ -118,8 +118,10 @@ class TestGenerateSitemap:
             project_preprint_osf.url,
             project_preprint_other.url,
             registration_active.url,
-            '/{}/'.format(preprint_osf._id),
-            '/preprints/{}/{}/'.format(provider_other._id, preprint_other._id),
+            '/preprints/{}/{}'.format(preprint_osf.provider._id, preprint_osf._id),
+            '/preprints/{}/{}'.format(provider_other._id, preprint_other._id),
+            '/{}/download/?format=pdf'.format(preprint_osf._id),
+            '/{}/download/?format=pdf'.format(preprint_other._id)
         ])
         urls_to_include = [urljoin(settings.DOMAIN, item) for item in urls_to_include]
 

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -203,16 +203,30 @@ class Sitemap(object):
         objs = (Preprint.objects.can_view()
                     .select_related('node', 'provider', 'primary_file'))
         progress.start(objs.count() * 2, 'PREP: ')
-        osf = PreprintProvider.objects.get(_id='osf')
         for obj in objs:
             try:
                 preprint_date = obj.modified.strftime('%Y-%m-%d')
                 config = settings.SITEMAP_PREPRINT_CONFIG
-                preprint_url = obj.url
-                provider = obj.provider
+                preprint_url = os.path.join('preprints', obj.provider._id, obj._id)
                 config['loc'] = urljoin(settings.DOMAIN, preprint_url)
                 config['lastmod'] = preprint_date
                 self.add_url(config)
+
+                # Preprint file urls
+                try:
+                    file_config = settings.SITEMAP_PREPRINT_FILE_CONFIG
+                    file_config['loc'] = urljoin(
+                        settings.DOMAIN,
+                        os.path.join(
+                            obj._id,
+                            'download',
+                            '?format=pdf'
+                        )
+                    )
+                    file_config['lastmod'] = preprint_date
+                    self.add_url(file_config)
+                except Exception as e:
+                    self.log_errors(obj.primary_file, obj.primary_file._id, e)
 
             except Exception as e:
                 self.log_errors(obj, obj._id, e)


### PR DESCRIPTION
## Purpose
Improve Google indexing of Preprints.

## Changes
- Avoid redirects on web view paths
- Include file download links for preprint content indexing. The meta tags present on the page satisfy Google Scholar, but not Google Search.

## QA Notes
- I've verified sitemap generation locally with this, but other behavior can only be tested as Google indexes production content. Likely dev-test.

## Documentation
N/A

## Side Effects
None expected.

## Ticket

[ENG-4919]

[ENG-4919]: https://openscience.atlassian.net/browse/ENG-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ