### PR TITLE
[WIP] removed all usages of mock library, replaced them with stdlib

### DIFF
--- a/addons/base/tests/models.py
+++ b/addons/base/tests/models.py
@@ -1,6 +1,6 @@
 import abc
 
-import mock
+from unittest import mock
 import pytest
 import pytz
 import datetime

--- a/addons/base/tests/serializers.py
+++ b/addons/base/tests/serializers.py
@@ -1,6 +1,6 @@
 import abc
 
-import mock
+from unittest import mock
 from framework.auth import Auth
 from nose.tools import (assert_equal, assert_false, assert_in,
                         assert_is_not_none, assert_raises, assert_true)

--- a/addons/base/tests/views.py
+++ b/addons/base/tests/views.py
@@ -1,5 +1,5 @@
 from future.moves.urllib.parse import urlparse, parse_qs
-import mock
+from unittest import mock
 from nose.tools import *  # noqa
 import responses
 from rest_framework import status as http_status

--- a/addons/bitbucket/tests/test_models.py
+++ b/addons/bitbucket/tests/test_models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 import pytest
 import unittest
 from nose.tools import *  # noqa

--- a/addons/bitbucket/tests/test_serializer.py
+++ b/addons/bitbucket/tests/test_serializer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the Bitbucket addon."""
 
-import mock
+from unittest import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 

--- a/addons/bitbucket/tests/test_views.py
+++ b/addons/bitbucket/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from rest_framework import status as http_status
 
-import mock
+from unittest import mock
 import datetime
 import unittest
 import pytest

--- a/addons/bitbucket/tests/utils.py
+++ b/addons/bitbucket/tests/utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from addons.bitbucket.api import BitbucketClient
 

--- a/addons/boa/tests/test_serializer.py
+++ b/addons/boa/tests/test_serializer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from tests.base import OsfTestCase

--- a/addons/boa/tests/test_tasks.py
+++ b/addons/boa/tests/test_tasks.py
@@ -2,7 +2,7 @@ from asynctest import TestCase as AsyncTestCase
 from boaapi.boa_client import BoaException
 from boaapi.status import CompilerStatus, ExecutionStatus
 from http.client import HTTPMessage
-import mock
+from unittest import mock
 import pytest
 from unittest.mock import ANY, MagicMock
 from urllib.error import HTTPError

--- a/addons/boa/tests/test_views.py
+++ b/addons/boa/tests/test_views.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from rest_framework import status as http_status
 

--- a/addons/box/tests/test_models.py
+++ b/addons/box/tests/test_models.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import unittest
 
 import pytest

--- a/addons/box/tests/test_serializer.py
+++ b/addons/box/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the Box addon."""
-import mock
+from unittest import mock
 import pytest
 
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin

--- a/addons/box/tests/test_views.py
+++ b/addons/box/tests/test_views.py
@@ -3,7 +3,7 @@
 from django.utils import timezone
 from rest_framework import status as http_status
 from nose.tools import *  # noqa (PEP8 asserts)
-import mock
+from unittest import mock
 import pytest
 from urllib3.exceptions import MaxRetryError
 

--- a/addons/box/tests/utils.py
+++ b/addons/box/tests/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from contextlib import contextmanager
 
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase

--- a/addons/dataverse/tests/test_client.py
+++ b/addons/dataverse/tests/test_client.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from nose.tools import (
     assert_equal, assert_raises, assert_true,
     assert_false, assert_in, assert_is, assert_is_none

--- a/addons/dataverse/tests/test_model.py
+++ b/addons/dataverse/tests/test_model.py
@@ -1,5 +1,5 @@
 from nose.tools import *  # noqa
-import mock
+from unittest import mock
 import pytest
 import unittest
 

--- a/addons/dataverse/tests/test_serializer.py
+++ b/addons/dataverse/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # noqa
-import mock
+from unittest import mock
 import pytest
 
 

--- a/addons/dataverse/tests/test_views.py
+++ b/addons/dataverse/tests/test_views.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose.tools import (assert_false, assert_equal, assert_in, assert_true)
-import mock
+from unittest import mock
 import pytest
 import unittest
 

--- a/addons/dataverse/tests/utils.py
+++ b/addons/dataverse/tests/utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from dataverse import Connection, Dataverse, Dataset, DataverseFile
 

--- a/addons/dropbox/tests/test_models.py
+++ b/addons/dropbox/tests/test_models.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+from unittest import mock
 import pytest
 from addons.base.tests.models import (OAuthAddonNodeSettingsTestSuiteMixin,
                                       OAuthAddonUserSettingTestSuiteMixin)

--- a/addons/dropbox/tests/test_views.py
+++ b/addons/dropbox/tests/test_views.py
@@ -7,7 +7,7 @@ from nose.tools import assert_equal
 from tests.base import OsfTestCase
 from urllib3.exceptions import MaxRetryError
 
-import mock
+from unittest import mock
 import pytest
 from addons.base.tests import views as views_testing
 from addons.dropbox.tests.utils import (

--- a/addons/dropbox/tests/utils.py
+++ b/addons/dropbox/tests/utils.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-import mock
+from unittest import mock
 from addons.base.tests.base import AddonTestCase, OAuthAddonTestCaseMixin
 from addons.dropbox.models import Provider
 from addons.dropbox.tests.factories import DropboxAccountFactory

--- a/addons/figshare/tests/test_models.py
+++ b/addons/figshare/tests/test_models.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from nose.tools import assert_false, assert_equal
 import pytest
 import unittest

--- a/addons/figshare/tests/test_serializer.py
+++ b/addons/figshare/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the Figshare addon."""
-import mock
+from unittest import mock
 import pytest
 
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin

--- a/addons/figshare/tests/test_views.py
+++ b/addons/figshare/tests/test_views.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 from rest_framework import status as http_status
-import mock
+from unittest import mock
 from nose.tools import assert_equal
 import pytest
 

--- a/addons/figshare/tests/utils.py
+++ b/addons/figshare/tests/utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
 from addons.figshare.models import FigshareProvider

--- a/addons/forward/tests/test_views.py
+++ b/addons/forward/tests/test_views.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from nose.tools import assert_equal

--- a/addons/github/tests/test_models.py
+++ b/addons/github/tests/test_models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 import pytest
 import unittest
 from json import dumps

--- a/addons/github/tests/test_serializer.py
+++ b/addons/github/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the GitHub addon."""
-import mock
+from unittest import mock
 import pytest
 
 from tests.base import OsfTestCase

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from github3.repos.branch import Branch
 from nose.tools import *  # noqa: F403
 from json import dumps
-import mock
+from unittest import mock
 import pytest
 
 from framework.auth import Auth

--- a/addons/github/tests/utils.py
+++ b/addons/github/tests/utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from json import dumps
 import github3
 from addons.github.api import GitHubClient

--- a/addons/gitlab/tests/test_models.py
+++ b/addons/gitlab/tests/test_models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 import pytest
 import unittest
 from nose.tools import *  # noqa

--- a/addons/gitlab/tests/test_serializer.py
+++ b/addons/gitlab/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the GitLab addon."""
-import mock
+from unittest import mock
 import pytest
 
 from tests.base import OsfTestCase

--- a/addons/gitlab/tests/test_views.py
+++ b/addons/gitlab/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from rest_framework import status as http_status
 
-import mock
+from unittest import mock
 import datetime
 import pytest
 import unittest

--- a/addons/gitlab/tests/utils.py
+++ b/addons/gitlab/tests/utils.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from addons.gitlab.api import GitLabClient
 
 from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase

--- a/addons/googledrive/tests/test_models.py
+++ b/addons/googledrive/tests/test_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 import unittest

--- a/addons/googledrive/tests/test_serializer.py
+++ b/addons/googledrive/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the Box addon."""
-import mock
+from unittest import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 

--- a/addons/googledrive/tests/test_views.py
+++ b/addons/googledrive/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from nose.tools import *  # noqa
 import pytest
 

--- a/addons/mendeley/tests/test_api.py
+++ b/addons/mendeley/tests/test_api.py
@@ -1,5 +1,5 @@
 import datetime
-import mock
+from unittest import mock
 from nose.tools import assert_equal
 import pytest
 import time

--- a/addons/mendeley/tests/test_models.py
+++ b/addons/mendeley/tests/test_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 import unittest
 

--- a/addons/mendeley/tests/test_views.py
+++ b/addons/mendeley/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from future.moves.urllib.parse import urlparse, urljoin
 

--- a/addons/onedrive/tests/test_client.py
+++ b/addons/onedrive/tests/test_client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-import mock
+from unittest import mock
 
 from addons.onedrive import settings
 from addons.onedrive.client import OneDriveClient

--- a/addons/onedrive/tests/test_models.py
+++ b/addons/onedrive/tests/test_models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 import unittest
 

--- a/addons/onedrive/tests/test_serializer.py
+++ b/addons/onedrive/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the OneDrive addon."""
-import mock
+from unittest import mock
 import pytest
 
 from addons.onedrive.models import OneDriveProvider

--- a/addons/onedrive/tests/test_views.py
+++ b/addons/onedrive/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 
 from addons.base.tests import views

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-import mock
+from unittest import mock
 import unittest
 
 import pytest

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import json
-import mock
+from unittest import mock
 import datetime
 
 import pytest

--- a/addons/owncloud/tests/test_serializer.py
+++ b/addons/owncloud/tests/test_serializer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from tests.base import OsfTestCase

--- a/addons/owncloud/tests/test_views.py
+++ b/addons/owncloud/tests/test_views.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from rest_framework import status as http_status
 

--- a/addons/s3/tests/test_model.py
+++ b/addons/s3/tests/test_model.py
@@ -1,5 +1,5 @@
 # from nose.tools import *  # noqa
-import mock
+from unittest import mock
 from nose.tools import (assert_false, assert_true,
     assert_equal, assert_is_none)
 import pytest

--- a/addons/s3/tests/test_serializer.py
+++ b/addons/s3/tests/test_serializer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Serializer tests for the S3 addon."""
-import mock
+from unittest import mock
 import pytest
 
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin

--- a/addons/s3/tests/test_view.py
+++ b/addons/s3/tests/test_view.py
@@ -2,7 +2,7 @@
 from rest_framework import status as http_status
 
 from boto.exception import S3ResponseError
-import mock
+from unittest import mock
 from nose.tools import (assert_equal, assert_equals,
     assert_true, assert_in, assert_false)
 import pytest

--- a/addons/wiki/tests/test_views.py
+++ b/addons/wiki/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Views tests for the wiki addon."""
 import pytest
-import mock
+from unittest import mock
 import pytz
 import datetime
 from django.utils import timezone

--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -5,7 +5,7 @@
 from copy import deepcopy
 from rest_framework import status as http_status
 import time
-import mock
+from unittest import mock
 import pytest
 import pytz
 import datetime

--- a/addons/zotero/tests/test_models.py
+++ b/addons/zotero/tests/test_models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 import unittest
-import mock
+from unittest import mock
 from framework.auth import Auth
 from nose.tools import (assert_equal, assert_is_none, assert_true, assert_false,
     assert_is, assert_in)

--- a/addons/zotero/tests/test_views.py
+++ b/addons/zotero/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from future.moves.urllib.parse import urlparse, urljoin
 import responses

--- a/admin_tests/common_auth/test_views.py
+++ b/admin_tests/common_auth/test_views.py
@@ -1,5 +1,5 @@
 from nose import tools as nt
-import mock
+from unittest import mock
 
 from django.test import RequestFactory
 from django.http import Http404

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import pytest
-import mock
+from unittest import mock
 import pytz
 import datetime
 

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -1,6 +1,6 @@
 import pytest
 import json
-import mock
+from unittest import mock
 from io import StringIO
 
 import responses

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from django.test import RequestFactory
 from django.urls import reverse

--- a/admin_tests/registration_providers/test_views.py
+++ b/admin_tests/registration_providers/test_views.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-import mock
+from unittest import mock
 
 from django.test import RequestFactory
 

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import furl
 import pytz
 import pytest

--- a/api/addons/forward/test_views.py
+++ b/api/addons/forward/test_views.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from addons.forward.tests.utils import ForwardAddonTestCase

--- a/api_tests/applications/views/test_application_detail.py
+++ b/api_tests/applications/views/test_application_detail.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from website.util import api_v2_url
 from tests.base import assert_dict_contains_subset

--- a/api_tests/applications/views/test_application_list.py
+++ b/api_tests/applications/views/test_application_list.py
@@ -1,6 +1,6 @@
 import pytest
 import copy
-import mock
+from unittest import mock
 
 from osf.models import ApiOAuth2Application
 from website.util import api_v2_url

--- a/api_tests/applications/views/test_application_reset.py
+++ b/api_tests/applications/views/test_application_reset.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from website.util import api_v2_url
 from api.base.settings import API_BASE

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -2,7 +2,7 @@
 Tests related to authenticating API requests
 """
 
-import mock
+from unittest import mock
 
 import pytest
 from nose.tools import *  # noqa:

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -2,7 +2,7 @@
 from django.http import HttpResponse
 
 from future.moves.urllib.parse import urlparse
-import mock
+from unittest import mock
 from nose.tools import *  # noqa:
 from rest_framework.test import APIRequestFactory
 from django.test.utils import override_settings

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import itsdangerous
-import mock
+from unittest import mock
 from nose.tools import *  # noqa:
 import unittest
 from django.utils import timezone

--- a/api_tests/base/test_throttling.py
+++ b/api_tests/base/test_throttling.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from nose.tools import *  # noqa:
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # noqa:
-import mock  # noqa
+from unittest import mock  # noqa
 import unittest
 import pytest
 from importlib import import_module

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -2,7 +2,7 @@
 from rest_framework import status as http_status
 import pkgutil
 
-import mock
+from unittest import mock
 
 from nose import SkipTest
 from nose.tools import *  # noqa:

--- a/api_tests/chronos/views/test_chronos_submission_detail.py
+++ b/api_tests/chronos/views/test_chronos_submission_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from osf_tests.factories import AuthUserFactory, ChronosJournalFactory, ChronosSubmissionFactory, PreprintFactory

--- a/api_tests/chronos/views/test_chronos_submission_list.py
+++ b/api_tests/chronos/views/test_chronos_submission_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from datetime import timedelta

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from future.moves.urllib.parse import urlparse
 

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-import mock
+from unittest import mock
 import pytest
 
 from addons.wiki.tests.factories import WikiFactory

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-import mock
+from unittest import mock
 import pytest
 
 from addons.wiki.tests.factories import WikiFactory

--- a/api_tests/crossref/views/test_crossref_email_response.py
+++ b/api_tests/crossref/views/test_crossref_email_response.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import hmac
 import hashlib

--- a/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import random
 
 from framework.auth.core import Auth

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from framework.auth.core import Auth

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import itsdangerous
-import mock
+from unittest import mock
 import pytest
 import pytz
 from django.utils import timezone

--- a/api_tests/metrics/test_counted_usage.py
+++ b/api_tests/metrics/test_counted_usage.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from unittest from unittest import mock
+from unittest import mock
 
 from osf_tests.factories import (
     AuthUserFactory,

--- a/api_tests/metrics/test_counted_usage.py
+++ b/api_tests/metrics/test_counted_usage.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 import pytest
-from unittest import mock
+from unittest from unittest import mock
 
 from osf_tests.factories import (
     AuthUserFactory,

--- a/api_tests/metrics/test_parse_datetimes.py
+++ b/api_tests/metrics/test_parse_datetimes.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from datetime import datetime
 from django.utils import timezone

--- a/api_tests/metrics/test_preprint_metrics.py
+++ b/api_tests/metrics/test_preprint_metrics.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from datetime import datetime
 
 from website.app import setup_django

--- a/api_tests/metrics/test_queries.py
+++ b/api_tests/metrics/test_queries.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 
 import pytest
 

--- a/api_tests/metrics/test_queries.py
+++ b/api_tests/metrics/test_queries.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 
 import pytest
 

--- a/api_tests/metrics/test_reports.py
+++ b/api_tests/metrics/test_reports.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 
 import pytest
 

--- a/api_tests/metrics/test_reports.py
+++ b/api_tests/metrics/test_reports.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 
 import pytest
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -2,7 +2,7 @@
 import abc
 from json import dumps
 
-import mock
+from unittest import mock
 import pytest
 import mendeley
 from nose.tools import *  # noqa:

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-import mock
+from unittest import mock
 import pytest
 import random
 from nose.tools import *  # noqa:

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.utils import timezone
 from future.moves.urllib.parse import urlparse
-import mock
+from unittest import mock
 from nose.tools import *  # noqa:
 import pytest
 from rest_framework import exceptions

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth

--- a/api_tests/nodes/views/test_node_view_only_links_detail.py
+++ b/api_tests/nodes/views/test_node_view_only_links_detail.py
@@ -1,5 +1,5 @@
 import pytz
-import mock
+from unittest import mock
 import datetime
 import pytest
 

--- a/api_tests/nodes/views/test_node_wiki_list.py
+++ b/api_tests/nodes/views/test_node_wiki_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from rest_framework import exceptions

--- a/api_tests/preprints/views/test_preprint_contributors_list.py
+++ b/api_tests/preprints/views/test_preprint_contributors_list.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
-import mock
+from unittest import mock
 import pytest
 import random
 from django.utils import timezone

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import datetime
 import responses

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import datetime as dt
 
 from nose.tools import *  # noqa:

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from django.utils import timezone
 

--- a/api_tests/providers/collections/views/test_collections_provider_moderator_list.py
+++ b/api_tests/providers/collections/views/test_collections_provider_moderator_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/providers/preprints/views/test_preprint_provider_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from waffle.testutils import override_switch
 

--- a/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/providers/preprints/views/test_preprint_provider_preprints_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_preprints_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from django.utils import timezone
 from api.base.settings.defaults import API_BASE

--- a/api_tests/providers/registrations/views/test_registration_provider_bulk_upload.py
+++ b/api_tests/providers/registrations/views/test_registration_provider_bulk_upload.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 import hashlib
 from rest_framework.exceptions import NotFound
 

--- a/api_tests/providers/tasks/test_bulk_upload.py
+++ b/api_tests/providers/tasks/test_bulk_upload.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import uuid
 

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import datetime
 from future.moves.urllib.parse import urlparse

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 
 from framework.auth.core import Auth
 from api.base.settings.defaults import API_BASE

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from nose.tools import *  # noqa:
 

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1,6 +1,6 @@
 import dateutil.relativedelta
 from django.utils import timezone
-import mock
+from unittest import mock
 from nose.tools import *  # noqa:
 import pytest
 

--- a/api_tests/requests/views/test_request_actions_create.py
+++ b/api_tests/requests/views/test_request_actions_create.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/requests/views/test_request_list_create.py
+++ b/api_tests/requests/views/test_request_list_create.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from osf.utils import workflows

--- a/api_tests/resources/views/test_resource_detail.py
+++ b/api_tests/resources/views/test_resource_detail.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 from urllib.parse import urljoin
 
 import pytest

--- a/api_tests/resources/views/test_resource_detail.py
+++ b/api_tests/resources/views/test_resource_detail.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 from urllib.parse import urljoin
 
 import pytest

--- a/api_tests/share/_utils.py
+++ b/api_tests/share/_utils.py
@@ -1,6 +1,6 @@
 import contextlib
 from urllib.parse import urlsplit
-from unittest import mock
+from unittest from unittest import mock
 
 from django.http import QueryDict
 import responses

--- a/api_tests/share/_utils.py
+++ b/api_tests/share/_utils.py
@@ -1,6 +1,6 @@
 import contextlib
 from urllib.parse import urlsplit
-from unittest from unittest import mock
+from unittest import mock
 
 from django.http import QueryDict
 import responses

--- a/api_tests/share/test_share_preprint.py
+++ b/api_tests/share/test_share_preprint.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest from unittest import mock
+from unittest import mock
 
 import pytest
 import responses

--- a/api_tests/share/test_share_preprint.py
+++ b/api_tests/share/test_share_preprint.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest import mock
+from unittest from unittest import mock
 
 import pytest
 import responses

--- a/api_tests/test/views/test_throttling.py
+++ b/api_tests/test/views/test_throttling.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/tokens/views/test_token_detail.py
+++ b/api_tests/tokens/views/test_token_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.scopes.serializers import SCOPES_RELATIONSHIP_VERSION

--- a/api_tests/tokens/views/test_token_list.py
+++ b/api_tests/tokens/views/test_token_list.py
@@ -1,5 +1,5 @@
 import copy
-import mock
+from unittest import mock
 import pytest
 
 from api.scopes.serializers import SCOPES_RELATIONSHIP_VERSION

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/users/views/test_user_claim.py
+++ b/api_tests/users/views/test_user_claim.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from django.utils import timezone
 

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from future.moves.urllib.parse import urlparse, parse_qs
 import datetime as dt

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -3,7 +3,7 @@ from importlib import import_module
 
 import itsdangerous
 from django.conf import settings as django_conf_settings
-import mock
+from unittest import mock
 import pytest
 import unittest
 from future.moves.urllib.parse import urlparse, parse_qs

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 
 from api.base.settings.defaults import API_BASE

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import (

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import furl
 import pytz

--- a/api_tests/wikis/views/test_wiki_version_detail.py
+++ b/api_tests/wikis/views/test_wiki_version_detail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import furl
 import datetime
 import pytz

--- a/api_tests/wikis/views/test_wiki_versions_list.py
+++ b/api_tests/wikis/views/test_wiki_versions_list.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from addons.wiki.models import WikiPage, WikiVersion

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from unittest from unittest import mock
+from unittest import mock
 import logging
 import os
 import re

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from unittest import mock
+from unittest from unittest import mock
 import logging
 import os
 import re

--- a/osf_tests/embargoes/test_embargoes.py
+++ b/osf_tests/embargoes/test_embargoes.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import datetime
 

--- a/osf_tests/external/akismet/test_akismet.py
+++ b/osf_tests/external/akismet/test_akismet.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import responses
 from urllib.parse import parse_qs

--- a/osf_tests/external/oopspam/test_oopspam.py
+++ b/osf_tests/external/oopspam/test_oopspam.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import responses
 
 import pytest

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -3,7 +3,7 @@ import time
 from importlib import import_module
 
 import datetime
-import mock
+from unittest import mock
 from factory import SubFactory
 from factory.fuzzy import FuzzyDateTime, FuzzyAttribute, FuzzyChoice
 from mock import patch, Mock

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -6,7 +6,7 @@ import datetime
 from unittest import mock
 from factory import SubFactory
 from factory.fuzzy import FuzzyDateTime, FuzzyAttribute, FuzzyChoice
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 import factory
 import pytz

--- a/osf_tests/management_commands/test_approve_pending_schema_responses.py
+++ b/osf_tests/management_commands/test_approve_pending_schema_responses.py
@@ -1,7 +1,7 @@
 import pytest
 
 from django.utils import timezone
-from unittest from unittest import mock
+from unittest import mock
 
 from osf.management.commands.approve_pending_schema_responses import approve_pending_schema_responses
 from osf.models import SchemaResponse

--- a/osf_tests/management_commands/test_approve_pending_schema_responses.py
+++ b/osf_tests/management_commands/test_approve_pending_schema_responses.py
@@ -1,7 +1,7 @@
 import pytest
 
 from django.utils import timezone
-from unittest import mock
+from unittest from unittest import mock
 
 from osf.management.commands.approve_pending_schema_responses import approve_pending_schema_responses
 from osf.models import SchemaResponse

--- a/osf_tests/management_commands/test_backfill_domain_references.py
+++ b/osf_tests/management_commands/test_backfill_domain_references.py
@@ -1,5 +1,5 @@
 import logging
-import mock
+from unittest import mock
 import pytest
 from django.contrib.contenttypes.models import ContentType
 

--- a/osf_tests/management_commands/test_check_crossref_dois.py
+++ b/osf_tests/management_commands/test_check_crossref_dois.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 import os
-import mock
+from unittest import mock
 import pytest
 import json
 from datetime import timedelta

--- a/osf_tests/management_commands/test_correct_registration_moderation_states.py
+++ b/osf_tests/management_commands/test_correct_registration_moderation_states.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from django.utils import timezone
 from osf.management.commands.correct_registration_moderation_states import correct_registration_moderation_states

--- a/osf_tests/management_commands/test_email_all_users.py
+++ b/osf_tests/management_commands/test_email_all_users.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from django.utils import timezone

--- a/osf_tests/management_commands/test_recatalog_metadata.py
+++ b/osf_tests/management_commands/test_recatalog_metadata.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest from unittest import mock
+from unittest import mock
 from operator import attrgetter
 
 from django.core.management import call_command

--- a/osf_tests/management_commands/test_recatalog_metadata.py
+++ b/osf_tests/management_commands/test_recatalog_metadata.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest import mock
+from unittest from unittest import mock
 from operator import attrgetter
 
 from django.core.management import call_command

--- a/osf_tests/management_commands/test_update_registration_schemas.py
+++ b/osf_tests/management_commands/test_update_registration_schemas.py
@@ -1,5 +1,5 @@
 import copy
-import mock
+from unittest import mock
 import random
 import pytest
 

--- a/osf_tests/metadata/test_basket.py
+++ b/osf_tests/metadata/test_basket.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 
 import rdflib
 import pytest

--- a/osf_tests/metadata/test_basket.py
+++ b/osf_tests/metadata/test_basket.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 
 import rdflib
 import pytest

--- a/osf_tests/metadata/test_gatherer_registry.py
+++ b/osf_tests/metadata/test_gatherer_registry.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 
 import rdflib
 

--- a/osf_tests/metadata/test_gatherer_registry.py
+++ b/osf_tests/metadata/test_gatherer_registry.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 
 import rdflib
 

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -1,6 +1,6 @@
 import datetime
 import pathlib
-from unittest import mock
+from unittest from unittest import mock
 
 import rdflib
 

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -1,6 +1,6 @@
 import datetime
 import pathlib
-from unittest from unittest import mock
+from unittest import mock
 
 import rdflib
 

--- a/osf_tests/metrics/test_daily_report.py
+++ b/osf_tests/metrics/test_daily_report.py
@@ -1,5 +1,5 @@
 from datetime import date
-from unittest import mock
+from unittest from unittest import mock
 
 import pytest
 from elasticsearch_metrics import metrics

--- a/osf_tests/metrics/test_daily_report.py
+++ b/osf_tests/metrics/test_daily_report.py
@@ -1,5 +1,5 @@
 from datetime import date
-from unittest from unittest import mock
+from unittest import mock
 
 import pytest
 from elasticsearch_metrics import metrics

--- a/osf_tests/metrics/test_metric_mixin.py
+++ b/osf_tests/metrics/test_metric_mixin.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from elasticsearch_metrics import metrics
 

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -8,7 +8,7 @@ import responses
 from unittest import mock  # noqa
 from django.utils import timezone
 from django.db import IntegrityError
-from mock import call
+from unittest.mock import call
 import pytest
 from nose.tools import *  # noqa: F403
 

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -5,7 +5,7 @@ import random
 from contextlib import ExitStack, contextmanager
 
 import responses
-import mock  # noqa
+from unittest import mock  # noqa
 from django.utils import timezone
 from django.db import IntegrityError
 from mock import call

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from django.db import IntegrityError

--- a/osf_tests/test_collection_submission.py
+++ b/osf_tests/test_collection_submission.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from osf_tests.factories import (

--- a/osf_tests/test_comment.py
+++ b/osf_tests/test_comment.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytz
 import pytest
 import datetime

--- a/osf_tests/test_draft_registration.py
+++ b/osf_tests/test_draft_registration.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from framework.auth.core import Auth

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import mock
+from unittest import mock
 import time
 import unittest
 import logging

--- a/osf_tests/test_generate_sitemap.py
+++ b/osf_tests/test_generate_sitemap.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-import mock
+from unittest import mock
 import shutil
 import tempfile
 import xml

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from future.moves.urllib.parse import quote
 from django.utils import timezone

--- a/osf_tests/test_identifiers.py
+++ b/osf_tests/test_identifiers.py
@@ -1,4 +1,4 @@
-from unittest from unittest import mock
+from unittest import mock
 from urllib.parse import urljoin
 
 import pytest

--- a/osf_tests/test_identifiers.py
+++ b/osf_tests/test_identifiers.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest from unittest import mock
 from urllib.parse import urljoin
 
 import pytest

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -1,7 +1,7 @@
 
 from django.db import IntegrityError
 from django.utils import timezone
-import mock
+from unittest import mock
 from past.builtins import basestring
 import pytest
 

--- a/osf_tests/test_management_commands.py
+++ b/osf_tests/test_management_commands.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 import time
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -1,6 +1,6 @@
 import datetime
 
-import mock
+from unittest import mock
 import pytest
 import pytz
 import responses

--- a/osf_tests/test_node_license.py
+++ b/osf_tests/test_node_license.py
@@ -1,5 +1,5 @@
 import json
-import mock
+from unittest import mock
 import pytest
 import builtins
 

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from types import SimpleNamespace

--- a/osf_tests/test_oauth_application.py
+++ b/osf_tests/test_oauth_application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 import pytest
 
 from django.db import DataError

--- a/osf_tests/test_osfgroup.py
+++ b/osf_tests/test_osfgroup.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import time
 from django.contrib.auth.models import Group

--- a/osf_tests/test_outcomes.py
+++ b/osf_tests/test_outcomes.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import pytest
 from django.db import IntegrityError

--- a/osf_tests/test_pigeon.py
+++ b/osf_tests/test_pigeon.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from osf_tests.factories import RegistrationFactory, AuthUserFactory, EmbargoFactory, NodeFactory
 from osf.external.internet_archive.tasks import _archive_to_ia, _update_ia_metadata

--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -3,7 +3,7 @@ import datetime as dt
 
 
 import pytest
-import mock
+from unittest import mock
 from django.utils import timezone
 from waffle.testutils import override_switch
 

--- a/osf_tests/test_region.py
+++ b/osf_tests/test_region.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from framework.auth import Auth

--- a/osf_tests/test_registration_moderation_notifications.py
+++ b/osf_tests/test_registration_moderation_notifications.py
@@ -1,5 +1,5 @@
 import pytest
-import mock
+from unittest import mock
 from mock import call
 
 from django.utils import timezone

--- a/osf_tests/test_registration_moderation_notifications.py
+++ b/osf_tests/test_registration_moderation_notifications.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest import mock
-from mock import call
+from unittest.mock import call
 
 from django.utils import timezone
 from osf.management.commands.add_notification_subscription import add_reviews_notification_setting

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from addons.wiki.models import WikiVersion

--- a/osf_tests/test_reviewable.py
+++ b/osf_tests/test_reviewable.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from osf.models import Preprint

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests ported from tests/test_sanctions.py and tests/test_registrations.py"""
-import mock
+from unittest import mock
 import pytest
 import datetime
 

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from nose.tools import assert_raises

--- a/osf_tests/test_session.py
+++ b/osf_tests/test_session.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError
 from django.utils import timezone
 import itsdangerous
 import pytest
-from unittest import mock
+from unittest from unittest import mock
 
 from api.base.authentication.drf import drf_get_session_from_cookie
 from framework.sessions import set_current_session, flask_get_session_from_cookie, get_session, create_session

--- a/osf_tests/test_session.py
+++ b/osf_tests/test_session.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError
 from django.utils import timezone
 import itsdangerous
 import pytest
-from unittest from unittest import mock
+from unittest import mock
 
 from api.base.authentication.drf import drf_get_session_from_cookie
 from framework.sessions import set_current_session, flask_get_session_from_cookie, get_session, create_session

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import Group
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from django.conf import settings as django_conf_settings
-import mock
+from unittest import mock
 import itsdangerous
 import pytest
 import pytz

--- a/osf_tests/users/test_last_login_date.py
+++ b/osf_tests/users/test_last_login_date.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytz
 import pytest
 import itsdangerous

--- a/osf_tests/utils.py
+++ b/osf_tests/utils.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime as dt
 import functools
-import mock
+from unittest import mock
 
 from framework.auth import Auth
 from django.utils import timezone

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,6 @@ asynctest==0.13.0
 nose
 factory-boy==2.10.0
 webtest-plus==0.3.3
-mock==2.0.0
 Faker==4.0.1
 schema==0.3.1
 responses==0.10.6

--- a/scripts/create_fakes.py
+++ b/scripts/create_fakes.py
@@ -36,7 +36,7 @@ from __future__ import print_function, absolute_import
 
 import ast
 import sys
-import mock
+from unittest import mock
 import argparse
 import logging
 

--- a/scripts/tests/test_approve_embargo_terminations.py
+++ b/scripts/tests/test_approve_embargo_terminations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 from datetime import timedelta
 
 from django.utils import timezone

--- a/scripts/tests/test_deactivate_requested_accounts.py
+++ b/scripts/tests/test_deactivate_requested_accounts.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import mock
+from unittest import mock
 
 from nose.tools import *  # noqa
 

--- a/scripts/tests/test_files_to_import_structure.py
+++ b/scripts/tests/test_files_to_import_structure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from tests.base import OsfTestCase
 from scripts.EGAP.files_to_import_structure import action_files_by_name
 

--- a/scripts/tests/test_populate_popular_projects_and_registrations.py
+++ b/scripts/tests/test_populate_popular_projects_and_registrations.py
@@ -1,6 +1,6 @@
 from nose.tools import *  # noqa
 
-import mock
+from unittest import mock
 
 from tests.base import OsfTestCase
 from osf_tests.factories import ProjectFactory, RegistrationFactory

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 from django.utils import timezone
 from nose.tools import *  # noqa
 

--- a/scripts/tests/test_send_queued_mails.py
+++ b/scripts/tests/test_send_queued_mails.py
@@ -1,4 +1,4 @@
-import mock  # noqa
+from unittest import mock  # noqa
 from datetime import timedelta
 
 from django.utils import timezone

--- a/scripts/tests/test_triggered_mails.py
+++ b/scripts/tests/test_triggered_mails.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from datetime import timedelta
 
 from django.utils import timezone

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ import uuid
 
 import blinker
 import responses
-import mock
+from unittest import mock
 import pytest
 
 from django.test import TestCase as DjangoTestCase

--- a/tests/framework_tests/test_email.py
+++ b/tests/framework_tests/test_email.py
@@ -2,7 +2,7 @@
 import unittest
 import smtplib
 
-import mock
+from unittest import mock
 from nose.tools import *  # noqa: F403
 import sendgrid
 

--- a/tests/framework_tests/test_sentry.py
+++ b/tests/framework_tests/test_sentry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
-import mock
+from unittest import mock
 from django.conf import settings as django_conf_settings
 from importlib import import_module
 

--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import os
-import mock
+from unittest import mock
 import lxml
 import pytest
 import responses

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -10,7 +10,7 @@ import furl
 import itsdangerous
 import jwe
 import jwt
-import mock
+from unittest import mock
 import pytest
 from django.utils import timezone
 from framework.auth import cas, signing

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@
 import unittest
 from nose.tools import *  # noqa; PEP8 asserts
 from webtest_plus import TestApp as WebtestApp  # py.test tries to collect `TestApp`
-import mock
+from unittest import mock
 from future.moves.urllib.parse import urlparse, urljoin, quote
 from rest_framework import status as http_status
 

--- a/tests/test_cas_authentication.py
+++ b/tests/test_cas_authentication.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import furl
 import responses
-import mock
+from unittest import mock
 from nose.tools import *  # noqa: F403
 import pytest
 import unittest

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 
 import hmac

--- a/tests/test_ember_osf_web.py
+++ b/tests/test_ember_osf_web.py
@@ -1,5 +1,5 @@
 
-import mock
+from unittest import mock
 from flask import request
 
 from tests.base import OsfTestCase

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-import mock
+from unittest import mock
 from nose.tools import *
 
 from website.notifications.events.base import Event, register, event_registry

--- a/tests/test_institutions/test_affiliation_via_orcid.py
+++ b/tests/test_institutions/test_affiliation_via_orcid.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import pytest
 

--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from hashlib import md5
-import mock
+from unittest import mock
 import pytest
 from mailchimp3.mailchimpclient import MailChimpError
 from nose.tools import *  # noqa; PEP8 asserts

--- a/tests/test_node_licenses.py
+++ b/tests/test_node_licenses.py
@@ -2,7 +2,7 @@
 import builtins
 import json
 import unittest
-import mock
+from unittest import mock
 
 import pytest
 from django.core.exceptions import ValidationError

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,5 +1,5 @@
 import collections
-import mock
+from unittest import mock
 from babel import dates, Locale
 from schema import Schema, And, Use, Or
 from django.utils import timezone

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3,7 +3,7 @@ import logging
 from rest_framework import status as http_status
 import json
 import logging
-import mock
+from unittest import mock
 import time
 from future.moves.urllib.parse import urlparse, urljoin, parse_qs
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2,7 +2,7 @@
 from nose.tools import *  # noqa: F403
 import jwe
 import jwt
-import mock
+from unittest import mock
 import furl
 import pytest
 import time

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -7,7 +7,7 @@ import pytz
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-import mock
+from unittest import mock
 import pytest
 from nose.tools import *  # noqa
 from transitions import MachineError

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -1,6 +1,6 @@
 import datetime
 
-import mock
+from unittest import mock
 from django.utils import timezone
 from nose.tools import *  # noqa
 from tests.base import fake, OsfTestCase

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -3,7 +3,7 @@
 import datetime
 from rest_framework import status as http_status
 
-import mock
+from unittest import mock
 import pytest
 from django.utils import timezone
 from django.db import DataError

--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 import datetime as dt
-import mock
+from unittest import mock
 from rest_framework import status as http_status
 import pytz
 from django.utils import timezone

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
-import mock
+from unittest import mock
 from nose.tools import *  # noqa: F403
 
 from tests.base import OsfTestCase

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import mock
+from unittest import mock
 import datetime as dt
 from nose.tools import *  # noqa (PEP8 asserts)
 

--- a/tests/test_spam_mixin.py
+++ b/tests/test_spam_mixin.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from nose.tools import assert_equal, assert_in, assert_raises
 
-import mock
+from unittest import mock
 
 from framework.auth import Auth
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from nose.tools import *  # noqa: F403
 import unittest
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,7 +1,7 @@
 import jwt
 from rest_framework import status as http_status
 
-import mock
+from unittest import mock
 from django.db.models import Q
 from nose.tools import *  # noqa
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
-import mock
+from unittest import mock
 import os
 import pytest
 import time

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ import datetime as dt
 from rest_framework import status as http_status
 import json
 import time
-import mock
+from unittest import mock
 from http.cookies import SimpleCookie
 
 import unittest

--- a/tests/test_websitefiles.py
+++ b/tests/test_websitefiles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from past.builtins import basestring
-import mock
+from unittest import mock
 from django.utils import timezone
 from nose.tools import *  # noqa
 

--- a/tests/test_webtests.py
+++ b/tests/test_webtests.py
@@ -7,7 +7,7 @@ import logging
 import unittest
 
 import markupsafe
-import mock
+from unittest import mock
 import pytest
 from nose.tools import *  # noqa: F403
 import re

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
 import functools
-import mock
+from unittest import mock
 
 from django.http import HttpRequest
 from django.utils import timezone


### PR DESCRIPTION
## Purpose

Remove all usages of mock, library, use stdlib variant instead

## Changes

Changed `import mock` to `from unittest import mock`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Test may begin failing

## Documentation

## Side Effects


## Ticket

