### PR TITLE
[ENG-5204] Fix another occurrence of the private view url reverse bug

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -658,7 +658,7 @@ class RelationshipField(ser.Field):
             # Handle private endpoint view serialization when it is a relationship in a public one
             if kwargs.get('version', False):
                 kwargs.pop('version')
-                view_url = utils.absolute_reverse(view, kwargs=kwargs)
+                view_url = drf_reverse(view, kwargs=kwargs)
             else:
                 raise e
         return resolve(view_url)


### PR DESCRIPTION
## Purpose

Fix another occurrence of the private view url reverse bug when it is a relationship of a public view

Related [bug](https://www.notion.so/cos/embedding-the-template-relationship-through-the-node-cedar-record-list-view-failed-with-NoReverseMat-66c46bb6577847cb80ff20b4c08931f4)

A similar [fix](https://github.com/CenterForOpenScience/osf.io/pull/10519/commits/34e6772b8b7c50ee2b4191f6ce58cbc03e68b35e) on a similar issue previously

## Changes

N/A

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5204
