### PR TITLE
ENG-5211 updated base image to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-alpine3.17
 
 # Creation of www-data group was removed as it is created by default in alpine 3.14 and higher
+# Alpine does not create a www-data user, so we still need to create that. 82 is the standard
+# uid/guid for www-data in Alpine.
 RUN set -x \
     && adduser -h /var/www -u 82 -D -S -G www-data www-data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-alpine3.17
 
-# Source: https://github.com/docker-library/httpd/blob/7976cabe162268bd5ad2d233d61e340447bfc371/2.4/alpine/Dockerfile#L3
+# Creation of www-data group was removed as it is created by default in alpine 3.14 and higher
 RUN set -x \
     && adduser -h /var/www -u 82 -D -S -G www-data www-data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@
 # To install addon requirements: inv requirements --addons
 # To install dev requirements: inv requirements --dev
 # To install release requirements: inv requirements --release
-
+setuptools<58.0.0
 future==0.18.2
 invoke==0.15.0
 Werkzeug==1.0.0
 Flask==1.0
-gevent==1.2.2
+gevent==21.12.0
 Mako==1.0.7
 Markdown==3.3.7
 WTForms==1.0.4
@@ -82,7 +82,7 @@ django-storages==1.6.6
 google-cloud-storage==0.22.0  # dependency of django-storages, hard-pin to version
 django-dirtyfields==1.3.1
 django-extensions==3.2.0
-psycopg2==2.7.3 --no-binary psycopg2
+psycopg2==2.8.4 --no-binary psycopg2
 django-bulk-update==2.2.0
 
 # Reviews requirements


### PR DESCRIPTION

## Purpose

Update docker image to python 3.10

## Changes
Updated docker image to alpine 3.17 which includes Python 3.10 and NodeJS 18
Bumped libraries which refused to complie on python 3.10 (because of changes in Python C API)

## QA Notes

NodeJS 18 may break some things in the future, but for now everything works

## Documentation


## Side Effects

Node JS 18 may break Node related stuff. LIbraries which are bumped may break things

## Ticket

https://openscience.atlassian.net/browse/ENG-5212
