### PR TITLE
[Cedar] Bug-fix: new templates should be added as inactive

### DIFF
--- a/osf/management/commands/fetch_cedar_metadata_templates.py
+++ b/osf/management/commands/fetch_cedar_metadata_templates.py
@@ -55,11 +55,12 @@ def ingest_cedar_metadata_templates():
                 )
                 updated.add(cedar_id)
         else:
-            # Initial version should be active
+            # Initial version should also be inactive
             CedarMetadataTemplate.objects.create(
                 schema_name=schema_name,
                 template=template,
                 cedar_id=cedar_id,
+                active=False,
                 template_version=1
             )
             newly_added.add(cedar_id)


### PR DESCRIPTION
## Purpose

New templates should be added as inactive;

Fixed this [bug](https://www.notion.so/cos/Admin-initial-version-of-a-template-should-also-be-added-as-inactive-f42b8ac5c54d441388ee45d558376f0d).

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

N/A


## Side Effects

N/A

## Ticket

N/A
