### PR TITLE
fixed preprints service startup as we are not using bower for it anymore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,7 +294,6 @@ services:
       - /bin/bash
       - -c
       - yarn --frozen-lockfile &&
-       ./node_modules/.bin/bower install --allow-root --config.interactive=false &&
        yarn start --host 0.0.0.0 --port 4201 --live-reload-port 41954
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Purpose

Preprints service won't start as entrypoint is using bower which is missing from container runtime

## Changes

Removed line in entrypoint which invoked bower

## QA Notes

## Documentation

## Side Effects

## Ticket
https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?selectedIssue=ENG-5209
