### PR TITLE
[ENG-5203] Add metadata records relationships to nodes, registrations and files

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -946,6 +946,11 @@ class RelationshipField(ser.Field):
                     elif related_type == 'custom-file-metadata':
                         related_id = resolved_url.kwargs['guid_id']
                         related_type = 'custom-file-metadata-records'
+                    elif related_type == 'cedar-metadata-templates' and related_class.view_name == 'cedar-metadata-template-detail':
+                        related_id = resolved_url.kwargs['template_id']
+                    elif related_type == 'guids' and related_class.view_name == 'guid-detail':
+                        related_id = resolved_url.kwargs['guids']
+                        related_type = related_meta.get('django_content_type', 'guids')
                     else:
                         related_id = resolved_url.kwargs[related_type[:-1] + '_id']
                 except KeyError:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -948,9 +948,6 @@ class RelationshipField(ser.Field):
                         related_type = 'custom-file-metadata-records'
                     elif related_type == 'cedar-metadata-templates' and related_class.view_name == 'cedar-metadata-template-detail':
                         related_id = resolved_url.kwargs['template_id']
-                    elif related_type == 'guids' and related_class.view_name == 'guid-detail':
-                        related_id = resolved_url.kwargs['guids']
-                        related_type = related_meta.get('django_content_type', 'guids')
                     else:
                         related_id = resolved_url.kwargs[related_type[:-1] + '_id']
                 except KeyError:

--- a/api/cedar_metadata_records/serializers.py
+++ b/api/cedar_metadata_records/serializers.py
@@ -97,8 +97,7 @@ class CedarMetadataRecordsListCreateSerializer(CedarMetadataRecordsBaseSerialize
         related_view='guids:guid-detail',
         related_view_kwargs={'guids': '<guid._id>'},
         related_meta={
-            'type': 'get_target_type',
-            'id': 'get_target_id',
+            'django_content_type': 'get_target_type',
         },
         # always_embed=True,
         read_only=False,
@@ -108,11 +107,6 @@ class CedarMetadataRecordsListCreateSerializer(CedarMetadataRecordsBaseSerialize
     template = CedarMetadataTemplateRelationshipField(
         related_view='cedar-metadata-templates:cedar-metadata-template-detail',
         related_view_kwargs={'template_id': '<template._id>'},
-        related_meta={
-            'type': 'get_template_type',
-            'id': 'get_template_id',
-        },
-        # always_embed=True,
         read_only=False,
         required=True,
     )
@@ -147,21 +141,14 @@ class CedarMetadataRecordsDetailSerializer(CedarMetadataRecordsBaseSerializer):
         related_view='guids:guid-detail',
         related_view_kwargs={'guids': '<guid._id>'},
         related_meta={
-            'type': 'get_target_type',
-            'id': 'get_target_id',
+            'django_content_type': 'get_target_type',
         },
-        # always_embed=True,
         read_only=True,
     )
 
     template = RelationshipField(
         related_view='cedar-metadata-templates:cedar-metadata-template-detail',
         related_view_kwargs={'template_id': '<template._id>'},
-        related_meta={
-            'type': 'get_template_type',
-            'id': 'get_template_id',
-        },
-        # always_embed=True,
         read_only=True,
     )
 

--- a/api/cedar_metadata_records/utils.py
+++ b/api/cedar_metadata_records/utils.py
@@ -1,0 +1,29 @@
+import logging
+
+from osf.models import BaseFileNode, CedarMetadataRecord, Node, Registration
+
+logger = logging.getLogger(__name__)
+
+
+def get_guids_related_view(obj):
+    assert isinstance(obj, CedarMetadataRecord), 'object must be a CedarMetadataRecord'
+    referent = obj.guid.referent
+    if isinstance(referent, Node):
+        return 'nodes:node-detail'
+    elif isinstance(referent, Registration):
+        return 'registrations:registration-detail'
+    elif isinstance(referent, BaseFileNode):
+        return 'files:file-detail'
+    else:
+        raise NotImplementedError()
+
+
+def get_guids_related_view_kwargs(obj):
+    assert isinstance(obj, CedarMetadataRecord), 'object must be a CedarMetadataRecord'
+    referent = obj.guid.referent
+    if isinstance(referent, (Node, Registration)):
+        return {'node_id': '<guid._id>'}
+    elif isinstance(referent, BaseFileNode):
+        return {'file_id': '<guid._id>'}
+    else:
+        raise NotImplementedError()

--- a/api/cedar_metadata_records/views.py
+++ b/api/cedar_metadata_records/views.py
@@ -14,8 +14,11 @@ from api.base.parsers import (
 from api.base.versioning import PrivateVersioning
 from api.base.views import JSONAPIBaseView
 from api.cedar_metadata_records.permissions import CedarMetadataRecordPermission
-from api.cedar_metadata_records.serializers import CedarMetadataRecordsSerializer, CedarMetadataRecordsCreateSerializer
-
+from api.cedar_metadata_records.serializers import (
+    CedarMetadataRecordsListSerializer,
+    CedarMetadataRecordsListCreateSerializer,
+    CedarMetadataRecordsDetailSerializer,
+)
 from framework.auth.oauth_scopes import CoreScopes
 
 from osf.models import CedarMetadataRecord
@@ -33,7 +36,7 @@ class CedarMetadataRecordList(JSONAPIBaseView, ListCreateAPIView, ListFilterMixi
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.CEDAR_METADATA_RECORD_WRITE]
 
-    serializer_class = CedarMetadataRecordsCreateSerializer
+    serializer_class = CedarMetadataRecordsListSerializer
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON, )
     model_class = CedarMetadataRecord
 
@@ -41,6 +44,12 @@ class CedarMetadataRecordList(JSONAPIBaseView, ListCreateAPIView, ListFilterMixi
     versioning_class = PrivateVersioning
     view_category = 'cedar-metadata-records'
     view_name = 'cedar-metadata-record-list'
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return CedarMetadataRecordsListCreateSerializer
+        else:
+            return CedarMetadataRecordsListSerializer
 
     def get_default_queryset(self):
         return CedarMetadataRecord.objects.filter(is_published=True)
@@ -59,7 +68,7 @@ class CedarMetadataRecordDetail(JSONAPIBaseView, RetrieveUpdateDestroyAPIView):
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.CEDAR_METADATA_RECORD_WRITE]
 
-    serializer_class = CedarMetadataRecordsSerializer
+    serializer_class = CedarMetadataRecordsDetailSerializer
 
     # This view goes under the _/ namespace
     versioning_class = PrivateVersioning

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -393,6 +393,11 @@ class FileSerializer(BaseFileSerializer):
         help_text='Whether to mark the file as unviewed for the current user',
     )
 
+    cedar_metadata_records = RelationshipField(
+        related_view='files:file-cedar-metadata-records-list',
+        related_view_kwargs={'file_id': '<_id>'},
+    )
+
     def get_target_type(self, obj):
         if isinstance(obj, Preprint):
             return 'preprints'

--- a/api/files/urls.py
+++ b/api/files/urls.py
@@ -6,6 +6,7 @@ app_name = 'osf'
 
 urlpatterns = [
     re_path(r'^(?P<file_id>\w+)/$', views.FileDetail.as_view(), name=views.FileDetail.view_name),
+    re_path(r'^(?P<file_id>\w+)/cedar_metadata_records/$', views.FileCedarMetadataRecordsList.as_view(), name=views.FileCedarMetadataRecordsList.view_name),
     re_path(r'^(?P<file_id>\w+)/versions/$', views.FileVersionsList.as_view(), name=views.FileVersionsList.view_name),
     re_path(r'^(?P<file_id>\w+)/versions/(?P<version_id>\w+)/$', views.FileVersionDetail.as_view(), name=views.FileVersionDetail.view_name),
 ]

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -537,6 +537,11 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
         related_view_kwargs={'node_id': '<_id>'},
     )
 
+    cedar_metadata_records = RelationshipField(
+        related_view='nodes:node-cedar-metadata-records-list',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
+
     @property
     def subjects_related_view(self):
         # Overrides TaxonomizableSerializerMixin

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     re_path(r'^(?P<node_id>\w+)/addons/(?P<provider>\w+)/folders/$', views.NodeAddonFolderList.as_view(), name=views.NodeAddonFolderList.view_name),
     re_path(r'^(?P<node_id>\w+)/bibliographic_contributors/$', views.NodeBibliographicContributorsList.as_view(), name=views.NodeBibliographicContributorsList.view_name),
     re_path(r'^(?P<node_id>\w+)/children/$', views.NodeChildrenList.as_view(), name=views.NodeChildrenList.view_name),
+    re_path(r'^(?P<node_id>\w+)/cedar_metadata_records/$', views.NodeCedarMetadataRecordsList.as_view(), name=views.NodeCedarMetadataRecordsList.view_name),
     re_path(r'^(?P<node_id>\w+)/citation/$', views.NodeCitationDetail.as_view(), name=views.NodeCitationDetail.view_name),
     re_path(r'^(?P<node_id>\w+)/citation/(?P<style_id>[-\w]+)/$', views.NodeCitationStyleDetail.as_view(), name=views.NodeCitationStyleDetail.view_name),
     re_path(r'^(?P<node_id>\w+)/comments/$', views.NodeCommentsList.as_view(), name=views.NodeCommentsList.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -57,6 +57,8 @@ from api.base.views import (
     WaterButlerMixin,
 )
 from api.base.waffle_decorators import require_flag
+from api.cedar_metadata_records.serializers import CedarMetadataRecordsListSerializer
+from api.cedar_metadata_records.permissions import CedarMetadataRecordPermission
 from api.citations.utils import render_citation
 from api.comments.permissions import CanCommentOrPublic
 from api.comments.serializers import (
@@ -150,6 +152,7 @@ from osf.models import (
     Guid,
     File,
     Folder,
+    CedarMetadataRecord,
 )
 from addons.osfstorage.models import Region
 from osf.utils.permissions import ADMIN, WRITE_NODE
@@ -2285,3 +2288,25 @@ class NodeSettings(JSONAPIBaseView, generics.RetrieveUpdateAPIView, NodeMixin):
         context['wiki_addon'] = node.get_addon('wiki')
         context['forward_addon'] = node.get_addon('forward')
         return context
+
+
+class NodeCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+
+    permission_classes = (
+        CedarMetadataRecordPermission,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+    required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = CedarMetadataRecordsListSerializer
+
+    view_category = 'nodes'
+    view_name = 'node-cedar-metadata-records-list'
+
+    def get_default_queryset(self):
+        return CedarMetadataRecord.objects.filter(guid___id=self.kwargs['node_id'])
+
+    def get_queryset(self):
+        return self.get_queryset_from_request()

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -398,6 +398,11 @@ class RegistrationSerializer(NodeSerializer):
         related_view_kwargs={'node_id': '<_id>'},
     ))
 
+    cedar_metadata_records = RelationshipField(
+        related_view='registrations:registration-cedar-metadata-records-list',
+        related_view_kwargs={'node_id': '<_id>'},
+    )
+
     @property
     def subjects_related_view(self):
         # Overrides TaxonomizableSerializerMixin

--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     re_path(r'^$', views.RegistrationList.as_view(), name=views.RegistrationList.view_name),
     re_path(r'^(?P<node_id>\w+)/$', views.RegistrationDetail.as_view(), name=views.RegistrationDetail.view_name),
     re_path(r'^(?P<node_id>\w+)/bibliographic_contributors/$', views.RegistrationBibliographicContributorsList.as_view(), name=views.RegistrationBibliographicContributorsList.view_name),
+    re_path(r'^(?P<node_id>\w+)/cedar_metadata_records/$', views.RegistrationCedarMetadataRecordsList.as_view(), name=views.RegistrationCedarMetadataRecordsList.view_name),
     re_path(r'^(?P<node_id>\w+)/children/$', views.RegistrationChildrenList.as_view(), name=views.RegistrationChildrenList.view_name),
     re_path(r'^(?P<node_id>\w+)/comments/$', views.RegistrationCommentsList.as_view(), name=views.RegistrationCommentsList.view_name),
     re_path(r'^(?P<node_id>\w+)/contributors/$', views.RegistrationContributorsList.as_view(), name=views.RegistrationContributorsList.view_name),

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -2,7 +2,7 @@ from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import ValidationError, NotFound, PermissionDenied
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import Registration, OSFUser, RegistrationProvider, OutcomeArtifact
+from osf.models import Registration, OSFUser, RegistrationProvider, OutcomeArtifact, CedarMetadataRecord
 from osf.utils.permissions import WRITE_NODE
 from osf.utils.workflows import ApprovalStates
 
@@ -35,6 +35,8 @@ from api.base.utils import (
     is_bulk_request,
     is_truthy,
 )
+from api.cedar_metadata_records.serializers import CedarMetadataRecordsListSerializer
+from api.cedar_metadata_records.permissions import CedarMetadataRecordPermission
 from api.comments.serializers import RegistrationCommentSerializer, CommentCreateSerializer
 from api.draft_registrations.views import DraftMixin
 from api.identifiers.serializers import RegistrationIdentifierSerializer
@@ -969,3 +971,25 @@ class RegistrationResourceList(JSONAPIBaseView, generics.ListAPIView, ListFilter
 
     def get_permissions_proxy(self):
         return self.get_node()
+
+
+class RegistrationCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+
+    permission_classes = (
+        CedarMetadataRecordPermission,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+    required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = CedarMetadataRecordsListSerializer
+
+    view_category = 'registrations'
+    view_name = 'registration-cedar-metadata-records-list'
+
+    def get_default_queryset(self):
+        return CedarMetadataRecord.objects.filter(guid___id=self.kwargs['node_id'])
+
+    def get_queryset(self):
+        return self.get_queryset_from_request()


### PR DESCRIPTION
## Purpose

### Primary

- [x] Add metadata records relationships to nodes, registrations and files

### Other Improvements

- [x] Re-structure serializer classes

* Finish missing features in https://github.com/CenterForOpenScience/osf.io/pull/10513

  - [x] Serialize and return `type` and `id` for relationship fields
  - [x] Make target relationship versatile to support nodes, registrations and files

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

See [API contacts](https://docs.google.com/document/d/1pfcG0Je0ZntMRNnF0hcLzqNody2ZjBlThoRduPiVzQA/edit#heading=h.rh0pxer1zy44) for details

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5203
