### PR TITLE
[ENG-5044] fix: multiple funding awards from the same funder

### DIFF
--- a/osf/metadata/serializers/datacite/datacite_tree_walker.py
+++ b/osf/metadata/serializers/datacite/datacite_tree_walker.py
@@ -268,33 +268,42 @@ class DataciteTreeWalker:
 
     def _visit_funding_references(self, parent_el):
         fundrefs_el = self.visit(parent_el, 'fundingReferences', is_list=True)
+        _visited_funders = set()
+        for _funding_award in sorted(self.basket[OSF.hasFunding]):
+            # datacite allows at most one funder per funding reference
+            _funder = next(self.basket[_funding_award:DCTERMS.contributor])
+            self._funding_reference(fundrefs_el, _funder, _funding_award)
+            _visited_funders.add(_funder)
         for _funder in self.basket[OSF.funder]:
-            fundref_el = self.visit(fundrefs_el, 'fundingReference')
-            self.visit(fundref_el, 'funderName', text=next(self.basket[_funder:FOAF.name], ''))
-            funder_identifier = next(self.basket[_funder:DCTERMS.identifier], '')
+            if _funder not in _visited_funders:
+                self._funding_reference(fundrefs_el, _funder)
+
+    def _funding_reference(self, fundrefs_el, funder, funding_award=None):
+        _fundref_el = self.visit(fundrefs_el, 'fundingReference')
+        self.visit(_fundref_el, 'funderName', text=next(self.basket[funder:FOAF.name], ''))
+        _funder_identifier = next(self.basket[funder:DCTERMS.identifier], '')
+        self.visit(
+            _fundref_el,
+            'funderIdentifier',
+            text=_funder_identifier,
+            attrib={
+                'funderIdentifierType': self._funder_identifier_type(_funder_identifier),
+            },
+        )
+        if funding_award is not None:
             self.visit(
-                fundref_el,
-                'funderIdentifier',
-                text=funder_identifier,
+                _fundref_el,
+                'awardNumber',
+                text=next(self.basket[funding_award:OSF.awardNumber], ''),
                 attrib={
-                    'funderIdentifierType': self._funder_identifier_type(funder_identifier),
+                    'awardURI': (
+                        str(funding_award)
+                        if isinstance(funding_award, rdflib.URIRef)
+                        else ''
+                    )
                 },
             )
-            for _funding_award in self.basket[OSF.hasFunding]:
-                if _funder in self.basket[_funding_award:DCTERMS.contributor]:
-                    self.visit(
-                        fundref_el,
-                        'awardNumber',
-                        text=next(self.basket[_funding_award:OSF.awardNumber], ''),
-                        attrib={
-                            'awardURI': (
-                                str(_funding_award)
-                                if isinstance(_funding_award, rdflib.URIRef)
-                                else ''
-                            )
-                        },
-                    )
-                    self.visit(fundref_el, 'awardTitle', text=next(self.basket[_funding_award:DCTERMS.title], ''))
+            self.visit(_fundref_el, 'awardTitle', text=next(self.basket[funding_award:DCTERMS.title], ''))
 
     def _visit_publication_year(self, parent_el, focus_iri):
         year_copyrighted = next(self.basket[focus_iri:DCTERMS.dateCopyrighted], None)

--- a/osf_tests/metadata/expected_metadata_files/file_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/file_full.turtle
@@ -28,8 +28,10 @@
     dcterms:title "this is a project title!"@en ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
-    osf:funder <https://doi.org/10.$$$$> ;
-    osf:hasFunding <https://moneypockets.example/millions> .
+    osf:funder <https://doi.org/10.$>,
+        <https://doi.org/10.$$$$> ;
+    osf:hasFunding <https://moneypockets.example/millions>,
+        <https://moneypockets.example/millions-more> .
 
 <http://localhost:5000/w3ibb?revision=1> a osf:FileVersion ;
     dcterms:created "2123-05-04" ;
@@ -46,12 +48,22 @@
     dcterms:title "because reasons" ;
     osf:awardNumber "10000000" .
 
+<https://moneypockets.example/millions-more> a osf:FundingAward ;
+    dcterms:contributor <https://doi.org/10.$$$$> ;
+    dcterms:identifier "https://moneypockets.example/millions-more" ;
+    dcterms:title "because reasons!" ;
+    osf:awardNumber "2000000" .
+
 <https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode> dcterms:identifier "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode" ;
     foaf:name "CC-By Attribution-NonCommercial-NoDerivatives 4.0 International" .
 
 <https://doi.org/10.$$$$> a dcterms:Agent ;
     dcterms:identifier "https://doi.org/10.$$$$" ;
     foaf:name "Mx. Moneypockets" .
+
+<https://doi.org/10.$> a dcterms:Agent ;
+    dcterms:identifier "https://doi.org/10.$" ;
+    foaf:name "Caring Fan" .
 
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;

--- a/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
@@ -50,8 +50,10 @@
     dcterms:title "this is a project title!"@en ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
-    osf:funder <https://doi.org/10.$$$$> ;
-    osf:hasFunding <https://moneypockets.example/millions> .
+    osf:funder <https://doi.org/10.$>,
+        <https://doi.org/10.$$$$> ;
+    osf:hasFunding <https://moneypockets.example/millions>,
+        <https://moneypockets.example/millions-more> .
 
 <http://localhost:8000/v2/subjects/subjwobb/> a skos:Concept ;
     skos:broader <http://localhost:8000/v2/subjects/subjwibb/> ;
@@ -76,6 +78,12 @@
     dcterms:identifier "https://moneypockets.example/millions" ;
     dcterms:title "because reasons" ;
     osf:awardNumber "10000000" .
+
+<https://moneypockets.example/millions-more> a osf:FundingAward ;
+    dcterms:contributor <https://doi.org/10.$$$$> ;
+    dcterms:identifier "https://moneypockets.example/millions-more" ;
+    dcterms:title "because reasons!" ;
+    osf:awardNumber "2000000" .
 
 <https://schema.datacite.org/meta/kernel-4.4/#Dataset> rdfs:label "Dataset"@en .
 
@@ -105,6 +113,10 @@
 <https://doi.org/10.$$$$> a dcterms:Agent ;
     dcterms:identifier "https://doi.org/10.$$$$" ;
     foaf:name "Mx. Moneypockets" .
+
+<https://doi.org/10.$> a dcterms:Agent ;
+    dcterms:identifier "https://doi.org/10.$" ;
+    foaf:name "Caring Fan" .
 
 <http://localhost:8000/v2/subjects/subjwibbb/> a skos:Concept ;
     skos:inScheme <https://bepress.com/reference_guide_dc/disciplines/> ;

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
@@ -59,6 +59,25 @@
         "funderIdentifierType": "Crossref Funder ID"
       },
       "funderName": "Mx. Moneypockets"
+    },
+    {
+      "awardNumber": {
+        "awardNumber": "2000000",
+        "awardURI": "https://moneypockets.example/millions-more"
+      },
+      "awardTitle": "because reasons!",
+      "funderIdentifier": {
+        "funderIdentifier": "https://doi.org/10.$$$$",
+        "funderIdentifierType": "Crossref Funder ID"
+      },
+      "funderName": "Mx. Moneypockets"
+    },
+    {
+      "funderIdentifier": {
+        "funderIdentifier": "https://doi.org/10.$",
+        "funderIdentifierType": "Crossref Funder ID"
+      },
+      "funderName": "Caring Fan"
     }
   ],
   "identifier": {

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
@@ -42,6 +42,16 @@
       <awardNumber awardURI="https://moneypockets.example/millions">10000000</awardNumber>
       <awardTitle>because reasons</awardTitle>
     </fundingReference>
+    <fundingReference>
+      <funderName>Mx. Moneypockets</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.$$$$</funderIdentifier>
+      <awardNumber awardURI="https://moneypockets.example/millions-more">2000000</awardNumber>
+      <awardTitle>because reasons!</awardTitle>
+    </fundingReference>
+    <fundingReference>
+      <funderName>Caring Fan</funderName>
+      <funderIdentifier funderIdentifierType="Crossref Funder ID">https://doi.org/10.$</funderIdentifier>
+    </fundingReference>
   </fundingReferences>
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="HasVersion">http://localhost:5000/w5ibb</relatedIdentifier>

--- a/osf_tests/metadata/expected_metadata_files/project_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_full.turtle
@@ -24,8 +24,10 @@
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
     dcat:accessService <http://localhost:5000> ;
     osf:contains <http://localhost:5000/w3ibb> ;
-    osf:funder <https://doi.org/10.$$$$> ;
-    osf:hasFunding <https://moneypockets.example/millions> ;
+    osf:funder <https://doi.org/10.$>,
+        <https://doi.org/10.$$$$> ;
+    osf:hasFunding <https://moneypockets.example/millions>,
+        <https://moneypockets.example/millions-more> ;
     osf:hostingInstitution <https://cos.io/> ;
     osf:supplements <http://localhost:5000/w4ibb> .
 
@@ -64,6 +66,12 @@
     dcterms:title "because reasons" ;
     osf:awardNumber "10000000" .
 
+<https://moneypockets.example/millions-more> a osf:FundingAward ;
+    dcterms:contributor <https://doi.org/10.$$$$> ;
+    dcterms:identifier "https://moneypockets.example/millions-more" ;
+    dcterms:title "because reasons!" ;
+    osf:awardNumber "2000000" .
+
 <https://cos.io/> a dcterms:Agent,
         foaf:Organization ;
     dcterms:identifier "https://cos.io/",
@@ -87,6 +95,10 @@
 <https://doi.org/10.$$$$> a dcterms:Agent ;
     dcterms:identifier "https://doi.org/10.$$$$" ;
     foaf:name "Mx. Moneypockets" .
+
+<https://doi.org/10.$> a dcterms:Agent ;
+    dcterms:identifier "https://doi.org/10.$" ;
+    foaf:name "Caring Fan" .
 
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;

--- a/osf_tests/metadata/expected_metadata_files/registration_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/registration_full.turtle
@@ -35,14 +35,22 @@
     dcterms:title "this is a project title!"@en ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4.4/#Dataset> ;
     owl:sameAs <https://doi.org/10.70102/FK2osf.io/w2ibb> ;
-    osf:funder <https://doi.org/10.$$$$> ;
-    osf:hasFunding <https://moneypockets.example/millions> .
+    osf:funder <https://doi.org/10.$>,
+        <https://doi.org/10.$$$$> ;
+    osf:hasFunding <https://moneypockets.example/millions>,
+        <https://moneypockets.example/millions-more> .
 
 <https://moneypockets.example/millions> a osf:FundingAward ;
     dcterms:contributor <https://doi.org/10.$$$$> ;
     dcterms:identifier "https://moneypockets.example/millions" ;
     dcterms:title "because reasons" ;
     osf:awardNumber "10000000" .
+
+<https://moneypockets.example/millions-more> a osf:FundingAward ;
+    dcterms:contributor <https://doi.org/10.$$$$> ;
+    dcterms:identifier "https://moneypockets.example/millions-more" ;
+    dcterms:title "because reasons!" ;
+    osf:awardNumber "2000000" .
 
 <https://cos.io/> a dcterms:Agent,
         foaf:Organization ;
@@ -62,6 +70,10 @@
 <https://doi.org/10.$$$$> a dcterms:Agent ;
     dcterms:identifier "https://doi.org/10.$$$$" ;
     foaf:name "Mx. Moneypockets" .
+
+<https://doi.org/10.$> a dcterms:Agent ;
+    dcterms:identifier "https://doi.org/10.$" ;
+    foaf:name "Caring Fan" .
 
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -222,13 +222,27 @@ class TestSerializers(OsfTestCase):
             'language': 'en',
             'resource_type_general': 'Dataset',
             'funding_info': [
-                {
+                {  # full funding reference:
                     'funder_name': 'Mx. Moneypockets',
                     'funder_identifier': 'https://doi.org/10.$$$$',
                     'funder_identifier_type': 'Crossref Funder ID',
                     'award_number': '10000000',
                     'award_uri': 'https://moneypockets.example/millions',
                     'award_title': 'because reasons',
+                }, {  # second funding award from the same funder:
+                    'funder_name': 'Mx. Moneypockets',
+                    'funder_identifier': 'https://doi.org/10.$$$$',
+                    'funder_identifier_type': 'Crossref Funder ID',
+                    'award_number': '2000000',
+                    'award_uri': 'https://moneypockets.example/millions-more',
+                    'award_title': 'because reasons!',
+                }, {  # no award info, just a funder:
+                    'funder_name': 'Caring Fan',
+                    'funder_identifier': 'https://doi.org/10.$',
+                    'funder_identifier_type': 'Crossref Funder ID',
+                    'award_number': '',
+                    'award_uri': '',
+                    'award_title': '',
                 },
             ],
         }, auth=self.user)


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
ensure valid xml for datacite when something has multiple funding references for the same funder
<!-- Describe the purpose of your changes -->

## Changes
- update tests to cover multiple funding references from the same funder
- fix broken datacite serialization logic
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify a project can have multiple funding references with the same funder id
- Verify the datacite-xml metadata for that project (at `/<guid>/metadata?format=datacite-xml`)
  1. downloads successfully
  2. contains multiple `<fundingReference>` tags (matching what's shown in the ui), each with no more than one `<awardNumber>` and `<awardTitle>`
- Verify that project can have a DOI minted successfully (in environments set up for DOI minting)

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-5044]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-5044]: https://openscience.atlassian.net/browse/ENG-5044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ