### PR TITLE
[ENG-5247] Support metadata download for a given record

### DIFF
--- a/api/cedar_metadata_records/serializers.py
+++ b/api/cedar_metadata_records/serializers.py
@@ -58,10 +58,17 @@ class CedarMetadataRecordsBaseSerializer(JSONAPISerializer):
         read_only=True,
     )
 
-    links = LinksField({'self': 'get_absolute_url'})
+    links = LinksField({
+        'self': 'get_absolute_url',
+        'download': 'get_download_link',
+    })
 
     def get_absolute_url(self, obj):
         return absolute_reverse('cedar-metadata-records:cedar-metadata-record-detail', kwargs={'record_id': obj._id})
+
+    def get_download_link(self, obj):
+        self_url = self.get_absolute_url(obj)
+        return self_url + '?action=download'
 
     def update(self, instance, validated_data):
         raise NotImplementedError

--- a/api/cedar_metadata_records/serializers.py
+++ b/api/cedar_metadata_records/serializers.py
@@ -60,15 +60,14 @@ class CedarMetadataRecordsBaseSerializer(JSONAPISerializer):
 
     links = LinksField({
         'self': 'get_absolute_url',
-        'download': 'get_download_link',
+        'metadata_download': 'get_metadata_download_link',
     })
 
     def get_absolute_url(self, obj):
         return absolute_reverse('cedar-metadata-records:cedar-metadata-record-detail', kwargs={'record_id': obj._id})
 
-    def get_download_link(self, obj):
-        self_url = self.get_absolute_url(obj)
-        return self_url + '?action=download'
+    def get_metadata_download_link(self, obj):
+        return absolute_reverse('cedar-metadata-records:cedar-metadata-record-metadata-download', kwargs={'record_id': obj._id})
 
     def update(self, instance, validated_data):
         raise NotImplementedError

--- a/api/cedar_metadata_records/urls.py
+++ b/api/cedar_metadata_records/urls.py
@@ -6,5 +6,6 @@ app_name = 'osf'
 
 urlpatterns = [
     re_path(r'^$', views.CedarMetadataRecordList.as_view(), name=views.CedarMetadataRecordList.view_name),
+    re_path(r'^(?P<record_id>[0-9A-Za-z]+)/metadata_download/$', views.CedarMetadataRecordMetadataDownload.as_view(), name=views.CedarMetadataRecordMetadataDownload.view_name),
     re_path(r'^(?P<record_id>[0-9A-Za-z]+)/$', views.CedarMetadataRecordDetail.as_view(), name=views.CedarMetadataRecordDetail.view_name),
 ]

--- a/api/cedar_metadata_records/views.py
+++ b/api/cedar_metadata_records/views.py
@@ -108,4 +108,5 @@ class CedarMetadataRecordMetadataDownload(JSONAPIBaseView, RetrieveAPIView):
 
     def get(self, request, **kwargs):
         record = self.get_object()
-        return Response(record.metadata)
+        file_name = f'{record._id}-{record.get_template_name()}-v{record.get_template_version()}.json'
+        return Response(record.metadata, headers={'Content-Disposition': f'attachment; filename={file_name}'})

--- a/api/cedar_metadata_records/views.py
+++ b/api/cedar_metadata_records/views.py
@@ -3,7 +3,8 @@ import logging
 
 from rest_framework import permissions as drf_permissions
 from rest_framework.exceptions import NotFound
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.views import Response
 
 from api.base import permissions as base_permissions
 from api.base.filters import ListFilterMixin
@@ -80,3 +81,31 @@ class CedarMetadataRecordDetail(JSONAPIBaseView, RetrieveUpdateDestroyAPIView):
             return CedarMetadataRecord.objects.get(_id=self.kwargs['record_id'])
         except CedarMetadataRecord.DoesNotExist:
             raise NotFound
+
+class CedarMetadataRecordMetadataDownload(JSONAPIBaseView, RetrieveAPIView):
+
+    permission_classes = (
+        CedarMetadataRecordPermission,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+    required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
+    required_write_scopes = [CoreScopes.CEDAR_METADATA_RECORD_WRITE]
+
+    # This view goes under the _/ namespace
+    versioning_class = PrivateVersioning
+    view_category = 'cedar-metadata-records'
+    view_name = 'cedar-metadata-record-metadata-download'
+
+    def get_object(self):
+        try:
+            return CedarMetadataRecord.objects.get(_id=self.kwargs['record_id'])
+        except CedarMetadataRecord.DoesNotExist:
+            raise NotFound
+
+    def get_serializer_class(self):
+        return None
+
+    def get(self, request, **kwargs):
+        record = self.get_object()
+        return Response(record.metadata)

--- a/api/cedar_metadata_records/views.py
+++ b/api/cedar_metadata_records/views.py
@@ -4,6 +4,7 @@ import logging
 from rest_framework import permissions as drf_permissions
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import ListCreateAPIView, RetrieveAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.renderers import JSONRenderer
 from rest_framework.views import Response
 
 from api.base import permissions as base_permissions
@@ -91,6 +92,8 @@ class CedarMetadataRecordMetadataDownload(JSONAPIBaseView, RetrieveAPIView):
     )
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.CEDAR_METADATA_RECORD_WRITE]
+
+    renderer_classes = [JSONRenderer]
 
     # This view goes under the _/ namespace
     versioning_class = PrivateVersioning

--- a/osf/models/cedar_metadata.py
+++ b/osf/models/cedar_metadata.py
@@ -40,6 +40,9 @@ class CedarMetadataRecord(ObjectIDMixin, BaseModel):
     def get_template_name(self):
         return self.template.schema_name
 
+    def get_template_version(self):
+        return self.template.template_version
+
     def save(self, *args, **kwargs):
         self.guid.referent.update_search()
         return super().save(*args, **kwargs)


### PR DESCRIPTION
## Purpose

Support metadata download for a given record

## Changes

* Add metadata download endpoint
* Add metadata download link to record serializer
* File name: `<guid>-<schema_name>-v<version_number>.json`

### Note for FE

```json
"links": {
    "self": "<domain>_/cedar_metadata_records/<record_id>/",
    "metadata_download": "<domain>/_/cedar_metadata_records/<record_id>/metadata_download/",
}
```

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5247
