### PR TITLE
[Cedar] Check node/registration/file permission before record permission

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -63,6 +63,9 @@ class FileMixin(object):
         return obj
 
 
+class FileCedarMetadataRecordMixin(FileMixin):
+    file_lookup_url_kwarg = 'file_id_or_guid'
+
 class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/files_detail).
     """
@@ -177,11 +180,12 @@ class FileVersionDetail(JSONAPIBaseView, generics.RetrieveAPIView, FileMixin):
         return context
 
 
-class FileCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+class FileCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, FileCedarMetadataRecordMixin):
 
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        PermissionWithGetter(ContributorOrPublic, 'target'),
     )
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.NULL]
@@ -192,6 +196,7 @@ class FileCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFi
     view_name = 'file-cedar-metadata-records-list'
 
     def get_default_queryset(self):
+        self.get_file()
         file_records = None
         file_id_or_guid = self.kwargs['file_id_or_guid']
         try:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2290,11 +2290,12 @@ class NodeSettings(JSONAPIBaseView, generics.RetrieveUpdateAPIView, NodeMixin):
         return context
 
 
-class NodeCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+class NodeCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, NodeMixin):
 
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        ContributorOrPublic,
     )
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.NULL]
@@ -2305,6 +2306,7 @@ class NodeCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFi
     view_name = 'node-cedar-metadata-records-list'
 
     def get_default_queryset(self):
+        self.get_node()
         node_records = CedarMetadataRecord.objects.filter(guid___id=self.kwargs['node_id'])
         user_auth = get_user_auth(self.request)
         record_ids = [record.id for record in node_records if can_view_record(user_auth, record, guid_type=Node)]

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -973,11 +973,12 @@ class RegistrationResourceList(JSONAPIBaseView, generics.ListAPIView, ListFilter
         return self.get_node()
 
 
-class RegistrationCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
+class RegistrationCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, RegistrationMixin):
 
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        ContributorOrModeratorOrPublic,
     )
     required_read_scopes = [CoreScopes.CEDAR_METADATA_RECORD_READ]
     required_write_scopes = [CoreScopes.NULL]
@@ -988,6 +989,7 @@ class RegistrationCedarMetadataRecordsList(JSONAPIBaseView, generics.ListAPIView
     view_name = 'registration-cedar-metadata-records-list'
 
     def get_default_queryset(self):
+        self.get_node()
         registration_records = CedarMetadataRecord.objects.filter(guid___id=self.kwargs['node_id'])
         user_auth = get_user_auth(self.request)
         record_ids = [record.id for record in registration_records if can_view_record(user_auth, record, guid_type=Registration)]

--- a/api_tests/files/views/test_file_cedar_metadata_record_list.py
+++ b/api_tests/files/views/test_file_cedar_metadata_record_list.py
@@ -74,18 +74,14 @@ class TestFileCedarMetadataRecordListPrivateFile(TestFileCedarMetadataRecord):
     def test_record_list_no_auth(self, app, file):
 
         file_guid = file.get_guid(create=False)
-        resp = app.get(f'/v2/files/{file_guid._id}/cedar_metadata_records/')
-        assert resp.status_code == 200
-        data_set = set([datum['id'] for datum in resp.json['data']])
-        assert len(data_set) == 0
+        resp = app.get(f'/v2/files/{file_guid._id}/cedar_metadata_records/', expect_errors=True)
+        assert resp.status_code == 401
 
     def test_record_list_with_invalid_auth(self, app, user_alt, file):
 
         file_guid = file.get_guid(create=False)
-        resp = app.get(f'/v2/files/{file_guid._id}/cedar_metadata_records/', auth=user_alt.auth)
-        assert resp.status_code == 200
-        data_set = set([datum['id'] for datum in resp.json['data']])
-        assert len(data_set) == 0
+        resp = app.get(f'/v2/files/{file_guid._id}/cedar_metadata_records/', auth=user_alt.auth, expect_errors=True)
+        assert resp.status_code == 403
 
     def test_record_list_with_read_auth(self, app, node, file, cedar_record_for_file, cedar_draft_record_for_file):
 

--- a/api_tests/nodes/views/test_node_cedar_metadata_record_list.py
+++ b/api_tests/nodes/views/test_node_cedar_metadata_record_list.py
@@ -68,17 +68,13 @@ class TestNodeCedarMetadataRecordListPrivateProject(TesNodeCedarMetadataRecord):
 
     def test_record_list_no_auth(self, app, node):
 
-        resp = app.get(f'/v2/nodes/{node._id}/cedar_metadata_records/')
-        assert resp.status_code == 200
-        data_set = set([datum['id'] for datum in resp.json['data']])
-        assert len(data_set) == 0
+        resp = app.get(f'/v2/nodes/{node._id}/cedar_metadata_records/', expect_errors=True)
+        assert resp.status_code == 401
 
     def test_record_list_with_invalid_auth(self, app, user_alt, node):
 
-        resp = app.get(f'/v2/nodes/{node._id}/cedar_metadata_records/', auth=user_alt.auth)
-        assert resp.status_code == 200
-        data_set = set([datum['id'] for datum in resp.json['data']])
-        assert len(data_set) == 0
+        resp = app.get(f'/v2/nodes/{node._id}/cedar_metadata_records/', auth=user_alt.auth, expect_errors=True)
+        assert resp.status_code == 403
 
     def test_record_list_with_read_auth(self, app, node, cedar_record_for_node, cedar_draft_record_for_node):
 


### PR DESCRIPTION
## Purpose

Check node/registration/file permission before record permission for node/registration/file-cedar-record-list-view.

* When the permission source is private, no-auth and non-contributor should return 401 and 403 respectively instead of an empty list.
* Unit tests updated to cover this change
* Note: registration is not affected since they are public though permission check is still performed for integrity

## Changes

See **Purpose**

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

N/A
