### PR TITLE
[Cedar] Bug Fix - Template List Should Only Return Active Ones

### DIFF
--- a/api/cedar_metadata_templates/views.py
+++ b/api/cedar_metadata_templates/views.py
@@ -31,7 +31,7 @@ class CedarMetadataTemplateList(JSONAPIBaseView, generics.ListAPIView, ListFilte
     view_name = 'cedar-metadata-template-list'
 
     def get_default_queryset(self):
-        return CedarMetadataTemplate.objects.all()
+        return CedarMetadataTemplate.objects.filter(active=True)
 
     def get_queryset(self):
         return self.get_queryset_from_request()


### PR DESCRIPTION
## Purpose

Template List Should Only Return Active Ones

See: https://www.notion.so/cos/CedarMetadataTemplateList-view-should-only-return-active-templates-a7cad22d080f47cf924e4d0b1bf3b15a

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
