### PR TITLE
[ENG-5258] Expand `FileCedarMetadataRecordList` view to support both `file_id` and `guid_id`

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -370,6 +370,14 @@ class BaseFileSerializer(JSONAPISerializer):
                 return guid._id
         return None
 
+    def get_file_guid_or_id(self, obj):
+        if obj:
+            guid = obj.get_guid()
+            if guid:
+                return guid._id
+            return obj._id
+        return None
+
     def get_absolute_url(self, obj):
         return api_v2_url('files/{}/'.format(obj._id))
 
@@ -395,7 +403,7 @@ class FileSerializer(BaseFileSerializer):
 
     cedar_metadata_records = RelationshipField(
         related_view='files:file-cedar-metadata-records-list',
-        related_view_kwargs={'file_guid': 'get_file_guid'},
+        related_view_kwargs={'file_id_or_guid': 'get_file_guid_or_id'},
     )
 
     def get_target_type(self, obj):

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -47,7 +47,7 @@ from api.base.serializers import (
     ShowIfVersion,
 )
 from api.base.utils import absolute_reverse, get_user_auth
-from api.base.exceptions import Conflict, JSONAPIException
+from api.base.exceptions import Conflict
 from api.base.versioning import get_kebab_snake_case_field
 
 class CheckoutField(ser.HyperlinkedRelatedField):
@@ -370,13 +370,6 @@ class BaseFileSerializer(JSONAPISerializer):
                 return guid._id
         return None
 
-    def get_file_guid_or_error(self, obj):
-        if obj:
-            guid = obj.get_guid()
-            if guid:
-                return guid._id
-        raise JSONAPIException
-
     def get_absolute_url(self, obj):
         return api_v2_url('files/{}/'.format(obj._id))
 
@@ -402,7 +395,7 @@ class FileSerializer(BaseFileSerializer):
 
     cedar_metadata_records = RelationshipField(
         related_view='files:file-cedar-metadata-records-list',
-        related_view_kwargs={'file_guid': 'get_file_guid_or_error'},
+        related_view_kwargs={'file_guid': 'get_file_guid'},
     )
 
     def get_target_type(self, obj):

--- a/api/files/urls.py
+++ b/api/files/urls.py
@@ -6,7 +6,7 @@ app_name = 'osf'
 
 urlpatterns = [
     re_path(r'^(?P<file_id>\w+)/$', views.FileDetail.as_view(), name=views.FileDetail.view_name),
-    re_path(r'^(?P<file_guid>\w+)/cedar_metadata_records/$', views.FileCedarMetadataRecordsList.as_view(), name=views.FileCedarMetadataRecordsList.view_name),
+    re_path(r'^(?P<file_id_or_guid>\w+)/cedar_metadata_records/$', views.FileCedarMetadataRecordsList.as_view(), name=views.FileCedarMetadataRecordsList.view_name),
     re_path(r'^(?P<file_id>\w+)/versions/$', views.FileVersionsList.as_view(), name=views.FileVersionsList.view_name),
     re_path(r'^(?P<file_id>\w+)/versions/(?P<version_id>\w+)/$', views.FileVersionDetail.as_view(), name=views.FileVersionDetail.view_name),
 ]

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -193,7 +193,17 @@ class FileCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFi
     view_name = 'file-cedar-metadata-records-list'
 
     def get_default_queryset(self):
-        return CedarMetadataRecord.objects.filter(guid___id=self.kwargs['file_guid'])
+        file_id_or_guid = self.kwargs['file_id_or_guid']
+        try:
+            Guid.objects.get(_id=file_id_or_guid)
+            return CedarMetadataRecord.objects.filter(guid___id=self.kwargs['file_id_or_guid'])
+        except Guid.DoesNotExist:
+            file = BaseFileNode.load(file_id_or_guid)
+            if file:
+                guid = file.get_guid()
+                if guid:
+                    return CedarMetadataRecord.objects.filter(guid___id=guid._id)
+        return CedarMetadataRecord.objects.none()
 
     def get_queryset(self):
         return self.get_queryset_from_request()


### PR DESCRIPTION
## Purpose

* `FileCedarMetadataRecordList` view now supports both `file_id` and `guid_id`;

* In addition, this PR fixed an unexpected side-effect from https://github.com/CenterForOpenScience/osf.io/pull/10531 where the file serializer fails if the file doesn't have a `guid` yet.

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5258
