### PR TITLE
[ENG-5325]  remove nose from tests (2/2)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -71,7 +71,7 @@ jobs:
         sudo apt-get install libxml2-dev libxslt-dev python-dev
     - uses: ./.github/actions/start-build
     - name: Run tests
-      run: invoke test_travis_addons -n 1
+      run: python3 -m invoke test-travis-addons -n 1
 
   website:
     runs-on: ubuntu-20.04
@@ -114,7 +114,7 @@ jobs:
         sudo apt-get install libxml2-dev libxslt-dev python-dev
     - uses: ./.github/actions/start-build
     - name: Run tests
-      run: invoke test_travis_website -n 1
+      run: python3 -m invoke test-travis-website -n 1
 
   api1_and_js:
     runs-on: ubuntu-20.04
@@ -158,9 +158,9 @@ jobs:
       - uses: ./.github/actions/start-build
       - name: NVM & yarn install
         run: |
-          invoke assets --dev
+          python3 -m invoke assets --dev
       - name: Run test
-        run: invoke test_travis_api1_and_js -n 1
+        run: python3 -m invoke test-travis-api1-and-js -n 1
 
   api2:
     runs-on: ubuntu-20.04
@@ -203,7 +203,7 @@ jobs:
         sudo apt-get install libxml2-dev libxslt-dev python-dev
     - uses: ./.github/actions/start-build
     - name: Run tests
-      run: invoke test_travis_api2 -n 1
+      run: python3 -m invoke test-travis-api2 -n 1
 
   api3_and_osf:
     runs-on: ubuntu-20.04
@@ -246,5 +246,5 @@ jobs:
         sudo apt-get install libxml2-dev libxslt-dev python-dev
     - uses: ./.github/actions/start-build
     - name: Run tests
-      run: invoke test_travis_api3_and_osf -n 1
+      run: python3 -m invoke test-travis-api3-and-osf -n 1
 

--- a/addons/bitbucket/tests/test_models.py
+++ b/addons/bitbucket/tests/test_models.py
@@ -55,7 +55,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         # common storage addons.
         settings = self.node_settings.serialize_waterbutler_settings()
         expected = {'owner': self.node_settings.user, 'repo': self.node_settings.repo}
-        self.assertEqual(settings, expected)
+        assert settings == expected
 
     @mock.patch(
         'addons.bitbucket.models.UserSettings.revoke_remote_oauth_access',
@@ -77,11 +77,11 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_repos.return_value = []
         mock_team_repos.return_value = []
         result = self.node_settings.to_json(self.user)
-        self.assertTrue(result['user_has_auth'])
-        self.assertEqual(result['bitbucket_user'], 'abc')
-        self.assertTrue(result['is_owner'])
-        self.assertTrue(result['valid_credentials'])
-        self.assertEqual(result.get('repo_names', None), [])
+        assert result['user_has_auth']
+        assert result['bitbucket_user'] == 'abc'
+        assert result['is_owner']
+        assert result['valid_credentials']
+        assert result.get('repo_names', None) == []
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repos')
     @mock.patch('addons.bitbucket.api.BitbucketClient.team_repos')
@@ -90,11 +90,11 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_team_repos.return_value = []
         not_owner = UserFactory()
         result = self.node_settings.to_json(not_owner)
-        self.assertFalse(result['user_has_auth'])
-        self.assertEqual(result['bitbucket_user'], 'abc')
-        self.assertFalse(result['is_owner'])
-        self.assertTrue(result['valid_credentials'])
-        self.assertEqual(result.get('repo_names', None), None)
+        assert not result['user_has_auth']
+        assert result['bitbucket_user'] == 'abc'
+        assert not result['is_owner']
+        assert result['valid_credentials']
+        assert result.get('repo_names', None) == None
 
 
 class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
@@ -104,7 +104,7 @@ class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.Test
     ExternalAccountFactory = BitbucketAccountFactory
 
     def test_public_id(self):
-        self.assertEqual(self.user.external_accounts.first().display_name, self.user_settings.public_id)
+        assert self.user.external_accounts.first().display_name == self.user_settings.public_id
 
 
 class TestCallbacks(OsfTestCase):
@@ -141,7 +141,7 @@ class TestCallbacks(OsfTestCase):
         mock_repo.side_effect = NotFoundError
 
         result = self.node_settings.before_make_public(self.project)
-        self.assertIs(result, None)
+        assert result is None
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_public_bb_public(self, mock_repo):
@@ -153,7 +153,7 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        self.assertFalse(message)
+        assert not message
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_public_bb_private(self, mock_repo):
@@ -165,8 +165,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        self.assertTrue(message)
-        self.assertIn('Users can view the contents of this private Bitbucket repository through this public project.', message[0])
+        assert message
+        assert 'Users can view the contents of this private Bitbucket repository through this public project.' in message[0]
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_repo_deleted(self, mock_repo):
@@ -178,8 +178,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        self.assertTrue(message)
-        self.assertIn('has been deleted.', message[0])
+        assert message
+        assert 'has been deleted.' in message[0]
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_private_bb_public(self, mock_repo):
@@ -189,8 +189,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        self.assertTrue(message)
-        self.assertIn('The files in this Bitbucket repo can be viewed on Bitbucket', message[0])
+        assert message
+        assert 'The files in this Bitbucket repo can be viewed on Bitbucket' in message[0]
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_private_bb_private(self, mock_repo):
@@ -200,85 +200,75 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        self.assertFalse(message)
+        assert not message
 
     def test_before_page_load_not_contributor(self):
         message = self.node_settings.before_page_load(self.project, UserFactory())
-        self.assertFalse(message)
+        assert not message
 
     def test_before_page_load_not_logged_in(self):
         message = self.node_settings.before_page_load(self.project, None)
-        self.assertFalse(message)
+        assert not message
 
     def test_before_remove_contributor_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.project.creator
         )
-        self.assertTrue(message)
+        assert message
 
     def test_before_remove_contributor_not_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.non_authenticator
         )
-        self.assertFalse(message)
+        assert not message
 
     def test_after_remove_contributor_authenticator_self(self):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, self.consolidated_auth
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
+        assert self.node_settings.user_settings == \
             None
-        )
-        self.assertTrue(message)
-        self.assertNotIn('You can re-authenticate', message)
+        assert message
+        assert 'You can re-authenticate' not in message
 
     def test_after_remove_contributor_authenticator_not_self(self):
         auth = Auth(user=self.non_authenticator)
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, auth
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
+        assert self.node_settings.user_settings == \
             None
-        )
-        self.assertTrue(message)
-        self.assertIn('You can re-authenticate', message)
+        assert message
+        assert 'You can re-authenticate' in message
 
     def test_after_remove_contributor_not_authenticator(self):
         self.node_settings.after_remove_contributor(
             self.project, self.non_authenticator, self.consolidated_auth
         )
-        self.assertNotEqual(
-            self.node_settings.user_settings,
-            None,
-        )
+        assert self.node_settings.user_settings != \
+            None
 
     def test_after_fork_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.project.creator,
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
-            clone.user_settings,
-        )
+        assert self.node_settings.user_settings == \
+            clone.user_settings
 
     def test_after_fork_not_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.non_authenticator,
         )
-        self.assertEqual(
-            clone.user_settings,
-            None,
-        )
+        assert clone.user_settings == \
+            None
 
     def test_after_delete(self):
         self.project.remove_node(Auth(user=self.project.creator))
         # Ensure that changes to node settings have been saved
         self.node_settings.reload()
-        self.assertTrue(self.node_settings.user_settings is None)
+        assert self.node_settings.user_settings is None
 
     @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
@@ -287,4 +277,4 @@ class TestCallbacks(OsfTestCase):
             auth=Auth(user=self.project.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.project),
         )
-        self.assertFalse(registration.has_addon('bitbucket'))
+        assert not registration.has_addon('bitbucket')

--- a/addons/bitbucket/tests/test_models.py
+++ b/addons/bitbucket/tests/test_models.py
@@ -1,7 +1,6 @@
 from unittest import mock
 import pytest
 import unittest
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase, get_default_metaschema
 from osf_tests.factories import (
@@ -56,7 +55,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         # common storage addons.
         settings = self.node_settings.serialize_waterbutler_settings()
         expected = {'owner': self.node_settings.user, 'repo': self.node_settings.repo}
-        assert_equal(settings, expected)
+        self.assertEqual(settings, expected)
 
     @mock.patch(
         'addons.bitbucket.models.UserSettings.revoke_remote_oauth_access',
@@ -78,11 +77,11 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_repos.return_value = []
         mock_team_repos.return_value = []
         result = self.node_settings.to_json(self.user)
-        assert_true(result['user_has_auth'])
-        assert_equal(result['bitbucket_user'], 'abc')
-        assert_true(result['is_owner'])
-        assert_true(result['valid_credentials'])
-        assert_equal(result.get('repo_names', None), [])
+        self.assertTrue(result['user_has_auth'])
+        self.assertEqual(result['bitbucket_user'], 'abc')
+        self.assertTrue(result['is_owner'])
+        self.assertTrue(result['valid_credentials'])
+        self.assertEqual(result.get('repo_names', None), [])
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repos')
     @mock.patch('addons.bitbucket.api.BitbucketClient.team_repos')
@@ -91,11 +90,11 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_team_repos.return_value = []
         not_owner = UserFactory()
         result = self.node_settings.to_json(not_owner)
-        assert_false(result['user_has_auth'])
-        assert_equal(result['bitbucket_user'], 'abc')
-        assert_false(result['is_owner'])
-        assert_true(result['valid_credentials'])
-        assert_equal(result.get('repo_names', None), None)
+        self.assertFalse(result['user_has_auth'])
+        self.assertEqual(result['bitbucket_user'], 'abc')
+        self.assertFalse(result['is_owner'])
+        self.assertTrue(result['valid_credentials'])
+        self.assertEqual(result.get('repo_names', None), None)
 
 
 class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
@@ -105,7 +104,7 @@ class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.Test
     ExternalAccountFactory = BitbucketAccountFactory
 
     def test_public_id(self):
-        assert_equal(self.user.external_accounts.first().display_name, self.user_settings.public_id)
+        self.assertEqual(self.user.external_accounts.first().display_name, self.user_settings.public_id)
 
 
 class TestCallbacks(OsfTestCase):
@@ -142,7 +141,7 @@ class TestCallbacks(OsfTestCase):
         mock_repo.side_effect = NotFoundError
 
         result = self.node_settings.before_make_public(self.project)
-        assert_is(result, None)
+        self.assertIs(result, None)
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_public_bb_public(self, mock_repo):
@@ -154,7 +153,7 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_public_bb_private(self, mock_repo):
@@ -166,8 +165,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        assert_true(message)
-        assert_in('Users can view the contents of this private Bitbucket repository through this public project.', message[0])
+        self.assertTrue(message)
+        self.assertIn('Users can view the contents of this private Bitbucket repository through this public project.', message[0])
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_repo_deleted(self, mock_repo):
@@ -179,8 +178,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        assert_true(message)
-        assert_in('has been deleted.', message[0])
+        self.assertTrue(message)
+        self.assertIn('has been deleted.', message[0])
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_private_bb_public(self, mock_repo):
@@ -190,8 +189,8 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        assert_true(message)
-        assert_in('The files in this Bitbucket repo can be viewed on Bitbucket', message[0])
+        self.assertTrue(message)
+        self.assertIn('The files in this Bitbucket repo can be viewed on Bitbucket', message[0])
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     def test_before_page_load_osf_private_bb_private(self, mock_repo):
@@ -201,56 +200,56 @@ class TestCallbacks(OsfTestCase):
             user=self.node_settings.user,
             repo=self.node_settings.repo,
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_page_load_not_contributor(self):
         message = self.node_settings.before_page_load(self.project, UserFactory())
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_page_load_not_logged_in(self):
         message = self.node_settings.before_page_load(self.project, None)
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_remove_contributor_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.project.creator
         )
-        assert_true(message)
+        self.assertTrue(message)
 
     def test_before_remove_contributor_not_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.non_authenticator
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_after_remove_contributor_authenticator_self(self):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, self.consolidated_auth
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             None
         )
-        assert_true(message)
-        assert_not_in('You can re-authenticate', message)
+        self.assertTrue(message)
+        self.assertNotIn('You can re-authenticate', message)
 
     def test_after_remove_contributor_authenticator_not_self(self):
         auth = Auth(user=self.non_authenticator)
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, auth
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             None
         )
-        assert_true(message)
-        assert_in('You can re-authenticate', message)
+        self.assertTrue(message)
+        self.assertIn('You can re-authenticate', message)
 
     def test_after_remove_contributor_not_authenticator(self):
         self.node_settings.after_remove_contributor(
             self.project, self.non_authenticator, self.consolidated_auth
         )
-        assert_not_equal(
+        self.assertNotEqual(
             self.node_settings.user_settings,
             None,
         )
@@ -260,7 +259,7 @@ class TestCallbacks(OsfTestCase):
         clone = self.node_settings.after_fork(
             self.project, fork, self.project.creator,
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             clone.user_settings,
         )
@@ -270,7 +269,7 @@ class TestCallbacks(OsfTestCase):
         clone = self.node_settings.after_fork(
             self.project, fork, self.non_authenticator,
         )
-        assert_equal(
+        self.assertEqual(
             clone.user_settings,
             None,
         )
@@ -279,7 +278,7 @@ class TestCallbacks(OsfTestCase):
         self.project.remove_node(Auth(user=self.project.creator))
         # Ensure that changes to node settings have been saved
         self.node_settings.reload()
-        assert_true(self.node_settings.user_settings is None)
+        self.assertTrue(self.node_settings.user_settings is None)
 
     @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
@@ -288,4 +287,4 @@ class TestCallbacks(OsfTestCase):
             auth=Auth(user=self.project.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.project),
         )
-        assert_false(registration.has_addon('bitbucket'))
+        self.assertFalse(registration.has_addon('bitbucket'))

--- a/addons/bitbucket/tests/test_serializer.py
+++ b/addons/bitbucket/tests/test_serializer.py
@@ -1,7 +1,6 @@
 """Serializer tests for the Bitbucket addon."""
 
 from unittest import mock
-from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 
 from tests.base import OsfTestCase

--- a/addons/bitbucket/tests/test_views.py
+++ b/addons/bitbucket/tests/test_views.py
@@ -73,8 +73,7 @@ class TestBitbucketConfigViews(BitbucketAddonTestCase, OAuthAddonConfigViewsTest
         }, auth=self.user.auth)
         assert res.status_code == http_status.HTTP_200_OK
         self.project.reload()
-        assert self.project.logs.latest().action == \
-            f'{self.ADDON_SHORT_NAME}_repo_linked'
+        assert self.project.logs.latest().action == f'{self.ADDON_SHORT_NAME}_repo_linked'
 
 
 class TestBitbucketViews(OsfTestCase):
@@ -136,8 +135,7 @@ class TestBitbucketViews(OsfTestCase):
         mock_branches.return_value = bitbucket_mock.branches.return_value
 
         branch, sha, branches = utils.get_refs(self.node_settings)
-        assert branch == \
-            bitbucket_mock.repo_default_branch.return_value
+        assert branch == bitbucket_mock.repo_default_branch.return_value
         assert sha == self._get_sha_for_branch(branch=None)  # Get refs for default branch
 
         expected_branches = [

--- a/addons/bitbucket/tests/test_views.py
+++ b/addons/bitbucket/tests/test_views.py
@@ -71,12 +71,10 @@ class TestBitbucketConfigViews(BitbucketAddonTestCase, OAuthAddonConfigViewsTest
             'bitbucket_user': 'octocat',
             'bitbucket_repo': 'repo_name',
         }, auth=self.user.auth)
-        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
+        assert res.status_code == http_status.HTTP_200_OK
         self.project.reload()
-        self.assertEqual(
-            self.project.logs.latest().action,
+        assert self.project.logs.latest().action == \
             f'{self.ADDON_SHORT_NAME}_repo_linked'
-        )
 
 
 class TestBitbucketViews(OsfTestCase):
@@ -138,17 +136,15 @@ class TestBitbucketViews(OsfTestCase):
         mock_branches.return_value = bitbucket_mock.branches.return_value
 
         branch, sha, branches = utils.get_refs(self.node_settings)
-        self.assertEqual(
-            branch,
+        assert branch == \
             bitbucket_mock.repo_default_branch.return_value
-        )
-        self.assertEqual(sha, self._get_sha_for_branch(branch=None))  # Get refs for default branch
+        assert sha == self._get_sha_for_branch(branch=None)  # Get refs for default branch
 
         expected_branches = [
             {'name': x['name'], 'sha': x['target']['hash']}
             for x in bitbucket_mock.branches.return_value
         ]
-        self.assertEqual(branches, expected_branches)
+        assert branches == expected_branches
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.branches')
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
@@ -162,29 +158,29 @@ class TestBitbucketViews(OsfTestCase):
         mock_branches.return_value = bitbucket_mock.branches.return_value
 
         branch, sha, branches = utils.get_refs(self.node_settings, 'master')
-        self.assertEqual(branch, 'master')
+        assert branch == 'master'
         branch_sha = self._get_sha_for_branch('master')
-        self.assertEqual(sha, branch_sha)
+        assert sha == branch_sha
 
         expected_branches = [
             {'name': x['name'], 'sha': x['target']['hash']}
             for x in bitbucket_mock.branches.return_value
         ]
-        self.assertEqual(branches, expected_branches)
+        assert branches == expected_branches
 
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        self.assertEqual(len(res.json['prompts']), 1)
+        assert len(res.json['prompts']) == 1
 
     def test_before_register(self):
         url = self.project.api_url + 'beforeregister/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        self.assertTrue('Bitbucket' in res.json['prompts'][1])
+        assert 'Bitbucket' in res.json['prompts'][1]
 
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
     def test_get_refs_sha_no_branch(self, mock_account):
-        with self.assertRaises(HTTPError):
+        with pytest.raises(HTTPError):
             utils.get_refs(self.node_settings, sha='12345')
 
     def check_hook_urls(self, urls, node, path, sha):
@@ -194,8 +190,8 @@ class TestBitbucketViews(OsfTestCase):
             'download': f'{url}?action=download&ref={sha}'
         }
 
-        self.assertEqual(urls['view'], expected_urls['view'])
-        self.assertEqual(urls['download'], expected_urls['download'])
+        assert urls['view'] == expected_urls['view']
+        assert urls['download'] == expected_urls['download']
 
 
 class TestBitbucketSettings(OsfTestCase):
@@ -238,9 +234,9 @@ class TestBitbucketSettings(OsfTestCase):
         self.project.reload()
         self.node_settings.reload()
 
-        self.assertEqual(self.node_settings.user, 'queen')
-        self.assertEqual(self.node_settings.repo, 'night at the opera')
-        self.assertEqual(self.project.logs.latest().action, 'bitbucket_repo_linked')
+        assert self.node_settings.user == 'queen'
+        assert self.node_settings.repo == 'night at the opera'
+        assert self.project.logs.latest().action == 'bitbucket_repo_linked'
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
@@ -264,7 +260,7 @@ class TestBitbucketSettings(OsfTestCase):
         self.project.reload()
         self.node_settings.reload()
 
-        self.assertEqual(self.project.logs.count(), log_count)
+        assert self.project.logs.count() == log_count
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
@@ -283,7 +279,7 @@ class TestBitbucketSettings(OsfTestCase):
             expect_errors=True
         ).maybe_follow()
 
-        self.assertEqual(res.status_code, 400)
+        assert res.status_code == 400
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.branches')
     def test_link_repo_registration(self, mock_branches):
@@ -307,7 +303,7 @@ class TestBitbucketSettings(OsfTestCase):
             expect_errors=True
         ).maybe_follow()
 
-        self.assertEqual(res.status_code, 400)
+        assert res.status_code == 400
 
     def test_deauthorize(self):
 
@@ -317,11 +313,11 @@ class TestBitbucketSettings(OsfTestCase):
 
         self.project.reload()
         self.node_settings.reload()
-        self.assertEqual(self.node_settings.user, None)
-        self.assertEqual(self.node_settings.repo, None)
-        self.assertEqual(self.node_settings.user_settings, None)
+        assert self.node_settings.user == None
+        assert self.node_settings.repo == None
+        assert self.node_settings.user_settings == None
 
-        self.assertEqual(self.project.logs.latest().action, 'bitbucket_node_deauthorized')
+        assert self.project.logs.latest().action == 'bitbucket_node_deauthorized'
 
 
 if __name__ == '__main__':

--- a/addons/bitbucket/tests/test_views.py
+++ b/addons/bitbucket/tests/test_views.py
@@ -5,7 +5,6 @@ import datetime
 import unittest
 import pytest
 
-from nose.tools import *  # noqa (PEP8 asserts)
 from tests.base import OsfTestCase, get_default_metaschema
 from osf_tests.factories import (
     ProjectFactory,
@@ -72,9 +71,9 @@ class TestBitbucketConfigViews(BitbucketAddonTestCase, OAuthAddonConfigViewsTest
             'bitbucket_user': 'octocat',
             'bitbucket_repo': 'repo_name',
         }, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
         self.project.reload()
-        assert_equal(
+        self.assertEqual(
             self.project.logs.latest().action,
             f'{self.ADDON_SHORT_NAME}_repo_linked'
         )
@@ -139,17 +138,17 @@ class TestBitbucketViews(OsfTestCase):
         mock_branches.return_value = bitbucket_mock.branches.return_value
 
         branch, sha, branches = utils.get_refs(self.node_settings)
-        assert_equal(
+        self.assertEqual(
             branch,
             bitbucket_mock.repo_default_branch.return_value
         )
-        assert_equal(sha, self._get_sha_for_branch(branch=None))  # Get refs for default branch
+        self.assertEqual(sha, self._get_sha_for_branch(branch=None))  # Get refs for default branch
 
         expected_branches = [
             {'name': x['name'], 'sha': x['target']['hash']}
             for x in bitbucket_mock.branches.return_value
         ]
-        assert_equal(branches, expected_branches)
+        self.assertEqual(branches, expected_branches)
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.branches')
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
@@ -163,29 +162,29 @@ class TestBitbucketViews(OsfTestCase):
         mock_branches.return_value = bitbucket_mock.branches.return_value
 
         branch, sha, branches = utils.get_refs(self.node_settings, 'master')
-        assert_equal(branch, 'master')
+        self.assertEqual(branch, 'master')
         branch_sha = self._get_sha_for_branch('master')
-        assert_equal(sha, branch_sha)
+        self.assertEqual(sha, branch_sha)
 
         expected_branches = [
             {'name': x['name'], 'sha': x['target']['hash']}
             for x in bitbucket_mock.branches.return_value
         ]
-        assert_equal(branches, expected_branches)
+        self.assertEqual(branches, expected_branches)
 
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        assert_equal(len(res.json['prompts']), 1)
+        self.assertEqual(len(res.json['prompts']), 1)
 
     def test_before_register(self):
         url = self.project.api_url + 'beforeregister/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
-        assert_true('Bitbucket' in res.json['prompts'][1])
+        self.assertTrue('Bitbucket' in res.json['prompts'][1])
 
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
     def test_get_refs_sha_no_branch(self, mock_account):
-        with assert_raises(HTTPError):
+        with self.assertRaises(HTTPError):
             utils.get_refs(self.node_settings, sha='12345')
 
     def check_hook_urls(self, urls, node, path, sha):
@@ -195,8 +194,8 @@ class TestBitbucketViews(OsfTestCase):
             'download': f'{url}?action=download&ref={sha}'
         }
 
-        assert_equal(urls['view'], expected_urls['view'])
-        assert_equal(urls['download'], expected_urls['download'])
+        self.assertEqual(urls['view'], expected_urls['view'])
+        self.assertEqual(urls['download'], expected_urls['download'])
 
 
 class TestBitbucketSettings(OsfTestCase):
@@ -239,9 +238,9 @@ class TestBitbucketSettings(OsfTestCase):
         self.project.reload()
         self.node_settings.reload()
 
-        assert_equal(self.node_settings.user, 'queen')
-        assert_equal(self.node_settings.repo, 'night at the opera')
-        assert_equal(self.project.logs.latest().action, 'bitbucket_repo_linked')
+        self.assertEqual(self.node_settings.user, 'queen')
+        self.assertEqual(self.node_settings.repo, 'night at the opera')
+        self.assertEqual(self.project.logs.latest().action, 'bitbucket_repo_linked')
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
@@ -265,7 +264,7 @@ class TestBitbucketSettings(OsfTestCase):
         self.project.reload()
         self.node_settings.reload()
 
-        assert_equal(self.project.logs.count(), log_count)
+        self.assertEqual(self.project.logs.count(), log_count)
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.repo')
     @mock.patch('addons.bitbucket.models.NodeSettings.external_account')
@@ -284,7 +283,7 @@ class TestBitbucketSettings(OsfTestCase):
             expect_errors=True
         ).maybe_follow()
 
-        assert_equal(res.status_code, 400)
+        self.assertEqual(res.status_code, 400)
 
     @mock.patch('addons.bitbucket.api.BitbucketClient.branches')
     def test_link_repo_registration(self, mock_branches):
@@ -308,7 +307,7 @@ class TestBitbucketSettings(OsfTestCase):
             expect_errors=True
         ).maybe_follow()
 
-        assert_equal(res.status_code, 400)
+        self.assertEqual(res.status_code, 400)
 
     def test_deauthorize(self):
 
@@ -318,11 +317,11 @@ class TestBitbucketSettings(OsfTestCase):
 
         self.project.reload()
         self.node_settings.reload()
-        assert_equal(self.node_settings.user, None)
-        assert_equal(self.node_settings.repo, None)
-        assert_equal(self.node_settings.user_settings, None)
+        self.assertEqual(self.node_settings.user, None)
+        self.assertEqual(self.node_settings.repo, None)
+        self.assertEqual(self.node_settings.user_settings, None)
 
-        assert_equal(self.project.logs.latest().action, 'bitbucket_node_deauthorized')
+        self.assertEqual(self.project.logs.latest().action, 'bitbucket_node_deauthorized')
 
 
 if __name__ == '__main__':

--- a/addons/box/tests/test_client.py
+++ b/addons/box/tests/test_client.py
@@ -22,4 +22,4 @@ class TestCore(unittest.TestCase):
 
     def test_get_addon_returns_box_user_settings(self):
         result = self.user.get_addon('box')
-        self.assertTrue(isinstance(result, UserSettings))
+        assert isinstance(result, UserSettings)

--- a/addons/box/tests/test_client.py
+++ b/addons/box/tests/test_client.py
@@ -1,4 +1,3 @@
-from nose.tools import assert_true
 import pytest
 import unittest
 
@@ -23,4 +22,4 @@ class TestCore(unittest.TestCase):
 
     def test_get_addon_returns_box_user_settings(self):
         result = self.user.get_addon('box')
-        assert_true(isinstance(result, UserSettings))
+        self.assertTrue(isinstance(result, UserSettings))

--- a/addons/box/tests/test_views.py
+++ b/addons/box/tests/test_views.py
@@ -91,10 +91,10 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            self.assertEqual(len(res.json), len(expected))
+            assert len(res.json) == len(expected)
             first = res.json[0]
-            self.assertIn('kind', first)
-            self.assertEqual(first['name'], contents[0]['name'])
+            assert 'kind' in first
+            assert first['name'] == contents[0]['name']
 
     @mock.patch('addons.box.models.NodeSettings.folder_id')
     def test_box_list_folders_if_folder_is_none(self, mock_folder):
@@ -102,7 +102,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
         mock_folder.__get__ = mock.Mock(return_value=None)
         url = self.project.api_url_for('box_folder_list')
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(len(res.json), 1)
+        assert len(res.json) == 1
 
     def test_box_list_folders_if_folder_is_none_and_folders_only(self):
         with patch_client('addons.box.models.Client'):
@@ -113,7 +113,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            self.assertEqual(len(res.json), len(expected))
+            assert len(res.json) == len(expected)
 
     def test_box_list_folders_folders_only(self):
         with patch_client('addons.box.models.Client'):
@@ -121,7 +121,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            self.assertEqual(len(res.json), len(expected))
+            assert len(res.json) == len(expected)
 
     def test_box_list_folders_doesnt_include_root(self):
         with mock.patch('addons.box.models.Client.folder') as folder_mock:
@@ -131,14 +131,14 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
 
-            self.assertEqual(len(res.json), len(expected))
+            assert len(res.json) == len(expected)
 
     @mock.patch('addons.box.models.Client.folder')
     def test_box_list_folders_returns_error_if_invalid_path(self, mock_metadata):
         mock_metadata.side_effect = BoxAPIException(status=404, message='File not found')
         url = self.project.api_url_for('box_folder_list', folder_id='lolwut')
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_404_NOT_FOUND)
+        assert res.status_code == http_status.HTTP_404_NOT_FOUND
 
     @mock.patch('addons.box.models.Client.folder')
     def test_box_list_folders_handles_max_retry_error(self, mock_metadata):
@@ -146,7 +146,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
         url = self.project.api_url_for('box_folder_list', folder_id='fo')
         mock_metadata.side_effect = MaxRetryError(mock_response, url)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
 
 
 class TestRestrictions(BoxAddonTestCase, OsfTestCase):
@@ -178,13 +178,13 @@ class TestRestrictions(BoxAddonTestCase, OsfTestCase):
         url = self.project.api_url_for('box_folder_list',
             path='foo bar')
         res = self.app.get(url, auth=self.contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
 
     def test_restricted_config_contrib_no_addon(self):
         url = api_url_for('box_set_config', pid=self.project._primary_key)
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
 
     def test_restricted_config_contrib_not_owner(self):
         # Contributor has box auth, but is not the node authorizer
@@ -194,4 +194,4 @@ class TestRestrictions(BoxAddonTestCase, OsfTestCase):
         url = api_url_for('box_set_config', pid=self.project._primary_key)
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN

--- a/addons/box/tests/test_views.py
+++ b/addons/box/tests/test_views.py
@@ -1,7 +1,6 @@
 """Views tests for the Box addon."""
 from django.utils import timezone
 from rest_framework import status as http_status
-from nose.tools import *  # noqa (PEP8 asserts)
 from unittest import mock
 import pytest
 from urllib3.exceptions import MaxRetryError
@@ -92,10 +91,10 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            assert_equal(len(res.json), len(expected))
+            self.assertEqual(len(res.json), len(expected))
             first = res.json[0]
-            assert_in('kind', first)
-            assert_equal(first['name'], contents[0]['name'])
+            self.assertIn('kind', first)
+            self.assertEqual(first['name'], contents[0]['name'])
 
     @mock.patch('addons.box.models.NodeSettings.folder_id')
     def test_box_list_folders_if_folder_is_none(self, mock_folder):
@@ -103,7 +102,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
         mock_folder.__get__ = mock.Mock(return_value=None)
         url = self.project.api_url_for('box_folder_list')
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(len(res.json), 1)
 
     def test_box_list_folders_if_folder_is_none_and_folders_only(self):
         with patch_client('addons.box.models.Client'):
@@ -114,7 +113,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            assert_equal(len(res.json), len(expected))
+            self.assertEqual(len(res.json), len(expected))
 
     def test_box_list_folders_folders_only(self):
         with patch_client('addons.box.models.Client'):
@@ -122,7 +121,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
-            assert_equal(len(res.json), len(expected))
+            self.assertEqual(len(res.json), len(expected))
 
     def test_box_list_folders_doesnt_include_root(self):
         with mock.patch('addons.box.models.Client.folder') as folder_mock:
@@ -132,14 +131,14 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
             contents = mock_client.folder('', list=True)['item_collection']['entries']
             expected = [each for each in contents if each['type'] == 'folder']
 
-            assert_equal(len(res.json), len(expected))
+            self.assertEqual(len(res.json), len(expected))
 
     @mock.patch('addons.box.models.Client.folder')
     def test_box_list_folders_returns_error_if_invalid_path(self, mock_metadata):
         mock_metadata.side_effect = BoxAPIException(status=404, message='File not found')
         url = self.project.api_url_for('box_folder_list', folder_id='lolwut')
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_404_NOT_FOUND)
+        self.assertEqual(res.status_code, http_status.HTTP_404_NOT_FOUND)
 
     @mock.patch('addons.box.models.Client.folder')
     def test_box_list_folders_handles_max_retry_error(self, mock_metadata):
@@ -147,7 +146,7 @@ class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
         url = self.project.api_url_for('box_folder_list', folder_id='fo')
         mock_metadata.side_effect = MaxRetryError(mock_response, url)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
 
 
 class TestRestrictions(BoxAddonTestCase, OsfTestCase):
@@ -179,13 +178,13 @@ class TestRestrictions(BoxAddonTestCase, OsfTestCase):
         url = self.project.api_url_for('box_folder_list',
             path='foo bar')
         res = self.app.get(url, auth=self.contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)
 
     def test_restricted_config_contrib_no_addon(self):
         url = api_url_for('box_set_config', pid=self.project._primary_key)
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
 
     def test_restricted_config_contrib_not_owner(self):
         # Contributor has box auth, but is not the node authorizer
@@ -195,4 +194,4 @@ class TestRestrictions(BoxAddonTestCase, OsfTestCase):
         url = api_url_for('box_set_config', pid=self.project._primary_key)
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)

--- a/addons/dataverse/tests/test_client.py
+++ b/addons/dataverse/tests/test_client.py
@@ -1,8 +1,4 @@
 from unittest import mock
-from nose.tools import (
-    assert_equal, assert_raises, assert_true,
-    assert_false, assert_in, assert_is, assert_is_none
-)
 import pytest
 import unittest
 
@@ -45,12 +41,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         c = _connect(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        assert_true(c)
+        self.assertTrue(c)
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_fail(self, mock_connection):
         mock_connection.side_effect = UnauthorizedError()
-        with assert_raises(UnauthorizedError):
+        with self.assertRaises(UnauthorizedError):
             _connect(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
@@ -61,16 +57,16 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         c = connect_or_error(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        assert_true(c)
+        self.assertTrue(c)
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_or_error_returns_401_when_client_raises_unauthorized_error(self, mock_connection):
         mock_connection.side_effect = UnauthorizedError()
-        with assert_raises(HTTPError) as cm:
+        with self.assertRaises(HTTPError) as cm:
             connect_or_error(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        assert_equal(cm.exception.code, 401)
+        self.assertEqual(cm.exception.code, 401)
 
     @mock.patch('addons.dataverse.client._connect')
     def test_connect_from_settings(self, mock_connect):
@@ -80,12 +76,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         )
 
         connection = connect_from_settings(node_settings)
-        assert_true(connection)
+        self.assertTrue(connection)
         mock_connect.assert_called_once_with(self.host, self.token)
 
     def test_connect_from_settings_none(self):
         connection = connect_from_settings(None)
-        assert_is_none(connection)
+        self.assertIsNone(connection)
 
     @mock.patch('addons.dataverse.client._connect')
     def test_connect_from_settings_or_401(self, mock_connect):
@@ -95,12 +91,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         )
 
         connection = connect_from_settings_or_401(node_settings)
-        assert_true(connection)
+        self.assertTrue(connection)
         mock_connect.assert_called_once_with(self.host, self.token)
 
     def test_connect_from_settings_or_401_none(self):
         connection = connect_from_settings_or_401(None)
-        assert_is_none(connection)
+        self.assertIsNone(connection)
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_from_settings_or_401_forbidden(self, mock_connection):
@@ -110,11 +106,11 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
             self.host, self.token,
         )
 
-        with assert_raises(HTTPError) as e:
+        with self.assertRaises(HTTPError) as e:
             connect_from_settings_or_401(node_settings)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        assert_equal(e.exception.code, 401)
+        self.assertEqual(e.exception.code, 401)
 
     def test_get_files(self):
         published = False
@@ -132,11 +128,11 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
 
     def test_publish_dataset_unpublished_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=False)
-        with assert_raises(HTTPError) as e:
+        with self.assertRaises(HTTPError) as e:
             publish_dataset(self.mock_dataset)
 
-        assert_false(self.mock_dataset.publish.called)
-        assert_equal(e.exception.code, 405)
+        self.assertFalse(self.mock_dataset.publish.called)
+        self.assertEqual(e.exception.code, 405)
 
     def test_get_datasets(self):
         mock_dataset1 = mock.create_autospec(Dataset)
@@ -150,23 +146,23 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         ]
 
         datasets = get_datasets(self.mock_dataverse)
-        assert_is(self.mock_dataverse.get_datasets.assert_called_once_with(timeout=settings.REQUEST_TIMEOUT), None)
-        assert_in(mock_dataset1, datasets)
-        assert_in(mock_dataset2, datasets)
-        assert_in(mock_dataset3, datasets)
+        self.assertIs(self.mock_dataverse.get_datasets.assert_called_once_with(timeout=settings.REQUEST_TIMEOUT), None)
+        self.assertIn(mock_dataset1, datasets)
+        self.assertIn(mock_dataset2, datasets)
+        self.assertIn(mock_dataset3, datasets)
 
     def test_get_datasets_no_dataverse(self):
         datasets = get_datasets(None)
-        assert_equal(datasets, [])
+        self.assertEqual(datasets, [])
 
     def test_get_dataset(self):
         self.mock_dataset.get_state.return_value = 'DRAFT'
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
         s = get_dataset(self.mock_dataverse, 'My hdl')
-        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
+        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
 
-        assert_equal(s, self.mock_dataset)
+        self.assertEqual(s, self.mock_dataset)
 
     @mock.patch('dataverse.dataverse.requests')
     def test_get_dataset_calls_patched_timeout_method(self, mock_requests):
@@ -177,30 +173,30 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         dataverse.collection.get.return_value = '123'
         mock_requests.get.side_effect = Exception('Done Testing')
 
-        with assert_raises(Exception) as e:
+        with self.assertRaises(Exception) as e:
             get_dataset(dataverse, 'My hdl')
-        assert_is(mock_requests.get.assert_called_once_with('123', auth='me', timeout=settings.REQUEST_TIMEOUT), None)
-        assert_equal(str(e.exception), 'Done Testing')
+        self.assertIs(mock_requests.get.assert_called_once_with('123', auth='me', timeout=settings.REQUEST_TIMEOUT), None)
+        self.assertEqual(str(e.exception), 'Done Testing')
 
     def test_get_deaccessioned_dataset(self):
         self.mock_dataset.get_state.return_value = 'DEACCESSIONED'
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
-        with assert_raises(HTTPError) as e:
+        with self.assertRaises(HTTPError) as e:
             get_dataset(self.mock_dataverse, 'My hdl')
 
-        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
-        assert_equal(e.exception.code, 410)
+        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
+        self.assertEqual(e.exception.code, 410)
 
     def test_get_bad_dataset(self):
         error = UnicodeDecodeError('utf-8', b'', 1, 2, 'jeepers')
         self.mock_dataset.get_state.side_effect = error
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
-        with assert_raises(HTTPError) as e:
+        with self.assertRaises(HTTPError) as e:
             get_dataset(self.mock_dataverse, 'My hdl')
-        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
-        assert_equal(e.exception.code, 406)
+        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
+        self.assertEqual(e.exception.code, 406)
 
     def test_get_dataverses(self):
         published_dv = mock.create_autospec(Dataverse)
@@ -214,9 +210,9 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         dvs = get_dataverses(self.mock_connection)
         self.mock_connection.get_dataverses.assert_called_once_with()
 
-        assert_in(published_dv, dvs)
-        assert_in(unpublished_dv, dvs)
-        assert_equal(len(dvs), 2)
+        self.assertIn(published_dv, dvs)
+        self.assertIn(unpublished_dv, dvs)
+        self.assertEqual(len(dvs), 2)
 
     def test_get_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=True)
@@ -225,7 +221,7 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         d = get_dataverse(self.mock_connection, 'ALIAS')
         self.mock_connection.get_dataverse.assert_called_once_with('ALIAS')
 
-        assert_equal(d, self.mock_dataverse)
+        self.assertEqual(d, self.mock_dataverse)
 
     def test_get_unpublished_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=False)
@@ -234,4 +230,4 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         d = get_dataverse(self.mock_connection, 'ALIAS')
         self.mock_connection.get_dataverse.assert_called_once_with('ALIAS')
 
-        assert_equal(d, self.mock_dataverse)
+        self.assertEqual(d, self.mock_dataverse)

--- a/addons/dataverse/tests/test_client.py
+++ b/addons/dataverse/tests/test_client.py
@@ -41,12 +41,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         c = _connect(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        self.assertTrue(c)
+        assert c
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_fail(self, mock_connection):
         mock_connection.side_effect = UnauthorizedError()
-        with self.assertRaises(UnauthorizedError):
+        with pytest.raises(UnauthorizedError):
             _connect(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
@@ -57,16 +57,16 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         c = connect_or_error(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        self.assertTrue(c)
+        assert c
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_or_error_returns_401_when_client_raises_unauthorized_error(self, mock_connection):
         mock_connection.side_effect = UnauthorizedError()
-        with self.assertRaises(HTTPError) as cm:
+        with pytest.raises(HTTPError) as cm:
             connect_or_error(self.host, self.token)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        self.assertEqual(cm.exception.code, 401)
+        assert cm.exception.code == 401
 
     @mock.patch('addons.dataverse.client._connect')
     def test_connect_from_settings(self, mock_connect):
@@ -76,12 +76,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         )
 
         connection = connect_from_settings(node_settings)
-        self.assertTrue(connection)
+        assert connection
         mock_connect.assert_called_once_with(self.host, self.token)
 
     def test_connect_from_settings_none(self):
         connection = connect_from_settings(None)
-        self.assertIsNone(connection)
+        assert connection is None
 
     @mock.patch('addons.dataverse.client._connect')
     def test_connect_from_settings_or_401(self, mock_connect):
@@ -91,12 +91,12 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         )
 
         connection = connect_from_settings_or_401(node_settings)
-        self.assertTrue(connection)
+        assert connection
         mock_connect.assert_called_once_with(self.host, self.token)
 
     def test_connect_from_settings_or_401_none(self):
         connection = connect_from_settings_or_401(None)
-        self.assertIsNone(connection)
+        assert connection is None
 
     @mock.patch('addons.dataverse.client.Connection')
     def test_connect_from_settings_or_401_forbidden(self, mock_connection):
@@ -106,11 +106,11 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
             self.host, self.token,
         )
 
-        with self.assertRaises(HTTPError) as e:
+        with pytest.raises(HTTPError) as e:
             connect_from_settings_or_401(node_settings)
 
         mock_connection.assert_called_once_with(self.host, self.token)
-        self.assertEqual(e.exception.code, 401)
+        assert e.exception.code == 401
 
     def test_get_files(self):
         published = False
@@ -128,11 +128,11 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
 
     def test_publish_dataset_unpublished_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=False)
-        with self.assertRaises(HTTPError) as e:
+        with pytest.raises(HTTPError) as e:
             publish_dataset(self.mock_dataset)
 
-        self.assertFalse(self.mock_dataset.publish.called)
-        self.assertEqual(e.exception.code, 405)
+        assert not self.mock_dataset.publish.called
+        assert e.exception.code == 405
 
     def test_get_datasets(self):
         mock_dataset1 = mock.create_autospec(Dataset)
@@ -146,23 +146,23 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         ]
 
         datasets = get_datasets(self.mock_dataverse)
-        self.assertIs(self.mock_dataverse.get_datasets.assert_called_once_with(timeout=settings.REQUEST_TIMEOUT), None)
-        self.assertIn(mock_dataset1, datasets)
-        self.assertIn(mock_dataset2, datasets)
-        self.assertIn(mock_dataset3, datasets)
+        assert self.mock_dataverse.get_datasets.assert_called_once_with(timeout=settings.REQUEST_TIMEOUT) is None
+        assert mock_dataset1 in datasets
+        assert mock_dataset2 in datasets
+        assert mock_dataset3 in datasets
 
     def test_get_datasets_no_dataverse(self):
         datasets = get_datasets(None)
-        self.assertEqual(datasets, [])
+        assert datasets == []
 
     def test_get_dataset(self):
         self.mock_dataset.get_state.return_value = 'DRAFT'
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
         s = get_dataset(self.mock_dataverse, 'My hdl')
-        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
+        assert self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT) is None
 
-        self.assertEqual(s, self.mock_dataset)
+        assert s == self.mock_dataset
 
     @mock.patch('dataverse.dataverse.requests')
     def test_get_dataset_calls_patched_timeout_method(self, mock_requests):
@@ -173,30 +173,30 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         dataverse.collection.get.return_value = '123'
         mock_requests.get.side_effect = Exception('Done Testing')
 
-        with self.assertRaises(Exception) as e:
+        with pytest.raises(Exception) as e:
             get_dataset(dataverse, 'My hdl')
-        self.assertIs(mock_requests.get.assert_called_once_with('123', auth='me', timeout=settings.REQUEST_TIMEOUT), None)
-        self.assertEqual(str(e.exception), 'Done Testing')
+        assert mock_requests.get.assert_called_once_with('123', auth='me', timeout=settings.REQUEST_TIMEOUT) is None
+        assert str(e.exception) == 'Done Testing'
 
     def test_get_deaccessioned_dataset(self):
         self.mock_dataset.get_state.return_value = 'DEACCESSIONED'
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
-        with self.assertRaises(HTTPError) as e:
+        with pytest.raises(HTTPError) as e:
             get_dataset(self.mock_dataverse, 'My hdl')
 
-        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
-        self.assertEqual(e.exception.code, 410)
+        assert self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT) is None
+        assert e.exception.code == 410
 
     def test_get_bad_dataset(self):
         error = UnicodeDecodeError('utf-8', b'', 1, 2, 'jeepers')
         self.mock_dataset.get_state.side_effect = error
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
-        with self.assertRaises(HTTPError) as e:
+        with pytest.raises(HTTPError) as e:
             get_dataset(self.mock_dataverse, 'My hdl')
-        self.assertIs(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
-        self.assertEqual(e.exception.code, 406)
+        assert self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT) is None
+        assert e.exception.code == 406
 
     def test_get_dataverses(self):
         published_dv = mock.create_autospec(Dataverse)
@@ -210,9 +210,9 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         dvs = get_dataverses(self.mock_connection)
         self.mock_connection.get_dataverses.assert_called_once_with()
 
-        self.assertIn(published_dv, dvs)
-        self.assertIn(unpublished_dv, dvs)
-        self.assertEqual(len(dvs), 2)
+        assert published_dv in dvs
+        assert unpublished_dv in dvs
+        assert len(dvs) == 2
 
     def test_get_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=True)
@@ -221,7 +221,7 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         d = get_dataverse(self.mock_connection, 'ALIAS')
         self.mock_connection.get_dataverse.assert_called_once_with('ALIAS')
 
-        self.assertEqual(d, self.mock_dataverse)
+        assert d == self.mock_dataverse
 
     def test_get_unpublished_dataverse(self):
         type(self.mock_dataverse).is_published = mock.PropertyMock(return_value=False)
@@ -230,4 +230,4 @@ class TestClient(DataverseAddonTestCase, unittest.TestCase):
         d = get_dataverse(self.mock_connection, 'ALIAS')
         self.mock_connection.get_dataverse.assert_called_once_with('ALIAS')
 
-        self.assertEqual(d, self.mock_dataverse)
+        assert d == self.mock_dataverse

--- a/addons/dataverse/tests/test_model.py
+++ b/addons/dataverse/tests/test_model.py
@@ -44,7 +44,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             auth=Auth(user=self.node.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.node),
         )
-        self.assertFalse(registration.has_addon('dataverse'))
+        assert not registration.has_addon('dataverse')
 
     ## Overrides ##
 
@@ -58,32 +58,28 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             metadata={'path': filename, 'materialized': filename},
         )
         self.node.reload()
-        self.assertEqual(self.node.logs.count(), nlog + 1)
-        self.assertEqual(
-            self.node.logs.latest().action,
-            f'{self.short_name}_{action}',
-        )
-        self.assertEqual(
-            self.node.logs.latest().params['filename'],
+        assert self.node.logs.count() == nlog + 1
+        assert self.node.logs.latest().action == \
+            f'{self.short_name}_{action}'
+        assert self.node.logs.latest().params['filename'] == \
             filename
-        )
 
     def test_set_folder(self):
         dataverse = utils.create_mock_dataverse()
         dataset = utils.create_mock_dataset()
         self.node_settings.set_folder(dataverse, dataset, auth=Auth(self.user))
         # Folder was set
-        self.assertEqual(self.node_settings.folder_id, dataset.id)
+        assert self.node_settings.folder_id == dataset.id
         # Log was saved
         last_log = self.node.logs.latest()
-        self.assertEqual(last_log.action, f'{self.short_name}_dataset_linked')
+        assert last_log.action == f'{self.short_name}_dataset_linked'
 
     def test_serialize_credentials(self):
         credentials = self.node_settings.serialize_waterbutler_credentials()
 
-        self.assertIsNotNone(self.node_settings.external_account.oauth_secret)
+        assert self.node_settings.external_account.oauth_secret is not None
         expected = {'token': self.node_settings.external_account.oauth_secret}
-        self.assertEqual(credentials, expected)
+        assert credentials == expected
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
@@ -93,7 +89,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             'id': self.node_settings.dataset_id,
             'name': self.node_settings.dataset,
         }
-        self.assertEqual(settings, expected)
+        assert settings == expected
 
 
 class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):

--- a/addons/dataverse/tests/test_model.py
+++ b/addons/dataverse/tests/test_model.py
@@ -1,4 +1,3 @@
-from nose.tools import *  # noqa
 from unittest import mock
 import pytest
 import unittest
@@ -45,7 +44,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             auth=Auth(user=self.node.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.node),
         )
-        assert_false(registration.has_addon('dataverse'))
+        self.assertFalse(registration.has_addon('dataverse'))
 
     ## Overrides ##
 
@@ -59,12 +58,12 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             metadata={'path': filename, 'materialized': filename},
         )
         self.node.reload()
-        assert_equal(self.node.logs.count(), nlog + 1)
-        assert_equal(
+        self.assertEqual(self.node.logs.count(), nlog + 1)
+        self.assertEqual(
             self.node.logs.latest().action,
             f'{self.short_name}_{action}',
         )
-        assert_equal(
+        self.assertEqual(
             self.node.logs.latest().params['filename'],
             filename
         )
@@ -74,17 +73,17 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
         dataset = utils.create_mock_dataset()
         self.node_settings.set_folder(dataverse, dataset, auth=Auth(self.user))
         # Folder was set
-        assert_equal(self.node_settings.folder_id, dataset.id)
+        self.assertEqual(self.node_settings.folder_id, dataset.id)
         # Log was saved
         last_log = self.node.logs.latest()
-        assert_equal(last_log.action, f'{self.short_name}_dataset_linked')
+        self.assertEqual(last_log.action, f'{self.short_name}_dataset_linked')
 
     def test_serialize_credentials(self):
         credentials = self.node_settings.serialize_waterbutler_credentials()
 
-        assert_is_not_none(self.node_settings.external_account.oauth_secret)
+        self.assertIsNotNone(self.node_settings.external_account.oauth_secret)
         expected = {'token': self.node_settings.external_account.oauth_secret}
-        assert_equal(credentials, expected)
+        self.assertEqual(credentials, expected)
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
@@ -94,7 +93,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, utils.DataverseAddo
             'id': self.node_settings.dataset_id,
             'name': self.node_settings.dataset,
         }
-        assert_equal(settings, expected)
+        self.assertEqual(settings, expected)
 
 
 class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):

--- a/addons/dataverse/tests/test_serializer.py
+++ b/addons/dataverse/tests/test_serializer.py
@@ -1,4 +1,3 @@
-from nose.tools import *  # noqa
 from unittest import mock
 import pytest
 
@@ -50,4 +49,4 @@ class TestDataverseSerializer(OAuthAddonSerializerTestSuiteMixin, OsfTestCase):
             'host': ea.oauth_key,
             'host_url': f'https://{ea.oauth_key}',
         }
-        assert_equal(self.ser.serialize_account(ea), expected)
+        self.assertEqual(self.ser.serialize_account(ea), expected)

--- a/addons/dataverse/tests/test_serializer.py
+++ b/addons/dataverse/tests/test_serializer.py
@@ -49,4 +49,4 @@ class TestDataverseSerializer(OAuthAddonSerializerTestSuiteMixin, OsfTestCase):
             'host': ea.oauth_key,
             'host_url': f'https://{ea.oauth_key}',
         }
-        self.assertEqual(self.ser.serialize_account(ea), expected)
+        assert self.ser.serialize_account(ea) == expected

--- a/addons/dataverse/tests/test_utils.py
+++ b/addons/dataverse/tests/test_utils.py
@@ -17,7 +17,7 @@ class TestUtils(DataverseAddonTestCase):
 
     def test_mock_connection(self):
         mock_connection = create_mock_connection()
-        assert mock_connection.token == "snowman-frosty"
+        assert mock_connection.token == 'snowman-frosty'
         assert len(mock_connection.get_dataverses()) == 3
         assert isinstance(mock_connection.get_dataverses()[0], Dataverse)
         assert (
@@ -26,34 +26,34 @@ class TestUtils(DataverseAddonTestCase):
         )
 
     def test_mock_dataverse(self):
-        mock_dv = create_mock_dataverse("Example 1")
-        assert mock_dv.title == "Example 1"
+        mock_dv = create_mock_dataverse('Example 1')
+        assert mock_dv.title == 'Example 1'
         assert mock_dv.is_published is True
-        assert mock_dv.alias == "ALIAS1"
+        assert mock_dv.alias == 'ALIAS1'
         assert len(mock_dv.get_datasets()) == 3
         assert isinstance(mock_dv.get_datasets()[0], Dataset)
         assert mock_dv.get_dataset_by_doi(mock_dv.get_datasets()[1].doi) == mock_dv.get_datasets()[1]
 
     def test_mock_dataset(self):
-        dataset_id = "DVN/23456"
-        doi = f"doi:12.3456/{dataset_id}"
+        dataset_id = 'DVN/23456'
+        doi = f'doi:12.3456/{dataset_id}'
         mock_dataset = create_mock_dataset(dataset_id)
         assert mock_dataset.doi == doi
-        assert mock_dataset.citation == f"Example Citation for {dataset_id}"
-        assert mock_dataset.title == f"Example ({dataset_id})"
+        assert mock_dataset.citation == f'Example Citation for {dataset_id}'
+        assert mock_dataset.title == f'Example ({dataset_id})'
         assert mock_dataset.doi == doi
-        assert mock_dataset.get_state() == "DRAFT"
+        assert mock_dataset.get_state() == 'DRAFT'
         assert len(mock_dataset.get_files()) == 1
         assert mock_dataset.get_files()[0].is_published is False
         assert mock_dataset.get_files(published=True)[0].is_published is True
-        assert mock_dataset.get_file("name.txt").is_published is False
-        assert mock_dataset.get_file("name.txt", published=True).is_published is True
-        assert mock_dataset.get_file_by_id("123").is_published is False
-        assert mock_dataset.get_file_by_id("123", published=True).is_published is True
+        assert mock_dataset.get_file('name.txt').is_published is False
+        assert mock_dataset.get_file('name.txt', published=True).is_published is True
+        assert mock_dataset.get_file_by_id('123').is_published is False
+        assert mock_dataset.get_file_by_id('123', published=True).is_published is True
 
     def test_mock_dvn_file(self):
-        fid = "65432"
+        fid = '65432'
         mock_file = create_mock_draft_file(fid)
-        assert mock_file.name == "file.txt"
+        assert mock_file.name == 'file.txt'
         assert mock_file.id == fid
         assert isinstance(mock_file, DataverseFile)

--- a/addons/dataverse/tests/test_utils.py
+++ b/addons/dataverse/tests/test_utils.py
@@ -1,13 +1,13 @@
-from nose.tools import (
-    assert_equal, assert_true, assert_false, assert_is_instance
-)
 import pytest
 
 from dataverse import Dataverse, Dataset, DataverseFile
 
 from addons.dataverse.tests.utils import (
-    create_mock_dataverse, create_mock_dataset, create_mock_draft_file,
-    create_mock_connection, DataverseAddonTestCase,
+    create_mock_dataverse,
+    create_mock_dataset,
+    create_mock_draft_file,
+    create_mock_connection,
+    DataverseAddonTestCase,
 )
 
 pytestmark = pytest.mark.django_db
@@ -17,45 +17,43 @@ class TestUtils(DataverseAddonTestCase):
 
     def test_mock_connection(self):
         mock_connection = create_mock_connection()
-        assert_equal(mock_connection.token, 'snowman-frosty')
-        assert_equal(len(mock_connection.get_dataverses()), 3)
-        assert_is_instance(mock_connection.get_dataverses()[0], Dataverse)
-        assert_equal(
-            mock_connection.get_dataverse(mock_connection.get_dataverses()[1].alias),
-            mock_connection.get_dataverses()[1],
+        assert mock_connection.token == "snowman-frosty"
+        assert len(mock_connection.get_dataverses()) == 3
+        assert isinstance(mock_connection.get_dataverses()[0], Dataverse)
+        assert (
+            mock_connection.get_dataverse(mock_connection.get_dataverses()[1].alias)
+            == mock_connection.get_dataverses()[1]
         )
 
     def test_mock_dataverse(self):
-        mock_dv = create_mock_dataverse('Example 1')
-        assert_equal(mock_dv.title, 'Example 1')
-        assert_true(mock_dv.is_published)
-        assert_equal(mock_dv.alias, 'ALIAS1')
-        assert_equal(len(mock_dv.get_datasets()), 3)
-        assert_is_instance(mock_dv.get_datasets()[0], Dataset)
-        assert_equal(mock_dv.get_dataset_by_doi(mock_dv.get_datasets()[1].doi),
-                     mock_dv.get_datasets()[1])
+        mock_dv = create_mock_dataverse("Example 1")
+        assert mock_dv.title == "Example 1"
+        assert mock_dv.is_published is True
+        assert mock_dv.alias == "ALIAS1"
+        assert len(mock_dv.get_datasets()) == 3
+        assert isinstance(mock_dv.get_datasets()[0], Dataset)
+        assert mock_dv.get_dataset_by_doi(mock_dv.get_datasets()[1].doi) == mock_dv.get_datasets()[1]
 
     def test_mock_dataset(self):
-        dataset_id = 'DVN/23456'
-        doi = f'doi:12.3456/{dataset_id}'
+        dataset_id = "DVN/23456"
+        doi = f"doi:12.3456/{dataset_id}"
         mock_dataset = create_mock_dataset(dataset_id)
-        assert_equal(mock_dataset.doi, doi)
-        assert_equal(mock_dataset.citation,
-                     f'Example Citation for {dataset_id}')
-        assert_equal(mock_dataset.title, f'Example ({dataset_id})')
-        assert_equal(mock_dataset.doi, doi)
-        assert_equal(mock_dataset.get_state(), 'DRAFT')
-        assert_equal(len(mock_dataset.get_files()), 1)
-        assert_false(mock_dataset.get_files()[0].is_published)
-        assert_true(mock_dataset.get_files(published=True)[0].is_published)
-        assert_false(mock_dataset.get_file('name.txt').is_published)
-        assert_true(mock_dataset.get_file('name.txt', published=True).is_published)
-        assert_false(mock_dataset.get_file_by_id('123').is_published)
-        assert_true(mock_dataset.get_file_by_id('123', published=True).is_published)
+        assert mock_dataset.doi == doi
+        assert mock_dataset.citation == f"Example Citation for {dataset_id}"
+        assert mock_dataset.title == f"Example ({dataset_id})"
+        assert mock_dataset.doi == doi
+        assert mock_dataset.get_state() == "DRAFT"
+        assert len(mock_dataset.get_files()) == 1
+        assert mock_dataset.get_files()[0].is_published is False
+        assert mock_dataset.get_files(published=True)[0].is_published is True
+        assert mock_dataset.get_file("name.txt").is_published is False
+        assert mock_dataset.get_file("name.txt", published=True).is_published is True
+        assert mock_dataset.get_file_by_id("123").is_published is False
+        assert mock_dataset.get_file_by_id("123", published=True).is_published is True
 
     def test_mock_dvn_file(self):
-        fid = '65432'
+        fid = "65432"
         mock_file = create_mock_draft_file(fid)
-        assert_equal(mock_file.name, 'file.txt')
-        assert_equal(mock_file.id, fid)
-        assert_is_instance(mock_file, DataverseFile)
+        assert mock_file.name == "file.txt"
+        assert mock_file.id == fid
+        assert isinstance(mock_file, DataverseFile)

--- a/addons/dataverse/tests/test_views.py
+++ b/addons/dataverse/tests/test_views.py
@@ -26,19 +26,19 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.delete(url, auth=self.user.auth)
 
         self.node_settings.reload()
-        self.assertFalse(self.node_settings.dataverse_alias)
-        self.assertFalse(self.node_settings.dataverse)
-        self.assertFalse(self.node_settings.dataset_doi)
-        self.assertFalse(self.node_settings.dataset)
-        self.assertFalse(self.node_settings.user_settings)
+        assert not self.node_settings.dataverse_alias
+        assert not self.node_settings.dataverse
+        assert not self.node_settings.dataset_doi
+        assert not self.node_settings.dataset
+        assert not self.node_settings.user_settings
 
         # Log states that node was deauthorized
         self.project.reload()
         last_log = self.project.logs.latest()
-        self.assertEqual(last_log.action, 'dataverse_node_deauthorized')
+        assert last_log.action == 'dataverse_node_deauthorized'
         log_params = last_log.params
-        self.assertEqual(log_params['node'], self.project._primary_key)
-        self.assertEqual(log_params['project'], None)
+        assert log_params['node'] == self.project._primary_key
+        assert log_params['project'] == None
 
     def test_user_config_get(self):
         url = api_url_for('dataverse_user_config_get')
@@ -46,9 +46,9 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         res = self.app.get(url, auth=new_user.auth)
 
         result = res.json.get('result')
-        self.assertFalse(result['userHasAuth'])
-        self.assertIn('hosts', result)
-        self.assertIn('create', result['urls'])
+        assert not result['userHasAuth']
+        assert 'hosts' in result
+        assert 'create' in result['urls']
 
         # userHasAuth is true with external accounts
         new_user.external_accounts.add(create_external_account())
@@ -56,7 +56,7 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         res = self.app.get(url, auth=self.user.auth)
 
         result = res.json.get('result')
-        self.assertTrue(result['userHasAuth'])
+        assert result['userHasAuth']
 
 class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
     connection = create_mock_connection()
@@ -82,10 +82,10 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
         params = {'alias': 'ALIAS1'}
         res = self.app.post_json(url, params, auth=self.user.auth)
 
-        self.assertEqual(len(res.json['datasets']), 3)
+        assert len(res.json['datasets']) == 3
         first = res.json['datasets'][0]
-        self.assertEqual(first['title'], 'Example (DVN/00001)')
-        self.assertEqual(first['doi'], 'doi:12.3456/DVN/00001')
+        assert first['title'] == 'Example (DVN/00001)'
+        assert first['doi'] == 'doi:12.3456/DVN/00001'
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     def test_set_config(self, mock_connection):
@@ -96,26 +96,24 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
             'dataverse': {'alias': 'ALIAS3'},
             'dataset': {'doi': 'doi:12.3456/DVN/00003'},
         }, auth=self.user.auth)
-        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
+        assert res.status_code == http_status.HTTP_200_OK
         self.project.reload()
-        self.assertEqual(
-            self.project.logs.latest().action,
+        assert self.project.logs.latest().action == \
             f'{self.ADDON_SHORT_NAME}_dataset_linked'
-        )
-        self.assertEqual(res.json['dataverse'], self.connection.get_dataverse('ALIAS3').title)
-        self.assertEqual(res.json['dataset'],
-            self.connection.get_dataverse('ALIAS3').get_dataset_by_doi('doi:12.3456/DVN/00003').title)
+        assert res.json['dataverse'] == self.connection.get_dataverse('ALIAS3').title
+        assert res.json['dataset'] == \
+            self.connection.get_dataverse('ALIAS3').get_dataset_by_doi('doi:12.3456/DVN/00003').title
 
     def test_get_config(self):
         url = self.project.api_url_for(f'{self.ADDON_SHORT_NAME}_get_config')
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
-        self.assertIn('result', res.json)
+        assert res.status_code == http_status.HTTP_200_OK
+        assert 'result' in res.json
         serialized = self.Serializer().serialize_settings(
             self.node_settings,
             self.user,
         )
-        self.assertEqual(serialized, res.json['result'])
+        assert serialized == res.json['result']
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     def test_set_config_no_dataset(self, mock_connection):
@@ -135,14 +133,14 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
         self.node_settings.reload()
 
         # Old settings did not change
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(self.node_settings.dataverse_alias, 'ALIAS2')
-        self.assertEqual(self.node_settings.dataset, 'Example (DVN/00001)')
-        self.assertEqual(self.node_settings.dataset_doi, 'doi:12.3456/DVN/00001')
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert self.node_settings.dataverse_alias == 'ALIAS2'
+        assert self.node_settings.dataset == 'Example (DVN/00001)'
+        assert self.node_settings.dataset_doi == 'doi:12.3456/DVN/00001'
 
         # Nothing was logged
         self.project.reload()
-        self.assertEqual(self.project.logs.count(), num_old_logs)
+        assert self.project.logs.count() == num_old_logs
 
 
 class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
@@ -173,16 +171,16 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         # Contributor can select between states, current state is correct
         res = self.app.get(url, auth=self.user.auth)
-        self.assertTrue(res.json[0]['permissions']['edit'])
-        self.assertTrue(res.json[0]['hasPublishedFiles'])
-        self.assertEqual(res.json[0]['version'], 'latest-published')
+        assert res.json[0]['permissions']['edit']
+        assert res.json[0]['hasPublishedFiles']
+        assert res.json[0]['version'] == 'latest-published'
 
         # Non-contributor gets published version, no options
         user2 = AuthUserFactory()
         res = self.app.get(url, auth=user2.auth)
-        self.assertFalse(res.json[0]['permissions']['edit'])
-        self.assertTrue(res.json[0]['hasPublishedFiles'])
-        self.assertEqual(res.json[0]['version'], 'latest-published')
+        assert not res.json[0]['permissions']['edit']
+        assert res.json[0]['hasPublishedFiles']
+        assert res.json[0]['version'] == 'latest-published'
 
     @mock.patch('addons.dataverse.views.client.get_custom_publish_text')
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
@@ -210,14 +208,14 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         # Contributor gets draft, no options
         res = self.app.get(url, auth=self.user.auth)
-        self.assertTrue(res.json[0]['permissions']['edit'])
-        self.assertFalse(res.json[0]['hasPublishedFiles'])
-        self.assertEqual(res.json[0]['version'], 'latest')
+        assert res.json[0]['permissions']['edit']
+        assert not res.json[0]['hasPublishedFiles']
+        assert res.json[0]['version'] == 'latest'
 
         # Non-contributor gets nothing
         user2 = AuthUserFactory()
         res = self.app.get(url, auth=user2.auth)
-        self.assertEqual(res.json, [])
+        assert res.json == []
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     @mock.patch('addons.dataverse.views.client.get_files')
@@ -230,7 +228,7 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         mock_connection.return_value = None
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json, [])
+        assert res.json == []
 
     def test_dataverse_root_incomplete(self):
         self.node_settings.dataset_doi = None
@@ -240,7 +238,7 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
                   pid=self.project._primary_key)
 
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json, [])
+        assert res.json == []
 
 
 class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
@@ -256,8 +254,8 @@ class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.put_json(url, params={'publish_both': False}, auth=self.user.auth)
 
         # Only dataset was published
-        self.assertFalse(mock_publish_dv.called)
-        self.assertTrue(mock_publish_ds.called)
+        assert not mock_publish_dv.called
+        assert mock_publish_ds.called
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings_or_401')
     @mock.patch('addons.dataverse.views.client.publish_dataset')
@@ -270,8 +268,8 @@ class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.put_json(url, params={'publish_both': True}, auth=self.user.auth)
 
         # Both Dataverse and dataset were published
-        self.assertTrue(mock_publish_dv.called)
-        self.assertTrue(mock_publish_ds.called)
+        assert mock_publish_dv.called
+        assert mock_publish_ds.called
 
 
 class TestDataverseRestrictions(DataverseAddonTestCase, OsfTestCase):
@@ -301,4 +299,4 @@ class TestDataverseRestrictions(DataverseAddonTestCase, OsfTestCase):
         }
         res = self.app.post_json(url, params, auth=self.contrib.auth,
                                  expect_errors=True)
-        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN

--- a/addons/dataverse/tests/test_views.py
+++ b/addons/dataverse/tests/test_views.py
@@ -1,4 +1,3 @@
-from nose.tools import (assert_false, assert_equal, assert_in, assert_true)
 from unittest import mock
 import pytest
 import unittest
@@ -27,19 +26,19 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.delete(url, auth=self.user.auth)
 
         self.node_settings.reload()
-        assert_false(self.node_settings.dataverse_alias)
-        assert_false(self.node_settings.dataverse)
-        assert_false(self.node_settings.dataset_doi)
-        assert_false(self.node_settings.dataset)
-        assert_false(self.node_settings.user_settings)
+        self.assertFalse(self.node_settings.dataverse_alias)
+        self.assertFalse(self.node_settings.dataverse)
+        self.assertFalse(self.node_settings.dataset_doi)
+        self.assertFalse(self.node_settings.dataset)
+        self.assertFalse(self.node_settings.user_settings)
 
         # Log states that node was deauthorized
         self.project.reload()
         last_log = self.project.logs.latest()
-        assert_equal(last_log.action, 'dataverse_node_deauthorized')
+        self.assertEqual(last_log.action, 'dataverse_node_deauthorized')
         log_params = last_log.params
-        assert_equal(log_params['node'], self.project._primary_key)
-        assert_equal(log_params['project'], None)
+        self.assertEqual(log_params['node'], self.project._primary_key)
+        self.assertEqual(log_params['project'], None)
 
     def test_user_config_get(self):
         url = api_url_for('dataverse_user_config_get')
@@ -47,9 +46,9 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         res = self.app.get(url, auth=new_user.auth)
 
         result = res.json.get('result')
-        assert_false(result['userHasAuth'])
-        assert_in('hosts', result)
-        assert_in('create', result['urls'])
+        self.assertFalse(result['userHasAuth'])
+        self.assertIn('hosts', result)
+        self.assertIn('create', result['urls'])
 
         # userHasAuth is true with external accounts
         new_user.external_accounts.add(create_external_account())
@@ -57,7 +56,7 @@ class TestAuthViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         res = self.app.get(url, auth=self.user.auth)
 
         result = res.json.get('result')
-        assert_true(result['userHasAuth'])
+        self.assertTrue(result['userHasAuth'])
 
 class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
     connection = create_mock_connection()
@@ -83,10 +82,10 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
         params = {'alias': 'ALIAS1'}
         res = self.app.post_json(url, params, auth=self.user.auth)
 
-        assert_equal(len(res.json['datasets']), 3)
+        self.assertEqual(len(res.json['datasets']), 3)
         first = res.json['datasets'][0]
-        assert_equal(first['title'], 'Example (DVN/00001)')
-        assert_equal(first['doi'], 'doi:12.3456/DVN/00001')
+        self.assertEqual(first['title'], 'Example (DVN/00001)')
+        self.assertEqual(first['doi'], 'doi:12.3456/DVN/00001')
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     def test_set_config(self, mock_connection):
@@ -97,26 +96,26 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
             'dataverse': {'alias': 'ALIAS3'},
             'dataset': {'doi': 'doi:12.3456/DVN/00003'},
         }, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
         self.project.reload()
-        assert_equal(
+        self.assertEqual(
             self.project.logs.latest().action,
             f'{self.ADDON_SHORT_NAME}_dataset_linked'
         )
-        assert_equal(res.json['dataverse'], self.connection.get_dataverse('ALIAS3').title)
-        assert_equal(res.json['dataset'],
+        self.assertEqual(res.json['dataverse'], self.connection.get_dataverse('ALIAS3').title)
+        self.assertEqual(res.json['dataset'],
             self.connection.get_dataverse('ALIAS3').get_dataset_by_doi('doi:12.3456/DVN/00003').title)
 
     def test_get_config(self):
         url = self.project.api_url_for(f'{self.ADDON_SHORT_NAME}_get_config')
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
-        assert_in('result', res.json)
+        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
+        self.assertIn('result', res.json)
         serialized = self.Serializer().serialize_settings(
             self.node_settings,
             self.user,
         )
-        assert_equal(serialized, res.json['result'])
+        self.assertEqual(serialized, res.json['result'])
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     def test_set_config_no_dataset(self, mock_connection):
@@ -136,14 +135,14 @@ class TestConfigViews(DataverseAddonTestCase, OAuthAddonConfigViewsTestCaseMixin
         self.node_settings.reload()
 
         # Old settings did not change
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        assert_equal(self.node_settings.dataverse_alias, 'ALIAS2')
-        assert_equal(self.node_settings.dataset, 'Example (DVN/00001)')
-        assert_equal(self.node_settings.dataset_doi, 'doi:12.3456/DVN/00001')
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.node_settings.dataverse_alias, 'ALIAS2')
+        self.assertEqual(self.node_settings.dataset, 'Example (DVN/00001)')
+        self.assertEqual(self.node_settings.dataset_doi, 'doi:12.3456/DVN/00001')
 
         # Nothing was logged
         self.project.reload()
-        assert_equal(self.project.logs.count(), num_old_logs)
+        self.assertEqual(self.project.logs.count(), num_old_logs)
 
 
 class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
@@ -174,16 +173,16 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         # Contributor can select between states, current state is correct
         res = self.app.get(url, auth=self.user.auth)
-        assert_true(res.json[0]['permissions']['edit'])
-        assert_true(res.json[0]['hasPublishedFiles'])
-        assert_equal(res.json[0]['version'], 'latest-published')
+        self.assertTrue(res.json[0]['permissions']['edit'])
+        self.assertTrue(res.json[0]['hasPublishedFiles'])
+        self.assertEqual(res.json[0]['version'], 'latest-published')
 
         # Non-contributor gets published version, no options
         user2 = AuthUserFactory()
         res = self.app.get(url, auth=user2.auth)
-        assert_false(res.json[0]['permissions']['edit'])
-        assert_true(res.json[0]['hasPublishedFiles'])
-        assert_equal(res.json[0]['version'], 'latest-published')
+        self.assertFalse(res.json[0]['permissions']['edit'])
+        self.assertTrue(res.json[0]['hasPublishedFiles'])
+        self.assertEqual(res.json[0]['version'], 'latest-published')
 
     @mock.patch('addons.dataverse.views.client.get_custom_publish_text')
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
@@ -211,14 +210,14 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         # Contributor gets draft, no options
         res = self.app.get(url, auth=self.user.auth)
-        assert_true(res.json[0]['permissions']['edit'])
-        assert_false(res.json[0]['hasPublishedFiles'])
-        assert_equal(res.json[0]['version'], 'latest')
+        self.assertTrue(res.json[0]['permissions']['edit'])
+        self.assertFalse(res.json[0]['hasPublishedFiles'])
+        self.assertEqual(res.json[0]['version'], 'latest')
 
         # Non-contributor gets nothing
         user2 = AuthUserFactory()
         res = self.app.get(url, auth=user2.auth)
-        assert_equal(res.json, [])
+        self.assertEqual(res.json, [])
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings')
     @mock.patch('addons.dataverse.views.client.get_files')
@@ -231,7 +230,7 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
 
         mock_connection.return_value = None
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json, [])
+        self.assertEqual(res.json, [])
 
     def test_dataverse_root_incomplete(self):
         self.node_settings.dataset_doi = None
@@ -241,7 +240,7 @@ class TestHgridViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
                   pid=self.project._primary_key)
 
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json, [])
+        self.assertEqual(res.json, [])
 
 
 class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
@@ -257,8 +256,8 @@ class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.put_json(url, params={'publish_both': False}, auth=self.user.auth)
 
         # Only dataset was published
-        assert_false(mock_publish_dv.called)
-        assert_true(mock_publish_ds.called)
+        self.assertFalse(mock_publish_dv.called)
+        self.assertTrue(mock_publish_ds.called)
 
     @mock.patch('addons.dataverse.views.client.connect_from_settings_or_401')
     @mock.patch('addons.dataverse.views.client.publish_dataset')
@@ -271,8 +270,8 @@ class TestCrudViews(DataverseAddonTestCase, OsfTestCase, unittest.TestCase):
         self.app.put_json(url, params={'publish_both': True}, auth=self.user.auth)
 
         # Both Dataverse and dataset were published
-        assert_true(mock_publish_dv.called)
-        assert_true(mock_publish_ds.called)
+        self.assertTrue(mock_publish_dv.called)
+        self.assertTrue(mock_publish_ds.called)
 
 
 class TestDataverseRestrictions(DataverseAddonTestCase, OsfTestCase):
@@ -302,4 +301,4 @@ class TestDataverseRestrictions(DataverseAddonTestCase, OsfTestCase):
         }
         res = self.app.post_json(url, params, auth=self.contrib.auth,
                                  expect_errors=True)
-        assert_equal(res.status_code, http_status.HTTP_403_FORBIDDEN)
+        self.assertEqual(res.status_code, http_status.HTTP_403_FORBIDDEN)

--- a/addons/figshare/tests/test_models.py
+++ b/addons/figshare/tests/test_models.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from nose.tools import assert_false, assert_equal
 import pytest
 import unittest
 
@@ -47,7 +46,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
             auth=Auth(user=self.node.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.node)
         )
-        assert_false(registration.has_addon('figshare'))
+        self.assertFalse(registration.has_addon('figshare'))
 
     # Overrides
 
@@ -58,9 +57,9 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_info.return_value = dict(path='project', name='Folder', id='1234567890')
         self.node_settings.set_folder(folder_id, auth=Auth(self.user))
         self.node_settings.save()
-        assert_equal(self.node_settings.folder_id, folder_id)
+        self.assertEqual(self.node_settings.folder_id, folder_id)
         last_log = self.node.logs.latest()
-        assert_equal(last_log.action, f'{self.short_name}_folder_selected')
+        self.assertEqual(last_log.action, f'{self.short_name}_folder_selected')
 
     def test_serialize_settings(self):
         # Custom `expected`
@@ -69,7 +68,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
             'container_id': self.node_settings.folder_id,
             'container_type': self.node_settings.folder_path
         }
-        assert_equal(settings, expected)
+        self.assertEqual(settings, expected)
 
 
 class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):

--- a/addons/figshare/tests/test_models.py
+++ b/addons/figshare/tests/test_models.py
@@ -46,7 +46,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
             auth=Auth(user=self.node.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.node)
         )
-        self.assertFalse(registration.has_addon('figshare'))
+        assert not registration.has_addon('figshare')
 
     # Overrides
 
@@ -57,9 +57,9 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
         mock_info.return_value = dict(path='project', name='Folder', id='1234567890')
         self.node_settings.set_folder(folder_id, auth=Auth(self.user))
         self.node_settings.save()
-        self.assertEqual(self.node_settings.folder_id, folder_id)
+        assert self.node_settings.folder_id == folder_id
         last_log = self.node.logs.latest()
-        self.assertEqual(last_log.action, f'{self.short_name}_folder_selected')
+        assert last_log.action == f'{self.short_name}_folder_selected'
 
     def test_serialize_settings(self):
         # Custom `expected`
@@ -68,7 +68,7 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, unittest.Tes
             'container_id': self.node_settings.folder_id,
             'container_type': self.node_settings.folder_path
         }
-        self.assertEqual(settings, expected)
+        assert settings == expected
 
 
 class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):

--- a/addons/figshare/tests/test_views.py
+++ b/addons/figshare/tests/test_views.py
@@ -38,10 +38,8 @@ class TestConfigViews(FigshareAddonTestCase, OAuthAddonConfigViewsTestCaseMixin,
         }, auth=self.user.auth)
         assert res.status_code == http_status.HTTP_200_OK
         self.project.reload()
-        assert self.project.logs.latest().action == \
-            f'{self.ADDON_SHORT_NAME}_folder_selected'
-        assert self.project.logs.latest().params['folder'] == \
-            self.folder['path']
+        assert self.project.logs.latest().action == f'{self.ADDON_SHORT_NAME}_folder_selected'
+        assert self.project.logs.latest().params['folder'] == self.folder['path']
         assert res.json['result']['folder']['path'] == self.folder['path']
 
     @mock.patch.object(FigshareClient, 'userinfo')

--- a/addons/figshare/tests/test_views.py
+++ b/addons/figshare/tests/test_views.py
@@ -36,17 +36,13 @@ class TestConfigViews(FigshareAddonTestCase, OAuthAddonConfigViewsTestCaseMixin,
         res = self.app.put_json(url, {
             'selected': self.folder
         }, auth=self.user.auth)
-        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
+        assert res.status_code == http_status.HTTP_200_OK
         self.project.reload()
-        self.assertEqual(
-            self.project.logs.latest().action,
+        assert self.project.logs.latest().action == \
             f'{self.ADDON_SHORT_NAME}_folder_selected'
-        )
-        self.assertEqual(
-            self.project.logs.latest().params['folder'],
+        assert self.project.logs.latest().params['folder'] == \
             self.folder['path']
-        )
-        self.assertEqual(res.json['result']['folder']['path'], self.folder['path'])
+        assert res.json['result']['folder']['path'] == self.folder['path']
 
     @mock.patch.object(FigshareClient, 'userinfo')
     def test_get_config(self, mock_about):

--- a/addons/figshare/tests/test_views.py
+++ b/addons/figshare/tests/test_views.py
@@ -2,7 +2,6 @@
 
 from rest_framework import status as http_status
 from unittest import mock
-from nose.tools import assert_equal
 import pytest
 
 from addons.base.tests.views import (
@@ -37,17 +36,17 @@ class TestConfigViews(FigshareAddonTestCase, OAuthAddonConfigViewsTestCaseMixin,
         res = self.app.put_json(url, {
             'selected': self.folder
         }, auth=self.user.auth)
-        assert_equal(res.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(res.status_code, http_status.HTTP_200_OK)
         self.project.reload()
-        assert_equal(
+        self.assertEqual(
             self.project.logs.latest().action,
             f'{self.ADDON_SHORT_NAME}_folder_selected'
         )
-        assert_equal(
+        self.assertEqual(
             self.project.logs.latest().params['folder'],
             self.folder['path']
         )
-        assert_equal(res.json['result']['folder']['path'], self.folder['path'])
+        self.assertEqual(res.json['result']['folder']['path'], self.folder['path'])
 
     @mock.patch.object(FigshareClient, 'userinfo')
     def test_get_config(self, mock_about):

--- a/addons/github/tests/test_models.py
+++ b/addons/github/tests/test_models.py
@@ -245,8 +245,7 @@ class TestCallbacks(OsfTestCase):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, self.consolidated_auth
         )
-        assert self.node_settings.user_settings == \
-            None
+        assert self.node_settings.user_settings is None
         assert message
         assert 'You can re-authenticate' not in message
 
@@ -255,8 +254,7 @@ class TestCallbacks(OsfTestCase):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, auth
         )
-        assert self.node_settings.user_settings == \
-            None
+        assert self.node_settings.user_settings is None
         assert message
         assert 'You can re-authenticate' in message
 
@@ -264,24 +262,21 @@ class TestCallbacks(OsfTestCase):
         self.node_settings.after_remove_contributor(
             self.project, self.non_authenticator, self.consolidated_auth
         )
-        assert self.node_settings.user_settings != \
-            None
+        assert self.node_settings.user_settings is not None
 
     def test_after_fork_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.project.creator,
         )
-        assert self.node_settings.user_settings == \
-            clone.user_settings
+        assert self.node_settings.user_settings == clone.user_settings
 
     def test_after_fork_not_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.non_authenticator,
         )
-        assert clone.user_settings == \
-            None
+        assert clone.user_settings == None
 
     def test_after_delete(self):
         self.project.remove_node(Auth(user=self.project.creator))

--- a/addons/github/tests/test_models.py
+++ b/addons/github/tests/test_models.py
@@ -54,7 +54,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         # common storage addons.
         settings = self.node_settings.serialize_waterbutler_settings()
         expected = {'owner': self.node_settings.user, 'repo': self.node_settings.repo}
-        self.assertEqual(settings, expected)
+        assert settings == expected
 
     @mock.patch(
         'addons.github.models.UserSettings.revoke_remote_oauth_access',
@@ -75,11 +75,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         mock_check_authorization.return_value = True
         mock_repos.return_value = {}
         result = self.node_settings.to_json(self.user)
-        self.assertTrue(result['user_has_auth'])
-        self.assertEqual(result['github_user'], 'abc')
-        self.assertTrue(result['is_owner'])
-        self.assertTrue(result['valid_credentials'])
-        self.assertEqual(result.get('repo_names', None), [])
+        assert result['user_has_auth']
+        assert result['github_user'] == 'abc'
+        assert result['is_owner']
+        assert result['valid_credentials']
+        assert result.get('repo_names', None) == []
 
     @mock.patch('addons.github.api.GitHubClient.repos')
     @mock.patch('addons.github.api.GitHubClient.check_authorization')
@@ -88,11 +88,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         mock_repos.return_value = {}
         not_owner = UserFactory()
         result = self.node_settings.to_json(not_owner)
-        self.assertFalse(result['user_has_auth'])
-        self.assertEqual(result['github_user'], 'abc')
-        self.assertFalse(result['is_owner'])
-        self.assertTrue(result['valid_credentials'])
-        self.assertEqual(result.get('repo_names', None), None)
+        assert not result['user_has_auth']
+        assert result['github_user'] == 'abc'
+        assert not result['is_owner']
+        assert result['valid_credentials']
+        assert result.get('repo_names', None) == None
 
 
     @mock.patch('addons.github.api.GitHubClient.repos')
@@ -106,11 +106,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
                                    ]
         result = self.node_settings.get_folders()
 
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['id'], '12345')
-        self.assertEqual(result[0]['name'], 'test')
-        self.assertEqual(result[0]['path'], 'test name/test')
-        self.assertEqual(result[0]['kind'], 'repo')
+        assert len(result) == 1
+        assert result[0]['id'] == '12345'
+        assert result[0]['name'] == 'test'
+        assert result[0]['path'] == 'test name/test'
+        assert result[0]['kind'] == 'repo'
 
 
     @mock.patch('addons.github.api.GitHubClient.repos')
@@ -134,7 +134,7 @@ class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
     ExternalAccountFactory = factories.GitHubAccountFactory
 
     def test_public_id(self):
-        self.assertEqual(self.user.external_accounts.first().display_name, self.user_settings.public_id)
+        assert self.user.external_accounts.first().display_name == self.user_settings.public_id
 
 
 class TestCallbacks(OsfTestCase):
@@ -175,7 +175,7 @@ class TestCallbacks(OsfTestCase):
         mock_repo.side_effect = NotFoundError
 
         result = self.node_settings.before_make_public(self.project)
-        self.assertIs(result, None)
+        assert result is None
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_public_gh_public(self, mock_repo):
@@ -187,7 +187,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        self.assertFalse(message)
+        assert not message
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_public_gh_private(self, mock_repo):
@@ -199,7 +199,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        self.assertTrue(message)
+        assert message
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_public(self, mock_repo):
@@ -209,7 +209,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        self.assertTrue(message)
+        assert message
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_private(self, mock_repo):
@@ -219,85 +219,75 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        self.assertFalse(message)
+        assert not message
 
     def test_before_page_load_not_contributor(self):
         message = self.node_settings.before_page_load(self.project, UserFactory())
-        self.assertFalse(message)
+        assert not message
 
     def test_before_page_load_not_logged_in(self):
         message = self.node_settings.before_page_load(self.project, None)
-        self.assertFalse(message)
+        assert not message
 
     def test_before_remove_contributor_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.project.creator
         )
-        self.assertTrue(message)
+        assert message
 
     def test_before_remove_contributor_not_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.non_authenticator
         )
-        self.assertFalse(message)
+        assert not message
 
     def test_after_remove_contributor_authenticator_self(self):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, self.consolidated_auth
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
+        assert self.node_settings.user_settings == \
             None
-        )
-        self.assertTrue(message)
-        self.assertNotIn('You can re-authenticate', message)
+        assert message
+        assert 'You can re-authenticate' not in message
 
     def test_after_remove_contributor_authenticator_not_self(self):
         auth = Auth(user=self.non_authenticator)
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, auth
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
+        assert self.node_settings.user_settings == \
             None
-        )
-        self.assertTrue(message)
-        self.assertIn('You can re-authenticate', message)
+        assert message
+        assert 'You can re-authenticate' in message
 
     def test_after_remove_contributor_not_authenticator(self):
         self.node_settings.after_remove_contributor(
             self.project, self.non_authenticator, self.consolidated_auth
         )
-        self.assertNotEqual(
-            self.node_settings.user_settings,
-            None,
-        )
+        assert self.node_settings.user_settings != \
+            None
 
     def test_after_fork_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.project.creator,
         )
-        self.assertEqual(
-            self.node_settings.user_settings,
-            clone.user_settings,
-        )
+        assert self.node_settings.user_settings == \
+            clone.user_settings
 
     def test_after_fork_not_authenticator(self):
         fork = ProjectFactory()
         clone = self.node_settings.after_fork(
             self.project, fork, self.non_authenticator,
         )
-        self.assertEqual(
-            clone.user_settings,
-            None,
-        )
+        assert clone.user_settings == \
+            None
 
     def test_after_delete(self):
         self.project.remove_node(Auth(user=self.project.creator))
         # Ensure that changes to node settings have been saved
         self.node_settings.reload()
-        self.assertTrue(self.node_settings.user_settings is None)
+        assert self.node_settings.user_settings is None
 
     @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
@@ -306,7 +296,7 @@ class TestCallbacks(OsfTestCase):
             auth=Auth(user=self.project.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.project),
         )
-        self.assertFalse(registration.has_addon('github'))
+        assert not registration.has_addon('github')
 
 
 class TestGithubNodeSettings(unittest.TestCase):
@@ -331,14 +321,14 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        self.assertTrue(res)
+        assert res
         mock_delete_hook.assert_called_with(*args)
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
     def test_delete_hook_no_hook(self, mock_delete_hook):
         res = self.node_settings.delete_hook()
-        self.assertFalse(res)
-        self.assertFalse(mock_delete_hook.called)
+        assert not res
+        assert not mock_delete_hook.called
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
     def test_delete_hook_not_found(self, mock_delete_hook):
@@ -351,7 +341,7 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        self.assertFalse(res)
+        assert not res
         mock_delete_hook.assert_called_with(*args)
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
@@ -365,5 +355,5 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        self.assertFalse(res)
+        assert not res
         mock_delete_hook.assert_called_with(*args)

--- a/addons/github/tests/test_models.py
+++ b/addons/github/tests/test_models.py
@@ -9,8 +9,6 @@ from addons.github.models import NodeSettings
 from addons.github.tests import factories
 from osf_tests.factories import ProjectFactory, UserFactory, DraftRegistrationFactory
 
-from nose.tools import (assert_equal, assert_false, assert_in, assert_is,
-                        assert_not_equal, assert_not_in, assert_true)
 
 from github3 import GitHubError
 from github3.repos import Repository
@@ -56,7 +54,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         # common storage addons.
         settings = self.node_settings.serialize_waterbutler_settings()
         expected = {'owner': self.node_settings.user, 'repo': self.node_settings.repo}
-        assert_equal(settings, expected)
+        self.assertEqual(settings, expected)
 
     @mock.patch(
         'addons.github.models.UserSettings.revoke_remote_oauth_access',
@@ -77,11 +75,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         mock_check_authorization.return_value = True
         mock_repos.return_value = {}
         result = self.node_settings.to_json(self.user)
-        assert_true(result['user_has_auth'])
-        assert_equal(result['github_user'], 'abc')
-        assert_true(result['is_owner'])
-        assert_true(result['valid_credentials'])
-        assert_equal(result.get('repo_names', None), [])
+        self.assertTrue(result['user_has_auth'])
+        self.assertEqual(result['github_user'], 'abc')
+        self.assertTrue(result['is_owner'])
+        self.assertTrue(result['valid_credentials'])
+        self.assertEqual(result.get('repo_names', None), [])
 
     @mock.patch('addons.github.api.GitHubClient.repos')
     @mock.patch('addons.github.api.GitHubClient.check_authorization')
@@ -90,11 +88,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         mock_repos.return_value = {}
         not_owner = UserFactory()
         result = self.node_settings.to_json(not_owner)
-        assert_false(result['user_has_auth'])
-        assert_equal(result['github_user'], 'abc')
-        assert_false(result['is_owner'])
-        assert_true(result['valid_credentials'])
-        assert_equal(result.get('repo_names', None), None)
+        self.assertFalse(result['user_has_auth'])
+        self.assertEqual(result['github_user'], 'abc')
+        self.assertFalse(result['is_owner'])
+        self.assertTrue(result['valid_credentials'])
+        self.assertEqual(result.get('repo_names', None), None)
 
 
     @mock.patch('addons.github.api.GitHubClient.repos')
@@ -108,11 +106,11 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
                                    ]
         result = self.node_settings.get_folders()
 
-        assert_equal(len(result), 1)
-        assert_equal(result[0]['id'], '12345')
-        assert_equal(result[0]['name'], 'test')
-        assert_equal(result[0]['path'], 'test name/test')
-        assert_equal(result[0]['kind'], 'repo')
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['id'], '12345')
+        self.assertEqual(result[0]['name'], 'test')
+        self.assertEqual(result[0]['path'], 'test name/test')
+        self.assertEqual(result[0]['kind'], 'repo')
 
 
     @mock.patch('addons.github.api.GitHubClient.repos')
@@ -136,7 +134,7 @@ class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
     ExternalAccountFactory = factories.GitHubAccountFactory
 
     def test_public_id(self):
-        assert_equal(self.user.external_accounts.first().display_name, self.user_settings.public_id)
+        self.assertEqual(self.user.external_accounts.first().display_name, self.user_settings.public_id)
 
 
 class TestCallbacks(OsfTestCase):
@@ -177,7 +175,7 @@ class TestCallbacks(OsfTestCase):
         mock_repo.side_effect = NotFoundError
 
         result = self.node_settings.before_make_public(self.project)
-        assert_is(result, None)
+        self.assertIs(result, None)
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_public_gh_public(self, mock_repo):
@@ -189,7 +187,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_public_gh_private(self, mock_repo):
@@ -201,7 +199,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        assert_true(message)
+        self.assertTrue(message)
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_public(self, mock_repo):
@@ -211,7 +209,7 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        assert_true(message)
+        self.assertTrue(message)
 
     @mock.patch('addons.github.api.GitHubClient.repo')
     def test_before_page_load_osf_private_gh_private(self, mock_repo):
@@ -221,56 +219,56 @@ class TestCallbacks(OsfTestCase):
             self.node_settings.user,
             self.node_settings.repo,
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_page_load_not_contributor(self):
         message = self.node_settings.before_page_load(self.project, UserFactory())
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_page_load_not_logged_in(self):
         message = self.node_settings.before_page_load(self.project, None)
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_before_remove_contributor_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.project.creator
         )
-        assert_true(message)
+        self.assertTrue(message)
 
     def test_before_remove_contributor_not_authenticator(self):
         message = self.node_settings.before_remove_contributor(
             self.project, self.non_authenticator
         )
-        assert_false(message)
+        self.assertFalse(message)
 
     def test_after_remove_contributor_authenticator_self(self):
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, self.consolidated_auth
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             None
         )
-        assert_true(message)
-        assert_not_in('You can re-authenticate', message)
+        self.assertTrue(message)
+        self.assertNotIn('You can re-authenticate', message)
 
     def test_after_remove_contributor_authenticator_not_self(self):
         auth = Auth(user=self.non_authenticator)
         message = self.node_settings.after_remove_contributor(
             self.project, self.project.creator, auth
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             None
         )
-        assert_true(message)
-        assert_in('You can re-authenticate', message)
+        self.assertTrue(message)
+        self.assertIn('You can re-authenticate', message)
 
     def test_after_remove_contributor_not_authenticator(self):
         self.node_settings.after_remove_contributor(
             self.project, self.non_authenticator, self.consolidated_auth
         )
-        assert_not_equal(
+        self.assertNotEqual(
             self.node_settings.user_settings,
             None,
         )
@@ -280,7 +278,7 @@ class TestCallbacks(OsfTestCase):
         clone = self.node_settings.after_fork(
             self.project, fork, self.project.creator,
         )
-        assert_equal(
+        self.assertEqual(
             self.node_settings.user_settings,
             clone.user_settings,
         )
@@ -290,7 +288,7 @@ class TestCallbacks(OsfTestCase):
         clone = self.node_settings.after_fork(
             self.project, fork, self.non_authenticator,
         )
-        assert_equal(
+        self.assertEqual(
             clone.user_settings,
             None,
         )
@@ -299,7 +297,7 @@ class TestCallbacks(OsfTestCase):
         self.project.remove_node(Auth(user=self.project.creator))
         # Ensure that changes to node settings have been saved
         self.node_settings.reload()
-        assert_true(self.node_settings.user_settings is None)
+        self.assertTrue(self.node_settings.user_settings is None)
 
     @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
@@ -308,7 +306,7 @@ class TestCallbacks(OsfTestCase):
             auth=Auth(user=self.project.creator),
             draft_registration=DraftRegistrationFactory(branched_from=self.project),
         )
-        assert_false(registration.has_addon('github'))
+        self.assertFalse(registration.has_addon('github'))
 
 
 class TestGithubNodeSettings(unittest.TestCase):
@@ -333,14 +331,14 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        assert_true(res)
+        self.assertTrue(res)
         mock_delete_hook.assert_called_with(*args)
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
     def test_delete_hook_no_hook(self, mock_delete_hook):
         res = self.node_settings.delete_hook()
-        assert_false(res)
-        assert_false(mock_delete_hook.called)
+        self.assertFalse(res)
+        self.assertFalse(mock_delete_hook.called)
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
     def test_delete_hook_not_found(self, mock_delete_hook):
@@ -353,7 +351,7 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        assert_false(res)
+        self.assertFalse(res)
         mock_delete_hook.assert_called_with(*args)
 
     @mock.patch('addons.github.api.GitHubClient.delete_hook')
@@ -367,5 +365,5 @@ class TestGithubNodeSettings(unittest.TestCase):
             self.node_settings.hook_id,
         )
         res = self.node_settings.delete_hook()
-        assert_false(res)
+        self.assertFalse(res)
         mock_delete_hook.assert_called_with(*args)

--- a/addons/github/tests/test_utils.py
+++ b/addons/github/tests/test_utils.py
@@ -31,7 +31,7 @@ class TestHookVerify(OsfTestCase):
 
     def test_verify_no_secret(self):
         self.node_settings.hook_secret = None
-        with self.assertRaises(HookError):
+        with pytest.raises(HookError):
             utils.verify_hook_signature(self.node_settings, {}, {})
 
     def test_verify_valid(self):
@@ -50,7 +50,7 @@ class TestHookVerify(OsfTestCase):
             assert 0
 
     def test_verify_invalid(self):
-        with self.assertRaises(HookError):
+        with pytest.raises(HookError):
             utils.verify_hook_signature(
                 self.node_settings,
                 HOOK_PAYLOAD,

--- a/addons/github/tests/test_utils.py
+++ b/addons/github/tests/test_utils.py
@@ -2,8 +2,6 @@ import json
 import hmac
 import hashlib
 
-import nose
-from nose.tools import *  # noqa
 import pytest
 
 from tests.base import OsfTestCase
@@ -33,7 +31,7 @@ class TestHookVerify(OsfTestCase):
 
     def test_verify_no_secret(self):
         self.node_settings.hook_secret = None
-        with assert_raises(HookError):
+        with self.assertRaises(HookError):
             utils.verify_hook_signature(self.node_settings, {}, {})
 
     def test_verify_valid(self):
@@ -52,13 +50,10 @@ class TestHookVerify(OsfTestCase):
             assert 0
 
     def test_verify_invalid(self):
-        with assert_raises(HookError):
+        with self.assertRaises(HookError):
             utils.verify_hook_signature(
                 self.node_settings,
                 HOOK_PAYLOAD,
                 {'X-Hub-Signature': 'invalid'}
             )
 
-
-if __name__ == '__main__':
-    nose.run()

--- a/addons/github/tests/test_views.py
+++ b/addons/github/tests/test_views.py
@@ -141,11 +141,9 @@ class TestGithubViews(OsfTestCase):
         mock_repo.return_value = github_mock.repo.return_value
         mock_branches.return_value = github_mock.branches.return_value
         branch, sha, branches = utils.get_refs(self.node_settings)
-        assert branch == \
-            github_mock.repo.return_value.default_branch
+        assert branch == github_mock.repo.return_value.default_branch
         assert sha == self._get_sha_for_branch(branch=None)  # Get refs for default branch
-        assert branches == \
-            github_mock.branches.return_value
+        assert branches == github_mock.branches.return_value
 
     @mock.patch('addons.github.api.GitHubClient.branches')
     @mock.patch('addons.github.api.GitHubClient.repo')
@@ -157,8 +155,7 @@ class TestGithubViews(OsfTestCase):
         assert branch == 'master'
         branch_sha = self._get_sha_for_branch('master')
         assert sha == branch_sha
-        assert branches == \
-            github_mock.branches.return_value
+        assert branches == github_mock.branches.return_value
 
     def test_before_fork(self):
         url = self.project.api_url + 'fork/before/'
@@ -527,9 +524,9 @@ class TestGithubSettings(OsfTestCase):
 
         self.project.reload()
         self.node_settings.reload()
-        assert self.node_settings.user == None
-        assert self.node_settings.repo == None
-        assert self.node_settings.user_settings == None
+        assert self.node_settings.user is None
+        assert self.node_settings.repo is None
+        assert self.node_settings.user_settings is None
 
         assert self.project.logs.latest().action == 'github_node_deauthorized'
 

--- a/addons/googledrive/tests/test_models.py
+++ b/addons/googledrive/tests/test_models.py
@@ -16,6 +16,7 @@ from addons.googledrive.tests.factories import (
 
 pytestmark = pytest.mark.django_db
 
+
 class TestGoogleDriveProvider(unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -79,14 +80,12 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def test_selected_folder_name_root(self):
         self.node_settings.folder_id = 'root'
 
-        assert self.node_settings.selected_folder_name == \
-            'Full Google Drive'
+        assert self.node_settings.selected_folder_name == 'Full Google Drive'
 
     def test_selected_folder_name_empty(self):
         self.node_settings.folder_id = None
 
-        assert self.node_settings.selected_folder_name == \
-            ''
+        assert self.node_settings.selected_folder_name == ''
 
     ## Overrides ##
 

--- a/addons/googledrive/tests/test_models.py
+++ b/addons/googledrive/tests/test_models.py
@@ -27,9 +27,9 @@ class TestGoogleDriveProvider(unittest.TestCase):
         fake_info = {'sub': '12345', 'name': 'fakename', 'profile': 'fakeUrl'}
         mock_client.return_value = fake_info
         res = self.provider.handle_callback(fake_response)
-        self.assertEqual(res['provider_id'], '12345')
-        self.assertEqual(res['display_name'], 'fakename')
-        self.assertEqual(res['profile_url'], 'fakeUrl')
+        assert res['provider_id'] == '12345'
+        assert res['display_name'] == 'fakename'
+        assert res['profile_url'] == 'fakeUrl'
 
 class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
 
@@ -66,31 +66,27 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         # The first call to .api returns a new object
         api = self.node_settings.api
         mock_gdp.assert_called_once_with(self.external_account)
-        self.assertEqual(api, mock_gdp())
+        assert api == mock_gdp()
 
     @mock.patch('addons.googledrive.models.GoogleDriveProvider')
     def test_api_cached(self, mock_gdp):
         # Repeated calls to .api returns the same object
         self.node_settings._api = 'testapi'
         api = self.node_settings.api
-        self.assertFalse(mock_gdp.called)
-        self.assertEqual(api, 'testapi')
+        assert not mock_gdp.called
+        assert api == 'testapi'
 
     def test_selected_folder_name_root(self):
         self.node_settings.folder_id = 'root'
 
-        self.assertEqual(
-            self.node_settings.selected_folder_name,
+        assert self.node_settings.selected_folder_name == \
             'Full Google Drive'
-        )
 
     def test_selected_folder_name_empty(self):
         self.node_settings.folder_id = None
 
-        self.assertEqual(
-            self.node_settings.selected_folder_name,
+        assert self.node_settings.selected_folder_name == \
             ''
-        )
 
     ## Overrides ##
 
@@ -103,10 +99,10 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         self.node_settings.set_folder(folder, auth=Auth(self.user))
         self.node_settings.save()
         # Folder was set
-        self.assertEqual(self.node_settings.folder_id, folder['id'])
+        assert self.node_settings.folder_id == folder['id']
         # Log was saved
         last_log = self.node.logs.latest()
-        self.assertEqual(last_log.action, f'{self.short_name}_folder_selected')
+        assert last_log.action == f'{self.short_name}_folder_selected'
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
@@ -118,4 +114,4 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
                 'path': self.node_settings.folder_path,
             }
         }
-        self.assertEqual(settings, expected)
+        assert settings == expected

--- a/addons/googledrive/tests/test_models.py
+++ b/addons/googledrive/tests/test_models.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 import unittest
 
@@ -28,9 +27,9 @@ class TestGoogleDriveProvider(unittest.TestCase):
         fake_info = {'sub': '12345', 'name': 'fakename', 'profile': 'fakeUrl'}
         mock_client.return_value = fake_info
         res = self.provider.handle_callback(fake_response)
-        assert_equal(res['provider_id'], '12345')
-        assert_equal(res['display_name'], 'fakename')
-        assert_equal(res['profile_url'], 'fakeUrl')
+        self.assertEqual(res['provider_id'], '12345')
+        self.assertEqual(res['display_name'], 'fakename')
+        self.assertEqual(res['profile_url'], 'fakeUrl')
 
 class TestUserSettings(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):
 
@@ -67,20 +66,20 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         # The first call to .api returns a new object
         api = self.node_settings.api
         mock_gdp.assert_called_once_with(self.external_account)
-        assert_equal(api, mock_gdp())
+        self.assertEqual(api, mock_gdp())
 
     @mock.patch('addons.googledrive.models.GoogleDriveProvider')
     def test_api_cached(self, mock_gdp):
         # Repeated calls to .api returns the same object
         self.node_settings._api = 'testapi'
         api = self.node_settings.api
-        assert_false(mock_gdp.called)
-        assert_equal(api, 'testapi')
+        self.assertFalse(mock_gdp.called)
+        self.assertEqual(api, 'testapi')
 
     def test_selected_folder_name_root(self):
         self.node_settings.folder_id = 'root'
 
-        assert_equal(
+        self.assertEqual(
             self.node_settings.selected_folder_name,
             'Full Google Drive'
         )
@@ -88,7 +87,7 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
     def test_selected_folder_name_empty(self):
         self.node_settings.folder_id = None
 
-        assert_equal(
+        self.assertEqual(
             self.node_settings.selected_folder_name,
             ''
         )
@@ -104,10 +103,10 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
         self.node_settings.set_folder(folder, auth=Auth(self.user))
         self.node_settings.save()
         # Folder was set
-        assert_equal(self.node_settings.folder_id, folder['id'])
+        self.assertEqual(self.node_settings.folder_id, folder['id'])
         # Log was saved
         last_log = self.node.logs.latest()
-        assert_equal(last_log.action, f'{self.short_name}_folder_selected')
+        self.assertEqual(last_log.action, f'{self.short_name}_folder_selected')
 
     def test_serialize_settings(self):
         settings = self.node_settings.serialize_waterbutler_settings()
@@ -119,4 +118,4 @@ class TestNodeSettings(OAuthAddonNodeSettingsTestSuiteMixin, unittest.TestCase):
                 'path': self.node_settings.folder_path,
             }
         }
-        assert_equal(settings, expected)
+        self.assertEqual(settings, expected)

--- a/addons/googledrive/tests/test_serializer.py
+++ b/addons/googledrive/tests/test_serializer.py
@@ -1,6 +1,5 @@
 """Serializer tests for the Box addon."""
 from unittest import mock
-from nose.tools import *  # noqa (PEP8 asserts)
 import pytest
 
 from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin
@@ -27,12 +26,12 @@ class TestGoogleDriveSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCas
         with mock.patch.object(type(self.node_settings), 'has_auth', return_value=False):
             serialized = self.ser.serialized_node_settings
         for setting in self.required_settings:
-            assert_in(setting, serialized['result'])
+            self.assertIn(setting, serialized['result'])
 
     def test_serialized_node_settings_authorized(self):
         with mock.patch.object(type(self.node_settings), 'has_auth', return_value=True):
             serialized = self.ser.serialized_node_settings
         for setting in self.required_settings:
-            assert_in(setting, serialized['result'])
+            self.assertIn(setting, serialized['result'])
         for setting in self.required_settings_authorized:
-            assert_in(setting, serialized['result'])
+            self.assertIn(setting, serialized['result'])

--- a/addons/googledrive/tests/test_serializer.py
+++ b/addons/googledrive/tests/test_serializer.py
@@ -26,12 +26,12 @@ class TestGoogleDriveSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCas
         with mock.patch.object(type(self.node_settings), 'has_auth', return_value=False):
             serialized = self.ser.serialized_node_settings
         for setting in self.required_settings:
-            self.assertIn(setting, serialized['result'])
+            assert setting in serialized['result']
 
     def test_serialized_node_settings_authorized(self):
         with mock.patch.object(type(self.node_settings), 'has_auth', return_value=True):
             serialized = self.ser.serialized_node_settings
         for setting in self.required_settings:
-            self.assertIn(setting, serialized['result'])
+            assert setting in serialized['result']
         for setting in self.required_settings_authorized:
-            self.assertIn(setting, serialized['result'])
+            assert setting in serialized['result']

--- a/addons/googledrive/tests/test_views.py
+++ b/addons/googledrive/tests/test_views.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from nose.tools import *  # noqa
 import pytest
 
 from addons.base.tests.views import OAuthAddonAuthViewsTestCaseMixin, OAuthAddonConfigViewsTestCaseMixin
@@ -52,8 +51,8 @@ class TestConfigViews(GoogleDriveAddonTestCase, OAuthAddonConfigViewsTestCaseMix
 
         url = self.project.api_url_for('googledrive_folder_list', folder_id=folderId)
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), len(sample_folder_data['items']))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), len(sample_folder_data['items']))
 
     @mock.patch.object(GoogleDriveClient, 'about')
     def test_folder_list(self, mock_about):

--- a/addons/googledrive/tests/test_views.py
+++ b/addons/googledrive/tests/test_views.py
@@ -51,8 +51,8 @@ class TestConfigViews(GoogleDriveAddonTestCase, OAuthAddonConfigViewsTestCaseMix
 
         url = self.project.api_url_for('googledrive_folder_list', folder_id=folderId)
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), len(sample_folder_data['items']))
+        assert res.status_code == 200
+        assert len(res.json) == len(sample_folder_data['items'])
 
     @mock.patch.object(GoogleDriveClient, 'about')
     def test_folder_list(self, mock_about):

--- a/addons/twofactor/tests/test_models.py
+++ b/addons/twofactor/tests/test_models.py
@@ -3,8 +3,6 @@ from future.moves.urllib.parse import urlparse, urljoin, parse_qs
 
 import pytest
 from addons.twofactor.tests.utils import _valid_code
-from nose.tools import (assert_equal, assert_false, assert_is_none,
-                        assert_is_not_none, assert_true)
 from osf_tests.factories import UserFactory
 
 pytestmark = pytest.mark.django_db
@@ -19,9 +17,9 @@ class TestCallbacks(unittest.TestCase):
         self.user_settings = self.user.get_addon('twofactor')
 
     def test_add_to_user(self):
-        assert_equal(self.user_settings.totp_drift, 0)
-        assert_is_not_none(self.user_settings.totp_secret)
-        assert_false(self.user_settings.is_confirmed)
+        self.assertEqual(self.user_settings.totp_drift, 0)
+        self.assertIsNotNone(self.user_settings.totp_secret)
+        self.assertFalse(self.user_settings.is_confirmed)
 
     def test_remove_from_unconfirmed_user(self):
         # drift defaults to 0. Change it so we can test it was changed back.
@@ -31,9 +29,9 @@ class TestCallbacks(unittest.TestCase):
         self.user.delete_addon('twofactor')
         self.user_settings.reload()
 
-        assert_equal(self.user_settings.totp_drift, 0)
-        assert_is_none(self.user_settings.totp_secret)
-        assert_false(self.user_settings.is_confirmed)
+        self.assertEqual(self.user_settings.totp_drift, 0)
+        self.assertIsNone(self.user_settings.totp_secret)
+        self.assertFalse(self.user_settings.is_confirmed)
 
     def test_remove_from_confirmed_user(self):
         # drift defaults to 0. Change it so we can test it was changed back.
@@ -44,9 +42,9 @@ class TestCallbacks(unittest.TestCase):
         self.user.delete_addon('twofactor')
         self.user_settings.reload()
 
-        assert_equal(self.user_settings.totp_drift, 0)
-        assert_is_none(self.user_settings.totp_secret)
-        assert_false(self.user_settings.is_confirmed)
+        self.assertEqual(self.user_settings.totp_drift, 0)
+        self.assertIsNone(self.user_settings.totp_secret)
+        self.assertFalse(self.user_settings.is_confirmed)
 
 
 class TestUserSettingsModel(unittest.TestCase):
@@ -68,15 +66,15 @@ class TestUserSettingsModel(unittest.TestCase):
         self.user.__class__.delete(self.user)
 
     def test_b32(self):
-        assert_equal(self.user_settings.totp_secret_b32, self.TOTP_SECRET_B32)
+        self.assertEqual(self.user_settings.totp_secret_b32, self.TOTP_SECRET_B32)
 
     def test_otpauth_url(self):
         url = urlparse(self.user_settings.otpauth_url)
 
-        assert_equal(url.scheme, 'otpauth')
-        assert_equal(url.netloc, 'totp')
-        assert_equal(url.path, f'/OSF:{self.user.username}')
-        assert_equal(
+        self.assertEqual(url.scheme, 'otpauth')
+        self.assertEqual(url.netloc, 'totp')
+        self.assertEqual(url.path, f'/OSF:{self.user.username}')
+        self.assertEqual(
             parse_qs(url.query),
             {'secret': [self.TOTP_SECRET_B32]}
         )
@@ -85,7 +83,7 @@ class TestUserSettingsModel(unittest.TestCase):
         # url = 'otpauth://totp/OSF:{}?secret=' + self.TOTP_SECRET_B32
 
         settings = self.user_settings.to_json(user=None)
-        assert_equal(
+        self.assertEqual(
             settings,
             {
                 'is_enabled': True,
@@ -100,32 +98,32 @@ class TestUserSettingsModel(unittest.TestCase):
         )
 
     def test_verify_valid_code(self):
-        assert_true(
+        self.assertTrue(
             self.user_settings.verify_code(_valid_code(self.TOTP_SECRET))
         )
 
     def test_verify_valid_core_drift(self):
         # use a code from 30 seconds in the future
-        assert_true(
+        self.assertTrue(
             self.user_settings.verify_code(
                 _valid_code(self.TOTP_SECRET, drift=1)
             )
         )
 
         # make sure drift is updated.
-        assert_equal(self.user_settings.totp_drift, 1)
+        self.assertEqual(self.user_settings.totp_drift, 1)
 
         # use a code from 60 seconds in the future
-        assert_true(
+        self.assertTrue(
             self.user_settings.verify_code(
                 _valid_code(self.TOTP_SECRET, drift=2)
             )
         )
 
         # make sure drift is updated.
-        assert_equal(self.user_settings.totp_drift, 2)
+        self.assertEqual(self.user_settings.totp_drift, 2)
 
         # use the current code (which is now 2 periods away from the drift)
-        assert_false(
+        self.assertFalse(
             self.user_settings.verify_code(_valid_code(self.TOTP_SECRET))
         )

--- a/addons/twofactor/tests/test_views.py
+++ b/addons/twofactor/tests/test_views.py
@@ -1,5 +1,4 @@
 import pytest
-from nose.tools import assert_equal, assert_false, assert_in, assert_true
 from tests.base import OsfTestCase
 from osf_tests.factories import AuthUserFactory
 from addons.twofactor.tests import _valid_code
@@ -27,8 +26,8 @@ class TestViews(OsfTestCase):
         # reload the user settings object from the DB
         self.user_settings.reload()
 
-        assert_true(self.user_settings.is_confirmed)
-        assert_equal(res.status_code, 200)
+        self.assertTrue(self.user_settings.is_confirmed)
+        self.assertEqual(res.status_code, 200)
 
     def test_confirm_code_failure(self):
         url = api_url_for('twofactor_settings_put')
@@ -38,11 +37,11 @@ class TestViews(OsfTestCase):
             auth=self.user.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
         json = res.json
-        assert_in('verification code', json['message_long'])
+        self.assertIn('verification code', json['message_long'])
 
         # reload the user settings object from the DB
         self.user_settings.reload()
 
-        assert_false(self.user_settings.is_confirmed)
+        self.assertFalse(self.user_settings.is_confirmed)

--- a/addons/twofactor/tests/test_views.py
+++ b/addons/twofactor/tests/test_views.py
@@ -26,8 +26,8 @@ class TestViews(OsfTestCase):
         # reload the user settings object from the DB
         self.user_settings.reload()
 
-        self.assertTrue(self.user_settings.is_confirmed)
-        self.assertEqual(res.status_code, 200)
+        assert self.user_settings.is_confirmed
+        assert res.status_code == 200
 
     def test_confirm_code_failure(self):
         url = api_url_for('twofactor_settings_put')
@@ -37,11 +37,11 @@ class TestViews(OsfTestCase):
             auth=self.user.auth,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
         json = res.json
-        self.assertIn('verification code', json['message_long'])
+        assert 'verification code' in json['message_long']
 
         # reload the user settings object from the DB
         self.user_settings.reload()
 
-        self.assertFalse(self.user_settings.is_confirmed)
+        assert not self.user_settings.is_confirmed

--- a/addons/zotero/tests/test_models.py
+++ b/addons/zotero/tests/test_models.py
@@ -2,8 +2,6 @@ import pytest
 import unittest
 from unittest import mock
 from framework.auth import Auth
-from nose.tools import (assert_equal, assert_is_none, assert_true, assert_false,
-    assert_is, assert_in)
 
 from addons.base.tests.utils import MockFolder, MockLibrary
 
@@ -80,16 +78,16 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
     def test_fields(self):
         node_settings = self.NodeSettingsClass(owner=ProjectFactory(), user_settings=self.user_settings)
         node_settings.save()
-        assert_true(node_settings.user_settings)
-        assert_equal(node_settings.user_settings.owner, self.user)
-        assert_true(hasattr(node_settings, 'folder_id'))
-        assert_true(hasattr(node_settings, 'library_id'))
-        assert_true(hasattr(node_settings, 'user_settings'))
+        self.assertTrue(node_settings.user_settings)
+        self.assertEqual(node_settings.user_settings.owner, self.user)
+        self.assertTrue(hasattr(node_settings, 'folder_id'))
+        self.assertTrue(hasattr(node_settings, 'library_id'))
+        self.assertTrue(hasattr(node_settings, 'user_settings'))
 
     def test_library_defaults_to_none(self):
         node_settings = self.NodeSettingsClass(user_settings=self.user_settings)
         node_settings.save()
-        assert_is_none(node_settings.library_id)
+        self.assertIsNone(node_settings.library_id)
 
     def test_clear_settings(self):
         node_settings = self.NodeSettingsFactory()
@@ -98,40 +96,40 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         node_settings.save()
 
         node_settings.clear_settings()
-        assert_is_none(node_settings.folder_id)
-        assert_is_none(node_settings.library_id)
+        self.assertIsNone(node_settings.folder_id)
+        self.assertIsNone(node_settings.library_id)
 
     def test_delete(self):
-        assert_true(self.node_settings.user_settings)
-        assert_true(self.node_settings.folder_id)
+        self.assertTrue(self.node_settings.user_settings)
+        self.assertTrue(self.node_settings.folder_id)
         old_logs = list(self.node.logs.all())
         self.node_settings.delete()
         self.node_settings.save()
-        assert_is(self.node_settings.user_settings, None)
-        assert_is(self.node_settings.folder_id, None)
-        assert_is(self.node_settings.library_id, None)
-        assert_true(self.node_settings.deleted)
-        assert_equal(list(self.node.logs.all()), list(old_logs))
+        self.assertIs(self.node_settings.user_settings, None)
+        self.assertIs(self.node_settings.folder_id, None)
+        self.assertIs(self.node_settings.library_id, None)
+        self.assertTrue(self.node_settings.deleted)
+        self.assertEqual(list(self.node.logs.all()), list(old_logs))
 
     def test_deauthorize(self):
-        assert_true(self.node_settings.user_settings)
-        assert_true(self.node_settings.folder_id)
+        self.assertTrue(self.node_settings.user_settings)
+        self.assertTrue(self.node_settings.folder_id)
         self.node_settings.deauthorize(auth=Auth(self.user))
         self.node_settings.save()
-        assert_is(self.node_settings.user_settings, None)
-        assert_is(self.node_settings.folder_id, None)
-        assert_is(self.node_settings.library_id, None)
+        self.assertIs(self.node_settings.user_settings, None)
+        self.assertIs(self.node_settings.folder_id, None)
+        self.assertIs(self.node_settings.library_id, None)
 
         last_log = self.node.logs.first()
-        assert_equal(last_log.action, f'{self.short_name}_node_deauthorized')
+        self.assertEqual(last_log.action, f'{self.short_name}_node_deauthorized')
         params = last_log.params
-        assert_in('node', params)
-        assert_in('project', params)
+        self.assertIn('node', params)
+        self.assertIn('project', params)
 
     def test_fetch_library_name_personal(self):
         self.node_settings.library_id = 'personal'
 
-        assert_equal(
+        self.assertEqual(
             self.node_settings.fetch_library_name,
             'My library'
         )
@@ -145,9 +143,9 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         # No path is specified, so top level libraries are fetched
         libraries = self.node_settings.get_folders()
 
-        assert_equal(len(libraries), 2)
-        assert_equal(libraries[0]['kind'], 'library')
-        assert_equal(libraries[1]['kind'], 'library')
+        self.assertEqual(len(libraries), 2)
+        self.assertEqual(libraries[0]['kind'], 'library')
+        self.assertEqual(libraries[1]['kind'], 'library')
 
     @mock.patch('addons.zotero.models.Zotero._get_folders')
     def test_get_folders_second_level(self, mock_folders):
@@ -158,16 +156,16 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         # Path - personal, is specified, so folders are fetched from personal library.
         folders = self.node_settings.get_folders('personal')
 
-        assert_equal(len(folders), 3)
-        assert_equal(folders[0]['kind'], 'folder')
-        assert_equal(folders[0]['name'], 'All Documents')
-        assert_equal(folders[1]['kind'], 'folder')
-        assert_equal(folders[2]['kind'], 'folder')
+        self.assertEqual(len(folders), 3)
+        self.assertEqual(folders[0]['kind'], 'folder')
+        self.assertEqual(folders[0]['name'], 'All Documents')
+        self.assertEqual(folders[1]['kind'], 'folder')
+        self.assertEqual(folders[2]['kind'], 'folder')
 
     def test_selected_library_name_empty(self):
         self.node_settings.library_id = None
 
-        assert_equal(
+        self.assertEqual(
             self.node_settings.fetch_library_name,
             ''
         )
@@ -180,7 +178,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         with mock.patch.object(self.OAuthProviderClass, '_library_metadata', return_value=mock_library):
             name = self.node_settings.fetch_library_name
 
-        assert_equal(
+        self.assertEqual(
             name,
             'Fake Library'
         )
@@ -195,7 +193,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         self.node_settings.save()
         self.node_settings.list_id = folder_id
         self.node_settings.save()
-        assert_equal(self.node_settings.list_id, folder_id)
+        self.assertEqual(self.node_settings.list_id, folder_id)
 
         provider = self.ProviderClass()
 
@@ -210,19 +208,19 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         )
 
         # instance was updated
-        assert_equal(
+        self.assertEqual(
             self.node_settings.library_id,
             'fake-library-id',
         )
         # If library_id is being set, the folder_id is cleared.
-        assert_equal(
+        self.assertEqual(
             self.node_settings.list_id,
             None,
         )
 
         # user_settings was updated
         # TODO: the call to grant_oauth_access should be mocked
-        assert_true(
+        self.assertTrue(
             self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,
@@ -231,9 +229,9 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         )
 
         log = self.node.logs.latest()
-        assert_equal(log.action, f'{self.short_name}_library_selected')
-        assert_equal(log.params['library_id'], library_id)
-        assert_equal(log.params['library_name'], library_name)
+        self.assertEqual(log.action, f'{self.short_name}_library_selected')
+        self.assertEqual(log.params['library_id'], library_id)
+        self.assertEqual(log.params['library_name'], library_name)
 
 
 
@@ -264,7 +262,7 @@ class ZoteroUserSettingsTestCase(OAuthAddonUserSettingTestSuiteMixin, unittest.T
         )
         self.user_settings.save()
 
-        assert_true(
+        self.assertTrue(
             self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,
@@ -272,7 +270,7 @@ class ZoteroUserSettingsTestCase(OAuthAddonUserSettingTestSuiteMixin, unittest.T
             )
         )
 
-        assert_false(
+        self.assertFalse(
             self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,

--- a/addons/zotero/tests/test_models.py
+++ b/addons/zotero/tests/test_models.py
@@ -78,16 +78,16 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
     def test_fields(self):
         node_settings = self.NodeSettingsClass(owner=ProjectFactory(), user_settings=self.user_settings)
         node_settings.save()
-        self.assertTrue(node_settings.user_settings)
-        self.assertEqual(node_settings.user_settings.owner, self.user)
-        self.assertTrue(hasattr(node_settings, 'folder_id'))
-        self.assertTrue(hasattr(node_settings, 'library_id'))
-        self.assertTrue(hasattr(node_settings, 'user_settings'))
+        assert node_settings.user_settings
+        assert node_settings.user_settings.owner == self.user
+        assert hasattr(node_settings, 'folder_id')
+        assert hasattr(node_settings, 'library_id')
+        assert hasattr(node_settings, 'user_settings')
 
     def test_library_defaults_to_none(self):
         node_settings = self.NodeSettingsClass(user_settings=self.user_settings)
         node_settings.save()
-        self.assertIsNone(node_settings.library_id)
+        assert node_settings.library_id is None
 
     def test_clear_settings(self):
         node_settings = self.NodeSettingsFactory()
@@ -96,43 +96,41 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         node_settings.save()
 
         node_settings.clear_settings()
-        self.assertIsNone(node_settings.folder_id)
-        self.assertIsNone(node_settings.library_id)
+        assert node_settings.folder_id is None
+        assert node_settings.library_id is None
 
     def test_delete(self):
-        self.assertTrue(self.node_settings.user_settings)
-        self.assertTrue(self.node_settings.folder_id)
+        assert self.node_settings.user_settings
+        assert self.node_settings.folder_id
         old_logs = list(self.node.logs.all())
         self.node_settings.delete()
         self.node_settings.save()
-        self.assertIs(self.node_settings.user_settings, None)
-        self.assertIs(self.node_settings.folder_id, None)
-        self.assertIs(self.node_settings.library_id, None)
-        self.assertTrue(self.node_settings.deleted)
-        self.assertEqual(list(self.node.logs.all()), list(old_logs))
+        assert self.node_settings.user_settings is None
+        assert self.node_settings.folder_id is None
+        assert self.node_settings.library_id is None
+        assert self.node_settings.deleted
+        assert list(self.node.logs.all()) == list(old_logs)
 
     def test_deauthorize(self):
-        self.assertTrue(self.node_settings.user_settings)
-        self.assertTrue(self.node_settings.folder_id)
+        assert self.node_settings.user_settings
+        assert self.node_settings.folder_id
         self.node_settings.deauthorize(auth=Auth(self.user))
         self.node_settings.save()
-        self.assertIs(self.node_settings.user_settings, None)
-        self.assertIs(self.node_settings.folder_id, None)
-        self.assertIs(self.node_settings.library_id, None)
+        assert self.node_settings.user_settings is None
+        assert self.node_settings.folder_id is None
+        assert self.node_settings.library_id is None
 
         last_log = self.node.logs.first()
-        self.assertEqual(last_log.action, f'{self.short_name}_node_deauthorized')
+        assert last_log.action == f'{self.short_name}_node_deauthorized'
         params = last_log.params
-        self.assertIn('node', params)
-        self.assertIn('project', params)
+        assert 'node' in params
+        assert 'project' in params
 
     def test_fetch_library_name_personal(self):
         self.node_settings.library_id = 'personal'
 
-        self.assertEqual(
-            self.node_settings.fetch_library_name,
+        assert self.node_settings.fetch_library_name == \
             'My library'
-        )
 
     @mock.patch('addons.zotero.models.Zotero._fetch_libraries')
     def test_get_folders_top_level(self, mock_libraries):
@@ -143,9 +141,9 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         # No path is specified, so top level libraries are fetched
         libraries = self.node_settings.get_folders()
 
-        self.assertEqual(len(libraries), 2)
-        self.assertEqual(libraries[0]['kind'], 'library')
-        self.assertEqual(libraries[1]['kind'], 'library')
+        assert len(libraries) == 2
+        assert libraries[0]['kind'] == 'library'
+        assert libraries[1]['kind'] == 'library'
 
     @mock.patch('addons.zotero.models.Zotero._get_folders')
     def test_get_folders_second_level(self, mock_folders):
@@ -156,19 +154,17 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         # Path - personal, is specified, so folders are fetched from personal library.
         folders = self.node_settings.get_folders('personal')
 
-        self.assertEqual(len(folders), 3)
-        self.assertEqual(folders[0]['kind'], 'folder')
-        self.assertEqual(folders[0]['name'], 'All Documents')
-        self.assertEqual(folders[1]['kind'], 'folder')
-        self.assertEqual(folders[2]['kind'], 'folder')
+        assert len(folders) == 3
+        assert folders[0]['kind'] == 'folder'
+        assert folders[0]['name'] == 'All Documents'
+        assert folders[1]['kind'] == 'folder'
+        assert folders[2]['kind'] == 'folder'
 
     def test_selected_library_name_empty(self):
         self.node_settings.library_id = None
 
-        self.assertEqual(
-            self.node_settings.fetch_library_name,
+        assert self.node_settings.fetch_library_name == \
             ''
-        )
 
     def test_selected_library_name(self):
         # Mock the return from api call to get the library's name
@@ -178,10 +174,8 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         with mock.patch.object(self.OAuthProviderClass, '_library_metadata', return_value=mock_library):
             name = self.node_settings.fetch_library_name
 
-        self.assertEqual(
-            name,
+        assert name == \
             'Fake Library'
-        )
 
     def test_set_library(self):
         folder_id = 'fake-folder-id'
@@ -193,7 +187,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         self.node_settings.save()
         self.node_settings.list_id = folder_id
         self.node_settings.save()
-        self.assertEqual(self.node_settings.list_id, folder_id)
+        assert self.node_settings.list_id == folder_id
 
         provider = self.ProviderClass()
 
@@ -208,30 +202,24 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         )
 
         # instance was updated
-        self.assertEqual(
-            self.node_settings.library_id,
-            'fake-library-id',
-        )
+        assert self.node_settings.library_id == \
+            'fake-library-id'
         # If library_id is being set, the folder_id is cleared.
-        self.assertEqual(
-            self.node_settings.list_id,
-            None,
-        )
+        assert self.node_settings.list_id == \
+            None
 
         # user_settings was updated
         # TODO: the call to grant_oauth_access should be mocked
-        self.assertTrue(
-            self.user_settings.verify_oauth_access(
+        assert self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,
                 metadata={'library': 'fake-library-id'}
             )
-        )
 
         log = self.node.logs.latest()
-        self.assertEqual(log.action, f'{self.short_name}_library_selected')
-        self.assertEqual(log.params['library_id'], library_id)
-        self.assertEqual(log.params['library_name'], library_name)
+        assert log.action == f'{self.short_name}_library_selected'
+        assert log.params['library_id'] == library_id
+        assert log.params['library_name'] == library_name
 
 
 
@@ -262,18 +250,14 @@ class ZoteroUserSettingsTestCase(OAuthAddonUserSettingTestSuiteMixin, unittest.T
         )
         self.user_settings.save()
 
-        self.assertTrue(
-            self.user_settings.verify_oauth_access(
+        assert self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,
                 metadata={'library': 'fake_library_id'}
             )
-        )
 
-        self.assertFalse(
-            self.user_settings.verify_oauth_access(
+        assert not self.user_settings.verify_oauth_access(
                 node=self.node,
                 external_account=self.external_account,
                 metadata={'library': 'another_library_id'}
             )
-        )

--- a/addons/zotero/tests/test_models.py
+++ b/addons/zotero/tests/test_models.py
@@ -26,6 +26,7 @@ from addons.zotero.provider import ZoteroCitationsProvider
 
 pytestmark = pytest.mark.django_db
 
+
 class ZoteroProviderTestCase(CitationAddonProviderTestSuiteMixin, unittest.TestCase):
 
     short_name = 'zotero'
@@ -129,8 +130,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
     def test_fetch_library_name_personal(self):
         self.node_settings.library_id = 'personal'
 
-        assert self.node_settings.fetch_library_name == \
-            'My library'
+        assert self.node_settings.fetch_library_name == 'My library'
 
     @mock.patch('addons.zotero.models.Zotero._fetch_libraries')
     def test_get_folders_top_level(self, mock_libraries):
@@ -163,8 +163,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
     def test_selected_library_name_empty(self):
         self.node_settings.library_id = None
 
-        assert self.node_settings.fetch_library_name == \
-            ''
+        assert self.node_settings.fetch_library_name == ''
 
     def test_selected_library_name(self):
         # Mock the return from api call to get the library's name
@@ -174,8 +173,7 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         with mock.patch.object(self.OAuthProviderClass, '_library_metadata', return_value=mock_library):
             name = self.node_settings.fetch_library_name
 
-        assert name == \
-            'Fake Library'
+        assert name == 'Fake Library'
 
     def test_set_library(self):
         folder_id = 'fake-folder-id'
@@ -202,11 +200,9 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         )
 
         # instance was updated
-        assert self.node_settings.library_id == \
-            'fake-library-id'
+        assert self.node_settings.library_id == 'fake-library-id'
         # If library_id is being set, the folder_id is cleared.
-        assert self.node_settings.list_id == \
-            None
+        assert self.node_settings.list_id is None
 
         # user_settings was updated
         # TODO: the call to grant_oauth_access should be mocked
@@ -220,7 +216,6 @@ class ZoteroNodeSettingsTestCase(OAuthCitationsNodeSettingsTestSuiteMixin, unitt
         assert log.action == f'{self.short_name}_library_selected'
         assert log.params['library_id'] == library_id
         assert log.params['library_name'] == library_name
-
 
 
 class ZoteroUserSettingsTestCase(OAuthAddonUserSettingTestSuiteMixin, unittest.TestCase):

--- a/addons/zotero/tests/test_views.py
+++ b/addons/zotero/tests/test_views.py
@@ -4,7 +4,6 @@ from future.moves.urllib.parse import urlparse, urljoin
 import responses
 
 from framework.auth import Auth
-from nose.tools import (assert_equal, assert_true, assert_false)
 from addons.base.tests import views
 from addons.base.tests.utils import MockLibrary, MockFolder
 from addons.zotero.models import Zotero
@@ -69,13 +68,13 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
             self.library.json['id'],
             self.library.name
         )
-        assert_false(self.node_settings.complete)
-        assert_equal(self.node_settings.list_id, None)
-        assert_equal(self.node_settings.library_id, 'Fake Library Key')
+        self.assertFalse(self.node_settings.complete)
+        self.assertEqual(self.node_settings.list_id, None)
+        self.assertEqual(self.node_settings.library_id, 'Fake Library Key')
         res = self.citationsProvider().widget(self.project.get_addon(self.ADDON_SHORT_NAME))
-        assert_false(res['complete'])
-        assert_equal(res['list_id'], None)
-        assert_equal(res['library_id'], 'Fake Library Key')
+        self.assertFalse(res['complete'])
+        self.assertEqual(res['list_id'], None)
+        self.assertEqual(res['library_id'], 'Fake Library Key')
 
     def test_widget_view_complete(self):
         # JSON: everything a widget needs
@@ -98,13 +97,13 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
             self.folder.name,
             Auth(self.user),
         )
-        assert_true(self.node_settings.complete)
-        assert_equal(self.node_settings.list_id, 'Fake Key')
-        assert_equal(self.node_settings.library_id, 'Fake Library Key')
+        self.assertTrue(self.node_settings.complete)
+        self.assertEqual(self.node_settings.list_id, 'Fake Key')
+        self.assertEqual(self.node_settings.library_id, 'Fake Library Key')
         res = self.citationsProvider().widget(self.project.get_addon(self.ADDON_SHORT_NAME))
-        assert_true(res['complete'])
-        assert_equal(res['list_id'], 'Fake Key')
-        assert_equal(res['library_id'], 'Fake Library Key')
+        self.assertTrue(res['complete'])
+        self.assertEqual(res['list_id'], 'Fake Key')
+        self.assertEqual(res['library_id'], 'Fake Library Key')
 
     @responses.activate
     def test_citation_list_root_only_unfiled_items_included(self):
@@ -134,7 +133,7 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
         children = res.json['contents']
         # There are three items, one folder and two files, but one of the files gets pulled out because it
         # belongs to a collection
-        assert_equal(len(children), 2)
-        assert_equal(children[0]['kind'], 'folder')
-        assert_equal(children[1]['kind'], 'file')
-        assert_true(children[1].get('csl') is not None)
+        self.assertEqual(len(children), 2)
+        self.assertEqual(children[0]['kind'], 'folder')
+        self.assertEqual(children[1]['kind'], 'file')
+        self.assertTrue(children[1].get('csl') is not None)

--- a/addons/zotero/tests/test_views.py
+++ b/addons/zotero/tests/test_views.py
@@ -68,13 +68,13 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
             self.library.json['id'],
             self.library.name
         )
-        self.assertFalse(self.node_settings.complete)
-        self.assertEqual(self.node_settings.list_id, None)
-        self.assertEqual(self.node_settings.library_id, 'Fake Library Key')
+        assert not self.node_settings.complete
+        assert self.node_settings.list_id == None
+        assert self.node_settings.library_id == 'Fake Library Key'
         res = self.citationsProvider().widget(self.project.get_addon(self.ADDON_SHORT_NAME))
-        self.assertFalse(res['complete'])
-        self.assertEqual(res['list_id'], None)
-        self.assertEqual(res['library_id'], 'Fake Library Key')
+        assert not res['complete']
+        assert res['list_id'] == None
+        assert res['library_id'] == 'Fake Library Key'
 
     def test_widget_view_complete(self):
         # JSON: everything a widget needs
@@ -97,13 +97,13 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
             self.folder.name,
             Auth(self.user),
         )
-        self.assertTrue(self.node_settings.complete)
-        self.assertEqual(self.node_settings.list_id, 'Fake Key')
-        self.assertEqual(self.node_settings.library_id, 'Fake Library Key')
+        assert self.node_settings.complete
+        assert self.node_settings.list_id == 'Fake Key'
+        assert self.node_settings.library_id == 'Fake Library Key'
         res = self.citationsProvider().widget(self.project.get_addon(self.ADDON_SHORT_NAME))
-        self.assertTrue(res['complete'])
-        self.assertEqual(res['list_id'], 'Fake Key')
-        self.assertEqual(res['library_id'], 'Fake Library Key')
+        assert res['complete']
+        assert res['list_id'] == 'Fake Key'
+        assert res['library_id'] == 'Fake Library Key'
 
     @responses.activate
     def test_citation_list_root_only_unfiled_items_included(self):
@@ -133,7 +133,7 @@ class TestConfigViews(ZoteroTestCase, views.OAuthCitationAddonConfigViewsTestCas
         children = res.json['contents']
         # There are three items, one folder and two files, but one of the files gets pulled out because it
         # belongs to a collection
-        self.assertEqual(len(children), 2)
-        self.assertEqual(children[0]['kind'], 'folder')
-        self.assertEqual(children[1]['kind'], 'file')
-        self.assertTrue(children[1].get('csl') is not None)
+        assert len(children) == 2
+        assert children[0]['kind'] == 'folder'
+        assert children[1]['kind'] == 'file'
+        assert children[1].get('csl') is not None

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -5,7 +5,6 @@ Tests related to authenticating API requests
 from unittest import mock
 
 import pytest
-from nose.tools import *  # noqa:
 from django.middleware import csrf
 from waffle.testutils import override_switch
 
@@ -50,8 +49,8 @@ class TestBasicAuthenticationValidation(ApiTestCase):
 
     def test_missing_credential_fails(self):
         res = self.app.get(self.unreachable_url, auth=None, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(
             res.json.get('errors')[0]['detail'],
             'Authentication credentials were not provided.'
         )
@@ -62,15 +61,15 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=(self.user1.username, 'invalid password'),
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(
             res.json.get('errors')[0]['detail'],
             'Invalid username/password.'
         )
 
     def test_valid_credential_authenticates_and_has_permissions(self):
         res = self.app.get(self.reachable_url, auth=self.user1.auth)
-        assert_equal(res.status_code, 200, msg=res.json)
+        self.assertEqual(res.status_code, 200, msg=res.json)
 
     def test_valid_credential_authenticates_but_user_lacks_object_permissions(
             self):
@@ -79,7 +78,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=self.user1.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 403, msg=res.json)
+        self.assertEqual(res.status_code, 403, msg=res.json)
 
     def test_valid_credential_but_twofactor_required(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -93,9 +92,9 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=self.user1.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_equal(res.headers['X-OSF-OTP'], 'required; app')
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.headers['X-OSF-OTP'], 'required; app')
+        self.assertEqual(
             res.json.get('errors')[0]['detail'],
             'Must specify two-factor authentication OTP code.'
         )
@@ -113,9 +112,9 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             headers={'X-OSF-OTP': 'invalid otp'},
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_true('X-OSF-OTP' not in res.headers)
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertTrue('X-OSF-OTP' not in res.headers)
+        self.assertEqual(
             res.json.get('errors')[0]['detail'],
             'Invalid two-factor authentication OTP code.'
         )
@@ -131,7 +130,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             self.reachable_url, auth=self.user1.auth,
             headers={'X-OSF-OTP': _valid_code(self.TOTP_SECRET)}
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
 
 class TestOAuthValidation(ApiTestCase):
@@ -166,8 +165,8 @@ class TestOAuthValidation(ApiTestCase):
             auth=None, auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(
             res.json.get('errors')[0]['detail'],
             'Authentication credentials were not provided.'
         )
@@ -184,7 +183,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='invalid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 401, msg=res.json)
+        self.assertEqual(res.status_code, 401, msg=res.json)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_returns_unknown_user_thus_fails(self, mock_user_info):
@@ -198,7 +197,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 401, msg=res.json)
+        self.assertEqual(res.status_code, 401, msg=res.json)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_and_has_permissions(
@@ -213,7 +212,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token',
             auth_type='jwt'
         )
-        assert_equal(res.status_code, 200, msg=res.json)
+        self.assertEqual(res.status_code, 200, msg=res.json)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_but_user_lacks_object_permissions(
@@ -227,7 +226,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 403, msg=res.json)
+        self.assertEqual(res.status_code, 403, msg=res.json)
 
 
 class TestOAuthScopedAccess(ApiTestCase):
@@ -258,7 +257,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_cant_write_user_view(self, mock_user_info):
@@ -280,7 +279,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_implies_read_permissions_for_user_view(
@@ -294,7 +293,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_can_write_user_view(self, mock_user_info):
@@ -316,10 +315,10 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 200)
-        assert_dict_contains_subset(
-            payload['data']['attributes'],
-            res.json['data']['attributes']
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            res.json['data']['attributes'],
+            payload['data']['attributes'] | res.json['data']['attributes'],
         )
 
     @mock.patch('framework.auth.cas.CasClient.profile')
@@ -335,7 +334,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_read_scope_can_read_guid_view_and_user_can_view_project(
@@ -350,10 +349,10 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, redirect_url)
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.location, redirect_url)
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        assert_equal(
+        self.assertEqual(
             redirect_res.json['data']['attributes']['title'],
             project.title
         )
@@ -371,10 +370,10 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, redirect_url)
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.location, redirect_url)
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        assert_equal(
+        self.assertEqual(
             redirect_res.json['data']['attributes']['title'],
             project.title
         )
@@ -392,14 +391,14 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, redirect_url)
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.location, redirect_url)
         redirect_res = res.follow(
             auth='some_valid_token',
             auth_type='jwt',
             expect_errors=True
         )
-        assert_equal(redirect_res.status_code, 403)
+        self.assertEqual(redirect_res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_write_scope_can_read_guid_view_and_user_cannot_view_project(
@@ -414,13 +413,13 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, redirect_url)
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.location, redirect_url)
         redirect_res = res.follow(
             auth='some_valid_token',
             auth_type='jwt',
             expect_errors=True)
-        assert_equal(redirect_res.status_code, 403)
+        self.assertEqual(redirect_res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_email_scope_can_read_email(self, mock_user_info):
@@ -429,8 +428,8 @@ class TestOAuthScopedAccess(ApiTestCase):
         )
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['attributes']['email'],
             self.user.username
         )
@@ -442,9 +441,9 @@ class TestOAuthScopedAccess(ApiTestCase):
         )
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        assert_equal(res.status_code, 200)
-        assert_not_in('email', res.json['data']['attributes'])
-        assert_not_in(self.user.username, res.json)
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn('email', res.json['data']['attributes'])
+        self.assertNotIn(self.user.username, res.json)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_email_scope_cannot_read_other_email(self, mock_user_info):
@@ -456,9 +455,9 @@ class TestOAuthScopedAccess(ApiTestCase):
             base_route='/', base_prefix='v2/'
         )
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        assert_equal(res.status_code, 200)
-        assert_not_in('email', res.json['data']['attributes'])
-        assert_not_in(self.user2.username, res.json)
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn('email', res.json['data']['attributes'])
+        self.assertNotIn(self.user2.username, res.json)
 
 
 @pytest.mark.django_db

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -50,8 +50,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
     def test_missing_credential_fails(self):
         res = self.app.get(self.unreachable_url, auth=None, expect_errors=True)
         assert res.status_code == 401
-        assert res.json.get('errors')[0]['detail'] == \
-            'Authentication credentials were not provided.'
+        assert res.json.get('errors')[0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_invalid_credential_fails(self):
         res = self.app.get(
@@ -60,8 +59,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             expect_errors=True
         )
         assert res.status_code == 401
-        assert res.json.get('errors')[0]['detail'] == \
-            'Invalid username/password.'
+        assert res.json.get('errors')[0]['detail'] == 'Invalid username/password.'
 
     def test_valid_credential_authenticates_and_has_permissions(self):
         res = self.app.get(self.reachable_url, auth=self.user1.auth)
@@ -90,8 +88,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         )
         assert res.status_code == 401
         assert res.headers['X-OSF-OTP'] == 'required; app'
-        assert res.json.get('errors')[0]['detail'] == \
-            'Must specify two-factor authentication OTP code.'
+        assert res.json.get('errors')[0]['detail'] == 'Must specify two-factor authentication OTP code.'
 
     def test_valid_credential_twofactor_invalid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -108,8 +105,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         )
         assert res.status_code == 401
         assert 'X-OSF-OTP' not in res.headers
-        assert res.json.get('errors')[0]['detail'] == \
-            'Invalid two-factor authentication OTP code.'
+        assert res.json.get('errors')[0]['detail'] == 'Invalid two-factor authentication OTP code.'
 
     def test_valid_credential_twofactor_valid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -158,8 +154,7 @@ class TestOAuthValidation(ApiTestCase):
             expect_errors=True
         )
         assert res.status_code == 401
-        assert res.json.get('errors')[0]['detail'] == \
-            'Authentication credentials were not provided.'
+        assert res.json.get('errors')[0]['detail'] == 'Authentication credentials were not provided.'
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_invalid_token_fails(self, mock_user_info):
@@ -306,8 +301,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             expect_errors=True
         )
         assert res.status_code == 200
-        assert res.json['data']['attributes'] == \
-            payload['data']['attributes'] | res.json['data']['attributes']
+        assert res.json['data']['attributes'] == payload['data']['attributes'] | res.json['data']['attributes']
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_node_write_scope_cant_read_user_view(self, mock_user_info):
@@ -340,8 +334,7 @@ class TestOAuthScopedAccess(ApiTestCase):
         assert res.status_code == 302
         assert res.location == redirect_url
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        assert redirect_res.json['data']['attributes']['title'] == \
-            project.title
+        assert redirect_res.json['data']['attributes']['title'] == project.title
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_write_scope_can_read_guid_view_and_user_can_view_project(
@@ -359,8 +352,7 @@ class TestOAuthScopedAccess(ApiTestCase):
         assert res.status_code == 302
         assert res.location == redirect_url
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        assert redirect_res.json['data']['attributes']['title'] == \
-            project.title
+        assert redirect_res.json['data']['attributes']['title'] == project.title
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_read_scope_can_read_guid_view_and_user_cannot_view_project(
@@ -372,9 +364,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             base_route='/', base_prefix='v2/'
         )
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        redirect_url = '{}{}nodes/{}/'.format(
-            API_DOMAIN, API_BASE, project._id
-        )
+        redirect_url = f'{API_DOMAIN}{API_BASE}nodes/{project._id}/'
         assert res.status_code == 302
         assert res.location == redirect_url
         redirect_res = res.follow(
@@ -394,9 +384,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             base_route='/', base_prefix='v2/'
         )
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        redirect_url = '{}{}nodes/{}/'.format(
-            API_DOMAIN, API_BASE, project._id
-        )
+        redirect_url = f'{API_DOMAIN}{API_BASE}nodes/{project._id}/'
         assert res.status_code == 302
         assert res.location == redirect_url
         redirect_res = res.follow(
@@ -413,8 +401,7 @@ class TestOAuthScopedAccess(ApiTestCase):
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
         assert res.status_code == 200
-        assert res.json['data']['attributes']['email'] == \
-            self.user.username
+        assert res.json['data']['attributes']['email'] == self.user.username
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_non_user_email_scope_cannot_read_email(self, mock_user_info):

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -49,11 +49,9 @@ class TestBasicAuthenticationValidation(ApiTestCase):
 
     def test_missing_credential_fails(self):
         res = self.app.get(self.unreachable_url, auth=None, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(
-            res.json.get('errors')[0]['detail'],
+        assert res.status_code == 401
+        assert res.json.get('errors')[0]['detail'] == \
             'Authentication credentials were not provided.'
-        )
 
     def test_invalid_credential_fails(self):
         res = self.app.get(
@@ -61,15 +59,13 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=(self.user1.username, 'invalid password'),
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(
-            res.json.get('errors')[0]['detail'],
+        assert res.status_code == 401
+        assert res.json.get('errors')[0]['detail'] == \
             'Invalid username/password.'
-        )
 
     def test_valid_credential_authenticates_and_has_permissions(self):
         res = self.app.get(self.reachable_url, auth=self.user1.auth)
-        self.assertEqual(res.status_code, 200, msg=res.json)
+        assert res.status_code == 200, res.json
 
     def test_valid_credential_authenticates_but_user_lacks_object_permissions(
             self):
@@ -78,7 +74,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=self.user1.auth,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403, msg=res.json)
+        assert res.status_code == 403, res.json
 
     def test_valid_credential_but_twofactor_required(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -92,12 +88,10 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             auth=self.user1.auth,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.headers['X-OSF-OTP'], 'required; app')
-        self.assertEqual(
-            res.json.get('errors')[0]['detail'],
+        assert res.status_code == 401
+        assert res.headers['X-OSF-OTP'] == 'required; app'
+        assert res.json.get('errors')[0]['detail'] == \
             'Must specify two-factor authentication OTP code.'
-        )
 
     def test_valid_credential_twofactor_invalid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -112,12 +106,10 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             headers={'X-OSF-OTP': 'invalid otp'},
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertTrue('X-OSF-OTP' not in res.headers)
-        self.assertEqual(
-            res.json.get('errors')[0]['detail'],
+        assert res.status_code == 401
+        assert 'X-OSF-OTP' not in res.headers
+        assert res.json.get('errors')[0]['detail'] == \
             'Invalid two-factor authentication OTP code.'
-        )
 
     def test_valid_credential_twofactor_valid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
@@ -130,7 +122,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             self.reachable_url, auth=self.user1.auth,
             headers={'X-OSF-OTP': _valid_code(self.TOTP_SECRET)}
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
 
 class TestOAuthValidation(ApiTestCase):
@@ -165,11 +157,9 @@ class TestOAuthValidation(ApiTestCase):
             auth=None, auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(
-            res.json.get('errors')[0]['detail'],
+        assert res.status_code == 401
+        assert res.json.get('errors')[0]['detail'] == \
             'Authentication credentials were not provided.'
-        )
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_invalid_token_fails(self, mock_user_info):
@@ -183,7 +173,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='invalid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401, msg=res.json)
+        assert res.status_code == 401, res.json
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_returns_unknown_user_thus_fails(self, mock_user_info):
@@ -197,7 +187,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401, msg=res.json)
+        assert res.status_code == 401, res.json
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_and_has_permissions(
@@ -212,7 +202,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token',
             auth_type='jwt'
         )
-        self.assertEqual(res.status_code, 200, msg=res.json)
+        assert res.status_code == 200, res.json
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_but_user_lacks_object_permissions(
@@ -226,7 +216,7 @@ class TestOAuthValidation(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403, msg=res.json)
+        assert res.status_code == 403, res.json
 
 
 class TestOAuthScopedAccess(ApiTestCase):
@@ -257,7 +247,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_cant_write_user_view(self, mock_user_info):
@@ -279,7 +269,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_implies_read_permissions_for_user_view(
@@ -293,7 +283,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_can_write_user_view(self, mock_user_info):
@@ -315,11 +305,9 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['attributes'],
-            payload['data']['attributes'] | res.json['data']['attributes'],
-        )
+        assert res.status_code == 200
+        assert res.json['data']['attributes'] == \
+            payload['data']['attributes'] | res.json['data']['attributes']
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_node_write_scope_cant_read_user_view(self, mock_user_info):
@@ -334,7 +322,7 @@ class TestOAuthScopedAccess(ApiTestCase):
             auth='some_valid_token', auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_read_scope_can_read_guid_view_and_user_can_view_project(
@@ -349,13 +337,11 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, redirect_url)
+        assert res.status_code == 302
+        assert res.location == redirect_url
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        self.assertEqual(
-            redirect_res.json['data']['attributes']['title'],
+        assert redirect_res.json['data']['attributes']['title'] == \
             project.title
-        )
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_write_scope_can_read_guid_view_and_user_can_view_project(
@@ -370,13 +356,11 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, redirect_url)
+        assert res.status_code == 302
+        assert res.location == redirect_url
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
-        self.assertEqual(
-            redirect_res.json['data']['attributes']['title'],
+        assert redirect_res.json['data']['attributes']['title'] == \
             project.title
-        )
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_read_scope_can_read_guid_view_and_user_cannot_view_project(
@@ -391,14 +375,14 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, redirect_url)
+        assert res.status_code == 302
+        assert res.location == redirect_url
         redirect_res = res.follow(
             auth='some_valid_token',
             auth_type='jwt',
             expect_errors=True
         )
-        self.assertEqual(redirect_res.status_code, 403)
+        assert redirect_res.status_code == 403
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_write_scope_can_read_guid_view_and_user_cannot_view_project(
@@ -413,13 +397,13 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(
             API_DOMAIN, API_BASE, project._id
         )
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, redirect_url)
+        assert res.status_code == 302
+        assert res.location == redirect_url
         redirect_res = res.follow(
             auth='some_valid_token',
             auth_type='jwt',
             expect_errors=True)
-        self.assertEqual(redirect_res.status_code, 403)
+        assert redirect_res.status_code == 403
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_email_scope_can_read_email(self, mock_user_info):
@@ -428,11 +412,9 @@ class TestOAuthScopedAccess(ApiTestCase):
         )
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['attributes']['email'],
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['email'] == \
             self.user.username
-        )
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_non_user_email_scope_cannot_read_email(self, mock_user_info):
@@ -441,9 +423,9 @@ class TestOAuthScopedAccess(ApiTestCase):
         )
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        self.assertEqual(res.status_code, 200)
-        self.assertNotIn('email', res.json['data']['attributes'])
-        self.assertNotIn(self.user.username, res.json)
+        assert res.status_code == 200
+        assert 'email' not in res.json['data']['attributes']
+        assert self.user.username not in res.json
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_email_scope_cannot_read_other_email(self, mock_user_info):
@@ -455,9 +437,9 @@ class TestOAuthScopedAccess(ApiTestCase):
             base_route='/', base_prefix='v2/'
         )
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
-        self.assertEqual(res.status_code, 200)
-        self.assertNotIn('email', res.json['data']['attributes'])
-        self.assertNotIn(self.user2.username, res.json)
+        assert res.status_code == 200
+        assert 'email' not in res.json['data']['attributes']
+        assert self.user2.username not in res.json
 
 
 @pytest.mark.django_db

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -106,12 +106,10 @@ class TestFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         assert 'string_field' in fields['filter[string_field]']
-        assert fields['filter[string_field]']['string_field']['op'] == \
-            'icontains'
+        assert fields['filter[string_field]']['string_field']['op'] == 'icontains'
 
         assert 'list_field' in fields['filter[list_field]']
-        assert fields['filter[list_field]']['list_field']['op'] == \
-            'contains'
+        assert fields['filter[list_field]']['list_field']['op'] == 'contains'
 
         assert 'int_field' in fields['filter[int_field]']
         assert fields['filter[int_field]']['int_field']['op'] == 'eq'
@@ -129,19 +127,16 @@ class TestFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         assert 'string_field' in fields['filter[string_field]']
-        assert fields['filter[string_field]']['string_field']['value'] == \
-            'foo'
+        assert fields['filter[string_field]']['string_field']['value'] == 'foo'
 
         assert 'list_field' in fields['filter[list_field]']
-        assert fields['filter[list_field]']['list_field']['value'] == \
-            'bar'
+        assert fields['filter[list_field]']['list_field']['value'] == 'bar'
 
         assert 'int_field' in fields['filter[int_field]']
         assert fields['filter[int_field]']['int_field']['value'] == 42
 
         assert 'bool_field' in fields.get('filter[bool_field]')
-        assert fields['filter[bool_field]']['bool_field']['value'] == \
-            False
+        assert fields['filter[bool_field]']['bool_field']['value'] is False
 
     def test_parse_query_params_uses_field_source_attribute(self):
         query_params = {

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -105,23 +105,19 @@ class TestFilterMixin(ApiTestCase):
         }
 
         fields = self.view.parse_query_params(query_params)
-        self.assertIn('string_field', fields['filter[string_field]'])
-        self.assertEqual(
-            fields['filter[string_field]']['string_field']['op'],
+        assert 'string_field' in fields['filter[string_field]']
+        assert fields['filter[string_field]']['string_field']['op'] == \
             'icontains'
-        )
 
-        self.assertIn('list_field', fields['filter[list_field]'])
-        self.assertEqual(
-            fields['filter[list_field]']['list_field']['op'],
+        assert 'list_field' in fields['filter[list_field]']
+        assert fields['filter[list_field]']['list_field']['op'] == \
             'contains'
-        )
 
-        self.assertIn('int_field', fields['filter[int_field]'])
-        self.assertEqual(fields['filter[int_field]']['int_field']['op'], 'eq')
+        assert 'int_field' in fields['filter[int_field]']
+        assert fields['filter[int_field]']['int_field']['op'] == 'eq'
 
-        self.assertIn('bool_field', fields['filter[bool_field]'])
-        self.assertEqual(fields['filter[bool_field]']['bool_field']['op'], 'eq')
+        assert 'bool_field' in fields['filter[bool_field]']
+        assert fields['filter[bool_field]']['bool_field']['op'] == 'eq'
 
     def test_parse_query_params_casts_values(self):
         query_params = {
@@ -132,26 +128,20 @@ class TestFilterMixin(ApiTestCase):
         }
 
         fields = self.view.parse_query_params(query_params)
-        self.assertIn('string_field', fields['filter[string_field]'])
-        self.assertEqual(
-            fields['filter[string_field]']['string_field']['value'],
+        assert 'string_field' in fields['filter[string_field]']
+        assert fields['filter[string_field]']['string_field']['value'] == \
             'foo'
-        )
 
-        self.assertIn('list_field', fields['filter[list_field]'])
-        self.assertEqual(
-            fields['filter[list_field]']['list_field']['value'],
+        assert 'list_field' in fields['filter[list_field]']
+        assert fields['filter[list_field]']['list_field']['value'] == \
             'bar'
-        )
 
-        self.assertIn('int_field', fields['filter[int_field]'])
-        self.assertEqual(fields['filter[int_field]']['int_field']['value'], 42)
+        assert 'int_field' in fields['filter[int_field]']
+        assert fields['filter[int_field]']['int_field']['value'] == 42
 
-        self.assertIn('bool_field', fields.get('filter[bool_field]'))
-        self.assertEqual(
-            fields['filter[bool_field]']['bool_field']['value'],
+        assert 'bool_field' in fields.get('filter[bool_field]')
+        assert fields['filter[bool_field]']['bool_field']['value'] == \
             False
-        )
 
     def test_parse_query_params_uses_field_source_attribute(self):
         query_params = {
@@ -160,9 +150,9 @@ class TestFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
-        self.assertEqual(parsed_field['source_field_name'], 'foobar')
-        self.assertEqual(parsed_field['value'], False)
-        self.assertEqual(parsed_field['op'], 'eq')
+        assert parsed_field['source_field_name'] == 'foobar'
+        assert parsed_field['value'] == False
+        assert parsed_field['op'] == 'eq'
 
     def test_parse_query_params_generalizes_dates(self):
         query_params = {
@@ -175,9 +165,9 @@ class TestFilterMixin(ApiTestCase):
         for key, field_name in fields.items():
             for match in field_name['date_field']:
                 if match['op'] == 'gte':
-                    self.assertEqual(match['value'], start)
+                    assert match['value'] == start
                 elif match['op'] == 'lt':
-                    self.assertEqual(match['value'], stop)
+                    assert match['value'] == stop
                 else:
                     self.fail()
 
@@ -189,9 +179,9 @@ class TestFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         for key, field_name in fields.items():
             if field_name['int_field']['op'] == 'gt':
-                self.assertEqual(field_name['int_field']['value'], 42)
+                assert field_name['int_field']['value'] == 42
             elif field_name['int_field']['op'] == 'lte':
-                self.assertEqual(field_name['int_field']['value'], 9000)
+                assert field_name['int_field']['value'] == 9000
             else:
                 self.fail()
 
@@ -203,9 +193,9 @@ class TestFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         for key, field_name in fields.items():
             if field_name['string_field']['op'] == 'contains':
-                self.assertEqual(field_name['string_field']['value'], 'foo')
+                assert field_name['string_field']['value'] == 'foo'
             elif field_name['string_field']['op'] == 'icontains':
-                self.assertEqual(field_name['string_field']['value'], 'bar')
+                assert field_name['string_field']['value'] == 'bar'
             else:
                 self.fail()
 
@@ -213,28 +203,28 @@ class TestFilterMixin(ApiTestCase):
         query_params = {
             'filter[fake]': 'foo'
         }
-        with self.assertRaises(InvalidFilterError):
+        with pytest.raises(InvalidFilterError):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterComparisonType(self):
         query_params = {
             'filter[string_field][gt]': 'foo'
         }
-        with self.assertRaises(InvalidFilterComparisonType):
+        with pytest.raises(InvalidFilterComparisonType):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterMatchType(self):
         query_params = {
             'filter[date_field][icontains]': '2015'
         }
-        with self.assertRaises(InvalidFilterMatchType):
+        with pytest.raises(InvalidFilterMatchType):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterOperator(self):
         query_params = {
             'filter[int_field][bar]': 42
         }
-        with self.assertRaises(InvalidFilterOperator):
+        with pytest.raises(InvalidFilterOperator):
             self.view.parse_query_params(query_params)
 
     def test_InvalidFilterOperator_parameterizes_valid_operators(self):
@@ -248,7 +238,7 @@ class TestFilterMixin(ApiTestCase):
                 r'one of (?P<ops>.+)\.$',
                 err.detail
             ).groupdict()['ops']
-            self.assertEqual(ops, 'gt, gte, lt, lte, eq, ne')
+            assert ops == 'gt, gte, lt, lte, eq, ne'
 
         query_params = {
             'filter[string_field][bar]': 'foo'
@@ -260,7 +250,7 @@ class TestFilterMixin(ApiTestCase):
                 r'one of (?P<ops>.+)\.$',
                 err.detail
             ).groupdict()['ops']
-            self.assertEqual(ops, 'contains, icontains, eq, ne')
+            assert ops == 'contains, icontains, eq, ne'
 
     def test_parse_query_params_supports_multiple_filters(self):
         """
@@ -279,49 +269,47 @@ class TestFilterMixin(ApiTestCase):
         value = 'true'
         field = FakeSerializer._declared_fields['bool_field']
         value = self.view.convert_value(value, field)
-        self.assertTrue(isinstance(value, bool))
-        self.assertTrue(value)
+        assert isinstance(value, bool)
+        assert value
 
     def test_convert_value_date(self):
         value = '2014-12-12'
         field = FakeSerializer._declared_fields['date_field']
         value = self.view.convert_value(value, field)
-        self.assertTrue(isinstance(value, datetime.datetime))
-        self.assertEqual(
-            value,
+        assert isinstance(value, datetime.datetime)
+        assert value == \
             parser.parse('2014-12-12').replace(tzinfo=pytz.utc)
-        )
 
     def test_convert_value_int(self):
         value = '9000'
         field = FakeSerializer._declared_fields['int_field']
         value = self.view.convert_value(value, field)
-        self.assertEqual(value, 9000)
+        assert value == 9000
 
     def test_convert_value_float(self):
         value = '42'
         field = FakeSerializer._declared_fields['float_field']
         value = self.view.convert_value(value, field)
-        self.assertEqual(value, 42.0)
+        assert value == 42.0
 
     def test_convert_value_null_for_list(self):
         value = 'null'
         field = FakeSerializer._declared_fields['list_field']
         value = self.view.convert_value(value, field)
-        self.assertEqual(value, [])
+        assert value == []
 
     def test_multiple_filter_params_bad_filter(self):
         query_params = {
             'filter[string_field, not_a_field]': 'test'
         }
-        with self.assertRaises(InvalidFilterError):
+        with pytest.raises(InvalidFilterError):
             self.view.parse_query_params(query_params)
 
     def test_bad_filter_operator(self):
         query_params = {
             'filter[relationship_field][invalid]': 'false',
         }
-        with self.assertRaises(InvalidFilterOperator):
+        with pytest.raises(InvalidFilterOperator):
             self.view.parse_query_params(query_params)
 
 
@@ -345,9 +333,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            self.assertNotEqual(record._id, 3)
+            assert record._id != 3
         for id in (1, 2):
-            self.assertIn(id, [f._id for f in filtered])
+            assert id in [f._id for f in filtered]
 
     def test_get_filtered_queryset_for_list_respects_special_case_of_ids_being_list(
             self):
@@ -365,9 +353,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            self.assertNotEqual(record._id, 3)
+            assert record._id != 3
         for id in (1, 2):
-            self.assertIn(id, [f._id for f in filtered])
+            assert id in [f._id for f in filtered]
 
     def test_get_filtered_queryset_for_list_respects_id_always_being_list(
             self):
@@ -385,9 +373,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            self.assertEqual(record._id, '2')
+            assert record._id == '2'
         for id in ('1', '3'):
-            self.assertNotIn(id, [f._id for f in filtered])
+            assert id not in [f._id for f in filtered]
 
     def test_parse_query_params_uses_field_source_attribute(self):
         query_params = {
@@ -396,9 +384,9 @@ class TestListFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
-        self.assertEqual(parsed_field['source_field_name'], 'foobar')
-        self.assertEqual(parsed_field['value'], False)
-        self.assertEqual(parsed_field['op'], 'eq')
+        assert parsed_field['source_field_name'] == 'foobar'
+        assert parsed_field['value'] == False
+        assert parsed_field['op'] == 'eq'
 
 @pytest.mark.django_db
 class TestOSFOrderingFilter(ApiTestCase):
@@ -430,7 +418,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        self.assertEqual(sorted_output, ['Activity', 'NewProj', 'Proj', 'Zip'])
+        assert sorted_output == ['Activity', 'NewProj', 'Proj', 'Zip']
 
     def test_filter_queryset_forward_duplicate(self):
         query_to_be_sorted = [
@@ -440,7 +428,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        self.assertEqual(sorted_output, ['Activity', 'Activity', 'NewProj', 'Zip'])
+        assert sorted_output == ['Activity', 'Activity', 'NewProj', 'Zip']
 
     def test_filter_queryset_reverse(self):
         query_to_be_sorted = [
@@ -450,7 +438,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['-title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        self.assertEqual(sorted_output, ['Zip', 'Proj', 'NewProj', 'Activity'])
+        assert sorted_output == ['Zip', 'Proj', 'NewProj', 'Activity']
 
     def test_filter_queryset_reverse_duplicate(self):
         query_to_be_sorted = [
@@ -460,7 +448,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['-title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        self.assertEqual(sorted_output, ['Zip', 'NewProj', 'Activity', 'Activity'])
+        assert sorted_output == ['Zip', 'NewProj', 'Activity', 'Activity']
 
     def test_filter_queryset_handles_multiple_fields(self):
         objs = [self.query_with_num(title='NewProj', number=10),
@@ -471,7 +459,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             x.number for x in sorted(
                 objs, key=cmp_to_key(filters.sort_multiple(['title', '-number']))
             )]
-        self.assertEqual(actual, [40, 30, 10, 20])
+        assert actual == [40, 30, 10, 20]
 
     def get_node_sort_url(self, field, ascend=True):
         if not ascend:
@@ -518,61 +506,61 @@ class TestQueryPatternRegex(TestCase):
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        self.assertEqual(fields, 'name')
-        self.assertEqual(field_names[0], 'name')
+        assert fields == 'name'
+        assert field_names[0] == 'name'
 
     def test_double_field_filter(self):
         filter_str = 'filter[name,id]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        self.assertEqual(fields, 'name,id')
-        self.assertEqual(field_names[0], 'name')
-        self.assertEqual(field_names[1], 'id')
+        assert fields == 'name,id'
+        assert field_names[0] == 'name'
+        assert field_names[1] == 'id'
 
     def test_multiple_field_filter(self):
         filter_str = 'filter[name,id,another,field,here]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        self.assertEqual(fields, 'name,id,another,field,here')
-        self.assertEquals(len(field_names), 5)
+        assert fields == 'name,id,another,field,here'
+        assert len(field_names) == 5
 
     def test_single_field_filter_end_comma(self):
         filter_str = 'filter[name,]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match
 
     def test_multiple_field_filter_end_comma(self):
         filter_str = 'filter[name,id,]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match
 
     def test_multiple_field_filter_with_spaces(self):
         filter_str = 'filter[name,  id]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        self.assertEqual(fields, 'name,  id')
-        self.assertEqual(field_names[0], 'name')
-        self.assertEqual(field_names[1], 'id')
+        assert fields == 'name,  id'
+        assert field_names[0] == 'name'
+        assert field_names[1] == 'id'
 
     def test_multiple_field_filter_with_blank_field(self):
         filter_str = 'filter[name,  ,  id]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match
 
     def test_multiple_field_filter_non_match(self):
         filter_str = 'filter[name; id]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match
 
     def test_single_field_filter_non_match(self):
         filter_str = 'fitler[name]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match
 
     def test_single_field_non_alphanumeric_character(self):
         filter_str = 'fitler[<name>]'
         match = self.filter_regex.match(filter_str)
-        self.assertFalse(match)
+        assert not match

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -6,8 +6,6 @@ import pytz
 from dateutil import parser
 from django.utils import timezone
 
-from nose.tools import *  # noqa:
-
 from rest_framework import generics
 from rest_framework import serializers as ser
 
@@ -107,23 +105,23 @@ class TestFilterMixin(ApiTestCase):
         }
 
         fields = self.view.parse_query_params(query_params)
-        assert_in('string_field', fields['filter[string_field]'])
-        assert_equal(
+        self.assertIn('string_field', fields['filter[string_field]'])
+        self.assertEqual(
             fields['filter[string_field]']['string_field']['op'],
             'icontains'
         )
 
-        assert_in('list_field', fields['filter[list_field]'])
-        assert_equal(
+        self.assertIn('list_field', fields['filter[list_field]'])
+        self.assertEqual(
             fields['filter[list_field]']['list_field']['op'],
             'contains'
         )
 
-        assert_in('int_field', fields['filter[int_field]'])
-        assert_equal(fields['filter[int_field]']['int_field']['op'], 'eq')
+        self.assertIn('int_field', fields['filter[int_field]'])
+        self.assertEqual(fields['filter[int_field]']['int_field']['op'], 'eq')
 
-        assert_in('bool_field', fields['filter[bool_field]'])
-        assert_equal(fields['filter[bool_field]']['bool_field']['op'], 'eq')
+        self.assertIn('bool_field', fields['filter[bool_field]'])
+        self.assertEqual(fields['filter[bool_field]']['bool_field']['op'], 'eq')
 
     def test_parse_query_params_casts_values(self):
         query_params = {
@@ -134,23 +132,23 @@ class TestFilterMixin(ApiTestCase):
         }
 
         fields = self.view.parse_query_params(query_params)
-        assert_in('string_field', fields['filter[string_field]'])
-        assert_equal(
+        self.assertIn('string_field', fields['filter[string_field]'])
+        self.assertEqual(
             fields['filter[string_field]']['string_field']['value'],
             'foo'
         )
 
-        assert_in('list_field', fields['filter[list_field]'])
-        assert_equal(
+        self.assertIn('list_field', fields['filter[list_field]'])
+        self.assertEqual(
             fields['filter[list_field]']['list_field']['value'],
             'bar'
         )
 
-        assert_in('int_field', fields['filter[int_field]'])
-        assert_equal(fields['filter[int_field]']['int_field']['value'], 42)
+        self.assertIn('int_field', fields['filter[int_field]'])
+        self.assertEqual(fields['filter[int_field]']['int_field']['value'], 42)
 
-        assert_in('bool_field', fields.get('filter[bool_field]'))
-        assert_equal(
+        self.assertIn('bool_field', fields.get('filter[bool_field]'))
+        self.assertEqual(
             fields['filter[bool_field]']['bool_field']['value'],
             False
         )
@@ -162,9 +160,9 @@ class TestFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
-        assert_equal(parsed_field['source_field_name'], 'foobar')
-        assert_equal(parsed_field['value'], False)
-        assert_equal(parsed_field['op'], 'eq')
+        self.assertEqual(parsed_field['source_field_name'], 'foobar')
+        self.assertEqual(parsed_field['value'], False)
+        self.assertEqual(parsed_field['op'], 'eq')
 
     def test_parse_query_params_generalizes_dates(self):
         query_params = {
@@ -177,9 +175,9 @@ class TestFilterMixin(ApiTestCase):
         for key, field_name in fields.items():
             for match in field_name['date_field']:
                 if match['op'] == 'gte':
-                    assert_equal(match['value'], start)
+                    self.assertEqual(match['value'], start)
                 elif match['op'] == 'lt':
-                    assert_equal(match['value'], stop)
+                    self.assertEqual(match['value'], stop)
                 else:
                     self.fail()
 
@@ -191,9 +189,9 @@ class TestFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         for key, field_name in fields.items():
             if field_name['int_field']['op'] == 'gt':
-                assert_equal(field_name['int_field']['value'], 42)
+                self.assertEqual(field_name['int_field']['value'], 42)
             elif field_name['int_field']['op'] == 'lte':
-                assert_equal(field_name['int_field']['value'], 9000)
+                self.assertEqual(field_name['int_field']['value'], 9000)
             else:
                 self.fail()
 
@@ -205,9 +203,9 @@ class TestFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         for key, field_name in fields.items():
             if field_name['string_field']['op'] == 'contains':
-                assert_equal(field_name['string_field']['value'], 'foo')
+                self.assertEqual(field_name['string_field']['value'], 'foo')
             elif field_name['string_field']['op'] == 'icontains':
-                assert_equal(field_name['string_field']['value'], 'bar')
+                self.assertEqual(field_name['string_field']['value'], 'bar')
             else:
                 self.fail()
 
@@ -215,28 +213,28 @@ class TestFilterMixin(ApiTestCase):
         query_params = {
             'filter[fake]': 'foo'
         }
-        with assert_raises(InvalidFilterError):
+        with self.assertRaises(InvalidFilterError):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterComparisonType(self):
         query_params = {
             'filter[string_field][gt]': 'foo'
         }
-        with assert_raises(InvalidFilterComparisonType):
+        with self.assertRaises(InvalidFilterComparisonType):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterMatchType(self):
         query_params = {
             'filter[date_field][icontains]': '2015'
         }
-        with assert_raises(InvalidFilterMatchType):
+        with self.assertRaises(InvalidFilterMatchType):
             self.view.parse_query_params(query_params)
 
     def test_parse_query_params_raises_InvalidFilterOperator(self):
         query_params = {
             'filter[int_field][bar]': 42
         }
-        with assert_raises(InvalidFilterOperator):
+        with self.assertRaises(InvalidFilterOperator):
             self.view.parse_query_params(query_params)
 
     def test_InvalidFilterOperator_parameterizes_valid_operators(self):
@@ -250,7 +248,7 @@ class TestFilterMixin(ApiTestCase):
                 r'one of (?P<ops>.+)\.$',
                 err.detail
             ).groupdict()['ops']
-            assert_equal(ops, 'gt, gte, lt, lte, eq, ne')
+            self.assertEqual(ops, 'gt, gte, lt, lte, eq, ne')
 
         query_params = {
             'filter[string_field][bar]': 'foo'
@@ -262,7 +260,7 @@ class TestFilterMixin(ApiTestCase):
                 r'one of (?P<ops>.+)\.$',
                 err.detail
             ).groupdict()['ops']
-            assert_equal(ops, 'contains, icontains, eq, ne')
+            self.assertEqual(ops, 'contains, icontains, eq, ne')
 
     def test_parse_query_params_supports_multiple_filters(self):
         """
@@ -273,23 +271,23 @@ class TestFilterMixin(ApiTestCase):
         }
         # FIXME: This test may only be checking one field
         fields = self.view.parse_query_params(query_params)
-        assert_in('string_field', fields.get('filter[string_field]'))
+        self.assertIn('string_field', fields.get('filter[string_field]'))
         for key, field_name in fields.items():
-            assert_in(field_name['string_field']['value'], ('foo', 'bar'))
+            self.assertIn(field_name['string_field']['value'], ('foo', 'bar'))
         """
     def test_convert_value_bool(self):
         value = 'true'
         field = FakeSerializer._declared_fields['bool_field']
         value = self.view.convert_value(value, field)
-        assert_true(isinstance(value, bool))
-        assert_true(value)
+        self.assertTrue(isinstance(value, bool))
+        self.assertTrue(value)
 
     def test_convert_value_date(self):
         value = '2014-12-12'
         field = FakeSerializer._declared_fields['date_field']
         value = self.view.convert_value(value, field)
-        assert_true(isinstance(value, datetime.datetime))
-        assert_equal(
+        self.assertTrue(isinstance(value, datetime.datetime))
+        self.assertEqual(
             value,
             parser.parse('2014-12-12').replace(tzinfo=pytz.utc)
         )
@@ -298,32 +296,32 @@ class TestFilterMixin(ApiTestCase):
         value = '9000'
         field = FakeSerializer._declared_fields['int_field']
         value = self.view.convert_value(value, field)
-        assert_equal(value, 9000)
+        self.assertEqual(value, 9000)
 
     def test_convert_value_float(self):
         value = '42'
         field = FakeSerializer._declared_fields['float_field']
         value = self.view.convert_value(value, field)
-        assert_equal(value, 42.0)
+        self.assertEqual(value, 42.0)
 
     def test_convert_value_null_for_list(self):
         value = 'null'
         field = FakeSerializer._declared_fields['list_field']
         value = self.view.convert_value(value, field)
-        assert_equal(value, [])
+        self.assertEqual(value, [])
 
     def test_multiple_filter_params_bad_filter(self):
         query_params = {
             'filter[string_field, not_a_field]': 'test'
         }
-        with assert_raises(InvalidFilterError):
+        with self.assertRaises(InvalidFilterError):
             self.view.parse_query_params(query_params)
 
     def test_bad_filter_operator(self):
         query_params = {
             'filter[relationship_field][invalid]': 'false',
         }
-        with assert_raises(InvalidFilterOperator):
+        with self.assertRaises(InvalidFilterOperator):
             self.view.parse_query_params(query_params)
 
 
@@ -347,9 +345,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            assert_not_equal(record._id, 3)
+            self.assertNotEqual(record._id, 3)
         for id in (1, 2):
-            assert_in(id, [f._id for f in filtered])
+            self.assertIn(id, [f._id for f in filtered])
 
     def test_get_filtered_queryset_for_list_respects_special_case_of_ids_being_list(
             self):
@@ -367,9 +365,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            assert_not_equal(record._id, 3)
+            self.assertNotEqual(record._id, 3)
         for id in (1, 2):
-            assert_in(id, [f._id for f in filtered])
+            self.assertIn(id, [f._id for f in filtered])
 
     def test_get_filtered_queryset_for_list_respects_id_always_being_list(
             self):
@@ -387,9 +385,9 @@ class TestListFilterMixin(ApiTestCase):
         filtered = self.view.get_filtered_queryset(
             field_name, params, default_queryset)
         for record in filtered:
-            assert_equal(record._id, '2')
+            self.assertEqual(record._id, '2')
         for id in ('1', '3'):
-            assert_not_in(id, [f._id for f in filtered])
+            self.assertNotIn(id, [f._id for f in filtered])
 
     def test_parse_query_params_uses_field_source_attribute(self):
         query_params = {
@@ -398,9 +396,9 @@ class TestListFilterMixin(ApiTestCase):
 
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
-        assert_equal(parsed_field['source_field_name'], 'foobar')
-        assert_equal(parsed_field['value'], False)
-        assert_equal(parsed_field['op'], 'eq')
+        self.assertEqual(parsed_field['source_field_name'], 'foobar')
+        self.assertEqual(parsed_field['value'], False)
+        self.assertEqual(parsed_field['op'], 'eq')
 
 @pytest.mark.django_db
 class TestOSFOrderingFilter(ApiTestCase):
@@ -432,7 +430,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output, ['Activity', 'NewProj', 'Proj', 'Zip'])
+        self.assertEqual(sorted_output, ['Activity', 'NewProj', 'Proj', 'Zip'])
 
     def test_filter_queryset_forward_duplicate(self):
         query_to_be_sorted = [
@@ -442,7 +440,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output, ['Activity', 'Activity', 'NewProj', 'Zip'])
+        self.assertEqual(sorted_output, ['Activity', 'Activity', 'NewProj', 'Zip'])
 
     def test_filter_queryset_reverse(self):
         query_to_be_sorted = [
@@ -452,7 +450,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['-title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output, ['Zip', 'Proj', 'NewProj', 'Activity'])
+        self.assertEqual(sorted_output, ['Zip', 'Proj', 'NewProj', 'Activity'])
 
     def test_filter_queryset_reverse_duplicate(self):
         query_to_be_sorted = [
@@ -462,7 +460,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             key=cmp_to_key(filters.sort_multiple(['-title']))
         )
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output, ['Zip', 'NewProj', 'Activity', 'Activity'])
+        self.assertEqual(sorted_output, ['Zip', 'NewProj', 'Activity', 'Activity'])
 
     def test_filter_queryset_handles_multiple_fields(self):
         objs = [self.query_with_num(title='NewProj', number=10),
@@ -473,7 +471,7 @@ class TestOSFOrderingFilter(ApiTestCase):
             x.number for x in sorted(
                 objs, key=cmp_to_key(filters.sort_multiple(['title', '-number']))
             )]
-        assert_equal(actual, [40, 30, 10, 20])
+        self.assertEqual(actual, [40, 30, 10, 20])
 
     def get_node_sort_url(self, field, ascend=True):
         if not ascend:
@@ -520,61 +518,61 @@ class TestQueryPatternRegex(TestCase):
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        assert_equal(fields, 'name')
-        assert_equal(field_names[0], 'name')
+        self.assertEqual(fields, 'name')
+        self.assertEqual(field_names[0], 'name')
 
     def test_double_field_filter(self):
         filter_str = 'filter[name,id]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        assert_equal(fields, 'name,id')
-        assert_equal(field_names[0], 'name')
-        assert_equal(field_names[1], 'id')
+        self.assertEqual(fields, 'name,id')
+        self.assertEqual(field_names[0], 'name')
+        self.assertEqual(field_names[1], 'id')
 
     def test_multiple_field_filter(self):
         filter_str = 'filter[name,id,another,field,here]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        assert_equal(fields, 'name,id,another,field,here')
-        assert_equals(len(field_names), 5)
+        self.assertEqual(fields, 'name,id,another,field,here')
+        self.assertEquals(len(field_names), 5)
 
     def test_single_field_filter_end_comma(self):
         filter_str = 'filter[name,]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)
 
     def test_multiple_field_filter_end_comma(self):
         filter_str = 'filter[name,id,]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)
 
     def test_multiple_field_filter_with_spaces(self):
         filter_str = 'filter[name,  id]'
         match = self.filter_regex.match(filter_str)
         fields = match.groupdict()['fields']
         field_names = re.findall(self.filter_fields, fields)
-        assert_equal(fields, 'name,  id')
-        assert_equal(field_names[0], 'name')
-        assert_equal(field_names[1], 'id')
+        self.assertEqual(fields, 'name,  id')
+        self.assertEqual(field_names[0], 'name')
+        self.assertEqual(field_names[1], 'id')
 
     def test_multiple_field_filter_with_blank_field(self):
         filter_str = 'filter[name,  ,  id]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)
 
     def test_multiple_field_filter_non_match(self):
         filter_str = 'filter[name; id]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)
 
     def test_single_field_filter_non_match(self):
         filter_str = 'fitler[name]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)
 
     def test_single_field_non_alphanumeric_character(self):
         filter_str = 'fitler[<name>]'
         match = self.filter_regex.match(filter_str)
-        assert_false(match)
+        self.assertFalse(match)

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -146,7 +146,7 @@ class TestFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
         assert parsed_field['source_field_name'] == 'foobar'
-        assert parsed_field['value'] == False
+        assert parsed_field['value'] is False
         assert parsed_field['op'] == 'eq'
 
     def test_parse_query_params_generalizes_dates(self):
@@ -380,7 +380,7 @@ class TestListFilterMixin(ApiTestCase):
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
         assert parsed_field['source_field_name'] == 'foobar'
-        assert parsed_field['value'] == False
+        assert parsed_field['value'] is False
         assert parsed_field['op'] == 'eq'
 
 @pytest.mark.django_db

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -38,7 +38,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
+        assert response['Access-Control-Allow-Origin'] == domain.geturl()
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_preprintproviders_added_to_cors_whitelist(self):
@@ -53,7 +53,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
+        assert response['Access-Control-Allow-Origin'] == domain.geturl()
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_cookies_does_not_get_cors_headers(self):
@@ -64,7 +64,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         with mock.patch.object(request, 'COOKIES', True):
             self.middleware.process_request(request)
             self.middleware.process_response(request, response)
-        self.assertNotIn('Access-Control-Allow-Origin', response)
+        assert 'Access-Control-Allow-Origin' not in response
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_Authorization_gets_cors_headers(self):
@@ -78,7 +78,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
+        assert response['Access-Control-Allow-Origin'] == domain.geturl()
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_Authorization_and_cookie_does_not_get_cors_headers(
@@ -94,7 +94,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         with mock.patch.object(request, 'COOKIES', True):
             self.middleware.process_request(request)
             self.middleware.process_response(request, response)
-        self.assertNotIn('Access-Control-Allow-Origin', response)
+        assert 'Access-Control-Allow-Origin' not in response
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(
@@ -110,4 +110,4 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
+        assert response['Access-Control-Allow-Origin'] == domain.geturl()

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -2,7 +2,6 @@ from django.http import HttpResponse
 
 from future.moves.urllib.parse import urlparse
 from unittest import mock
-from nose.tools import *  # noqa:
 from rest_framework.test import APIRequestFactory
 from django.test.utils import override_settings
 
@@ -39,7 +38,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_preprintproviders_added_to_cors_whitelist(self):
@@ -54,7 +53,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_cookies_does_not_get_cors_headers(self):
@@ -65,7 +64,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         with mock.patch.object(request, 'COOKIES', True):
             self.middleware.process_request(request)
             self.middleware.process_response(request, response)
-        assert_not_in('Access-Control-Allow-Origin', response)
+        self.assertNotIn('Access-Control-Allow-Origin', response)
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_Authorization_gets_cors_headers(self):
@@ -79,7 +78,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_cross_origin_request_with_Authorization_and_cookie_does_not_get_cors_headers(
@@ -95,7 +94,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         with mock.patch.object(request, 'COOKIES', True):
             self.middleware.process_request(request)
             self.middleware.process_response(request, response)
-        assert_not_in('Access-Control-Allow-Origin', response)
+        self.assertNotIn('Access-Control-Allow-Origin', response)
 
     @override_settings(CORS_ORIGIN_ALLOW_ALL=False)
     def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(
@@ -111,4 +110,4 @@ class TestCorsMiddleware(MiddlewareTestCase):
         response = HttpResponse()
         self.middleware.process_request(request)
         self.middleware.process_response(request, response)
-        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+        self.assertEqual(response['Access-Control-Allow-Origin'], domain.geturl())

--- a/api_tests/base/test_pagination.py
+++ b/api_tests/base/test_pagination.py
@@ -26,28 +26,28 @@ class TestJSONAPIPagination(ApiTestCase):
 
     def test_pagination_links_v2(self):
         res = self.app.get(self.url_version_2_0, auth=self.user)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         links = res.json['links']
         meta = res.json['links']['meta']
-        self.assertNotIn('self', links)
-        self.assertIn('first', links)
-        self.assertIn('next', links)
-        self.assertIn('last', links)
-        self.assertIn('prev', links)
-        self.assertIn('meta', links)
-        self.assertIn('total', meta)
-        self.assertIn('per_page', meta)
+        assert 'self' not in links
+        assert 'first' in links
+        assert 'next' in links
+        assert 'last' in links
+        assert 'prev' in links
+        assert 'meta' in links
+        assert 'total' in meta
+        assert 'per_page' in meta
 
     def test_pagination_links_updated_version(self):
         res = self.app.get(self.url_version_2_1, auth=self.user)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         links = res.json['links']
         meta = res.json['meta']
-        self.assertIn('self', links)
-        self.assertIn('first', links)
-        self.assertIn('next', links)
-        self.assertIn('last', links)
-        self.assertIn('prev', links)
-        self.assertNotIn('meta', links)
-        self.assertIn('total', meta)
-        self.assertIn('per_page', meta)
+        assert 'self' in links
+        assert 'first' in links
+        assert 'next' in links
+        assert 'last' in links
+        assert 'prev' in links
+        assert 'meta' not in links
+        assert 'total' in meta
+        assert 'per_page' in meta

--- a/api_tests/base/test_pagination.py
+++ b/api_tests/base/test_pagination.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa:
-
 from osf_tests import factories
 from tests.base import ApiTestCase
 
@@ -28,28 +26,28 @@ class TestJSONAPIPagination(ApiTestCase):
 
     def test_pagination_links_v2(self):
         res = self.app.get(self.url_version_2_0, auth=self.user)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         links = res.json['links']
         meta = res.json['links']['meta']
-        assert_not_in('self', links)
-        assert_in('first', links)
-        assert_in('next', links)
-        assert_in('last', links)
-        assert_in('prev', links)
-        assert_in('meta', links)
-        assert_in('total', meta)
-        assert_in('per_page', meta)
+        self.assertNotIn('self', links)
+        self.assertIn('first', links)
+        self.assertIn('next', links)
+        self.assertIn('last', links)
+        self.assertIn('prev', links)
+        self.assertIn('meta', links)
+        self.assertIn('total', meta)
+        self.assertIn('per_page', meta)
 
     def test_pagination_links_updated_version(self):
         res = self.app.get(self.url_version_2_1, auth=self.user)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         links = res.json['links']
         meta = res.json['meta']
-        assert_in('self', links)
-        assert_in('first', links)
-        assert_in('next', links)
-        assert_in('last', links)
-        assert_in('prev', links)
-        assert_not_in('meta', links)
-        assert_in('total', meta)
-        assert_in('per_page', meta)
+        self.assertIn('self', links)
+        self.assertIn('first', links)
+        self.assertIn('next', links)
+        self.assertIn('last', links)
+        self.assertIn('prev', links)
+        self.assertNotIn('meta', links)
+        self.assertIn('total', meta)
+        self.assertIn('per_page', meta)

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -1,6 +1,5 @@
 import itsdangerous
 from unittest import mock
-from nose.tools import *  # noqa:
 import unittest
 from django.utils import timezone
 from importlib import import_module
@@ -21,6 +20,7 @@ from osf.utils.permissions import ADMIN
 
 SessionStore = import_module(django_conf_settings.SESSION_ENGINE).SessionStore
 
+
 class TestWelcomeToApi(ApiTestCase):
     def setUp(self):
         super().setUp()
@@ -33,41 +33,41 @@ class TestWelcomeToApi(ApiTestCase):
 
     def test_returns_200_for_logged_out_user(self):
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['meta']['current_user'], None)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.json['meta']['current_user'], None)
 
     def test_returns_current_user_info_when_logged_in(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(
             res.json['meta']['current_user']['data']['attributes']['given_name'],
             self.user.given_name
         )
 
     def test_current_user_accepted_tos(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(
             res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'],
             False
         )
         self.user.accepted_terms_of_service = timezone.now()
         self.user.save()
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(
             res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'],
             True
         )
 
     def test_returns_302_redirect_for_base_url(self):
         res = self.app.get('/')
-        assert_equal(res.status_code, 302)
-        assert_equal(res.location, '/v2/')
+        self.assertEqual(res.status_code, 302)
+        self.assertEqual(res.location, '/v2/')
 
     def test_cookie_has_admin(self):
         session = SessionStore()
@@ -77,13 +77,13 @@ class TestWelcomeToApi(ApiTestCase):
         self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
 
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['meta'][ADMIN], True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['meta'][ADMIN], True)
 
     def test_basic_auth_does_not_have_admin(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_not_in(ADMIN, res.json['meta'].keys())
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn(ADMIN, res.json['meta'].keys())
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     # TODO: Remove when available outside of DEV_MODE
@@ -118,8 +118,8 @@ class TestWelcomeToApi(ApiTestCase):
             }
         )
 
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['meta'][ADMIN], True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['meta'][ADMIN], True)
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     def test_non_admin_scoped_token_does_not_have_admin(self, mock_auth):
@@ -149,5 +149,5 @@ class TestWelcomeToApi(ApiTestCase):
             }
         )
 
-        assert_equal(res.status_code, 200)
-        assert_not_in(ADMIN, res.json['meta'].keys())
+        self.assertEqual(res.status_code, 200)
+        self.assertNotIn(ADMIN, res.json['meta'].keys())

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -33,41 +33,35 @@ class TestWelcomeToApi(ApiTestCase):
 
     def test_returns_200_for_logged_out_user(self):
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(res.json['meta']['current_user'], None)
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['meta']['current_user'] == None
 
     def test_returns_current_user_info_when_logged_in(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(
-            res.json['meta']['current_user']['data']['attributes']['given_name'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['meta']['current_user']['data']['attributes']['given_name'] == \
             self.user.given_name
-        )
 
     def test_current_user_accepted_tos(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(
-            res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] == \
             False
-        )
         self.user.accepted_terms_of_service = timezone.now()
         self.user.save()
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(
-            res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] == \
             True
-        )
 
     def test_returns_302_redirect_for_base_url(self):
         res = self.app.get('/')
-        self.assertEqual(res.status_code, 302)
-        self.assertEqual(res.location, '/v2/')
+        assert res.status_code == 302
+        assert res.location == '/v2/'
 
     def test_cookie_has_admin(self):
         session = SessionStore()
@@ -77,13 +71,13 @@ class TestWelcomeToApi(ApiTestCase):
         self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
 
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['meta'][ADMIN], True)
+        assert res.status_code == 200
+        assert res.json['meta'][ADMIN] == True
 
     def test_basic_auth_does_not_have_admin(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertNotIn(ADMIN, res.json['meta'].keys())
+        assert res.status_code == 200
+        assert ADMIN not in res.json['meta'].keys()
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     # TODO: Remove when available outside of DEV_MODE
@@ -118,8 +112,8 @@ class TestWelcomeToApi(ApiTestCase):
             }
         )
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['meta'][ADMIN], True)
+        assert res.status_code == 200
+        assert res.json['meta'][ADMIN] == True
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     def test_non_admin_scoped_token_does_not_have_admin(self, mock_auth):
@@ -149,5 +143,5 @@ class TestWelcomeToApi(ApiTestCase):
             }
         )
 
-        self.assertEqual(res.status_code, 200)
-        self.assertNotIn(ADMIN, res.json['meta'].keys())
+        assert res.status_code == 200
+        assert ADMIN not in res.json['meta'].keys()

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -35,28 +35,25 @@ class TestWelcomeToApi(ApiTestCase):
         res = self.app.get(self.url)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
-        assert res.json['meta']['current_user'] == None
+        assert res.json['meta']['current_user'] is None
 
     def test_returns_current_user_info_when_logged_in(self):
         res = self.app.get(self.url, auth=self.user.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
-        assert res.json['meta']['current_user']['data']['attributes']['given_name'] == \
-            self.user.given_name
+        assert res.json['meta']['current_user']['data']['attributes']['given_name'] == self.user.given_name
 
     def test_current_user_accepted_tos(self):
         res = self.app.get(self.url, auth=self.user.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
-        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] == \
-            False
+        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] is False
         self.user.accepted_terms_of_service = timezone.now()
         self.user.save()
         res = self.app.get(self.url, auth=self.user.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
-        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] == \
-            True
+        assert res.json['meta']['current_user']['data']['attributes']['accepted_terms_of_service'] is True
 
     def test_returns_302_redirect_for_base_url(self):
         res = self.app.get('/')

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -69,7 +69,7 @@ class TestWelcomeToApi(ApiTestCase):
 
         res = self.app.get(self.url)
         assert res.status_code == 200
-        assert res.json['meta'][ADMIN] == True
+        assert res.json['meta'][ADMIN] is True
 
     def test_basic_auth_does_not_have_admin(self):
         res = self.app.get(self.url, auth=self.user.auth)
@@ -110,7 +110,7 @@ class TestWelcomeToApi(ApiTestCase):
         )
 
         assert res.status_code == 200
-        assert res.json['meta'][ADMIN] == True
+        assert res.json['meta'][ADMIN] is True
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
     def test_non_admin_scoped_token_does_not_have_admin(self, mock_auth):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -628,9 +628,9 @@ class VersionedDateTimeField(DbTestCase):
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
         assert datetime.strftime(
-                self.old_date_without_microseconds,
-                self.old_format_without_microseconds
-            ) == data['attributes']['date_modified']
+            self.old_date_without_microseconds,
+            self.old_format_without_microseconds
+        ) == data['attributes']['date_modified']
 
     def test_old_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
@@ -643,9 +643,9 @@ class VersionedDateTimeField(DbTestCase):
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
         assert datetime.strftime(
-                self.old_date_without_microseconds,
-                self.new_format
-            ) == data['attributes']['date_modified']
+            self.old_date_without_microseconds,
+            self.new_format
+        ) == data['attributes']['date_modified']
 
     def test_new_date_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
@@ -658,9 +658,9 @@ class VersionedDateTimeField(DbTestCase):
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
         assert datetime.strftime(
-                self.new_date_without_microseconds,
-                self.old_format_without_microseconds
-            ) == data['attributes']['date_modified']
+            self.new_date_without_microseconds,
+            self.old_format_without_microseconds
+        ) == data['attributes']['date_modified']
 
     def test_new_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
@@ -673,9 +673,9 @@ class VersionedDateTimeField(DbTestCase):
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
         assert datetime.strftime(
-                self.new_date_without_microseconds,
-                self.new_format
-            ) == data['attributes']['date_modified']
+            self.new_date_without_microseconds,
+            self.new_format
+        ) == data['attributes']['date_modified']
 
     # regression test for https://openscience.atlassian.net/browse/PLAT-1350
     # VersionedDateTimeField was treating version 2.10 and higher as decimals,

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -7,7 +7,6 @@ from pytz import utc
 from datetime import datetime
 from future.moves.urllib.parse import quote
 
-from nose.tools import *  # noqa:
 import re
 
 from tests.base import ApiTestCase, DbTestCase
@@ -198,11 +197,11 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
         non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'storage', 'children', 'groups', 'subjects_acceptable']
 
         for field in NodeSerializer._declared_fields:
-            assert_in(field, RegistrationSerializer._declared_fields)
+            self.assertIn(field, RegistrationSerializer._declared_fields)
             reg_field = RegistrationSerializer._declared_fields[field]
 
             if field not in visible_on_withdrawals and field not in non_registration_fields:
-                assert_true(
+                self.assertTrue(
                     isinstance(reg_field, base_serializers.HideIfWithdrawal) or
                     isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or
                     isinstance(reg_field, base_serializers.ShowIfVersion) or
@@ -223,8 +222,8 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
                 base_serializers.HideIfRegistration)]
 
         for field in hide_if_registration_fields:
-            assert_in(field, node_relationships)
-            assert_not_in(field, registration_relationships)
+            self.assertIn(field, node_relationships)
+            self.assertNotIn(field, registration_relationships)
 
 
 class TestNullLinks(ApiTestCase):
@@ -233,9 +232,9 @@ class TestNullLinks(ApiTestCase):
         req = make_drf_request_with_version(version='2.0')
         rep = FakeSerializer(FakeModel, context={'request': req}).data['data']
 
-        assert_not_in('null_field', rep['links'])
-        assert_in('valued_field', rep['links'])
-        assert_not_in('null_link_field', rep['relationships'])
+        self.assertNotIn('null_field', rep['links'])
+        self.assertIn('valued_field', rep['links'])
+        self.assertNotIn('null_link_field', rep['relationships'])
 
 
 class TestApiBaseSerializers(ApiTestCase):
@@ -267,7 +266,7 @@ class TestApiBaseSerializers(ApiTestCase):
                     serializer, 'get_absolute_url'
                 ), 'No get_absolute_url method'
 
-                assert_not_equal(
+                self.assertNotEqual(
                     serializer.get_absolute_url,
                     base_get_absolute_url
                 )
@@ -283,11 +282,11 @@ class TestApiBaseSerializers(ApiTestCase):
                 for item in relation:
                     link = list(item['links'].values())[0]
                     link_meta = link.get('meta', {})
-                    assert_not_in('count', link_meta)
+                    self.assertNotIn('count', link_meta)
             else:
                 link = list(relation['links'].values())[0]
                 link_meta = link.get('meta', {})
-                assert_not_in('count', link_meta)
+                self.assertNotIn('count', link_meta)
 
     def test_counts_included_in_link_fields_with_related_counts_query_param(
             self):
@@ -303,7 +302,7 @@ class TestApiBaseSerializers(ApiTestCase):
             related_meta = getattr(field, 'related_meta', {})
             if related_meta and related_meta.get('count', False):
                 link = list(relation['links'].values())[0]
-                assert_in('count', link['meta'], field)
+                self.assertIn('count', link['meta'], field)
 
     def test_related_counts_excluded_query_param_false(self):
 
@@ -316,11 +315,11 @@ class TestApiBaseSerializers(ApiTestCase):
                 for item in relation:
                     link = item['links'].values()[0]
                     link_meta = link.get('meta', {})
-                    assert_not_in('count', link_meta)
+                    self.assertNotIn('count', link_meta)
             else:
                 link = list(relation['links'].values())[0]
                 link_meta = link.get('meta', {})
-                assert_not_in('count', link_meta)
+                self.assertNotIn('count', link_meta)
 
     def test_invalid_related_counts_value_raises_bad_request(self):
 
@@ -329,7 +328,7 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'related_counts': 'fish'},
             expect_errors=True
         )
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
 
     def test_invalid_embed_value_raise_bad_request(self):
         res = self.app.get(
@@ -337,16 +336,16 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'embed': 'foo'},
             expect_errors=True
         )
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        assert_equal(
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'The following fields are not embeddable: foo'
         )
 
     def test_embed_does_not_remove_relationship(self):
         res = self.app.get(self.url, params={'embed': 'root'})
-        assert_equal(res.status_code, 200)
-        assert_in(
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(
             self.url,
             res.json['data']['relationships']['root']['links']['related']['href']
         )
@@ -367,16 +366,16 @@ class TestApiBaseSerializers(ApiTestCase):
                     link = item['links'].values()[0]
                     related_meta = getattr(field, 'related_meta', {})
                     if related_meta and related_meta.get('count', False) and key == 'children':
-                        assert_in('count', link['meta'])
+                        self.assertIn('count', link['meta'])
                     else:
-                        assert_not_in('count', link.get('meta', {}))
+                        self.assertNotIn('count', link.get('meta', {}))
             elif relation != {'data': None}:
                 link = list(relation['links'].values())[0]
                 related_meta = getattr(field, 'related_meta', {})
                 if related_meta and related_meta.get('count', False) and key == 'children':
-                    assert_in('count', link['meta'])
+                    self.assertIn('count', link['meta'])
                 else:
-                    assert_not_in('count', link.get('meta', {}))
+                    self.assertNotIn('count', link.get('meta', {}))
 
     def test_counts_included_in_children_and_contributors_fields_with_field_csv_related_counts_query_param(
             self):
@@ -397,16 +396,16 @@ class TestApiBaseSerializers(ApiTestCase):
                     link = item['links'].values()[0]
                     related_meta = getattr(field, 'related_meta', {})
                     if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
-                        assert_in('count', link['meta'])
+                        self.assertIn('count', link['meta'])
                     else:
-                        assert_not_in('count', link.get('meta', {}))
+                        self.assertNotIn('count', link.get('meta', {}))
             elif relation != {'data': None}:
                 link = list(relation['links'].values())[0]
                 related_meta = getattr(field, 'related_meta', {})
                 if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
-                    assert_in('count', link['meta'])
+                    self.assertIn('count', link['meta'])
                 else:
-                    assert_not_in('count', link.get('meta', {}))
+                    self.assertNotIn('count', link.get('meta', {}))
 
     def test_error_when_requesting_related_counts_for_attribute_field(self):
 
@@ -415,8 +414,8 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'related_counts': 'title'},
             expect_errors=True
         )
-        assert_equal(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        assert_equal(
+        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             "Acceptable values for the related_counts query param are 'true', 'false', or any of the relationship fields; got 'title'"
         )
@@ -487,9 +486,9 @@ class TestRelationshipField:
         ).data['data']
 
         meta = data['relationships']['parent_with_meta']['links']['related']['meta']
-        assert_not_in('count', meta)
-        assert_in('extra', meta)
-        assert_equal(meta['extra'], 'foo')
+        self.assertNotIn('count', meta)
+        self.assertIn('extra', meta)
+        self.assertEqual(meta['extra'], 'foo')
 
     def test_serializing_empty_to_one(self):
         req = make_drf_request_with_version(version='2.2')
@@ -519,11 +518,11 @@ class TestRelationshipField:
         ).data['data']
 
         relationship_field = data['relationships']['self_and_related_field']['links']
-        assert_in(
+        self.assertIn(
             f'/v2/nodes/{node._id}/contributors/',
             relationship_field['self']['href']
         )
-        assert_in(
+        self.assertIn(
             f'/v2/nodes/{node._id}/',
             relationship_field['related']['href']
         )
@@ -536,7 +535,7 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['two_url_kwargs']['links']
-        assert_in(
+        self.assertIn(
             f'/v2/nodes/{node._id}/node_links/{node._id}/',
             field['related']['href']
         )
@@ -549,11 +548,11 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['field_with_filters']['links']
-        assert_in(
+        self.assertIn(
             quote('filter[target]=hello', safe='?='),
             field['related']['href']
         )
-        assert_in(
+        self.assertIn(
             quote('filter[woop]=yea', safe='?='),
             field['related']['href']
         )
@@ -565,7 +564,7 @@ class TestRelationshipField:
         data = self.BasicNodeSerializer(
             node, context={'request': req}
         ).data['data']
-        assert_not_in('registered_from', data['relationships'])
+        self.assertNotIn('registered_from', data['relationships'])
 
         registration = factories.RegistrationFactory(project=node)
         data = self.BasicNodeSerializer(
@@ -573,7 +572,7 @@ class TestRelationshipField:
                 'request': req}
         ).data['data']
         field = data['relationships']['registered_from']['links']
-        assert_in(f'/v2/nodes/{node._id}/', field['related']['href'])
+        self.assertIn(f'/v2/nodes/{node._id}/', field['related']['href'])
 
 
 class TestShowIfVersion(ApiTestCase):
@@ -586,12 +585,12 @@ class TestShowIfVersion(ApiTestCase):
     def test_node_links_allowed_version_node_serializer(self):
         req = make_drf_request_with_version(version='2.0')
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_in('node_links', data['relationships'])
+        self.assertIn('node_links', data['relationships'])
 
     def test_node_links_bad_version_node_serializer(self):
         req = make_drf_request_with_version(version='2.1')
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_not_in('node_links', data['relationships'])
+        self.assertNotIn('node_links', data['relationships'])
 
     def test_node_links_allowed_version_registration_serializer(self):
         req = make_drf_request_with_version(version='2.0')
@@ -599,7 +598,7 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        assert_in('node_links', data['relationships'])
+        self.assertIn('node_links', data['relationships'])
 
     def test_node_links_bad_version_registration_serializer(self):
         req = make_drf_request_with_version(version='2.1')
@@ -607,7 +606,7 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        assert_not_in('node_links', data['relationships'])
+        self.assertNotIn('node_links', data['relationships'])
 
     def test_node_links_withdrawn_registration(self):
         factories.WithdrawnRegistrationFactory(
@@ -618,14 +617,14 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        assert_not_in('node_links', data['relationships'])
+        self.assertNotIn('node_links', data['relationships'])
 
         req = make_drf_request_with_version(version='2.1')
         data = RegistrationSerializer(
             self.registration,
             context={'request': req}
         ).data['data']
-        assert_not_in('node_links', data['relationships'])
+        self.assertNotIn('node_links', data['relationships'])
 
 
 class VersionedDateTimeField(DbTestCase):
@@ -648,7 +647,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(self.old_date, self.old_format),
             data['attributes']['date_modified']
         )
@@ -657,7 +656,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(
                 self.old_date_without_microseconds,
                 self.old_format_without_microseconds
@@ -669,7 +668,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(self.old_date, self.new_format),
             data['attributes']['date_modified']
         )
@@ -678,7 +677,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(
                 self.old_date_without_microseconds,
                 self.new_format
@@ -690,7 +689,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(self.new_date, self.old_format),
             data['attributes']['date_modified']
         )
@@ -699,7 +698,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(
                 self.new_date_without_microseconds,
                 self.old_format_without_microseconds
@@ -711,7 +710,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(self.new_date, self.new_format),
             data['attributes']['date_modified']
         )
@@ -720,7 +719,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(
                 self.new_date_without_microseconds,
                 self.new_format
@@ -735,7 +734,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.10')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert_equal(
+        self.assertEqual(
             datetime.strftime(self.old_date, self.new_format),
             data['attributes']['date_modified']
         )

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -197,16 +197,14 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
         non_registration_fields = ['registrations', 'draft_registrations', 'templated_by_count', 'settings', 'storage', 'children', 'groups', 'subjects_acceptable']
 
         for field in NodeSerializer._declared_fields:
-            self.assertIn(field, RegistrationSerializer._declared_fields)
+            assert field in RegistrationSerializer._declared_fields
             reg_field = RegistrationSerializer._declared_fields[field]
 
             if field not in visible_on_withdrawals and field not in non_registration_fields:
-                self.assertTrue(
-                    isinstance(reg_field, base_serializers.HideIfWithdrawal) or
-                    isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or
-                    isinstance(reg_field, base_serializers.ShowIfVersion) or
+                assert isinstance(reg_field, base_serializers.HideIfWithdrawal) or \
+                    isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or \
+                    isinstance(reg_field, base_serializers.ShowIfVersion) or \
                     isinstance(reg_field, base_serializers.ShowIfAdminScopeOrAnonymous)
-                )
 
     def test_hide_if_registration_fields(self):
 
@@ -222,8 +220,8 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
                 base_serializers.HideIfRegistration)]
 
         for field in hide_if_registration_fields:
-            self.assertIn(field, node_relationships)
-            self.assertNotIn(field, registration_relationships)
+            assert field in node_relationships
+            assert field not in registration_relationships
 
 
 class TestNullLinks(ApiTestCase):
@@ -232,9 +230,9 @@ class TestNullLinks(ApiTestCase):
         req = make_drf_request_with_version(version='2.0')
         rep = FakeSerializer(FakeModel, context={'request': req}).data['data']
 
-        self.assertNotIn('null_field', rep['links'])
-        self.assertIn('valued_field', rep['links'])
-        self.assertNotIn('null_link_field', rep['relationships'])
+        assert 'null_field' not in rep['links']
+        assert 'valued_field' in rep['links']
+        assert 'null_link_field' not in rep['relationships']
 
 
 class TestApiBaseSerializers(ApiTestCase):
@@ -266,10 +264,8 @@ class TestApiBaseSerializers(ApiTestCase):
                     serializer, 'get_absolute_url'
                 ), 'No get_absolute_url method'
 
-                self.assertNotEqual(
-                    serializer.get_absolute_url,
+                assert serializer.get_absolute_url != \
                     base_get_absolute_url
-                )
 
     def test_counts_not_included_in_link_fields_by_default(self):
 
@@ -282,11 +278,11 @@ class TestApiBaseSerializers(ApiTestCase):
                 for item in relation:
                     link = list(item['links'].values())[0]
                     link_meta = link.get('meta', {})
-                    self.assertNotIn('count', link_meta)
+                    assert 'count' not in link_meta
             else:
                 link = list(relation['links'].values())[0]
                 link_meta = link.get('meta', {})
-                self.assertNotIn('count', link_meta)
+                assert 'count' not in link_meta
 
     def test_counts_included_in_link_fields_with_related_counts_query_param(
             self):
@@ -302,7 +298,7 @@ class TestApiBaseSerializers(ApiTestCase):
             related_meta = getattr(field, 'related_meta', {})
             if related_meta and related_meta.get('count', False):
                 link = list(relation['links'].values())[0]
-                self.assertIn('count', link['meta'], field)
+                assert 'count' in link['meta'], field
 
     def test_related_counts_excluded_query_param_false(self):
 
@@ -315,11 +311,11 @@ class TestApiBaseSerializers(ApiTestCase):
                 for item in relation:
                     link = item['links'].values()[0]
                     link_meta = link.get('meta', {})
-                    self.assertNotIn('count', link_meta)
+                    assert 'count' not in link_meta
             else:
                 link = list(relation['links'].values())[0]
                 link_meta = link.get('meta', {})
-                self.assertNotIn('count', link_meta)
+                assert 'count' not in link_meta
 
     def test_invalid_related_counts_value_raises_bad_request(self):
 
@@ -328,7 +324,7 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'related_counts': 'fish'},
             expect_errors=True
         )
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
 
     def test_invalid_embed_value_raise_bad_request(self):
         res = self.app.get(
@@ -336,19 +332,15 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'embed': 'foo'},
             expect_errors=True
         )
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert res.json['errors'][0]['detail'] == \
             'The following fields are not embeddable: foo'
-        )
 
     def test_embed_does_not_remove_relationship(self):
         res = self.app.get(self.url, params={'embed': 'root'})
-        self.assertEqual(res.status_code, 200)
-        self.assertIn(
-            self.url,
+        assert res.status_code == 200
+        assert self.url in \
             res.json['data']['relationships']['root']['links']['related']['href']
-        )
 
     def test_counts_included_in_children_field_with_children_related_counts_query_param(
             self):
@@ -366,16 +358,16 @@ class TestApiBaseSerializers(ApiTestCase):
                     link = item['links'].values()[0]
                     related_meta = getattr(field, 'related_meta', {})
                     if related_meta and related_meta.get('count', False) and key == 'children':
-                        self.assertIn('count', link['meta'])
+                        assert 'count' in link['meta']
                     else:
-                        self.assertNotIn('count', link.get('meta', {}))
+                        assert 'count' not in link.get('meta', {})
             elif relation != {'data': None}:
                 link = list(relation['links'].values())[0]
                 related_meta = getattr(field, 'related_meta', {})
                 if related_meta and related_meta.get('count', False) and key == 'children':
-                    self.assertIn('count', link['meta'])
+                    assert 'count' in link['meta']
                 else:
-                    self.assertNotIn('count', link.get('meta', {}))
+                    assert 'count' not in link.get('meta', {})
 
     def test_counts_included_in_children_and_contributors_fields_with_field_csv_related_counts_query_param(
             self):
@@ -396,16 +388,16 @@ class TestApiBaseSerializers(ApiTestCase):
                     link = item['links'].values()[0]
                     related_meta = getattr(field, 'related_meta', {})
                     if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
-                        self.assertIn('count', link['meta'])
+                        assert 'count' in link['meta']
                     else:
-                        self.assertNotIn('count', link.get('meta', {}))
+                        assert 'count' not in link.get('meta', {})
             elif relation != {'data': None}:
                 link = list(relation['links'].values())[0]
                 related_meta = getattr(field, 'related_meta', {})
                 if related_meta and related_meta.get('count', False) and key == 'children' or key == 'contributors':
-                    self.assertIn('count', link['meta'])
+                    assert 'count' in link['meta']
                 else:
-                    self.assertNotIn('count', link.get('meta', {}))
+                    assert 'count' not in link.get('meta', {})
 
     def test_error_when_requesting_related_counts_for_attribute_field(self):
 
@@ -414,11 +406,9 @@ class TestApiBaseSerializers(ApiTestCase):
             params={'related_counts': 'title'},
             expect_errors=True
         )
-        self.assertEqual(res.status_code, http_status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
+        assert res.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert res.json['errors'][0]['detail'] == \
             "Acceptable values for the related_counts query param are 'true', 'false', or any of the relationship fields; got 'title'"
-        )
 
 
 @pytest.mark.django_db
@@ -486,9 +476,9 @@ class TestRelationshipField:
         ).data['data']
 
         meta = data['relationships']['parent_with_meta']['links']['related']['meta']
-        self.assertNotIn('count', meta)
-        self.assertIn('extra', meta)
-        self.assertEqual(meta['extra'], 'foo')
+        assert 'count' not in meta
+        assert 'extra' in meta
+        assert meta['extra'] == 'foo'
 
     def test_serializing_empty_to_one(self):
         req = make_drf_request_with_version(version='2.2')
@@ -518,14 +508,10 @@ class TestRelationshipField:
         ).data['data']
 
         relationship_field = data['relationships']['self_and_related_field']['links']
-        self.assertIn(
-            f'/v2/nodes/{node._id}/contributors/',
+        assert f'/v2/nodes/{node._id}/contributors/' in \
             relationship_field['self']['href']
-        )
-        self.assertIn(
-            f'/v2/nodes/{node._id}/',
+        assert f'/v2/nodes/{node._id}/' in \
             relationship_field['related']['href']
-        )
 
     def test_field_with_two_kwargs(self):
         req = make_drf_request_with_version(version='2.0')
@@ -535,10 +521,8 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['two_url_kwargs']['links']
-        self.assertIn(
-            f'/v2/nodes/{node._id}/node_links/{node._id}/',
+        assert f'/v2/nodes/{node._id}/node_links/{node._id}/' in \
             field['related']['href']
-        )
 
     def test_field_with_two_filters(self):
         req = make_drf_request_with_version(version='2.0')
@@ -548,14 +532,10 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['field_with_filters']['links']
-        self.assertIn(
-            quote('filter[target]=hello', safe='?='),
+        assert quote('filter[target]=hello', safe='?=') in \
             field['related']['href']
-        )
-        self.assertIn(
-            quote('filter[woop]=yea', safe='?='),
+        assert quote('filter[woop]=yea', safe='?=') in \
             field['related']['href']
-        )
 
     def test_field_with_callable_related_attrs(self):
         req = make_drf_request_with_version(version='2.0')
@@ -564,7 +544,7 @@ class TestRelationshipField:
         data = self.BasicNodeSerializer(
             node, context={'request': req}
         ).data['data']
-        self.assertNotIn('registered_from', data['relationships'])
+        assert 'registered_from' not in data['relationships']
 
         registration = factories.RegistrationFactory(project=node)
         data = self.BasicNodeSerializer(
@@ -572,7 +552,7 @@ class TestRelationshipField:
                 'request': req}
         ).data['data']
         field = data['relationships']['registered_from']['links']
-        self.assertIn(f'/v2/nodes/{node._id}/', field['related']['href'])
+        assert f'/v2/nodes/{node._id}/' in field['related']['href']
 
 
 class TestShowIfVersion(ApiTestCase):
@@ -585,12 +565,12 @@ class TestShowIfVersion(ApiTestCase):
     def test_node_links_allowed_version_node_serializer(self):
         req = make_drf_request_with_version(version='2.0')
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertIn('node_links', data['relationships'])
+        assert 'node_links' in data['relationships']
 
     def test_node_links_bad_version_node_serializer(self):
         req = make_drf_request_with_version(version='2.1')
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertNotIn('node_links', data['relationships'])
+        assert 'node_links' not in data['relationships']
 
     def test_node_links_allowed_version_registration_serializer(self):
         req = make_drf_request_with_version(version='2.0')
@@ -598,7 +578,7 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        self.assertIn('node_links', data['relationships'])
+        assert 'node_links' in data['relationships']
 
     def test_node_links_bad_version_registration_serializer(self):
         req = make_drf_request_with_version(version='2.1')
@@ -606,7 +586,7 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        self.assertNotIn('node_links', data['relationships'])
+        assert 'node_links' not in data['relationships']
 
     def test_node_links_withdrawn_registration(self):
         factories.WithdrawnRegistrationFactory(
@@ -617,14 +597,14 @@ class TestShowIfVersion(ApiTestCase):
             self.registration,
             context={'request': req}
         ).data['data']
-        self.assertNotIn('node_links', data['relationships'])
+        assert 'node_links' not in data['relationships']
 
         req = make_drf_request_with_version(version='2.1')
         data = RegistrationSerializer(
             self.registration,
             context={'request': req}
         ).data['data']
-        self.assertNotIn('node_links', data['relationships'])
+        assert 'node_links' not in data['relationships']
 
 
 class VersionedDateTimeField(DbTestCase):
@@ -647,85 +627,69 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(self.old_date, self.old_format),
+        assert datetime.strftime(self.old_date, self.old_format) == \
             data['attributes']['date_modified']
-        )
 
     def test_old_date_without_microseconds_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(
+        assert datetime.strftime(
                 self.old_date_without_microseconds,
                 self.old_format_without_microseconds
-            ),
+            ) == \
             data['attributes']['date_modified']
-        )
 
     def test_old_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(self.old_date, self.new_format),
+        assert datetime.strftime(self.old_date, self.new_format) == \
             data['attributes']['date_modified']
-        )
 
     def test_old_date_without_microseconds_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.old_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(
+        assert datetime.strftime(
                 self.old_date_without_microseconds,
                 self.new_format
-            ),
+            ) == \
             data['attributes']['date_modified']
-        )
 
     def test_new_date_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(self.new_date, self.old_format),
+        assert datetime.strftime(self.new_date, self.old_format) == \
             data['attributes']['date_modified']
-        )
 
     def test_new_date_without_microseconds_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(
+        assert datetime.strftime(
                 self.new_date_without_microseconds,
                 self.old_format_without_microseconds
-            ),
+            ) == \
             data['attributes']['date_modified']
-        )
 
     def test_new_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(self.new_date, self.new_format),
+        assert datetime.strftime(self.new_date, self.new_format) == \
             data['attributes']['date_modified']
-        )
 
     def test_new_date_without_microseconds_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.new_date_without_microseconds)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(
+        assert datetime.strftime(
                 self.new_date_without_microseconds,
                 self.new_format
-            ),
+            ) == \
             data['attributes']['date_modified']
-        )
 
     # regression test for https://openscience.atlassian.net/browse/PLAT-1350
     # VersionedDateTimeField was treating version 2.10 and higher as decimals,
@@ -734,7 +698,5 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.10')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        self.assertEqual(
-            datetime.strftime(self.old_date, self.new_format),
+        assert datetime.strftime(self.old_date, self.new_format) == \
             data['attributes']['date_modified']
-        )

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -201,10 +201,12 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
             reg_field = RegistrationSerializer._declared_fields[field]
 
             if field not in visible_on_withdrawals and field not in non_registration_fields:
-                assert isinstance(reg_field, base_serializers.HideIfWithdrawal) or \
-                    isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or \
-                    isinstance(reg_field, base_serializers.ShowIfVersion) or \
+                assert (
+                    isinstance(reg_field, base_serializers.HideIfWithdrawal) or
+                    isinstance(reg_field, base_serializers.HideIfWithdrawalOrWikiDisabled) or
+                    isinstance(reg_field, base_serializers.ShowIfVersion) or
                     isinstance(reg_field, base_serializers.ShowIfAdminScopeOrAnonymous)
+                )
 
     def test_hide_if_registration_fields(self):
 
@@ -260,12 +262,8 @@ class TestApiBaseSerializers(ApiTestCase):
             if serializer == WaffleSerializer or serializer == BaseWaffleSerializer:
                 continue
             if not re.match('^(api_test|test).*', serializer.__module__):
-                assert hasattr(
-                    serializer, 'get_absolute_url'
-                ), 'No get_absolute_url method'
-
-                assert serializer.get_absolute_url != \
-                    base_get_absolute_url
+                assert hasattr(serializer, 'get_absolute_url'), 'No get_absolute_url method'
+                assert serializer.get_absolute_url != base_get_absolute_url
 
     def test_counts_not_included_in_link_fields_by_default(self):
 
@@ -333,14 +331,12 @@ class TestApiBaseSerializers(ApiTestCase):
             expect_errors=True
         )
         assert res.status_code == http_status.HTTP_400_BAD_REQUEST
-        assert res.json['errors'][0]['detail'] == \
-            'The following fields are not embeddable: foo'
+        assert res.json['errors'][0]['detail'] == 'The following fields are not embeddable: foo'
 
     def test_embed_does_not_remove_relationship(self):
         res = self.app.get(self.url, params={'embed': 'root'})
         assert res.status_code == 200
-        assert self.url in \
-            res.json['data']['relationships']['root']['links']['related']['href']
+        assert self.url in res.json['data']['relationships']['root']['links']['related']['href']
 
     def test_counts_included_in_children_field_with_children_related_counts_query_param(
             self):
@@ -407,8 +403,11 @@ class TestApiBaseSerializers(ApiTestCase):
             expect_errors=True
         )
         assert res.status_code == http_status.HTTP_400_BAD_REQUEST
-        assert res.json['errors'][0]['detail'] == \
-            "Acceptable values for the related_counts query param are 'true', 'false', or any of the relationship fields; got 'title'"
+        assert (
+            res.json['errors'][0]['detail'] ==
+            "Acceptable values for the related_counts query param are 'true', 'false', "
+            "or any of the relationship fields; got 'title'"
+        )
 
 
 @pytest.mark.django_db
@@ -508,10 +507,8 @@ class TestRelationshipField:
         ).data['data']
 
         relationship_field = data['relationships']['self_and_related_field']['links']
-        assert f'/v2/nodes/{node._id}/contributors/' in \
-            relationship_field['self']['href']
-        assert f'/v2/nodes/{node._id}/' in \
-            relationship_field['related']['href']
+        assert f'/v2/nodes/{node._id}/contributors/' in relationship_field['self']['href']
+        assert f'/v2/nodes/{node._id}/' in relationship_field['related']['href']
 
     def test_field_with_two_kwargs(self):
         req = make_drf_request_with_version(version='2.0')
@@ -521,8 +518,7 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['two_url_kwargs']['links']
-        assert f'/v2/nodes/{node._id}/node_links/{node._id}/' in \
-            field['related']['href']
+        assert f'/v2/nodes/{node._id}/node_links/{node._id}/' in field['related']['href']
 
     def test_field_with_two_filters(self):
         req = make_drf_request_with_version(version='2.0')
@@ -532,10 +528,8 @@ class TestRelationshipField:
             node, context={'request': req}
         ).data['data']
         field = data['relationships']['field_with_filters']['links']
-        assert quote('filter[target]=hello', safe='?=') in \
-            field['related']['href']
-        assert quote('filter[woop]=yea', safe='?=') in \
-            field['related']['href']
+        assert quote('filter[target]=hello', safe='?=') in field['related']['href']
+        assert quote('filter[woop]=yea', safe='?=') in field['related']['href']
 
     def test_field_with_callable_related_attrs(self):
         req = make_drf_request_with_version(version='2.0')
@@ -627,8 +621,7 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert datetime.strftime(self.old_date, self.old_format) == \
-            data['attributes']['date_modified']
+        assert datetime.strftime(self.old_date, self.old_format) == data['attributes']['date_modified']
 
     def test_old_date_without_microseconds_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
@@ -637,15 +630,13 @@ class VersionedDateTimeField(DbTestCase):
         assert datetime.strftime(
                 self.old_date_without_microseconds,
                 self.old_format_without_microseconds
-            ) == \
-            data['attributes']['date_modified']
+            ) == data['attributes']['date_modified']
 
     def test_old_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert datetime.strftime(self.old_date, self.new_format) == \
-            data['attributes']['date_modified']
+        assert datetime.strftime(self.old_date, self.new_format) == data['attributes']['date_modified']
 
     def test_old_date_without_microseconds_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
@@ -654,15 +645,13 @@ class VersionedDateTimeField(DbTestCase):
         assert datetime.strftime(
                 self.old_date_without_microseconds,
                 self.new_format
-            ) == \
-            data['attributes']['date_modified']
+            ) == data['attributes']['date_modified']
 
     def test_new_date_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert datetime.strftime(self.new_date, self.old_format) == \
-            data['attributes']['date_modified']
+        assert datetime.strftime(self.new_date, self.old_format) == data['attributes']['date_modified']
 
     def test_new_date_without_microseconds_formats_to_old_format(self):
         req = make_drf_request_with_version(version='2.0')
@@ -671,15 +660,13 @@ class VersionedDateTimeField(DbTestCase):
         assert datetime.strftime(
                 self.new_date_without_microseconds,
                 self.old_format_without_microseconds
-            ) == \
-            data['attributes']['date_modified']
+            ) == data['attributes']['date_modified']
 
     def test_new_date_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
         setattr(self.node, 'last_logged', self.new_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert datetime.strftime(self.new_date, self.new_format) == \
-            data['attributes']['date_modified']
+        assert datetime.strftime(self.new_date, self.new_format) == data['attributes']['date_modified']
 
     def test_new_date_without_microseconds_formats_to_new_format(self):
         req = make_drf_request_with_version(version='2.2')
@@ -688,8 +675,7 @@ class VersionedDateTimeField(DbTestCase):
         assert datetime.strftime(
                 self.new_date_without_microseconds,
                 self.new_format
-            ) == \
-            data['attributes']['date_modified']
+            ) == data['attributes']['date_modified']
 
     # regression test for https://openscience.atlassian.net/browse/PLAT-1350
     # VersionedDateTimeField was treating version 2.10 and higher as decimals,
@@ -698,5 +684,4 @@ class VersionedDateTimeField(DbTestCase):
         req = make_drf_request_with_version(version='2.10')
         setattr(self.node, 'last_logged', self.old_date)
         data = NodeSerializer(self.node, context={'request': req}).data['data']
-        assert datetime.strftime(self.old_date, self.new_format) == \
-            data['attributes']['date_modified']
+        assert datetime.strftime(self.old_date, self.new_format) == data['attributes']['date_modified']

--- a/api_tests/base/test_throttling.py
+++ b/api_tests/base/test_throttling.py
@@ -14,8 +14,8 @@ class TestDefaultThrottleClasses(ApiTestCase):
         '''
         base_url = f'/{API_BASE}nodes/'
         res = self.app.get(base_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_base.call_count, 4)  # UserRateThrottle get_ident is called twice due to cache key
+        assert res.status_code == 200
+        assert mock_base.call_count == 4  # UserRateThrottle get_ident is called twice due to cache key
 
 
 class TestRootThrottle(ApiTestCase):
@@ -28,14 +28,14 @@ class TestRootThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.RootAnonThrottle.allow_request')
     def test_root_throttle_unauthenticated_request(self, mock_allow):
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 1)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 1
 
     @mock.patch('rest_framework.throttling.UserRateThrottle.allow_request')
     def test_root_throttle_authenticated_request(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 1)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 1
 
 
 class TestUserRateThrottle(ApiTestCase):
@@ -48,8 +48,8 @@ class TestUserRateThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.UserRateThrottle.allow_request')
     def test_user_rate_allow_request_called(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 1)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 1
 
 
 class TestBurstRateThrottle(ApiTestCase):
@@ -62,8 +62,8 @@ class TestBurstRateThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.BurstRateThrottle.allow_request')
     def test_user_rate_allow_request_called(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 1)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 1
 
 
 class TestNonCookieAuthThrottle(ApiTestCase):
@@ -78,8 +78,8 @@ class TestNonCookieAuthThrottle(ApiTestCase):
         two sibling classes of throttle.
         '''
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 2)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 2
 
 
 class TestAddContributorEmailThrottle(ApiTestCase):
@@ -116,8 +116,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
     def test_add_contrib_throttle_rate_allow_request_not_called(
             self, mock_allow):
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(mock_allow.call_count, 0)
+        assert res.status_code == 200
+        assert mock_allow.call_count == 0
 
     @mock.patch('api.base.throttling.AddContributorThrottle.allow_request')
     def test_add_contrib_throttle_rate_allow_request_called(self, mock_allow):
@@ -125,8 +125,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
             self.public_url,
             self.data_user_two,
             auth=self.user.auth)
-        self.assertEqual(res.status_code, 201)
-        self.assertEqual(mock_allow.call_count, 1)
+        assert res.status_code == 201
+        assert mock_allow.call_count == 1
 
     @mock.patch('api.base.throttling.NonCookieAuthThrottle.allow_request')
     @mock.patch('rest_framework.throttling.UserRateThrottle.allow_request')
@@ -134,8 +134,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
     def test_add_contrib_throttle_rate_and_default_rates_called(
             self, mock_contrib_allow, mock_user_allow, mock_anon_allow):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         # NonCookieAuthThrottle is called twice as it's used by two sibling classes of throttle.
-        self.assertEqual(mock_anon_allow.call_count, 2)
-        self.assertEqual(mock_user_allow.call_count, 1)
-        self.assertEqual(mock_contrib_allow.call_count, 1)
+        assert mock_anon_allow.call_count == 2
+        assert mock_user_allow.call_count == 1
+        assert mock_contrib_allow.call_count == 1

--- a/api_tests/base/test_throttling.py
+++ b/api_tests/base/test_throttling.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from nose.tools import *  # noqa:
 
 from api.base.settings.defaults import API_BASE
 
@@ -15,8 +14,8 @@ class TestDefaultThrottleClasses(ApiTestCase):
         '''
         base_url = f'/{API_BASE}nodes/'
         res = self.app.get(base_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_base.call_count, 4)  # UserRateThrottle get_ident is called twice due to cache key
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_base.call_count, 4)  # UserRateThrottle get_ident is called twice due to cache key
 
 
 class TestRootThrottle(ApiTestCase):
@@ -29,14 +28,14 @@ class TestRootThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.RootAnonThrottle.allow_request')
     def test_root_throttle_unauthenticated_request(self, mock_allow):
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 1)
 
     @mock.patch('rest_framework.throttling.UserRateThrottle.allow_request')
     def test_root_throttle_authenticated_request(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 1)
 
 
 class TestUserRateThrottle(ApiTestCase):
@@ -49,8 +48,8 @@ class TestUserRateThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.UserRateThrottle.allow_request')
     def test_user_rate_allow_request_called(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 1)
 
 
 class TestBurstRateThrottle(ApiTestCase):
@@ -63,8 +62,8 @@ class TestBurstRateThrottle(ApiTestCase):
     @mock.patch('api.base.throttling.BurstRateThrottle.allow_request')
     def test_user_rate_allow_request_called(self, mock_allow):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 1)
 
 
 class TestNonCookieAuthThrottle(ApiTestCase):
@@ -79,8 +78,8 @@ class TestNonCookieAuthThrottle(ApiTestCase):
         two sibling classes of throttle.
         '''
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 2)
 
 
 class TestAddContributorEmailThrottle(ApiTestCase):
@@ -117,8 +116,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
     def test_add_contrib_throttle_rate_allow_request_not_called(
             self, mock_allow):
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(mock_allow.call_count, 0)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(mock_allow.call_count, 0)
 
     @mock.patch('api.base.throttling.AddContributorThrottle.allow_request')
     def test_add_contrib_throttle_rate_allow_request_called(self, mock_allow):
@@ -126,8 +125,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
             self.public_url,
             self.data_user_two,
             auth=self.user.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(mock_allow.call_count, 1)
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(mock_allow.call_count, 1)
 
     @mock.patch('api.base.throttling.NonCookieAuthThrottle.allow_request')
     @mock.patch('rest_framework.throttling.UserRateThrottle.allow_request')
@@ -135,8 +134,8 @@ class TestAddContributorEmailThrottle(ApiTestCase):
     def test_add_contrib_throttle_rate_and_default_rates_called(
             self, mock_contrib_allow, mock_user_allow, mock_anon_allow):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         # NonCookieAuthThrottle is called twice as it's used by two sibling classes of throttle.
-        assert_equal(mock_anon_allow.call_count, 2)
-        assert_equal(mock_user_allow.call_count, 1)
-        assert_equal(mock_contrib_allow.call_count, 1)
+        self.assertEqual(mock_anon_allow.call_count, 2)
+        self.assertEqual(mock_user_allow.call_count, 1)
+        self.assertEqual(mock_contrib_allow.call_count, 1)

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -1,4 +1,3 @@
-from nose.tools import *  # noqa:
 from unittest import mock
 import unittest
 import pytest
@@ -20,102 +19,82 @@ class TestTruthyFalsy:
     """
 
     def test_truthy(self):
-        assert_equal(api_utils.TRUTHY, fields.BooleanField.TRUE_VALUES)
+        assert api_utils.TRUTHY == fields.BooleanField.TRUE_VALUES
 
     def test_falsy(self):
-        assert_equal(api_utils.FALSY, fields.BooleanField.FALSE_VALUES)
+        assert api_utils.FALSY == fields.BooleanField.FALSE_VALUES
 
 
 class TestIsDeprecated(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.min_version = '2.0'
-        self.max_version = '2.5'
+        self.min_version = "2.0"
+        self.max_version = "2.5"
 
     def test_is_deprecated(self):
-        request_version = '2.6'
-        is_deprecated = api_utils.is_deprecated(
-            request_version, self.min_version, self.max_version)
-        assert_equal(is_deprecated, True)
+        request_version = "2.6"
+        is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
+        assert is_deprecated == True
 
     def test_is_not_deprecated(self):
-        request_version = '2.5'
-        is_deprecated = api_utils.is_deprecated(
-            request_version, self.min_version, self.max_version)
-        assert_equal(is_deprecated, False)
+        request_version = "2.5"
+        is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
+        assert is_deprecated == False
 
     def test_is_deprecated_larger_versions(self):
-        request_version = '2.10'
-        is_deprecated = api_utils.is_deprecated(
-            request_version, self.min_version, self.max_version
-        )
+        request_version = "2.10"
+        is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
         assert is_deprecated is True
+
 
 @pytest.mark.django_db
 class TestFlaskDjangoIntegration:
     def test_push_status_message_no_response(self):
-        status_message = 'This is a message'
-        statuses = ['info', 'warning', 'warn', 'success', 'danger', 'default']
+        status_message = "This is a message"
+        statuses = ["info", "warning", "warn", "success", "danger", "default"]
         for status in statuses:
             try:
-                with mock.patch('framework.status.get_session', return_value=SessionStore()):
+                with mock.patch("framework.status.get_session", return_value=SessionStore()):
                     push_status_message(status_message, kind=status)
             except BaseException:
-                assert_true(
-                    False,
-                    f'Exception from push_status_message via API v2 with type "{status}".'
-                )
+                assert False, f'Exception from push_status_message via API v2 with type "{status}".'
 
     def test_push_status_message_expected_error(self):
-        status_message = 'This is a message'
+        status_message = "This is a message"
         try:
-            push_status_message(status_message, kind='error')
-            assert_true(
-                False,
-                'push_status_message() should have generated a ValidationError exception.'
-            )
-        except ValidationError as e:
-            assert_equal(
-                e.detail[0],
-                status_message,
-                'push_status_message() should have passed along the message with the Exception.'
-            )
-        except RuntimeError:
-            assert_true(
-                False,
-                'push_status_message() should have caught the runtime error and replaced it.'
-            )
-        except BaseException:
-            assert_true(
-                False,
-                'Exception from push_status_message when called from the v2 API with type "error"'
-            )
+            push_status_message(status_message, kind="error")
+            assert False, "push_status_message() should have generated a ValidationError exception."
 
-    @mock.patch('framework.status.get_session')
+        except ValidationError as e:
+            assert (
+                e.detail[0] == status_message
+            ), "push_status_message() should have passed along the message with the Exception."
+
+        except RuntimeError:
+            assert False, "push_status_message() should have caught the runtime error and replaced it."
+
+        except BaseException:
+            assert False, 'Exception from push_status_message when called from the v2 API with type "error"'
+
+    @mock.patch("framework.status.get_session")
     def test_push_status_message_unexpected_error(self, mock_get_session):
-        status_message = 'This is a message'
-        exception_message = 'this is some very unexpected problem'
+        status_message = "This is a message"
+        exception_message = "this is some very unexpected problem"
         mock_session = mock.Mock()
-        mock_session.attach_mock(mock.Mock(side_effect=RuntimeError(exception_message)), 'get')
+        mock_session.attach_mock(mock.Mock(side_effect=RuntimeError(exception_message)), "get")
         mock_get_session.return_value = mock_session
         try:
-            push_status_message(status_message, kind='error')
-            assert_true(
-                False,
-                'push_status_message() should have generated a RuntimeError exception.'
-            )
+            push_status_message(status_message, kind="error")
+            assert False, "push_status_message() should have generated a RuntimeError exception."
         except ValidationError:
-            assert_true(
-                False,
-                'push_status_message() should have re-raised the RuntimeError not gotten ValidationError.'
-            )
+            assert False, "push_status_message() should have re-raised the RuntimeError not gotten ValidationError."
         except RuntimeError as e:
-            assert_equal(str(e),
-                         exception_message,
-                         'push_status_message() should have re-raised the '
-                         'original RuntimeError with the original message.')
+            assert str(e) == exception_message, (
+                "push_status_message() should have re-raised the " "original RuntimeError with the original message."
+            )
+
         except BaseException:
-            assert_true(
-                False, 'Unexpected Exception from push_status_message when called '
-                'from the v2 API with type "error"')
+            assert False, (
+                "Unexpected Exception from push_status_message when called " 'from the v2 API with type "error"'
+            )

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -29,21 +29,21 @@ class TestIsDeprecated(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.min_version = "2.0"
-        self.max_version = "2.5"
+        self.min_version = '2.0'
+        self.max_version = '2.5'
 
     def test_is_deprecated(self):
-        request_version = "2.6"
+        request_version = '2.6'
         is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
-        assert is_deprecated == True
+        assert is_deprecated is True
 
     def test_is_not_deprecated(self):
-        request_version = "2.5"
+        request_version = '2.5'
         is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
-        assert is_deprecated == False
+        assert is_deprecated is False
 
     def test_is_deprecated_larger_versions(self):
-        request_version = "2.10"
+        request_version = '2.10'
         is_deprecated = api_utils.is_deprecated(request_version, self.min_version, self.max_version)
         assert is_deprecated is True
 
@@ -51,50 +51,50 @@ class TestIsDeprecated(unittest.TestCase):
 @pytest.mark.django_db
 class TestFlaskDjangoIntegration:
     def test_push_status_message_no_response(self):
-        status_message = "This is a message"
-        statuses = ["info", "warning", "warn", "success", "danger", "default"]
+        status_message = 'This is a message'
+        statuses = ['info', 'warning', 'warn', 'success', 'danger', 'default']
         for status in statuses:
             try:
-                with mock.patch("framework.status.get_session", return_value=SessionStore()):
+                with mock.patch('framework.status.get_session', return_value=SessionStore()):
                     push_status_message(status_message, kind=status)
             except BaseException:
                 assert False, f'Exception from push_status_message via API v2 with type "{status}".'
 
     def test_push_status_message_expected_error(self):
-        status_message = "This is a message"
+        status_message = 'This is a message'
         try:
-            push_status_message(status_message, kind="error")
-            assert False, "push_status_message() should have generated a ValidationError exception."
+            push_status_message(status_message, kind='error')
+            assert False, 'push_status_message() should have generated a ValidationError exception.'
 
         except ValidationError as e:
             assert (
                 e.detail[0] == status_message
-            ), "push_status_message() should have passed along the message with the Exception."
+            ), 'push_status_message() should have passed along the message with the Exception.'
 
         except RuntimeError:
-            assert False, "push_status_message() should have caught the runtime error and replaced it."
+            assert False, 'push_status_message() should have caught the runtime error and replaced it.'
 
         except BaseException:
             assert False, 'Exception from push_status_message when called from the v2 API with type "error"'
 
-    @mock.patch("framework.status.get_session")
+    @mock.patch('framework.status.get_session')
     def test_push_status_message_unexpected_error(self, mock_get_session):
-        status_message = "This is a message"
-        exception_message = "this is some very unexpected problem"
+        status_message = 'This is a message'
+        exception_message = 'this is some very unexpected problem'
         mock_session = mock.Mock()
-        mock_session.attach_mock(mock.Mock(side_effect=RuntimeError(exception_message)), "get")
+        mock_session.attach_mock(mock.Mock(side_effect=RuntimeError(exception_message)), 'get')
         mock_get_session.return_value = mock_session
         try:
-            push_status_message(status_message, kind="error")
-            assert False, "push_status_message() should have generated a RuntimeError exception."
+            push_status_message(status_message, kind='error')
+            assert False, 'push_status_message() should have generated a RuntimeError exception.'
         except ValidationError:
-            assert False, "push_status_message() should have re-raised the RuntimeError not gotten ValidationError."
+            assert False, 'push_status_message() should have re-raised the RuntimeError not gotten ValidationError.'
         except RuntimeError as e:
             assert str(e) == exception_message, (
-                "push_status_message() should have re-raised the " "original RuntimeError with the original message."
+                'push_status_message() should have re-raised the ' 'original RuntimeError with the original message.'
             )
 
         except BaseException:
             assert False, (
-                "Unexpected Exception from push_status_message when called " 'from the v2 API with type "error"'
+                'Unexpected Exception from push_status_message when called ' 'from the v2 API with type "error"'
             )

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -148,7 +148,7 @@ class TestStatusView(ApiTestCase):
         res = self.app.get(url)
         assert res.status_code == 200
         assert 'maintenance' in res.json
-        assert res.json['maintenance'] == None
+        assert res.json['maintenance'] is None
 
     def test_status_view_with_maintenance(self):
         maintenance.set_maintenance(message='test')

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -88,12 +88,9 @@ class TestApiBaseViews(ApiTestCase):
             for cls in base_permissions:
                 if isinstance(cls, tuple):
                     has_cls = any([c in view.permission_classes for c in cls])
-                    assert has_cls, \
-                        f'{view} lacks the appropriate permission classes'
+                    assert has_cls, f'{view} lacks the appropriate permission classes'
                 else:
-                    assert cls in \
-                        view.permission_classes, \
-                        f'{view} lacks the appropriate permission classes'
+                    assert cls in view.permission_classes, f'{view} lacks the appropriate permission classes'
             for key in [READ, WRITE]:
                 scopes = getattr(view, f'required_{key}_scopes', None)
                 assert bool(scopes)
@@ -106,14 +103,12 @@ class TestApiBaseViews(ApiTestCase):
         for view in VIEW_CLASSES:
             if view in self.EXCLUDED_VIEWS:
                 continue
-            assert hasattr(view, '_get_embed_partial'), \
-                f'{view} lacks embed support'
+            assert hasattr(view, '_get_embed_partial'), f'{view} lacks embed support'
 
     def test_view_classes_define_or_override_serializer_class(self):
         for view in VIEW_CLASSES:
             has_serializer_class = getattr(view, 'serializer_class', None) or getattr(view, 'get_serializer_class', None)
-            assert has_serializer_class, \
-                f'{view} should include serializer class or override get_serializer_class()'
+            assert has_serializer_class, f'{view} should include serializer class or override get_serializer_class()'
 
     @mock.patch(
         'osf.models.OSFUser.is_confirmed',

--- a/api_tests/draft_nodes/views/test_draft_node_draft_registrations_list.py
+++ b/api_tests/draft_nodes/views/test_draft_node_draft_registrations_list.py
@@ -36,8 +36,7 @@ class TestDraftNodeDraftRegistrationsList:
     @pytest.fixture()
     def url_draft_node_draft_registrations(self, draft_node):
         # Specifies version to test functionality when using DraftRegistrationLegacySerializer
-        return '/{}draft_nodes/{}/draft_registrations/'.format(
-            API_BASE, draft_node._id)
+        return '/{}draft_nodes/{}/draft_registrations/'.format(API_BASE, draft_node._id)
 
     def test_draft_node_draft_registration_list(
             self, app, user, user_write_contrib, draft_registration, draft_node, url_draft_node_draft_registrations):

--- a/api_tests/draft_nodes/views/test_draft_node_files_lists.py
+++ b/api_tests/draft_nodes/views/test_draft_node_files_lists.py
@@ -70,17 +70,17 @@ class TestDraftNodeProvidersList(ApiTestCase):
         assert data['attributes']['provider'] == 'osfstorage'
         assert data['attributes']['node'] == self.draft_node._id
         assert data['attributes']['path'] == '/'
-        assert data['relationships']['target']['links']['related']['href'] == \
+        assert (
+            data['relationships']['target']['links']['related']['href'] ==
             f'{settings.API_DOMAIN}v2/draft_nodes/{self.draft_node._id}/'
+        )
 
     def test_returns_osfstorage_folder_version_two(self):
-        res = self.app.get(
-            f'{self.url}osfstorage/', auth=self.user.auth)
+        res = self.app.get(f'{self.url}osfstorage/', auth=self.user.auth)
         assert res.status_code == 200
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
-        res = self.app.get(
-            f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
+        res = self.app.get(f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
         assert res.status_code == 200
 
 
@@ -246,8 +246,7 @@ class TestNodeFilesList(ApiTestCase):
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(
@@ -261,8 +260,7 @@ class TestNodeFilesList(ApiTestCase):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
         self.draft_node.add_addon('github', auth=user_auth)
         addon = self.draft_node.get_addon('github')
@@ -447,8 +445,7 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert not self.draft_node.get_addon(provider)
         assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == \
-            f'The {provider} provider is not configured for this project.'
+        assert res.json['errors'][0]['detail'] == f'The {provider} provider is not configured for this project.'
 
     @responses.activate
     def test_handles_bad_waterbutler_request(self):
@@ -700,8 +697,7 @@ class TestDraftNodeStorageProviderDetail(ApiTestCase):
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert res.status_code == 200
-        assert res.json['data']['id'] == \
-            f'{self.draft_node._id}:osfstorage'
+        assert res.json['data']['id'] == f'{self.draft_node._id}:osfstorage'
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)

--- a/api_tests/draft_nodes/views/test_draft_node_files_lists.py
+++ b/api_tests/draft_nodes/views/test_draft_node_files_lists.py
@@ -61,29 +61,27 @@ class TestDraftNodeProvidersList(ApiTestCase):
 
     def test_returns_provider_data(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertTrue(isinstance(res.json['data'], list))
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.status_code == 200
+        assert isinstance(res.json['data'], list)
+        assert res.content_type == 'application/vnd.api+json'
         data = res.json['data'][0]
-        self.assertEqual(data['attributes']['kind'], 'folder')
-        self.assertEqual(data['attributes']['name'], 'osfstorage')
-        self.assertEqual(data['attributes']['provider'], 'osfstorage')
-        self.assertEqual(data['attributes']['node'], self.draft_node._id)
-        self.assertEqual(data['attributes']['path'], '/')
-        self.assertEqual(
-            data['relationships']['target']['links']['related']['href'],
+        assert data['attributes']['kind'] == 'folder'
+        assert data['attributes']['name'] == 'osfstorage'
+        assert data['attributes']['provider'] == 'osfstorage'
+        assert data['attributes']['node'] == self.draft_node._id
+        assert data['attributes']['path'] == '/'
+        assert data['relationships']['target']['links']['related']['href'] == \
             f'{settings.API_DOMAIN}v2/draft_nodes/{self.draft_node._id}/'
-        )
 
     def test_returns_osfstorage_folder_version_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
 
 def prepare_mock_wb_response(
@@ -187,7 +185,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_storage_addons_link(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertIn('storage_addons', res.json['data'][0]['links'])
+        assert 'storage_addons' in res.json['data'][0]['links']
 
     def test_returns_file_data(self):
         fobj = self.draft_node.get_addon(
@@ -195,11 +193,11 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertTrue(isinstance(res.json['data'], dict))
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(res.json['data']['attributes']['kind'], 'file')
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        assert res.status_code == 200
+        assert isinstance(res.json['data'], dict)
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['data']['attributes']['kind'] == 'file'
+        assert res.json['data']['attributes']['name'] == 'NewFile'
 
     def test_returns_osfstorage_folder_version_two(self):
         fobj = self.draft_node.get_addon(
@@ -207,7 +205,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         fobj = self.draft_node.get_addon(
@@ -215,7 +213,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/?version=2.2', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_list_returns_folder_data(self):
         fobj = self.draft_node.get_addon(
@@ -223,10 +221,10 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFolder')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['data'][0]['attributes']['name'] == 'NewFolder'
 
     def test_returns_folder_data(self):
         fobj = self.draft_node.get_addon(
@@ -234,41 +232,37 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 0)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 0
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 401
+        assert 'detail' in res.json['errors'][0]
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(
             self.private_url,
             auth=self.user_two.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 403
+        assert 'detail' in res.json['errors'][0]
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
         self.draft_node.add_addon('github', auth=user_auth)
         addon = self.draft_node.get_addon('github')
@@ -289,9 +283,9 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth)
         data = res.json['data']
         providers = [item['attributes']['provider'] for item in data]
-        self.assertEqual(len(data), 2)
-        self.assertIn('github', providers)
-        self.assertIn('osfstorage', providers)
+        assert len(data) == 2
+        assert 'github' in providers
+        assert 'osfstorage' in providers
 
     @responses.activate
     def test_vol_node_files_list(self):
@@ -305,14 +299,14 @@ class TestNodeFilesList(ApiTestCase):
         wb_request = responses.calls[-1].request
         url = furl.furl(wb_request.url)
 
-        self.assertEqual(url.query, f'meta=True&view_only={vol.key}')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
-        self.assertIn(vol.key, res.json['data'][0]['links']['info'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['move'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['upload'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['download'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['delete'])
+        assert url.query == f'meta=True&view_only={vol.key}'
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
+        assert vol.key in res.json['data'][0]['links']['info']
+        assert vol.key in res.json['data'][0]['links']['move']
+        assert vol.key in res.json['data'][0]['links']['upload']
+        assert vol.key in res.json['data'][0]['links']['download']
+        assert vol.key in res.json['data'][0]['links']['delete']
 
     @responses.activate
     def test_returns_node_files_list(self):
@@ -323,13 +317,13 @@ class TestNodeFilesList(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_returns_folder_metadata_not_children(self):
@@ -344,10 +338,10 @@ class TestNodeFilesList(ApiTestCase):
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/Folder/'
         res = self.app.get(url, params={'info': ''}, auth=self.user.auth)
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data'][0]['attributes']['kind'], 'folder')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'Folder')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data'][0]['attributes']['kind'] == 'folder'
+        assert res.json['data'][0]['attributes']['name'] == 'Folder'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_returns_node_file(self):
@@ -361,14 +355,14 @@ class TestNodeFilesList(ApiTestCase):
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         # test create
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['name'] == 'NewFile'
+        assert res.json['data']['attributes']['provider'] == 'github'
 
         # test get
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['name'] == 'NewFile'
+        assert res.json['data']['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_notfound_node_file_returns_folder(self):
@@ -382,7 +376,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     @responses.activate
     def test_notfound_node_folder_returns_file(self):
@@ -396,7 +390,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     @responses.activate
     def test_waterbutler_server_error_returns_503(self):
@@ -408,7 +402,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 503)
+        assert res.status_code == 503
 
     @responses.activate
     def test_waterbutler_invalid_data_returns_503(self):
@@ -424,7 +418,7 @@ class TestNodeFilesList(ApiTestCase):
         )
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 503)
+        assert res.status_code == 503
 
     @responses.activate
     def test_handles_unauthenticated_waterbutler_request(self):
@@ -432,8 +426,8 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 403
+        assert 'detail' in res.json['errors'][0]
 
     @responses.activate
     def test_handles_notfound_waterbutler_request(self):
@@ -443,19 +437,18 @@ class TestNodeFilesList(ApiTestCase):
         url = '/{}draft_nodes/{}/files/{}/'.format(API_BASE,
                                              self.draft_node._id, invalid_provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 404
+        assert 'detail' in res.json['errors'][0]
 
     def test_handles_request_to_provider_not_configured_on_project(self):
         provider = 'box'
         url = '/{}draft_nodes/{}/files/{}/'.format(
             API_BASE, self.draft_node._id, provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertFalse(self.draft_node.get_addon(provider))
-        self.assertEqual(res.status_code, 404)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            f'The {provider} provider is not configured for this project.')
+        assert not self.draft_node.get_addon(provider)
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == \
+            f'The {provider} provider is not configured for this project.'
 
     @responses.activate
     def test_handles_bad_waterbutler_request(self):
@@ -471,12 +464,12 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 503)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 503
+        assert 'detail' in res.json['errors'][0]
 
     def test_files_list_contains_relationships_object(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         assert 'relationships' in res.json['data'][0]
 
 
@@ -523,15 +516,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'abc'
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'abc'
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
     @responses.activate
     def test_node_files_filter_by_name_case_insensitive(self):
@@ -541,17 +534,17 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         # filters out 'abc', but finds 'xyz'
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         # filters out 'abc', but finds 'xyz'
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
     @responses.activate
     def test_node_files_are_filterable_by_path(self):
@@ -561,15 +554,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
     @responses.activate
     def test_node_files_are_filterable_by_kind(self):
@@ -579,15 +572,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
     @responses.activate
     def test_node_files_external_provider_can_filter_by_last_touched(self):
@@ -597,13 +590,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
             API_BASE, self.draft_node._id, yesterday_stamp.isoformat())
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 2)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 2)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
         yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
@@ -614,13 +607,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(len(res.json['errors']), 1)
+        assert res.status_code == 400
+        assert len(res.json['errors']) == 1
 
         # test get
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(len(res.json['errors']), 1)
+        assert res.status_code == 400
+        assert len(res.json['errors']) == 1
 
 
 class TestNodeFilesListPagination(ApiTestCase):
@@ -706,12 +699,10 @@ class TestDraftNodeStorageProviderDetail(ApiTestCase):
 
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['id'],
+        assert res.status_code == 200
+        assert res.json['data']['id'] == \
             f'{self.draft_node._id}:osfstorage'
-        )
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401

--- a/api_tests/draft_nodes/views/test_draft_node_files_lists.py
+++ b/api_tests/draft_nodes/views/test_draft_node_files_lists.py
@@ -4,8 +4,6 @@ import datetime
 import json
 from django.utils import timezone
 
-from nose.tools import *  # noqa: F403
-
 from framework.auth.core import Auth
 
 from api.base.settings.defaults import API_BASE
@@ -63,16 +61,16 @@ class TestDraftNodeProvidersList(ApiTestCase):
 
     def test_returns_provider_data(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_true(isinstance(res.json['data'], list))
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(isinstance(res.json['data'], list))
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
         data = res.json['data'][0]
-        assert_equal(data['attributes']['kind'], 'folder')
-        assert_equal(data['attributes']['name'], 'osfstorage')
-        assert_equal(data['attributes']['provider'], 'osfstorage')
-        assert_equal(data['attributes']['node'], self.draft_node._id)
-        assert_equal(data['attributes']['path'], '/')
-        assert_equal(
+        self.assertEqual(data['attributes']['kind'], 'folder')
+        self.assertEqual(data['attributes']['name'], 'osfstorage')
+        self.assertEqual(data['attributes']['provider'], 'osfstorage')
+        self.assertEqual(data['attributes']['node'], self.draft_node._id)
+        self.assertEqual(data['attributes']['path'], '/')
+        self.assertEqual(
             data['relationships']['target']['links']['related']['href'],
             f'{settings.API_DOMAIN}v2/draft_nodes/{self.draft_node._id}/'
         )
@@ -80,12 +78,12 @@ class TestDraftNodeProvidersList(ApiTestCase):
     def test_returns_osfstorage_folder_version_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
 
 def prepare_mock_wb_response(
@@ -189,7 +187,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_storage_addons_link(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_in('storage_addons', res.json['data'][0]['links'])
+        self.assertIn('storage_addons', res.json['data'][0]['links'])
 
     def test_returns_file_data(self):
         fobj = self.draft_node.get_addon(
@@ -197,11 +195,11 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_true(isinstance(res.json['data'], dict))
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['kind'], 'file')
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(isinstance(res.json['data'], dict))
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.json['data']['attributes']['kind'], 'file')
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
 
     def test_returns_osfstorage_folder_version_two(self):
         fobj = self.draft_node.get_addon(
@@ -209,7 +207,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         fobj = self.draft_node.get_addon(
@@ -217,7 +215,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/?version=2.2', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_list_returns_folder_data(self):
         fobj = self.draft_node.get_addon(
@@ -225,10 +223,10 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFolder')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFolder')
 
     def test_returns_folder_data(self):
         fobj = self.draft_node.get_addon(
@@ -236,21 +234,21 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 0)
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 0)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 401)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
@@ -260,14 +258,14 @@ class TestNodeFilesList(ApiTestCase):
             self.private_url,
             auth=self.user_two.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 403)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
@@ -291,9 +289,9 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth)
         data = res.json['data']
         providers = [item['attributes']['provider'] for item in data]
-        assert_equal(len(data), 2)
-        assert_in('github', providers)
-        assert_in('osfstorage', providers)
+        self.assertEqual(len(data), 2)
+        self.assertIn('github', providers)
+        self.assertIn('osfstorage', providers)
 
     @responses.activate
     def test_vol_node_files_list(self):
@@ -307,14 +305,14 @@ class TestNodeFilesList(ApiTestCase):
         wb_request = responses.calls[-1].request
         url = furl.furl(wb_request.url)
 
-        assert_equal(url.query, f'meta=True&view_only={vol.key}')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
-        assert_in(vol.key, res.json['data'][0]['links']['info'])
-        assert_in(vol.key, res.json['data'][0]['links']['move'])
-        assert_in(vol.key, res.json['data'][0]['links']['upload'])
-        assert_in(vol.key, res.json['data'][0]['links']['download'])
-        assert_in(vol.key, res.json['data'][0]['links']['delete'])
+        self.assertEqual(url.query, f'meta=True&view_only={vol.key}')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertIn(vol.key, res.json['data'][0]['links']['info'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['move'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['upload'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['download'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['delete'])
 
     @responses.activate
     def test_returns_node_files_list(self):
@@ -325,13 +323,13 @@ class TestNodeFilesList(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
     @responses.activate
     def test_returns_folder_metadata_not_children(self):
@@ -346,10 +344,10 @@ class TestNodeFilesList(ApiTestCase):
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/Folder/'
         res = self.app.get(url, params={'info': ''}, auth=self.user.auth)
 
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['attributes']['kind'], 'folder')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'Folder')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data'][0]['attributes']['kind'], 'folder')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'Folder')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
     @responses.activate
     def test_returns_node_file(self):
@@ -363,14 +361,14 @@ class TestNodeFilesList(ApiTestCase):
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         # test create
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data']['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
 
         # test get
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data']['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
 
     @responses.activate
     def test_notfound_node_file_returns_folder(self):
@@ -384,7 +382,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     @responses.activate
     def test_notfound_node_folder_returns_file(self):
@@ -398,7 +396,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     @responses.activate
     def test_waterbutler_server_error_returns_503(self):
@@ -410,7 +408,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 503)
+        self.assertEqual(res.status_code, 503)
 
     @responses.activate
     def test_waterbutler_invalid_data_returns_503(self):
@@ -426,7 +424,7 @@ class TestNodeFilesList(ApiTestCase):
         )
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 503)
+        self.assertEqual(res.status_code, 503)
 
     @responses.activate
     def test_handles_unauthenticated_waterbutler_request(self):
@@ -434,8 +432,8 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 403)
+        self.assertIn('detail', res.json['errors'][0])
 
     @responses.activate
     def test_handles_notfound_waterbutler_request(self):
@@ -445,17 +443,17 @@ class TestNodeFilesList(ApiTestCase):
         url = '/{}draft_nodes/{}/files/{}/'.format(API_BASE,
                                              self.draft_node._id, invalid_provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 404)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_handles_request_to_provider_not_configured_on_project(self):
         provider = 'box'
         url = '/{}draft_nodes/{}/files/{}/'.format(
             API_BASE, self.draft_node._id, provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_false(self.draft_node.get_addon(provider))
-        assert_equal(res.status_code, 404)
-        assert_equal(
+        self.assertFalse(self.draft_node.get_addon(provider))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             f'The {provider} provider is not configured for this project.')
 
@@ -473,12 +471,12 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}draft_nodes/{self.draft_node._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 503)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 503)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_files_list_contains_relationships_object(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         assert 'relationships' in res.json['data'][0]
 
 
@@ -525,15 +523,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'abc'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'abc'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
     @responses.activate
     def test_node_files_filter_by_name_case_insensitive(self):
@@ -543,17 +541,17 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         # filters out 'abc', but finds 'xyz'
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         # filters out 'abc', but finds 'xyz'
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
     @responses.activate
     def test_node_files_are_filterable_by_path(self):
@@ -563,15 +561,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
     @responses.activate
     def test_node_files_are_filterable_by_kind(self):
@@ -581,15 +579,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
     @responses.activate
     def test_node_files_external_provider_can_filter_by_last_touched(self):
@@ -599,13 +597,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
             API_BASE, self.draft_node._id, yesterday_stamp.isoformat())
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
         yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
@@ -616,13 +614,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(len(res.json['errors']), 1)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(len(res.json['errors']), 1)
 
         # test get
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(len(res.json['errors']), 1)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(len(res.json['errors']), 1)
 
 
 class TestNodeFilesListPagination(ApiTestCase):
@@ -708,12 +706,12 @@ class TestDraftNodeStorageProviderDetail(ApiTestCase):
 
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['id'],
             f'{self.draft_node._id}:osfstorage'
         )
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa:
-
 from tests.base import ApiTestCase
 from osf_tests.factories import (
     AuthUserFactory,
@@ -39,48 +37,48 @@ class TestInstitutionRegistrationList(ApiTestCase):
     def test_return_all_public_nodes(self):
         res = self.app.get(self.institution_node_url)
 
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
-        assert_in(self.registration1._id, ids)
-        assert_not_in(self.registration2._id, ids)
-        assert_not_in(self.registration3._id, ids)
+        self.assertIn(self.registration1._id, ids)
+        self.assertNotIn(self.registration2._id, ids)
+        self.assertNotIn(self.registration3._id, ids)
 
     def test_does_not_return_private_nodes_with_auth(self):
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
-        assert_in(self.registration1._id, ids)
-        assert_not_in(self.registration2._id, ids)
-        assert_not_in(self.registration3._id, ids)
+        self.assertIn(self.registration1._id, ids)
+        self.assertNotIn(self.registration2._id, ids)
+        self.assertNotIn(self.registration3._id, ids)
 
     def test_doesnt_return_retractions_without_auth(self):
         self.registration2.is_public = True
         self.registration2.save()
         WithdrawnRegistrationFactory(registration=self.registration2, user=self.user1)
-        assert_true(self.registration2.is_retracted)
+        self.assertTrue(self.registration2.is_retracted)
 
         res = self.app.get(self.institution_node_url)
 
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
-        assert_not_in(self.registration2._id, ids)
+        self.assertNotIn(self.registration2._id, ids)
 
     def test_doesnt_return_retractions_with_auth(self):
         WithdrawnRegistrationFactory(
             registration=self.registration2, user=self.user1)
 
-        assert_true(self.registration2.is_retracted)
+        self.assertTrue(self.registration2.is_retracted)
 
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
-        assert_not_in(self.registration2._id, ids)
+        self.assertNotIn(self.registration2._id, ids)
 
     def test_total_biographic_contributor_in_institution_registration(self):
         user3 = AuthUserFactory()
@@ -94,10 +92,10 @@ class TestInstitutionRegistrationList(ApiTestCase):
             API_BASE, registration3._id)
 
         res = self.app.get(registration3_url)
-        assert_true(
+        self.assertTrue(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
         )
-        assert_equal(
+        self.assertEqual(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'],
             2
         )

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -93,8 +93,7 @@ class TestInstitutionRegistrationList(ApiTestCase):
 
         res = self.app.get(registration3_url)
         assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
-        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'] == \
-            2
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'] == 2
 
 
 class TestRegistrationListFiltering(

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -37,48 +37,48 @@ class TestInstitutionRegistrationList(ApiTestCase):
     def test_return_all_public_nodes(self):
         res = self.app.get(self.institution_node_url)
 
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         ids = [each['id'] for each in res.json['data']]
 
-        self.assertIn(self.registration1._id, ids)
-        self.assertNotIn(self.registration2._id, ids)
-        self.assertNotIn(self.registration3._id, ids)
+        assert self.registration1._id in ids
+        assert self.registration2._id not in ids
+        assert self.registration3._id not in ids
 
     def test_does_not_return_private_nodes_with_auth(self):
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         ids = [each['id'] for each in res.json['data']]
 
-        self.assertIn(self.registration1._id, ids)
-        self.assertNotIn(self.registration2._id, ids)
-        self.assertNotIn(self.registration3._id, ids)
+        assert self.registration1._id in ids
+        assert self.registration2._id not in ids
+        assert self.registration3._id not in ids
 
     def test_doesnt_return_retractions_without_auth(self):
         self.registration2.is_public = True
         self.registration2.save()
         WithdrawnRegistrationFactory(registration=self.registration2, user=self.user1)
-        self.assertTrue(self.registration2.is_retracted)
+        assert self.registration2.is_retracted
 
         res = self.app.get(self.institution_node_url)
 
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         ids = [each['id'] for each in res.json['data']]
 
-        self.assertNotIn(self.registration2._id, ids)
+        assert self.registration2._id not in ids
 
     def test_doesnt_return_retractions_with_auth(self):
         WithdrawnRegistrationFactory(
             registration=self.registration2, user=self.user1)
 
-        self.assertTrue(self.registration2.is_retracted)
+        assert self.registration2.is_retracted
 
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         ids = [each['id'] for each in res.json['data']]
 
-        self.assertNotIn(self.registration2._id, ids)
+        assert self.registration2._id not in ids
 
     def test_total_biographic_contributor_in_institution_registration(self):
         user3 = AuthUserFactory()
@@ -92,13 +92,9 @@ class TestInstitutionRegistrationList(ApiTestCase):
             API_BASE, registration3._id)
 
         res = self.app.get(registration3_url)
-        self.assertTrue(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
-        )
-        self.assertEqual(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'],
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'] == \
             2
-        )
 
 
 class TestRegistrationListFiltering(

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -59,11 +59,10 @@ class NodeAddonListMixin:
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
             assert self.account_id == addon_data['external_account_id']
-            assert self.node_settings.has_auth == \
-                addon_data['node_has_auth']
+            assert self.node_settings.has_auth == addon_data['node_has_auth']
             assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            assert addon_data == None
+            assert addon_data is None
 
     def test_settings_list_GET_disabled(self):
         wrong_type = self.should_expect_errors()
@@ -118,8 +117,7 @@ class NodeAddonListMixin:
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
             assert self.account_id == addon_data['external_account_id']
-            assert self.node_settings.has_auth == \
-                addon_data['node_has_auth']
+            assert self.node_settings.has_auth == addon_data['node_has_auth']
             assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
             assert addon_data == None
@@ -141,8 +139,7 @@ class NodeAddonDetailMixin:
         if not wrong_type:
             addon_data = res.json['data']['attributes']
             assert self.account_id == addon_data['external_account_id']
-            assert self.node_settings.has_auth == \
-                addon_data['node_has_auth']
+            assert self.node_settings.has_auth == addon_data['node_has_auth']
             assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
             assert res.status_code == 404
@@ -350,8 +347,7 @@ class NodeAddonDetailMixin:
         )
         if not wrong_type:
             assert res.status_code == 409
-            assert 'Cannot set folder without authorization' == \
-                res.json['errors'][0]['detail']
+            assert 'Cannot set folder without authorization' == res.json['errors'][0]['detail']
         if wrong_type:
             assert res.status_code in [404, 501]
 
@@ -463,8 +459,7 @@ class NodeAddonDetailMixin:
             assert res.status_code == 200
             addon_data = res.json['data']['attributes']
             assert self.account_id == addon_data['external_account_id']
-            assert self.node_settings.has_auth == \
-                addon_data['node_has_auth']
+            assert self.node_settings.has_auth == addon_data['node_has_auth']
             assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
             assert res.status_code == 404
@@ -505,8 +500,7 @@ class NodeAddonFolderMixin:
             assert addon_data['kind'] in ('folder', 'repo')
             assert addon_data['name'] == self._mock_folder_result['name']
             assert addon_data['path'] == self._mock_folder_result['path']
-            assert addon_data['folder_id'] == \
-                self._mock_folder_result['id']
+            assert addon_data['folder_id'] == self._mock_folder_result['id']
         if wrong_type:
             assert res.status_code in [404, 501]
 
@@ -731,8 +725,7 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
         assert addon_data['kind'] in ('folder', 'repo')
         assert addon_data['name'] == self._mock_folder_result['name']
         assert addon_data['path'] == self._mock_folder_result['path']
-        assert addon_data['folder_id'] == \
-            self._mock_folder_result['id']
+        assert addon_data['folder_id'] == self._mock_folder_result['id']
 
     @property
     def _mock_folder_result(self):
@@ -769,8 +762,7 @@ class TestNodeMendeleyAddon(
         assert addon_data['kind'] == 'folder'
         assert addon_data['name'] == 'Test Mendeley Folder'
         assert addon_data['path'] == '/'
-        assert addon_data['folder_id'] == \
-            'fasdkljla-2341-4592-10po-fds0920dks0ds'
+        assert addon_data['folder_id'] == 'fasdkljla-2341-4592-10po-fds0920dks0ds'
 
 class TestNodeZoteroAddon(
         NodeOAuthCitationAddonTestSuiteMixin,
@@ -814,15 +806,13 @@ class TestNodeZoteroAddon(
         assert addon_data['kind'] == self._mock_folder_result['kind']
         assert addon_data['name'] == 'My Library'
         assert addon_data['path'] == 'personal'
-        assert addon_data['folder_id'] == \
-            'personal'
+        assert addon_data['folder_id'] == 'personal'
 
         addon_data = res.json['data'][1]['attributes']
         assert addon_data['kind'] == self._mock_folder_result['kind']
         assert addon_data['name'] == self._mock_folder_result['name']
         assert addon_data['path'] == self._mock_folder_result['path']
-        assert addon_data['folder_id'] == \
-            self._mock_folder_result['id']
+        assert addon_data['folder_id'] == self._mock_folder_result['id']
 
     @property
     def _mock_folder_result(self):
@@ -865,8 +855,7 @@ class TestNodeZoteroAddon(
         assert addon_data['kind'] == 'folder'
         assert addon_data['name'] == 'Test Folder'
         assert addon_data['path'] == '18497322'
-        assert addon_data['folder_id'] == \
-            'FSCFSLREF'
+        assert addon_data['folder_id'] == 'FSCFSLREF'
 
 # CONFIGURABLE
 
@@ -1111,9 +1100,7 @@ class TestNodeGoogleDriveAddon(
             auth=self.user.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert 'Must specify both folder_id and folder_path for {}'.format(
-                self.short_name) == \
-            res.json['errors'][0]['detail']
+        assert f'Must specify both folder_id and folder_path for {self.short_name}' == res.json['errors'][0]['detail']
 
 
 class TestNodeForwardAddon(
@@ -1287,8 +1274,7 @@ class TestNodeForwardAddon(
             auth=self.user.auth,
             expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == \
-            'Cannot set label without url'
+        assert res.json['errors'][0]['detail'] == 'Cannot set label without url'
 
     def test_settings_detail_PUT_only_url_sets_settings(self):
         self.node_settings.reset()

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -58,13 +58,12 @@ class NodeAddonListMixin:
 
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
-            self.assertEqual(self.account_id, addon_data['external_account_id'])
-            self.assertEqual(
-                self.node_settings.has_auth,
-                addon_data['node_has_auth'])
-            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
+            assert self.account_id == addon_data['external_account_id']
+            assert self.node_settings.has_auth == \
+                addon_data['node_has_auth']
+            assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            self.assertEqual(addon_data, None)
+            assert addon_data == None
 
     def test_settings_list_GET_disabled(self):
         wrong_type = self.should_expect_errors()
@@ -78,7 +77,7 @@ class NodeAddonListMixin:
             auth=self.user.auth,
             expect_errors=wrong_type)
         addon_data = self.get_response_for_addon(res)
-        self.assertEqual(addon_data, None)
+        assert addon_data == None
 
     def test_settings_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
@@ -86,20 +85,20 @@ class NodeAddonListMixin:
             {'id': self.short_name, 'type': 'node-addons'},
             auth=self.user.auth, expect_errors=True
         )
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.setting_list_url,
             {'id': self.short_name, 'type': 'node-addons'},
             auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_DELETE(self):
         res = self.app.delete(
             self.setting_list_url,
             auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_noncontrib_not_public(self):
         noncontrib = AuthUserFactory()
@@ -107,7 +106,7 @@ class NodeAddonListMixin:
             self.setting_list_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_settings_list_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -118,13 +117,12 @@ class NodeAddonListMixin:
             auth=noncontrib.auth)
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
-            self.assertEqual(self.account_id, addon_data['external_account_id'])
-            self.assertEqual(
-                self.node_settings.has_auth,
-                addon_data['node_has_auth'])
-            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
+            assert self.account_id == addon_data['external_account_id']
+            assert self.node_settings.has_auth == \
+                addon_data['node_has_auth']
+            assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            self.assertEqual(addon_data, None)
+            assert addon_data == None
 
 
 class NodeAddonDetailMixin:
@@ -142,13 +140,12 @@ class NodeAddonDetailMixin:
 
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(self.account_id, addon_data['external_account_id'])
-            self.assertEqual(
-                self.node_settings.has_auth,
-                addon_data['node_has_auth'])
-            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
+            assert self.account_id == addon_data['external_account_id']
+            assert self.node_settings.has_auth == \
+                addon_data['node_has_auth']
+            assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            self.assertEqual(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_settings_detail_GET_disabled(self):
         try:
@@ -160,7 +157,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_settings_detail_PUT_all_sets_settings(self):
         wrong_type = self.should_expect_errors(
@@ -187,11 +184,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], self.account_id)
-            self.assertEqual(addon_data['folder_id'], '0987654321')
-            self.assertTrue(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == self.account_id
+            assert addon_data['folder_id'] == '0987654321'
+            assert addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_PUT_none_and_enabled_clears_settings(self):
         wrong_type = self.should_expect_errors(
@@ -210,11 +207,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], None)
-            self.assertEqual(addon_data['folder_id'], None)
-            self.assertFalse(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == None
+            assert addon_data['folder_id'] == None
+            assert not addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
         wrong_type = self.should_expect_errors(
@@ -233,11 +230,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], None)
-            self.assertEqual(addon_data['folder_id'], None)
-            self.assertFalse(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == None
+            assert addon_data['folder_id'] == None
+            assert not addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_DELETE_disables(self):
         wrong_type = self.should_expect_errors()
@@ -246,11 +243,11 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=wrong_type)
         if not wrong_type:
-            self.assertEqual(res.status_code, 204)
+            assert res.status_code == 204
             self.node.reload()
-            self.assertFalse(self.node.has_addon(self.short_name))
+            assert not self.node.has_addon(self.short_name)
         if wrong_type:
-            self.assertIn(res.status_code, [404, 405])
+            assert res.status_code in [404, 405]
 
     def test_settings_detail_POST_enables(self):
         wrong_type = self.should_expect_errors()
@@ -271,11 +268,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], None)
-            self.assertEqual(addon_data['folder_id'], None)
-            self.assertFalse(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == None
+            assert addon_data['folder_id'] == None
+            assert not addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 405])
+            assert res.status_code in [404, 405]
 
     def test_settings_detail_PATCH_to_enable_and_add_external_account_id(self):
         wrong_type = self.should_expect_errors(
@@ -299,11 +296,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], self.account_id)
-            self.assertEqual(addon_data['folder_id'], None)
-            self.assertTrue(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == self.account_id
+            assert addon_data['folder_id'] == None
+            assert addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_PATCH_to_remove_external_account_id(self):
         wrong_type = self.should_expect_errors(
@@ -322,11 +319,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            self.assertEqual(addon_data['external_account_id'], None)
-            self.assertEqual(addon_data['folder_id'], None)
-            self.assertFalse(addon_data['node_has_auth'])
+            assert addon_data['external_account_id'] == None
+            assert addon_data['folder_id'] == None
+            assert not addon_data['node_has_auth']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
         wrong_type = self.should_expect_errors(
@@ -352,13 +349,11 @@ class NodeAddonDetailMixin:
             expect_errors=True
         )
         if not wrong_type:
-            self.assertEqual(res.status_code, 409)
-            self.assertEqual(
-                'Cannot set folder without authorization',
+            assert res.status_code == 409
+            assert 'Cannot set folder without authorization' == \
                 res.json['errors'][0]['detail']
-            )
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_settings_detail_PATCH_readcontrib_raises_error(self):
         read_user = AuthUserFactory()
@@ -375,7 +370,7 @@ class NodeAddonDetailMixin:
             }},
             auth=read_user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_settings_detail_DELETE_success(self):
         wrong_type = self.should_expect_errors()
@@ -384,9 +379,9 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=True)
         if not wrong_type:
-            self.assertEqual(res.status_code, 204)
+            assert res.status_code == 204
         else:
-            self.assertEqual(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_settings_detail_raises_error_if_DELETE_not_enabled(self):
         try:
@@ -398,7 +393,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_settings_detail_raises_error_if_POST_already_configured(self):
         wrong_type = self.should_expect_errors()
@@ -412,10 +407,10 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=True)
         if not wrong_type:
-            self.assertEqual(res.status_code, 400)
-            self.assertIn('already enabled', res.body.decode())
+            assert res.status_code == 400
+            assert 'already enabled' in res.body.decode()
         else:
-            self.assertEqual(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_GET(self):
         noncontrib = AuthUserFactory()
@@ -423,7 +418,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_PUT(self):
         noncontrib = AuthUserFactory()
@@ -438,7 +433,7 @@ class NodeAddonDetailMixin:
                 }
             }},
             auth=noncontrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_PATCH(self):
         noncontrib = AuthUserFactory()
@@ -453,7 +448,7 @@ class NodeAddonDetailMixin:
             }},
             auth=noncontrib.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_settings_detail_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -465,15 +460,14 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
 
         if not wrong_type:
-            self.assertEqual(res.status_code, 200)
+            assert res.status_code == 200
             addon_data = res.json['data']['attributes']
-            self.assertEqual(self.account_id, addon_data['external_account_id'])
-            self.assertEqual(
-                self.node_settings.has_auth,
-                addon_data['node_has_auth'])
-            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
+            assert self.account_id == addon_data['external_account_id']
+            assert self.node_settings.has_auth == \
+                addon_data['node_has_auth']
+            assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            self.assertEqual(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_settings_detail_noncontrib_public_cannot_edit(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -489,7 +483,7 @@ class NodeAddonDetailMixin:
             }},
             auth=noncontrib.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
 
 class NodeAddonFolderMixin:
@@ -508,14 +502,13 @@ class NodeAddonFolderMixin:
 
         if not wrong_type:
             addon_data = res.json['data'][0]['attributes']
-            self.assertIn(addon_data['kind'], ('folder', 'repo'))
-            self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
-            self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
-            self.assertEqual(
-                addon_data['folder_id'],
-                self._mock_folder_result['id'])
+            assert addon_data['kind'] in ('folder', 'repo')
+            assert addon_data['name'] == self._mock_folder_result['name']
+            assert addon_data['path'] == self._mock_folder_result['path']
+            assert addon_data['folder_id'] == \
+                self._mock_folder_result['id']
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
     def test_folder_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
@@ -523,7 +516,7 @@ class NodeAddonFolderMixin:
             {'id': self.short_name, 'type': 'node-addon-folders'},
             auth=self.user.auth, expect_errors=True
         )
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_folder_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
@@ -531,14 +524,14 @@ class NodeAddonFolderMixin:
             {'id': self.short_name, 'type': 'node-addon-folders'},
             auth=self.user.auth, expect_errors=True
         )
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_folder_list_raises_error_if_DELETE(self):
         res = self.app.delete(
             self.folder_url,
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_folder_list_GET_raises_error_noncontrib_not_public(self):
         noncontrib = AuthUserFactory()
@@ -546,7 +539,7 @@ class NodeAddonFolderMixin:
             self.folder_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_folder_list_GET_raises_error_writecontrib_not_authorizer(self):
         wrong_type = self.should_expect_errors()
@@ -560,9 +553,9 @@ class NodeAddonFolderMixin:
             auth=write_user.auth,
             expect_errors=True)
         if wrong_type:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
         else:
-            self.assertEqual(res.status_code, 403)
+            assert res.status_code == 403
 
     def test_folder_list_GET_raises_error_admin_not_authorizer(self):
         wrong_type = self.should_expect_errors()
@@ -575,9 +568,9 @@ class NodeAddonFolderMixin:
             auth=admin_user.auth,
             expect_errors=True)
         if not wrong_type:
-            self.assertEqual(res.status_code, 403)
+            assert res.status_code == 403
         else:
-            self.assertIn(res.status_code, [404, 501])
+            assert res.status_code in [404, 501]
 
 
 class NodeAddonTestSuiteMixin(
@@ -735,12 +728,11 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        self.assertIn(addon_data['kind'], ('folder', 'repo'))
-        self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
-        self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
-        self.assertEqual(
-            addon_data['folder_id'],
-            self._mock_folder_result['id'])
+        assert addon_data['kind'] in ('folder', 'repo')
+        assert addon_data['name'] == self._mock_folder_result['name']
+        assert addon_data['path'] == self._mock_folder_result['path']
+        assert addon_data['folder_id'] == \
+            self._mock_folder_result['id']
 
     @property
     def _mock_folder_result(self):
@@ -774,12 +766,11 @@ class TestNodeMendeleyAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        self.assertEqual(addon_data['kind'], 'folder')
-        self.assertEqual(addon_data['name'], 'Test Mendeley Folder')
-        self.assertEqual(addon_data['path'], '/')
-        self.assertEqual(
-            addon_data['folder_id'],
-            'fasdkljla-2341-4592-10po-fds0920dks0ds')
+        assert addon_data['kind'] == 'folder'
+        assert addon_data['name'] == 'Test Mendeley Folder'
+        assert addon_data['path'] == '/'
+        assert addon_data['folder_id'] == \
+            'fasdkljla-2341-4592-10po-fds0920dks0ds'
 
 class TestNodeZoteroAddon(
         NodeOAuthCitationAddonTestSuiteMixin,
@@ -820,20 +811,18 @@ class TestNodeZoteroAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        self.assertEqual(addon_data['kind'], self._mock_folder_result['kind'])
-        self.assertEqual(addon_data['name'], 'My Library')
-        self.assertEqual(addon_data['path'], 'personal')
-        self.assertEqual(
-            addon_data['folder_id'],
-            'personal')
+        assert addon_data['kind'] == self._mock_folder_result['kind']
+        assert addon_data['name'] == 'My Library'
+        assert addon_data['path'] == 'personal'
+        assert addon_data['folder_id'] == \
+            'personal'
 
         addon_data = res.json['data'][1]['attributes']
-        self.assertEqual(addon_data['kind'], self._mock_folder_result['kind'])
-        self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
-        self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
-        self.assertEqual(
-            addon_data['folder_id'],
-            self._mock_folder_result['id'])
+        assert addon_data['kind'] == self._mock_folder_result['kind']
+        assert addon_data['name'] == self._mock_folder_result['name']
+        assert addon_data['path'] == self._mock_folder_result['path']
+        assert addon_data['folder_id'] == \
+            self._mock_folder_result['id']
 
     @property
     def _mock_folder_result(self):
@@ -873,12 +862,11 @@ class TestNodeZoteroAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        self.assertEqual(addon_data['kind'], 'folder')
-        self.assertEqual(addon_data['name'], 'Test Folder')
-        self.assertEqual(addon_data['path'], '18497322')
-        self.assertEqual(
-            addon_data['folder_id'],
-            'FSCFSLREF')
+        assert addon_data['kind'] == 'folder'
+        assert addon_data['name'] == 'Test Folder'
+        assert addon_data['path'] == '18497322'
+        assert addon_data['folder_id'] == \
+            'FSCFSLREF'
 
 # CONFIGURABLE
 
@@ -1122,11 +1110,10 @@ class TestNodeGoogleDriveAddon(
             self.setting_detail_url, data,
             auth=self.user.auth, expect_errors=True)
 
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(
-            'Must specify both folder_id and folder_path for {}'.format(
-                self.short_name),
-            res.json['errors'][0]['detail'])
+        assert res.status_code == 400
+        assert 'Must specify both folder_id and folder_path for {}'.format(
+                self.short_name) == \
+            res.json['errors'][0]['detail']
 
 
 class TestNodeForwardAddon(
@@ -1161,7 +1148,7 @@ class TestNodeForwardAddon(
             self.folder_url,
             auth=admin_user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 501)
+        assert res.status_code == 501
 
     def test_folder_list_GET_raises_error_writecontrib_not_authorizer(self):
         write_user = AuthUserFactory()
@@ -1173,7 +1160,7 @@ class TestNodeForwardAddon(
             self.folder_url,
             auth=write_user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 501)
+        assert res.status_code == 501
 
     def test_settings_detail_GET_enabled(self):
         res = self.app.get(
@@ -1181,8 +1168,8 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data']['attributes']
-        self.assertEqual(self.node_settings.url, addon_data['url'])
-        self.assertEqual(self.node_settings.label, addon_data['label'])
+        assert self.node_settings.url == addon_data['url']
+        assert self.node_settings.label == addon_data['label']
 
     def test_settings_detail_POST_enables(self):
         self.node.delete_addon(self.short_name, auth=self.auth)
@@ -1196,11 +1183,11 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data']['attributes']
-        self.assertEqual(addon_data['url'], None)
-        self.assertEqual(addon_data['label'], None)
+        assert addon_data['url'] == None
+        assert addon_data['label'] == None
 
         self.node.reload()
-        self.assertNotEqual(self.node.logs.latest().action, 'forward_url_changed')
+        assert self.node.logs.latest().action != 'forward_url_changed'
 
     def test_settings_detail_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -1209,10 +1196,10 @@ class TestNodeForwardAddon(
             self.setting_detail_url,
             auth=noncontrib.auth)
 
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         addon_data = res.json['data']['attributes']
-        self.assertEqual(self.node_settings.url, addon_data['url'])
-        self.assertEqual(self.node_settings.label, addon_data['label'])
+        assert self.node_settings.url == addon_data['url']
+        assert self.node_settings.label == addon_data['label']
 
     def test_settings_list_GET_enabled(self):
         res = self.app.get(
@@ -1220,8 +1207,8 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = self.get_response_for_addon(res)
-        self.assertEqual(self.node_settings.url, addon_data['url'])
-        self.assertEqual(self.node_settings.label, addon_data['label'])
+        assert self.node_settings.url == addon_data['url']
+        assert self.node_settings.label == addon_data['label']
 
     def test_settings_list_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -1231,8 +1218,8 @@ class TestNodeForwardAddon(
             auth=noncontrib.auth)
         addon_data = self.get_response_for_addon(res)
 
-        self.assertEqual(self.node_settings.url, addon_data['url'])
-        self.assertEqual(self.node_settings.label, addon_data['label'])
+        assert self.node_settings.url == addon_data['url']
+        assert self.node_settings.label == addon_data['label']
 
     def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
         # This test doesn't apply forward, as it does not use ExternalAccounts.
@@ -1263,11 +1250,11 @@ class TestNodeForwardAddon(
         res = self.app.put_json_api(self.setting_detail_url,
                                     data, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        self.assertEqual(addon_data['url'], self._mock_folder_info['url'])
-        self.assertEqual(addon_data['label'], self._mock_folder_info['label'])
+        assert addon_data['url'] == self._mock_folder_info['url']
+        assert addon_data['label'] == self._mock_folder_info['label']
 
         self.node.reload()
-        self.assertEqual(self.node.logs.latest().action, 'forward_url_changed')
+        assert self.node.logs.latest().action == 'forward_url_changed'
 
     def test_settings_detail_PUT_none_and_enabled_clears_settings(self):
         res = self.app.put_json_api(
@@ -1281,10 +1268,10 @@ class TestNodeForwardAddon(
                 }
             }}, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        self.assertFalse(addon_data['url'])
-        self.assertFalse(addon_data['label'])
+        assert not addon_data['url']
+        assert not addon_data['label']
 
-        self.assertNotEqual(self.node.logs.latest().action, 'forward_url_changed')
+        assert self.node.logs.latest().action != 'forward_url_changed'
 
     def test_settings_detail_PUT_only_label_and_enabled_clears_settings(self):
         res = self.app.put_json_api(
@@ -1299,10 +1286,9 @@ class TestNodeForwardAddon(
             }},
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'Cannot set label without url')
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == \
+            'Cannot set label without url'
 
     def test_settings_detail_PUT_only_url_sets_settings(self):
         self.node_settings.reset()
@@ -1320,11 +1306,11 @@ class TestNodeForwardAddon(
             self.setting_detail_url,
             data, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        self.assertEqual(addon_data['url'], self._mock_folder_info['url'])
-        self.assertFalse(addon_data['label'])
+        assert addon_data['url'] == self._mock_folder_info['url']
+        assert not addon_data['label']
 
         self.node.reload()
-        self.assertEqual(self.node.logs.latest().action, 'forward_url_changed')
+        assert self.node.logs.latest().action == 'forward_url_changed'
 
     def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
         # This test doesn't apply forward, as it does not use ExternalAccounts.

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -76,7 +76,7 @@ class NodeAddonListMixin:
             auth=self.user.auth,
             expect_errors=wrong_type)
         addon_data = self.get_response_for_addon(res)
-        assert addon_data == None
+        assert addon_data is None
 
     def test_settings_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
@@ -120,7 +120,7 @@ class NodeAddonListMixin:
             assert self.node_settings.has_auth == addon_data['node_has_auth']
             assert self.node_settings.folder_id == addon_data['folder_id']
         if wrong_type:
-            assert addon_data == None
+            assert addon_data is None
 
 
 class NodeAddonDetailMixin:
@@ -204,8 +204,8 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert addon_data['external_account_id'] == None
-            assert addon_data['folder_id'] == None
+            assert addon_data['external_account_id'] is None
+            assert addon_data['folder_id'] is None
             assert not addon_data['node_has_auth']
         if wrong_type:
             assert res.status_code in [404, 501]
@@ -227,8 +227,8 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert addon_data['external_account_id'] == None
-            assert addon_data['folder_id'] == None
+            assert addon_data['external_account_id'] is None
+            assert addon_data['folder_id'] is None
             assert not addon_data['node_has_auth']
         if wrong_type:
             assert res.status_code in [404, 501]
@@ -265,8 +265,8 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert addon_data['external_account_id'] == None
-            assert addon_data['folder_id'] == None
+            assert addon_data['external_account_id'] is None
+            assert addon_data['folder_id'] is None
             assert not addon_data['node_has_auth']
         if wrong_type:
             assert res.status_code in [404, 405]
@@ -294,7 +294,7 @@ class NodeAddonDetailMixin:
         if not wrong_type:
             addon_data = res.json['data']['attributes']
             assert addon_data['external_account_id'] == self.account_id
-            assert addon_data['folder_id'] == None
+            assert addon_data['folder_id'] is None
             assert addon_data['node_has_auth']
         if wrong_type:
             assert res.status_code in [404, 501]
@@ -316,8 +316,8 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert addon_data['external_account_id'] == None
-            assert addon_data['folder_id'] == None
+            assert addon_data['external_account_id'] is None
+            assert addon_data['folder_id'] is None
             assert not addon_data['node_has_auth']
         if wrong_type:
             assert res.status_code in [404, 501]
@@ -1170,8 +1170,8 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data']['attributes']
-        assert addon_data['url'] == None
-        assert addon_data['label'] == None
+        assert addon_data['url'] is None
+        assert addon_data['label'] is None
 
         self.node.reload()
         assert self.node.logs.latest().action != 'forward_url_changed'

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -4,7 +4,6 @@ from json import dumps
 from unittest import mock
 import pytest
 import mendeley
-from nose.tools import *  # noqa:
 from github3.repos import Repository
 
 
@@ -59,13 +58,13 @@ class NodeAddonListMixin:
 
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
-            assert_equal(self.account_id, addon_data['external_account_id'])
-            assert_equal(
+            self.assertEqual(self.account_id, addon_data['external_account_id'])
+            self.assertEqual(
                 self.node_settings.has_auth,
                 addon_data['node_has_auth'])
-            assert_equal(self.node_settings.folder_id, addon_data['folder_id'])
+            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
         if wrong_type:
-            assert_equal(addon_data, None)
+            self.assertEqual(addon_data, None)
 
     def test_settings_list_GET_disabled(self):
         wrong_type = self.should_expect_errors()
@@ -79,7 +78,7 @@ class NodeAddonListMixin:
             auth=self.user.auth,
             expect_errors=wrong_type)
         addon_data = self.get_response_for_addon(res)
-        assert_equal(addon_data, None)
+        self.assertEqual(addon_data, None)
 
     def test_settings_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
@@ -87,20 +86,20 @@ class NodeAddonListMixin:
             {'id': self.short_name, 'type': 'node-addons'},
             auth=self.user.auth, expect_errors=True
         )
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_settings_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.setting_list_url,
             {'id': self.short_name, 'type': 'node-addons'},
             auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_settings_list_raises_error_if_DELETE(self):
         res = self.app.delete(
             self.setting_list_url,
             auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_settings_list_raises_error_if_noncontrib_not_public(self):
         noncontrib = AuthUserFactory()
@@ -108,7 +107,7 @@ class NodeAddonListMixin:
             self.setting_list_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_settings_list_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -119,13 +118,13 @@ class NodeAddonListMixin:
             auth=noncontrib.auth)
         addon_data = self.get_response_for_addon(res)
         if not wrong_type:
-            assert_equal(self.account_id, addon_data['external_account_id'])
-            assert_equal(
+            self.assertEqual(self.account_id, addon_data['external_account_id'])
+            self.assertEqual(
                 self.node_settings.has_auth,
                 addon_data['node_has_auth'])
-            assert_equal(self.node_settings.folder_id, addon_data['folder_id'])
+            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
         if wrong_type:
-            assert_equal(addon_data, None)
+            self.assertEqual(addon_data, None)
 
 
 class NodeAddonDetailMixin:
@@ -143,13 +142,13 @@ class NodeAddonDetailMixin:
 
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(self.account_id, addon_data['external_account_id'])
-            assert_equal(
+            self.assertEqual(self.account_id, addon_data['external_account_id'])
+            self.assertEqual(
                 self.node_settings.has_auth,
                 addon_data['node_has_auth'])
-            assert_equal(self.node_settings.folder_id, addon_data['folder_id'])
+            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
         if wrong_type:
-            assert_equal(res.status_code, 404)
+            self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_GET_disabled(self):
         try:
@@ -161,7 +160,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_PUT_all_sets_settings(self):
         wrong_type = self.should_expect_errors(
@@ -188,11 +187,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], self.account_id)
-            assert_equal(addon_data['folder_id'], '0987654321')
-            assert_true(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], self.account_id)
+            self.assertEqual(addon_data['folder_id'], '0987654321')
+            self.assertTrue(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_PUT_none_and_enabled_clears_settings(self):
         wrong_type = self.should_expect_errors(
@@ -211,11 +210,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], None)
-            assert_equal(addon_data['folder_id'], None)
-            assert_false(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], None)
+            self.assertEqual(addon_data['folder_id'], None)
+            self.assertFalse(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
         wrong_type = self.should_expect_errors(
@@ -234,11 +233,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], None)
-            assert_equal(addon_data['folder_id'], None)
-            assert_false(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], None)
+            self.assertEqual(addon_data['folder_id'], None)
+            self.assertFalse(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_DELETE_disables(self):
         wrong_type = self.should_expect_errors()
@@ -247,11 +246,11 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=wrong_type)
         if not wrong_type:
-            assert_equal(res.status_code, 204)
+            self.assertEqual(res.status_code, 204)
             self.node.reload()
-            assert_false(self.node.has_addon(self.short_name))
+            self.assertFalse(self.node.has_addon(self.short_name))
         if wrong_type:
-            assert_in(res.status_code, [404, 405])
+            self.assertIn(res.status_code, [404, 405])
 
     def test_settings_detail_POST_enables(self):
         wrong_type = self.should_expect_errors()
@@ -272,11 +271,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], None)
-            assert_equal(addon_data['folder_id'], None)
-            assert_false(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], None)
+            self.assertEqual(addon_data['folder_id'], None)
+            self.assertFalse(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 405])
+            self.assertIn(res.status_code, [404, 405])
 
     def test_settings_detail_PATCH_to_enable_and_add_external_account_id(self):
         wrong_type = self.should_expect_errors(
@@ -300,11 +299,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], self.account_id)
-            assert_equal(addon_data['folder_id'], None)
-            assert_true(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], self.account_id)
+            self.assertEqual(addon_data['folder_id'], None)
+            self.assertTrue(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_PATCH_to_remove_external_account_id(self):
         wrong_type = self.should_expect_errors(
@@ -323,11 +322,11 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
         if not wrong_type:
             addon_data = res.json['data']['attributes']
-            assert_equal(addon_data['external_account_id'], None)
-            assert_equal(addon_data['folder_id'], None)
-            assert_false(addon_data['node_has_auth'])
+            self.assertEqual(addon_data['external_account_id'], None)
+            self.assertEqual(addon_data['folder_id'], None)
+            self.assertFalse(addon_data['node_has_auth'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
         wrong_type = self.should_expect_errors(
@@ -353,13 +352,13 @@ class NodeAddonDetailMixin:
             expect_errors=True
         )
         if not wrong_type:
-            assert_equal(res.status_code, 409)
-            assert_equal(
+            self.assertEqual(res.status_code, 409)
+            self.assertEqual(
                 'Cannot set folder without authorization',
                 res.json['errors'][0]['detail']
             )
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_settings_detail_PATCH_readcontrib_raises_error(self):
         read_user = AuthUserFactory()
@@ -376,7 +375,7 @@ class NodeAddonDetailMixin:
             }},
             auth=read_user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_settings_detail_DELETE_success(self):
         wrong_type = self.should_expect_errors()
@@ -385,9 +384,9 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=True)
         if not wrong_type:
-            assert_equal(res.status_code, 204)
+            self.assertEqual(res.status_code, 204)
         else:
-            assert_equal(res.status_code, 404)
+            self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_raises_error_if_DELETE_not_enabled(self):
         try:
@@ -399,7 +398,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_raises_error_if_POST_already_configured(self):
         wrong_type = self.should_expect_errors()
@@ -413,10 +412,10 @@ class NodeAddonDetailMixin:
             auth=self.user.auth,
             expect_errors=True)
         if not wrong_type:
-            assert_equal(res.status_code, 400)
-            assert_in('already enabled', res.body.decode())
+            self.assertEqual(res.status_code, 400)
+            self.assertIn('already enabled', res.body.decode())
         else:
-            assert_equal(res.status_code, 404)
+            self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_GET(self):
         noncontrib = AuthUserFactory()
@@ -424,7 +423,7 @@ class NodeAddonDetailMixin:
             self.setting_detail_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_PUT(self):
         noncontrib = AuthUserFactory()
@@ -439,7 +438,7 @@ class NodeAddonDetailMixin:
                 }
             }},
             auth=noncontrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_settings_detail_raises_error_if_noncontrib_not_public_PATCH(self):
         noncontrib = AuthUserFactory()
@@ -454,7 +453,7 @@ class NodeAddonDetailMixin:
             }},
             auth=noncontrib.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_settings_detail_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -466,15 +465,15 @@ class NodeAddonDetailMixin:
             expect_errors=wrong_type)
 
         if not wrong_type:
-            assert_equal(res.status_code, 200)
+            self.assertEqual(res.status_code, 200)
             addon_data = res.json['data']['attributes']
-            assert_equal(self.account_id, addon_data['external_account_id'])
-            assert_equal(
+            self.assertEqual(self.account_id, addon_data['external_account_id'])
+            self.assertEqual(
                 self.node_settings.has_auth,
                 addon_data['node_has_auth'])
-            assert_equal(self.node_settings.folder_id, addon_data['folder_id'])
+            self.assertEqual(self.node_settings.folder_id, addon_data['folder_id'])
         if wrong_type:
-            assert_equal(res.status_code, 404)
+            self.assertEqual(res.status_code, 404)
 
     def test_settings_detail_noncontrib_public_cannot_edit(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -490,7 +489,7 @@ class NodeAddonDetailMixin:
             }},
             auth=noncontrib.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
 
 class NodeAddonFolderMixin:
@@ -509,14 +508,14 @@ class NodeAddonFolderMixin:
 
         if not wrong_type:
             addon_data = res.json['data'][0]['attributes']
-            assert_in(addon_data['kind'], ('folder', 'repo'))
-            assert_equal(addon_data['name'], self._mock_folder_result['name'])
-            assert_equal(addon_data['path'], self._mock_folder_result['path'])
-            assert_equal(
+            self.assertIn(addon_data['kind'], ('folder', 'repo'))
+            self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
+            self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
+            self.assertEqual(
                 addon_data['folder_id'],
                 self._mock_folder_result['id'])
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
     def test_folder_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
@@ -524,7 +523,7 @@ class NodeAddonFolderMixin:
             {'id': self.short_name, 'type': 'node-addon-folders'},
             auth=self.user.auth, expect_errors=True
         )
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_folder_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
@@ -532,14 +531,14 @@ class NodeAddonFolderMixin:
             {'id': self.short_name, 'type': 'node-addon-folders'},
             auth=self.user.auth, expect_errors=True
         )
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_folder_list_raises_error_if_DELETE(self):
         res = self.app.delete(
             self.folder_url,
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_folder_list_GET_raises_error_noncontrib_not_public(self):
         noncontrib = AuthUserFactory()
@@ -547,7 +546,7 @@ class NodeAddonFolderMixin:
             self.folder_url,
             auth=noncontrib.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_folder_list_GET_raises_error_writecontrib_not_authorizer(self):
         wrong_type = self.should_expect_errors()
@@ -561,9 +560,9 @@ class NodeAddonFolderMixin:
             auth=write_user.auth,
             expect_errors=True)
         if wrong_type:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
         else:
-            assert_equal(res.status_code, 403)
+            self.assertEqual(res.status_code, 403)
 
     def test_folder_list_GET_raises_error_admin_not_authorizer(self):
         wrong_type = self.should_expect_errors()
@@ -576,9 +575,9 @@ class NodeAddonFolderMixin:
             auth=admin_user.auth,
             expect_errors=True)
         if not wrong_type:
-            assert_equal(res.status_code, 403)
+            self.assertEqual(res.status_code, 403)
         else:
-            assert_in(res.status_code, [404, 501])
+            self.assertIn(res.status_code, [404, 501])
 
 
 class NodeAddonTestSuiteMixin(
@@ -736,10 +735,10 @@ class TestNodeGitHubAddon(NodeOAuthAddonTestSuiteMixin, ApiAddonTestCase):
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        assert_in(addon_data['kind'], ('folder', 'repo'))
-        assert_equal(addon_data['name'], self._mock_folder_result['name'])
-        assert_equal(addon_data['path'], self._mock_folder_result['path'])
-        assert_equal(
+        self.assertIn(addon_data['kind'], ('folder', 'repo'))
+        self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
+        self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
+        self.assertEqual(
             addon_data['folder_id'],
             self._mock_folder_result['id'])
 
@@ -775,10 +774,10 @@ class TestNodeMendeleyAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        assert_equal(addon_data['kind'], 'folder')
-        assert_equal(addon_data['name'], 'Test Mendeley Folder')
-        assert_equal(addon_data['path'], '/')
-        assert_equal(
+        self.assertEqual(addon_data['kind'], 'folder')
+        self.assertEqual(addon_data['name'], 'Test Mendeley Folder')
+        self.assertEqual(addon_data['path'], '/')
+        self.assertEqual(
             addon_data['folder_id'],
             'fasdkljla-2341-4592-10po-fds0920dks0ds')
 
@@ -821,18 +820,18 @@ class TestNodeZoteroAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        assert_equal(addon_data['kind'], self._mock_folder_result['kind'])
-        assert_equal(addon_data['name'], 'My Library')
-        assert_equal(addon_data['path'], 'personal')
-        assert_equal(
+        self.assertEqual(addon_data['kind'], self._mock_folder_result['kind'])
+        self.assertEqual(addon_data['name'], 'My Library')
+        self.assertEqual(addon_data['path'], 'personal')
+        self.assertEqual(
             addon_data['folder_id'],
             'personal')
 
         addon_data = res.json['data'][1]['attributes']
-        assert_equal(addon_data['kind'], self._mock_folder_result['kind'])
-        assert_equal(addon_data['name'], self._mock_folder_result['name'])
-        assert_equal(addon_data['path'], self._mock_folder_result['path'])
-        assert_equal(
+        self.assertEqual(addon_data['kind'], self._mock_folder_result['kind'])
+        self.assertEqual(addon_data['name'], self._mock_folder_result['name'])
+        self.assertEqual(addon_data['path'], self._mock_folder_result['path'])
+        self.assertEqual(
             addon_data['folder_id'],
             self._mock_folder_result['id'])
 
@@ -874,10 +873,10 @@ class TestNodeZoteroAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data'][0]['attributes']
-        assert_equal(addon_data['kind'], 'folder')
-        assert_equal(addon_data['name'], 'Test Folder')
-        assert_equal(addon_data['path'], '18497322')
-        assert_equal(
+        self.assertEqual(addon_data['kind'], 'folder')
+        self.assertEqual(addon_data['name'], 'Test Folder')
+        self.assertEqual(addon_data['path'], '18497322')
+        self.assertEqual(
             addon_data['folder_id'],
             'FSCFSLREF')
 
@@ -1123,8 +1122,8 @@ class TestNodeGoogleDriveAddon(
             self.setting_detail_url, data,
             auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(
             'Must specify both folder_id and folder_path for {}'.format(
                 self.short_name),
             res.json['errors'][0]['detail'])
@@ -1162,7 +1161,7 @@ class TestNodeForwardAddon(
             self.folder_url,
             auth=admin_user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 501)
+        self.assertEqual(res.status_code, 501)
 
     def test_folder_list_GET_raises_error_writecontrib_not_authorizer(self):
         write_user = AuthUserFactory()
@@ -1174,7 +1173,7 @@ class TestNodeForwardAddon(
             self.folder_url,
             auth=write_user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 501)
+        self.assertEqual(res.status_code, 501)
 
     def test_settings_detail_GET_enabled(self):
         res = self.app.get(
@@ -1182,8 +1181,8 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data']['attributes']
-        assert_equal(self.node_settings.url, addon_data['url'])
-        assert_equal(self.node_settings.label, addon_data['label'])
+        self.assertEqual(self.node_settings.url, addon_data['url'])
+        self.assertEqual(self.node_settings.label, addon_data['label'])
 
     def test_settings_detail_POST_enables(self):
         self.node.delete_addon(self.short_name, auth=self.auth)
@@ -1197,11 +1196,11 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = res.json['data']['attributes']
-        assert_equal(addon_data['url'], None)
-        assert_equal(addon_data['label'], None)
+        self.assertEqual(addon_data['url'], None)
+        self.assertEqual(addon_data['label'], None)
 
         self.node.reload()
-        assert_not_equal(self.node.logs.latest().action, 'forward_url_changed')
+        self.assertNotEqual(self.node.logs.latest().action, 'forward_url_changed')
 
     def test_settings_detail_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -1210,10 +1209,10 @@ class TestNodeForwardAddon(
             self.setting_detail_url,
             auth=noncontrib.auth)
 
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         addon_data = res.json['data']['attributes']
-        assert_equal(self.node_settings.url, addon_data['url'])
-        assert_equal(self.node_settings.label, addon_data['label'])
+        self.assertEqual(self.node_settings.url, addon_data['url'])
+        self.assertEqual(self.node_settings.label, addon_data['label'])
 
     def test_settings_list_GET_enabled(self):
         res = self.app.get(
@@ -1221,8 +1220,8 @@ class TestNodeForwardAddon(
             auth=self.user.auth)
 
         addon_data = self.get_response_for_addon(res)
-        assert_equal(self.node_settings.url, addon_data['url'])
-        assert_equal(self.node_settings.label, addon_data['label'])
+        self.assertEqual(self.node_settings.url, addon_data['url'])
+        self.assertEqual(self.node_settings.label, addon_data['label'])
 
     def test_settings_list_noncontrib_public_can_view(self):
         self.node.set_privacy('public', auth=self.auth)
@@ -1232,8 +1231,8 @@ class TestNodeForwardAddon(
             auth=noncontrib.auth)
         addon_data = self.get_response_for_addon(res)
 
-        assert_equal(self.node_settings.url, addon_data['url'])
-        assert_equal(self.node_settings.label, addon_data['label'])
+        self.assertEqual(self.node_settings.url, addon_data['url'])
+        self.assertEqual(self.node_settings.label, addon_data['label'])
 
     def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
         # This test doesn't apply forward, as it does not use ExternalAccounts.
@@ -1264,11 +1263,11 @@ class TestNodeForwardAddon(
         res = self.app.put_json_api(self.setting_detail_url,
                                     data, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        assert_equal(addon_data['url'], self._mock_folder_info['url'])
-        assert_equal(addon_data['label'], self._mock_folder_info['label'])
+        self.assertEqual(addon_data['url'], self._mock_folder_info['url'])
+        self.assertEqual(addon_data['label'], self._mock_folder_info['label'])
 
         self.node.reload()
-        assert_equal(self.node.logs.latest().action, 'forward_url_changed')
+        self.assertEqual(self.node.logs.latest().action, 'forward_url_changed')
 
     def test_settings_detail_PUT_none_and_enabled_clears_settings(self):
         res = self.app.put_json_api(
@@ -1282,10 +1281,10 @@ class TestNodeForwardAddon(
                 }
             }}, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        assert_false(addon_data['url'])
-        assert_false(addon_data['label'])
+        self.assertFalse(addon_data['url'])
+        self.assertFalse(addon_data['label'])
 
-        assert_not_equal(self.node.logs.latest().action, 'forward_url_changed')
+        self.assertNotEqual(self.node.logs.latest().action, 'forward_url_changed')
 
     def test_settings_detail_PUT_only_label_and_enabled_clears_settings(self):
         res = self.app.put_json_api(
@@ -1300,8 +1299,8 @@ class TestNodeForwardAddon(
             }},
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'Cannot set label without url')
 
@@ -1321,11 +1320,11 @@ class TestNodeForwardAddon(
             self.setting_detail_url,
             data, auth=self.user.auth)
         addon_data = res.json['data']['attributes']
-        assert_equal(addon_data['url'], self._mock_folder_info['url'])
-        assert_false(addon_data['label'])
+        self.assertEqual(addon_data['url'], self._mock_folder_info['url'])
+        self.assertFalse(addon_data['label'])
 
         self.node.reload()
-        assert_equal(self.node.logs.latest().action, 'forward_url_changed')
+        self.assertEqual(self.node.logs.latest().action, 'forward_url_changed')
 
     def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
         # This test doesn't apply forward, as it does not use ExternalAccounts.

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from unittest import mock
 import pytest
 import random
-from nose.tools import *  # noqa:
 
 from api.base.settings.defaults import API_BASE
 from api.nodes.serializers import NodeContributorsCreateSerializer
@@ -14,13 +13,13 @@ from osf_tests.factories import (
     ProjectFactory,
     UnconfirmedUserFactory,
     UserFactory,
-
 )
 from osf.utils import permissions
 from rest_framework import exceptions
 from tests.base import capture_signals, fake
 from website.project.signals import contributor_added, contributor_removed
 from api_tests.utils import disconnected_from_listeners
+
 
 @pytest.fixture()
 def user():
@@ -41,27 +40,27 @@ class NodeCRUDTestCase:
 
     @pytest.fixture()
     def title(self):
-        return 'Cool Project'
+        return "Cool Project"
 
     @pytest.fixture()
     def title_new(self):
-        return 'Super Cool Project'
+        return "Super Cool Project"
 
     @pytest.fixture()
     def description(self):
-        return 'A Properly Cool Project'
+        return "A Properly Cool Project"
 
     @pytest.fixture()
     def description_new(self):
-        return 'An even cooler project'
+        return "An even cooler project"
 
     @pytest.fixture()
     def category(self):
-        return 'data'
+        return "data"
 
     @pytest.fixture()
     def category_new(self):
-        return 'project'
+        return "project"
 
     @pytest.fixture()
     def project_public(self, user, title, description, category):
@@ -70,7 +69,7 @@ class NodeCRUDTestCase:
             description=description,
             category=category,
             is_public=True,
-            creator=user
+            creator=user,
         )
 
     @pytest.fixture()
@@ -80,25 +79,26 @@ class NodeCRUDTestCase:
             description=description,
             category=category,
             is_public=False,
-            creator=user
+            creator=user,
         )
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/'
+        return f"/{API_BASE}nodes/{project_public._id}/"
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return f'/{API_BASE}nodes/{project_private._id}/'
+        return f"/{API_BASE}nodes/{project_private._id}/"
 
     @pytest.fixture()
     def url_fake(self):
-        return '/{}nodes/{}/'.format(API_BASE, '12345')
+        return "/{}nodes/{}/".format(API_BASE, "12345")
 
     @pytest.fixture()
     def make_contrib_id(self):
         def contrib_id(node_id, user_id):
-            return f'{node_id}-{user_id}'
+            return f"{node_id}-{user_id}"
+
         return contrib_id
 
 
@@ -108,27 +108,26 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
+        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
 
     def test_concatenated_id(self, app, user, project_public, url_public):
         res = app.get(url_public)
         assert res.status_code == 200
 
-        assert res.json['data'][0]['id'].split('-')[0] == project_public._id
-        assert res.json['data'][0]['id'] == '{}-{}'.format(
-            project_public._id, user._id)
+        assert res.json["data"][0]["id"].split("-")[0] == project_public._id
+        assert res.json["data"][0]["id"] == "{}-{}".format(project_public._id, user._id)
 
     def test_permissions_work_with_many_users(
-            self, app, user, project_private, url_private):
+        self, app, user, project_private, url_private
+    ):
         users = {
             permissions.ADMIN: [user._id],
             permissions.WRITE: [],
-            permissions.READ: []
+            permissions.READ: [],
         }
         for i in range(0, 25):
             perm = random.choice(list(users.keys()))
@@ -138,92 +137,117 @@ class TestNodeContributorList(NodeCRUDTestCase):
             users[perm].append(user._id)
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
+        data = res.json["data"]
         for user in data:
-            api_perm = user['attributes']['permission']
-            user_id = user['id'].split('-')[1]
-            assert user_id in users[api_perm], 'Permissions incorrect for {}. Should not have {} permission.'.format(
-                user_id, api_perm)
+            api_perm = user["attributes"]["permission"]
+            user_id = user["id"].split("-")[1]
+            assert (
+                user_id in users[api_perm]
+            ), "Permissions incorrect for {}. Should not have {} permission.".format(
+                user_id, api_perm
+            )
 
     def test_return(
-            self, app, user, user_two, project_public, project_private,
-            url_public, url_private, make_contrib_id):
+        self,
+        app,
+        user,
+        user_two,
+        project_public,
+        project_private,
+        url_public,
+        url_private,
+        make_contrib_id,
+    ):
 
         #   test_return_public_contributor_list_logged_in
         res = app.get(url_public, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['id'] == make_contrib_id(
-            project_public._id, user._id)
+        assert res.content_type == "application/vnd.api+json"
+        assert len(res.json["data"]) == 1
+        assert res.json["data"][0]["id"] == make_contrib_id(
+            project_public._id, user._id
+        )
 
-    #   test_return_private_contributor_list_logged_out
+        #   test_return_private_contributor_list_logged_out
         res = app.get(url_private, expect_errors=True)
         assert res.status_code == 401
-        assert 'detail' in res.json['errors'][0]
+        assert "detail" in res.json["errors"][0]
 
-    #   test_return_private_contributor_list_logged_in_non_contributor
+        #   test_return_private_contributor_list_logged_in_non_contributor
         res = app.get(url_private, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
-        assert 'detail' in res.json['errors'][0]
+        assert "detail" in res.json["errors"][0]
 
-    #   test_return_private_contributor_list_logged_in_osf_group_member
+        #   test_return_private_contributor_list_logged_in_osf_group_member
         res = app.get(url_private, auth=user_two.auth, expect_errors=True)
         osf_group = OSFGroupFactory(creator=user_two)
         project_private.add_osf_group(osf_group, permissions.READ)
         res = app.get(url_private, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['id'] == make_contrib_id(
-            project_private._id, user._id)
+        assert res.content_type == "application/vnd.api+json"
+        assert len(res.json["data"]) == 1
+        assert res.json["data"][0]["id"] == make_contrib_id(
+            project_private._id, user._id
+        )
 
     def test_return_public_contributor_list_logged_out(
-            self, app, user, user_two, project_public, url_public, make_contrib_id):
+        self, app, user, user_two, project_public, url_public, make_contrib_id
+    ):
         project_public.add_contributor(user_two, save=True)
 
         res = app.get(url_public)
         assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert len(res.json['data']) == 2
-        assert res.json['data'][0]['id'] == make_contrib_id(
-            project_public._id, user._id)
-        assert res.json['data'][1]['id'] == make_contrib_id(
-            project_public._id, user_two._id)
+        assert res.content_type == "application/vnd.api+json"
+        assert len(res.json["data"]) == 2
+        assert res.json["data"][0]["id"] == make_contrib_id(
+            project_public._id, user._id
+        )
+        assert res.json["data"][1]["id"] == make_contrib_id(
+            project_public._id, user_two._id
+        )
 
     def test_return_private_contributor_list_logged_in_contributor(
-            self, app, user, user_two, project_private, url_private, make_contrib_id):
+        self, app, user, user_two, project_private, url_private, make_contrib_id
+    ):
         project_private.add_contributor(user_two)
         project_private.save()
 
         res = app.get(url_private, auth=user.auth)
         assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert len(res.json['data']) == 2
-        assert res.json['data'][0]['id'] == make_contrib_id(
-            project_private._id, user._id)
-        assert res.json['data'][1]['id'] == make_contrib_id(
-            project_private._id, user_two._id)
+        assert res.content_type == "application/vnd.api+json"
+        assert len(res.json["data"]) == 2
+        assert res.json["data"][0]["id"] == make_contrib_id(
+            project_private._id, user._id
+        )
+        assert res.json["data"][1]["id"] == make_contrib_id(
+            project_private._id, user_two._id
+        )
 
     def test_filtering_on_obsolete_fields(self, app, user, url_public):
         # regression test for changes in filter fields
-        url_fullname = f'{url_public}?filter[fullname]=foo'
+        url_fullname = f"{url_public}?filter[fullname]=foo"
         res = app.get(url_fullname, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json['errors']
+        errors = res.json["errors"]
         assert len(errors) == 1
-        assert errors[0]['detail'] == '\'fullname\' is not a valid field for this endpoint.'
+        assert (
+            errors[0]["detail"] == "'fullname' is not a valid field for this endpoint."
+        )
 
         # middle_name is now middle_names
-        url_middle_name = f'{url_public}?filter[middle_name]=foo'
+        url_middle_name = f"{url_public}?filter[middle_name]=foo"
         res = app.get(url_middle_name, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json['errors']
+        errors = res.json["errors"]
         assert len(errors) == 1
-        assert errors[0]['detail'] == '\'middle_name\' is not a valid field for this endpoint.'
+        assert (
+            errors[0]["detail"]
+            == "'middle_name' is not a valid field for this endpoint."
+        )
 
     def test_disabled_contributors_contain_names_under_meta(
-            self, app, user, user_two, project_public, url_public, make_contrib_id):
+        self, app, user, user_two, project_public, url_public, make_contrib_id
+    ):
         project_public.add_contributor(user_two, save=True)
 
         user_two.is_disabled = True
@@ -231,71 +255,88 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
         res = app.get(url_public)
         assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert len(res.json['data']) == 2
-        assert res.json['data'][0]['id'] == make_contrib_id(
-            project_public._id, user._id)
-        assert res.json['data'][1]['id'] == make_contrib_id(
-            project_public._id, user_two._id)
-        assert res.json['data'][1]['embeds']['users']['errors'][0]['meta']['full_name'] == user_two.fullname
-        assert res.json['data'][1]['embeds']['users']['errors'][0]['detail'] == 'The requested user is no longer available.'
+        assert res.content_type == "application/vnd.api+json"
+        assert len(res.json["data"]) == 2
+        assert res.json["data"][0]["id"] == make_contrib_id(
+            project_public._id, user._id
+        )
+        assert res.json["data"][1]["id"] == make_contrib_id(
+            project_public._id, user_two._id
+        )
+        assert (
+            res.json["data"][1]["embeds"]["users"]["errors"][0]["meta"]["full_name"]
+            == user_two.fullname
+        )
+        assert (
+            res.json["data"][1]["embeds"]["users"]["errors"][0]["detail"]
+            == "The requested user is no longer available."
+        )
 
     def test_total_bibliographic_contributor_count_returned_in_metadata(
-            self, app, user_two, project_public, url_public):
+        self, app, user_two, project_public, url_public
+    ):
         non_bibliographic_user = UserFactory()
         project_public.add_contributor(
-            non_bibliographic_user,
-            visible=False,
-            auth=Auth(project_public.creator))
+            non_bibliographic_user, visible=False, auth=Auth(project_public.creator)
+        )
         project_public.save()
         res = app.get(url_public, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.json['links']['meta']['total_bibliographic'] == len(
-            project_public.visible_contributor_ids)
+        assert res.json["links"]["meta"]["total_bibliographic"] == len(
+            project_public.visible_contributor_ids
+        )
 
-    def test_unregistered_contributor_field_is_null_if_account_claimed(
-            self, app, user):
+    def test_unregistered_contributor_field_is_null_if_account_claimed(self, app, user):
         project = ProjectFactory(creator=user, is_public=True)
-        url = f'/{API_BASE}nodes/{project._id}/contributors/'
+        url = f"/{API_BASE}nodes/{project._id}/contributors/"
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get(
-            'unregistered_contributor') is None
+        assert len(res.json["data"]) == 1
+        assert res.json["data"][0]["attributes"].get("unregistered_contributor") is None
 
     def test_unregistered_contributors_show_up_as_name_associated_with_project(
-            self, app, user):
+        self, app, user
+    ):
         project = ProjectFactory(creator=user, is_public=True)
         project.add_unregistered_contributor(
-            'Robert Jackson',
-            'robert@gmail.com',
-            auth=Auth(user), save=True)
-        url = f'/{API_BASE}nodes/{project._id}/contributors/'
+            "Robert Jackson", "robert@gmail.com", auth=Auth(user), save=True
+        )
+        url = f"/{API_BASE}nodes/{project._id}/contributors/"
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 2
-        assert res.json['data'][1]['embeds']['users']['data']['attributes']['full_name'] == 'Robert Jackson'
-        assert res.json['data'][1]['attributes'].get(
-            'unregistered_contributor') == 'Robert Jackson'
+        assert len(res.json["data"]) == 2
+        assert (
+            res.json["data"][1]["embeds"]["users"]["data"]["attributes"]["full_name"]
+            == "Robert Jackson"
+        )
+        assert (
+            res.json["data"][1]["attributes"].get("unregistered_contributor")
+            == "Robert Jackson"
+        )
 
         project_two = ProjectFactory(creator=user, is_public=True)
         project_two.add_unregistered_contributor(
-            'Bob Jackson', 'robert@gmail.com', auth=Auth(user), save=True)
-        url = f'/{API_BASE}nodes/{project_two._id}/contributors/'
+            "Bob Jackson", "robert@gmail.com", auth=Auth(user), save=True
+        )
+        url = f"/{API_BASE}nodes/{project_two._id}/contributors/"
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 2
+        assert len(res.json["data"]) == 2
 
-        assert res.json['data'][1]['embeds']['users']['data']['attributes']['full_name'] == 'Robert Jackson'
-        assert res.json['data'][1]['attributes'].get(
-            'unregistered_contributor') == 'Bob Jackson'
+        assert (
+            res.json["data"][1]["embeds"]["users"]["data"]["attributes"]["full_name"]
+            == "Robert Jackson"
+        )
+        assert (
+            res.json["data"][1]["attributes"].get("unregistered_contributor")
+            == "Bob Jackson"
+        )
 
     def test_contributors_order_is_the_same_over_multiple_requests(
-            self, app, user, project_public, url_public):
+        self, app, user, project_public, url_public
+    ):
         project_public.add_unregistered_contributor(
-            'Robert Jackson',
-            'robert@gmail.com',
-            auth=Auth(user), save=True
+            "Robert Jackson", "robert@gmail.com", auth=Auth(user), save=True
         )
 
         for i in range(0, 10):
@@ -305,19 +346,12 @@ class TestNodeContributorList(NodeCRUDTestCase):
             else:
                 visible = False
             project_public.add_contributor(
-                new_user,
-                visible=visible,
-                auth=Auth(project_public.creator),
-                save=True
+                new_user, visible=visible, auth=Auth(project_public.creator), save=True
             )
-        req_one = app.get(
-            f'{url_public}?page=2',
-            auth=Auth(project_public.creator))
-        req_two = app.get(
-            f'{url_public}?page=2',
-            auth=Auth(project_public.creator))
-        id_one = [item['id'] for item in req_one.json['data']]
-        id_two = [item['id'] for item in req_two.json['data']]
+        req_one = app.get(f"{url_public}?page=2", auth=Auth(project_public.creator))
+        req_two = app.get(f"{url_public}?page=2", auth=Auth(project_public.creator))
+        id_one = [item["id"] for item in req_one.json["data"]]
+        id_two = [item["id"] for item in req_two.json["data"]]
         for a, b in zip(id_one, id_two):
             assert a == b
 
@@ -332,571 +366,480 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/?send_email=false'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/?send_email=false".format(
+            API_BASE, project_private._id
+        )
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return '/{}nodes/{}/contributors/?send_email=false'.format(
-            API_BASE, project_public._id)
+        return "/{}nodes/{}/contributors/?send_email=false".format(
+            API_BASE, project_public._id
+        )
 
     @pytest.fixture()
     def data_user_two(self, user_two):
         return {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "bibliographic": True,
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id,
+                "relationships": {
+                    "users": {
+                        "data": {
+                            "type": "users",
+                            "id": user_two._id,
                         }
                     }
-                }
+                },
             }
         }
 
     @pytest.fixture()
     def data_user_three(self, user_three):
         return {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "bibliographic": True,
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_three._id,
+                "relationships": {
+                    "users": {
+                        "data": {
+                            "type": "users",
+                            "id": user_three._id,
                         }
                     }
-                }
+                },
             }
         }
 
-    def test_add_contributors_errors(
-            self, app, user, user_two, user_three, url_public):
+    def test_add_contributors_errors(self, app, user, user_two, user_three, url_public):
 
         #   test_add_node_contributors_relationships_is_a_list
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': [{'contributor_id': user_three._id}]
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": [{"contributor_id": user_three._id}],
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
+        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
 
-    #   test_add_contributor_no_relationships
-        data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                }
-            }
-        }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        #   test_add_contributor_no_relationships
+        data = {"data": {"type": "contributors", "attributes": {"bibliographic": True}}}
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'A user ID or full name must be provided to add a contributor.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "A user ID or full name must be provided to add a contributor."
+        )
 
-    #   test_add_contributor_empty_relationships
+        #   test_add_contributor_empty_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {}
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'A user ID or full name must be provided to add a contributor.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "A user ID or full name must be provided to add a contributor."
+        )
 
-    #   test_add_contributor_no_user_key_in_relationships
+        #   test_add_contributor_no_user_key_in_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'id': user_two._id,
-                    'type': 'users'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"id": user_two._id, "type": "users"},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
+        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
 
-    #   test_add_contributor_no_data_in_relationships
+        #   test_add_contributor_no_data_in_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'users': {
-                        'id': user_two._id
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"users": {"id": user_two._id}},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data.'
+        assert res.json["errors"][0]["detail"] == "Request must include /data."
 
-    #   test_add_contributor_no_target_type_in_relationships
+        #   test_add_contributor_no_target_type_in_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"users": {"data": {"id": user_two._id}}},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /type.'
+        assert res.json["errors"][0]["detail"] == "Request must include /type."
 
-    #   test_add_contributor_no_target_id_in_relationships
+        #   test_add_contributor_no_target_id_in_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users'
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"users": {"data": {"type": "users"}}},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'A user ID or full name must be provided to add a contributor.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "A user ID or full name must be provided to add a contributor."
+        )
 
-    #   test_add_contributor_incorrect_target_id_in_relationships
+        #   test_add_contributor_incorrect_target_id_in_relationships
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': '12345'
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"users": {"data": {"type": "users", "id": "12345"}}},
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
 
-    #   test_add_contributor_no_type
+        #   test_add_contributor_no_type
         data = {
-            'data': {
-                'attributes': {
-                    'bibliographic': True
+            "data": {
+                "attributes": {"bibliographic": True},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['source']['pointer'] == '/data/type'
+        assert res.json["errors"][0]["source"]["pointer"] == "/data/type"
 
-    #   test_add_contributor_incorrect_type
+        #   test_add_contributor_incorrect_type
         data = {
-            'data': {
-                'type': 'Incorrect type',
-                'attributes': {
-                    'bibliographic': True
+            "data": {
+                "type": "Incorrect type",
+                "attributes": {"bibliographic": True},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 409
 
-    #   test_unregistered_contributor_invalid_email
+        #   test_unregistered_contributor_invalid_email
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'permission': 'admin',
-                    'email': 'jdoe@example.com',
-                    'full_name': 'John Doe'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "permission": "admin",
+                    "email": "jdoe@example.com",
+                    "full_name": "John Doe",
+                },
             }
         }
-        res = app.post_json_api(
-            url_public, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Unregistered contributor email address domain is blocked.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Unregistered contributor email address domain is blocked."
+        )
 
-    def test_contributor_create_invalid_data(
-            self, app, user_three, url_public):
+    def test_contributor_create_invalid_data(self, app, user_three, url_public):
         res = app.post_json_api(
-            url_public,
-            'Incorrect data',
-            auth=user_three.auth,
-            expect_errors=True)
+            url_public, "Incorrect data", auth=user_three.auth, expect_errors=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
+        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
 
         res = app.post_json_api(
-            url_public,
-            ['Incorrect data'],
-            auth=user_three.auth,
-            expect_errors=True)
+            url_public, ["Incorrect data"], auth=user_three.auth, expect_errors=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
+        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
 
     def test_add_contributor_dont_expose_email(
-            self, app, user, user_two, project_public, data_user_two, url_public):
+        self, app, user, user_two, project_public, data_user_two, url_public
+    ):
 
-        res = app.post_json_api(
-            url_public,
-            data_user_two,
-            auth=user.auth)
+        res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['attributes'].get('email') is None
+        assert res.json["data"]["attributes"].get("email") is None
 
     def test_add_contributor_is_visible_by_default(
-            self, app, user, user_two, project_public,
-            data_user_two, url_public):
-        del data_user_two['data']['attributes']['bibliographic']
+        self, app, user, user_two, project_public, data_user_two, url_public
+    ):
+        del data_user_two["data"]["attributes"]["bibliographic"]
         res = app.post_json_api(
-            url_public,
-            data_user_two,
-            auth=user.auth,
-            expect_errors=True)
+            url_public, data_user_two, auth=user.auth, expect_errors=True
+        )
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_public._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_public._id, user_two._id
+        )
 
         project_public.reload()
         assert user_two in project_public.contributors
         assert project_public.get_visible(user_two)
 
     def test_adds_bibliographic_contributor_public_project_admin(
-            self, app, user, user_two, project_public, data_user_two, url_public):
+        self, app, user, user_two, project_public, data_user_two, url_public
+    ):
         res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_public._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_public._id, user_two._id
+        )
 
         project_public.reload()
         assert user_two in project_public.contributors
 
     def test_adds_non_bibliographic_contributor_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': False
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": False},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_private, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
-        assert res.json['data']['attributes']['bibliographic'] is False
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
+        assert res.json["data"]["attributes"]["bibliographic"] is False
 
         project_private.reload()
         assert user_two in project_private.contributors
         assert not project_private.get_visible(user_two)
 
     def test_adds_contributor_public_project_non_admin(
-            self, app, user, user_two, user_three,
-            project_public, data_user_three, url_public):
+        self,
+        app,
+        user,
+        user_two,
+        user_three,
+        project_public,
+        data_user_three,
+        url_public,
+    ):
         project_public.add_contributor(
-            user_two,
-            permissions=permissions.WRITE,
-            auth=Auth(user),
-            save=True)
-        res = app.post_json_api(url_public, data_user_three,
-                                auth=user_two.auth, expect_errors=True)
+            user_two, permissions=permissions.WRITE, auth=Auth(user), save=True
+        )
+        res = app.post_json_api(
+            url_public, data_user_three, auth=user_two.auth, expect_errors=True
+        )
         assert res.status_code == 403
         project_public.reload()
         assert user_three not in project_public.contributors.all()
 
     def test_adds_contributor_public_project_non_admin_osf_group(
-            self, app, user, user_two, user_three,
-            project_public, data_user_three, url_public):
+        self,
+        app,
+        user,
+        user_two,
+        user_three,
+        project_public,
+        data_user_three,
+        url_public,
+    ):
         group = OSFGroupFactory(creator=user_two)
         project_public.add_osf_group(group, permissions.WRITE)
-        res = app.post_json_api(url_public, data_user_three,
-                                auth=user_two.auth, expect_errors=True)
+        res = app.post_json_api(
+            url_public, data_user_three, auth=user_two.auth, expect_errors=True
+        )
         assert res.status_code == 403
         project_public.reload()
         assert user_three not in project_public.contributors.all()
 
     def test_adds_contributor_public_project_non_contributor(
-            self, app, user_two, user_three, project_public, data_user_three, url_public):
-        res = app.post_json_api(url_public, data_user_three,
-                                auth=user_two.auth, expect_errors=True)
+        self, app, user_two, user_three, project_public, data_user_three, url_public
+    ):
+        res = app.post_json_api(
+            url_public, data_user_three, auth=user_two.auth, expect_errors=True
+        )
         assert res.status_code == 403
         assert user_three not in project_public.contributors.all()
 
     def test_adds_contributor_public_project_not_logged_in(
-            self, app, user_two, project_public, data_user_two, url_public):
+        self, app, user_two, project_public, data_user_two, url_public
+    ):
         res = app.post_json_api(url_public, data_user_two, expect_errors=True)
         assert res.status_code == 401
         assert user_two not in project_public.contributors.all()
 
     def test_adds_contributor_private_project_admin(
-            self, app, user, user_two, project_private,
-            data_user_two, url_private):
+        self, app, user, user_two, project_private, data_user_two, url_private
+    ):
         res = app.post_json_api(url_private, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
 
         project_private.reload()
         assert user_two in project_private.contributors
 
     def test_adds_contributor_private_project_osf_group_admin_perms(
-            self, app, user, user_two, user_three, project_private,
-            data_user_two, url_private):
+        self,
+        app,
+        user,
+        user_two,
+        user_three,
+        project_private,
+        data_user_two,
+        url_private,
+    ):
         osf_group = OSFGroupFactory(creator=user_three)
         project_private.add_osf_group(osf_group, permissions.ADMIN)
         res = app.post_json_api(url_private, data_user_two, auth=user_three.auth)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
 
         project_private.reload()
         assert user_two in project_private.contributors
 
     def test_adds_contributor_without_bibliographic_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_private, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 201
 
         project_private.reload()
         assert user_two in project_private.contributors
 
     def test_adds_admin_contributor_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
-                    'permission': permissions.ADMIN
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
 
         project_private.reload()
         assert user_two in project_private.contributors
         assert project_private.get_permissions(user_two) == [
-            permissions.READ, permissions.WRITE, permissions.ADMIN]
+            permissions.READ,
+            permissions.WRITE,
+            permissions.ADMIN,
+        ]
 
     def test_adds_write_contributor_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
-                    'permission': permissions.WRITE
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True, "permission": permissions.WRITE},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
-
-        project_private.reload()
-        assert user_two in project_private.contributors
-        assert project_private.get_permissions(
-            user_two) == [permissions.READ, permissions.WRITE]
-
-    def test_adds_read_contributor_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
-        data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
-                    'permission': permissions.READ
-                },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
-            }
-        }
-        res = app.post_json_api(url_private, data, auth=user.auth)
-        assert res.status_code == 201
-        assert res.json['data']['id'] == '{}-{}'.format(
-            project_private._id, user_two._id)
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
 
         project_private.reload()
         assert user_two in project_private.contributors
         assert project_private.get_permissions(user_two) == [
-            permissions.READ]
+            permissions.READ,
+            permissions.WRITE,
+        ]
 
-    def test_adds_invalid_permission_contributor_private_project_admin(
-            self, app, user, user_two, project_private, url_private):
+    def test_adds_read_contributor_private_project_admin(
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
-                    'permission': 'invalid',
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True, "permission": permissions.READ},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_private, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_private, data, auth=user.auth)
+        assert res.status_code == 201
+        assert res.json["data"]["id"] == "{}-{}".format(
+            project_private._id, user_two._id
+        )
+
+        project_private.reload()
+        assert user_two in project_private.contributors
+        assert project_private.get_permissions(user_two) == [permissions.READ]
+
+    def test_adds_invalid_permission_contributor_private_project_admin(
+        self, app, user, user_two, project_private, url_private
+    ):
+        data = {
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "bibliographic": True,
+                    "permission": "invalid",
+                },
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
+                },
+            }
+        }
+        res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
 
         project_private.reload()
         assert user_two not in project_private.contributors.all()
 
     def test_adds_none_permission_contributor_private_project_admin_uses_default_permissions(
-            self, app, user, user_two, project_private, url_private):
+        self, app, user, user_two, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True,
-                    'permission': None
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True, "permission": None},
+                "relationships": {
+                    "users": {"data": {"id": user_two._id, "type": "users"}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': user_two._id,
-                            'type': 'users'
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
@@ -907,66 +850,67 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert project_private.has_permission(user_two, permissions.WRITE)
 
     def test_adds_already_existing_contributor_private_project_admin(
-            self, app, user, user_two, project_private, data_user_two, url_private):
+        self, app, user, user_two, project_private, data_user_two, url_private
+    ):
         project_private.add_contributor(user_two, auth=Auth(user), save=True)
         project_private.reload()
 
-        res = app.post_json_api(url_private, data_user_two,
-                                auth=user.auth, expect_errors=True)
+        res = app.post_json_api(
+            url_private, data_user_two, auth=user.auth, expect_errors=True
+        )
         assert res.status_code == 400
 
     def test_adds_non_existing_user_private_project_admin(
-            self, app, user, project_private, url_private):
+        self, app, user, project_private, url_private
+    ):
         data = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'bibliographic': True
-                },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'id': 'FAKE',
-                            'type': 'users'
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"bibliographic": True},
+                "relationships": {"users": {"data": {"id": "FAKE", "type": "users"}}},
             }
         }
-        res = app.post_json_api(
-            url_private, data, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
 
         project_private.reload()
         assert len(project_private.contributors) == 1
 
     def test_adds_contributor_private_project_non_admin(
-            self, app, user, user_two, user_three,
-            project_private, data_user_three, url_private):
+        self,
+        app,
+        user,
+        user_two,
+        user_three,
+        project_private,
+        data_user_three,
+        url_private,
+    ):
         project_private.add_contributor(
-            user_two,
-            permissions=permissions.WRITE,
-            auth=Auth(user))
+            user_two, permissions=permissions.WRITE, auth=Auth(user)
+        )
         res = app.post_json_api(
-            url_private, data_user_three,
-            auth=user_two.auth, expect_errors=True)
+            url_private, data_user_three, auth=user_two.auth, expect_errors=True
+        )
         assert res.status_code == 403
 
         project_private.reload()
         assert user_three not in project_private.contributors.all()
 
     def test_adds_contributor_private_project_non_contributor(
-            self, app, user_two, user_three, project_private, data_user_three, url_private):
-        res = app.post_json_api(url_private, data_user_three,
-                                auth=user_two.auth, expect_errors=True)
+        self, app, user_two, user_three, project_private, data_user_three, url_private
+    ):
+        res = app.post_json_api(
+            url_private, data_user_three, auth=user_two.auth, expect_errors=True
+        )
         assert res.status_code == 403
 
         project_private.reload()
         assert user_three not in project_private.contributors.all()
 
     def test_adds_contributor_private_project_not_logged_in(
-            self, app, user_two, project_private, data_user_two, url_private):
+        self, app, user_two, project_private, data_user_two, url_private
+    ):
         res = app.post_json_api(url_private, data_user_two, expect_errors=True)
         assert res.status_code == 401
 
@@ -974,314 +918,283 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert user_two not in project_private.contributors.all()
 
     def test_add_unregistered_contributor_with_fullname(
-            self, app, user, project_public, url_public):
+        self, app, user, project_public, url_public
+    ):
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'John Doe',
-                }
-            }
-        }
-        res = app.post_json_api(url_public, payload, auth=user.auth)
-        project_public.reload()
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-        assert res.json['data']['attributes'].get('email') is None
-        assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
-            'guids___id', flat=True)
-
-    def test_add_contributor_with_fullname_and_email_unregistered_user(
-            self, app, user, project_public, url_public):
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'John Doe',
-                    'email': 'john@doe.com'
-                }
-            }
-        }
-        res = app.post_json_api(url_public, payload, auth=user.auth)
-        project_public.reload()
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-        assert res.json['data']['attributes'].get('email') is None
-        assert res.json['data']['attributes']['bibliographic'] is True
-        assert res.json['data']['attributes']['permission'] == permissions.WRITE
-        assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
-            'guids___id', flat=True)
-
-    def test_add_contributor_with_fullname_and_email_unregistered_user_set_attributes(
-            self, app, user, project_public, url_public):
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'John Doe',
-                    'email': 'john@doe.com',
-                    'bibliographic': False,
-                    'permission': permissions.READ
-                }
-            }
-        }
-        res = app.post_json_api(url_public, payload, auth=user.auth)
-        project_public.reload()
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
-        assert res.json['data']['attributes'].get('email') is None
-        assert res.json['data']['attributes']['bibliographic'] is False
-        assert res.json['data']['attributes']['permission'] == permissions.READ
-        assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
-            'guids___id', flat=True)
-
-    def test_add_contributor_with_fullname_and_email_registered_user(
-            self, app, user, project_public, url_public):
-        user_contrib = UserFactory()
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': user_contrib.fullname,
-                    'email': user_contrib.username
-                }
-            }
-        }
-        res = app.post_json_api(url_public, payload, auth=user.auth)
-        project_public.reload()
-        assert res.status_code == 201
-        assert res.json['data']['attributes']['unregistered_contributor'] is None
-        assert res.json['data']['attributes'].get('email') is None
-        assert res.json['data']['embeds']['users']['data']['id'] in project_public.contributors.values_list(
-            'guids___id', flat=True)
-
-    def test_add_unregistered_contributor_already_contributor(
-            self, app, user, project_public, url_public):
-        name, email = fake.name(), fake_email()
-        project_public.add_unregistered_contributor(
-            auth=Auth(user), fullname=name, email=email)
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Doesn\'t Matter',
-                    'email': email
-                }
-            }
-        }
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
-        project_public.reload()
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '{} is already a contributor.'.format(
-            name)
-
-    def test_add_contributor_user_is_deactivated_registered_payload(
-            self, app, user, url_public):
-        user_contrib = UserFactory()
-        user_contrib.date_disabled = datetime.utcnow()
-        user_contrib.save()
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {},
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_contrib._id
-                        }
-                    }
-                }
-            }
-        }
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added as contributors.'
-
-    def test_add_contributor_user_is_deactivated_unregistered_payload(
-            self, app, user, url_public):
-        user_contrib = UserFactory()
-        user_contrib.date_disabled = datetime.utcnow()
-        user_contrib.save()
-        payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': user_contrib.fullname,
-                    'email': user_contrib.username
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "full_name": "John Doe",
                 },
             }
         }
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
+        res = app.post_json_api(url_public, payload, auth=user.auth)
+        project_public.reload()
+        assert res.status_code == 201
+        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
+        assert res.json["data"]["attributes"].get("email") is None
+        assert res.json["data"]["embeds"]["users"]["data"][
+            "id"
+        ] in project_public.contributors.values_list("guids___id", flat=True)
+
+    def test_add_contributor_with_fullname_and_email_unregistered_user(
+        self, app, user, project_public, url_public
+    ):
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "John Doe", "email": "john@doe.com"},
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth)
+        project_public.reload()
+        assert res.status_code == 201
+        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
+        assert res.json["data"]["attributes"].get("email") is None
+        assert res.json["data"]["attributes"]["bibliographic"] is True
+        assert res.json["data"]["attributes"]["permission"] == permissions.WRITE
+        assert res.json["data"]["embeds"]["users"]["data"][
+            "id"
+        ] in project_public.contributors.values_list("guids___id", flat=True)
+
+    def test_add_contributor_with_fullname_and_email_unregistered_user_set_attributes(
+        self, app, user, project_public, url_public
+    ):
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "full_name": "John Doe",
+                    "email": "john@doe.com",
+                    "bibliographic": False,
+                    "permission": permissions.READ,
+                },
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth)
+        project_public.reload()
+        assert res.status_code == 201
+        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
+        assert res.json["data"]["attributes"].get("email") is None
+        assert res.json["data"]["attributes"]["bibliographic"] is False
+        assert res.json["data"]["attributes"]["permission"] == permissions.READ
+        assert res.json["data"]["embeds"]["users"]["data"][
+            "id"
+        ] in project_public.contributors.values_list("guids___id", flat=True)
+
+    def test_add_contributor_with_fullname_and_email_registered_user(
+        self, app, user, project_public, url_public
+    ):
+        user_contrib = UserFactory()
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "full_name": user_contrib.fullname,
+                    "email": user_contrib.username,
+                },
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth)
+        project_public.reload()
+        assert res.status_code == 201
+        assert res.json["data"]["attributes"]["unregistered_contributor"] is None
+        assert res.json["data"]["attributes"].get("email") is None
+        assert res.json["data"]["embeds"]["users"]["data"][
+            "id"
+        ] in project_public.contributors.values_list("guids___id", flat=True)
+
+    def test_add_unregistered_contributor_already_contributor(
+        self, app, user, project_public, url_public
+    ):
+        name, email = fake.name(), fake_email()
+        project_public.add_unregistered_contributor(
+            auth=Auth(user), fullname=name, email=email
+        )
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Doesn't Matter", "email": email},
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
+        project_public.reload()
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Deactivated users cannot be added as contributors.'
+        assert res.json["errors"][0]["detail"] == "{} is already a contributor.".format(
+            name
+        )
+
+    def test_add_contributor_user_is_deactivated_registered_payload(
+        self, app, user, url_public
+    ):
+        user_contrib = UserFactory()
+        user_contrib.date_disabled = datetime.utcnow()
+        user_contrib.save()
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_contrib._id}}
+                },
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Deactivated users cannot be added as contributors."
+        )
+
+    def test_add_contributor_user_is_deactivated_unregistered_payload(
+        self, app, user, url_public
+    ):
+        user_contrib = UserFactory()
+        user_contrib.date_disabled = datetime.utcnow()
+        user_contrib.save()
+        payload = {
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "full_name": user_contrib.fullname,
+                    "email": user_contrib.username,
+                },
+            }
+        }
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Deactivated users cannot be added as contributors."
+        )
 
     def test_add_contributor_index_returned(
-            self, app, user, data_user_two,
-            data_user_three, url_public):
+        self, app, user, data_user_two, data_user_three, url_public
+    ):
         res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['attributes']['index'] == 1
+        assert res.json["data"]["attributes"]["index"] == 1
 
         res = app.post_json_api(url_public, data_user_three, auth=user.auth)
         assert res.status_code == 201
-        assert res.json['data']['attributes']['index'] == 2
+        assert res.json["data"]["attributes"]["index"] == 2
 
     def test_add_contributor_set_index_out_of_range(
-            self, app, user, user_two, project_public, url_public):
+        self, app, user, user_two, project_public, url_public
+    ):
         user_contrib_one = UserFactory()
         project_public.add_contributor(user_contrib_one, save=True)
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'index': 4
+            "data": {
+                "type": "contributors",
+                "attributes": {"index": 4},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '4 is not a valid contributor index for node with id {}'.format(
-            project_public._id)
+        assert res.json["errors"][0][
+            "detail"
+        ] == "4 is not a valid contributor index for node with id {}".format(
+            project_public._id
+        )
 
     def test_add_contributor_set_index_first(
-            self, app, user, user_two, project_public, url_public):
+        self, app, user, user_two, project_public, url_public
+    ):
         user_contrib_one = UserFactory()
         project_public.add_contributor(user_contrib_one, save=True)
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'index': 0
+            "data": {
+                "type": "contributors",
+                "attributes": {"index": 0},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
         contributor_obj = project_public.contributor_set.get(user=user_two)
-        index = list(
-            project_public.get_contributor_order()
-        ).index(contributor_obj.pk)
+        index = list(project_public.get_contributor_order()).index(contributor_obj.pk)
         assert index == 0
 
     def test_add_contributor_set_index_last(
-            self, app, user, user_two, project_public, url_public):
+        self, app, user, user_two, project_public, url_public
+    ):
         user_contrib_one = UserFactory()
         project_public.add_contributor(user_contrib_one, save=True)
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'index': 3
+            "data": {
+                "type": "contributors",
+                "attributes": {"index": 3},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
         contributor_obj = project_public.contributor_set.get(user=user_two)
-        index = list(
-            project_public.get_contributor_order()
-        ).index(contributor_obj.pk)
+        index = list(project_public.get_contributor_order()).index(contributor_obj.pk)
         assert index == 3
 
-    def test_add_inactive_merged_user_as_contributor(
-            self, app, user, url_public):
+    def test_add_inactive_merged_user_as_contributor(self, app, user, url_public):
         primary_user = UserFactory()
         merged_user = UserFactory(merged_by=primary_user)
 
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {},
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': merged_user._id
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": merged_user._id}}
+                },
             }
         }
 
         res = app.post_json_api(url_public, payload, auth=user.auth)
         assert res.status_code == 201
-        contributor_added = res.json['data']['embeds']['users']['data']['id']
+        contributor_added = res.json["data"]["embeds"]["users"]["data"]["id"]
         assert contributor_added == primary_user._id
 
-    def test_add_unconfirmed_user_by_guid(
-            self, app, user, project_public, url_public):
+    def test_add_unconfirmed_user_by_guid(self, app, user, project_public, url_public):
         unconfirmed_user = UnconfirmedUserFactory()
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {},
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': unconfirmed_user._id
-                        }
-                    }
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": unconfirmed_user._id}}
+                },
             }
         }
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
         # if adding unregistered contrib by guid, fullname must be supplied
-        assert (
-            res.json['errors'][0]['detail'] ==
-            'Cannot add unconfirmed user {} to resource {}. You need to provide a full_name.'
-            .format(unconfirmed_user._id, project_public._id))
+        assert res.json["errors"][0][
+            "detail"
+        ] == "Cannot add unconfirmed user {} to resource {}. You need to provide a full_name.".format(
+            unconfirmed_user._id, project_public._id
+        )
 
-        payload['data']['attributes']['full_name'] = 'Susan B. Anthony'
-        res = app.post_json_api(
-            url_public, payload,
-            auth=user.auth, expect_errors=True)
+        payload["data"]["attributes"]["full_name"] = "Susan B. Anthony"
+        res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 201
-        assert res.json['data']['attributes']['unregistered_contributor'] == 'Susan B. Anthony'
+        assert (
+            res.json["data"]["attributes"]["unregistered_contributor"]
+            == "Susan B. Anthony"
+        )
 
 
 @pytest.mark.django_db
@@ -1296,57 +1209,51 @@ class TestNodeContributorCreateValidation(NodeCRUDTestCase):
     def validate_data(self, create_serializer):
         return create_serializer.validate_data
 
-    def test_add_contributor_validation(self, project_public, validate_data, create_serializer):
+    def test_add_contributor_validation(
+        self, project_public, validate_data, create_serializer
+    ):
 
         #   test_add_contributor_validation_user_id
-        validate_data(
-            create_serializer(),
-            project_public,
-            user_id='abcde')
+        validate_data(create_serializer(), project_public, user_id="abcde")
 
-    #   test_add_contributor_validation_user_id_fullname
+        #   test_add_contributor_validation_user_id_fullname
         validate_data(
-            create_serializer(),
-            project_public,
-            user_id='abcde',
-            full_name='Kanye')
+            create_serializer(), project_public, user_id="abcde", full_name="Kanye"
+        )
 
-    #   test_add_contributor_validation_user_id_email
+        #   test_add_contributor_validation_user_id_email
         with pytest.raises(exceptions.ValidationError):
             validate_data(
                 create_serializer(),
                 project_public,
-                user_id='abcde',
-                email='kanye@west.com')
+                user_id="abcde",
+                email="kanye@west.com",
+            )
 
-    #   test_add_contributor_validation_user_id_fullname_email
+        #   test_add_contributor_validation_user_id_fullname_email
         with pytest.raises(exceptions.ValidationError):
             validate_data(
                 create_serializer(),
                 project_public,
-                user_id='abcde',
-                full_name='Kanye',
-                email='kanye@west.com')
+                user_id="abcde",
+                full_name="Kanye",
+                email="kanye@west.com",
+            )
 
-    #   test_add_contributor_validation_fullname
-        validate_data(
-            create_serializer(),
-            project_public,
-            full_name='Kanye')
+        #   test_add_contributor_validation_fullname
+        validate_data(create_serializer(), project_public, full_name="Kanye")
 
-    #   test_add_contributor_validation_email
+        #   test_add_contributor_validation_email
         with pytest.raises(exceptions.ValidationError):
-            validate_data(
-                create_serializer(),
-                project_public,
-                email='kanye@west.com')
+            validate_data(create_serializer(), project_public, email="kanye@west.com")
 
-    #   test_add_contributor_validation_fullname_email
+        #   test_add_contributor_validation_fullname_email
         validate_data(
             create_serializer(),
             project_public,
-            full_name='Kanye',
-            email='kanye@west.com')
+            full_name="Kanye",
+            email="kanye@west.com",
+        )
 
 
 @pytest.mark.django_db
@@ -1356,43 +1263,35 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_project_contribs(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
+        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
 
-    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch("framework.auth.views.mails.send_mail")
     def test_add_contributor_no_email_if_false(
-            self, mock_mail, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=false'
+        self, mock_mail, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=false"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                    'email': 'kanye@west.com'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         assert mock_mail.call_count == 0
 
-    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch("framework.auth.views.mails.send_mail")
     def test_add_contributor_sends_email(
-            self, mock_mail, app, user, user_two,
-            url_project_contribs):
-        url = f'{url_project_contribs}?send_email=default'
+        self, mock_mail, app, user, user_two, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=default"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
 
@@ -1400,133 +1299,122 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
         assert res.status_code == 201
         assert mock_mail.call_count == 1
 
-    @mock.patch('website.project.signals.contributor_added.send')
+    @mock.patch("website.project.signals.contributor_added.send")
     def test_add_contributor_signal_if_default(
-            self, mock_send, app, user, user_two, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=default'
+        self, mock_send, app, user, user_two, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=default"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         args, kwargs = mock_send.call_args
         assert res.status_code == 201
-        assert 'default' == kwargs['email_template']
+        assert "default" == kwargs["email_template"]
 
     def test_add_contributor_signal_preprint_email_disallowed(
-            self, app, user, user_two, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=preprint'
+        self, app, user, user_two, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=preprint"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
+            "data": {
+                "type": "contributors",
+                "attributes": {},
+                "relationships": {
+                    "users": {"data": {"type": "users", "id": user_two._id}}
                 },
-                'relationships': {
-                    'users': {
-                        'data': {
-                            'type': 'users',
-                            'id': user_two._id
-                        }
-                    }
-                }
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'preprint is not a valid email preference.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "preprint is not a valid email preference."
+        )
 
-    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch("framework.auth.views.mails.send_mail")
     def test_add_unregistered_contributor_sends_email(
-            self, mock_mail, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=default'
+        self, mock_mail, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=default"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                    'email': 'kanye@west.com'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         assert mock_mail.call_count == 1
 
-    @mock.patch('website.project.signals.unreg_contributor_added.send')
+    @mock.patch("website.project.signals.unreg_contributor_added.send")
     def test_add_unregistered_contributor_signal_if_default(
-            self, mock_send, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=default'
+        self, mock_send, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=default"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                    'email': 'kanye@west.com'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         args, kwargs = mock_send.call_args
         assert res.status_code == 201
-        assert 'default' == kwargs['email_template']
+        assert "default" == kwargs["email_template"]
 
     def test_add_unregistered_contributor_signal_preprint_email_disallowed(
-            self, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=preprint'
+        self, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=preprint"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                    'email': 'kanye@west.com'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'preprint is not a valid email preference.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "preprint is not a valid email preference."
+        )
 
-    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch("framework.auth.views.mails.send_mail")
     def test_add_contributor_invalid_send_email_param(
-            self, mock_mail, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=true'
+        self, mock_mail, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=true"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                    'email': 'kanye@west.com'
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
             }
         }
-        res = app.post_json_api(
-            url, payload, auth=user.auth,
-            expect_errors=True)
+        res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'true is not a valid email preference.'
+        assert (
+            res.json["errors"][0]["detail"] == "true is not a valid email preference."
+        )
         assert mock_mail.call_count == 0
 
-    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch("framework.auth.views.mails.send_mail")
     def test_add_unregistered_contributor_without_email_no_email(
-            self, mock_mail, app, user, url_project_contribs):
-        url = f'{url_project_contribs}?send_email=default'
+        self, mock_mail, app, user, url_project_contribs
+    ):
+        url = f"{url_project_contribs}?send_email=default"
         payload = {
-            'data': {
-                'type': 'contributors',
-                'attributes': {
-                    'full_name': 'Kanye West',
-                }
+            "data": {
+                "type": "contributors",
+                "attributes": {
+                    "full_name": "Kanye West",
+                },
             }
         }
 
@@ -1546,217 +1434,227 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return '/{}nodes/{}/contributors/?send_email=false'.format(
-            API_BASE, project_public._id)
+        return "/{}nodes/{}/contributors/?send_email=false".format(
+            API_BASE, project_public._id
+        )
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/?send_email=false'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/?send_email=false".format(
+            API_BASE, project_private._id
+        )
 
     @pytest.fixture()
     def payload_one(self, user_two):
         return {
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True,
-                'permission': permissions.ADMIN
-            },
-            'relationships': {
-                'users': {
-                    'data': {
-                        'id': user_two._id,
-                        'type': 'users'
-                    }
-                }
-            }
+            "type": "contributors",
+            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+            "relationships": {"users": {"data": {"id": user_two._id, "type": "users"}}},
         }
 
     @pytest.fixture()
     def payload_two(self, user_three):
         return {
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': False,
-                'permission': permissions.READ
+            "type": "contributors",
+            "attributes": {"bibliographic": False, "permission": permissions.READ},
+            "relationships": {
+                "users": {"data": {"id": user_three._id, "type": "users"}}
             },
-            'relationships': {
-                'users': {
-                    'data': {
-                        'id': user_three._id,
-                        'type': 'users'
-                    }
-                }
-            }
         }
 
     def test_node_contributor_bulk_create_contributor_exists(
-            self, app, user, user_two, project_public,
-            payload_one, payload_two, url_public):
+        self, app, user, user_two, project_public, payload_one, payload_two, url_public
+    ):
         project_public.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         res = app.post_json_api(
             url_public,
-            {'data': [payload_two, payload_one]},
+            {"data": [payload_two, payload_one]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert 'is already a contributor' in res.json['errors'][0]['detail']
+        assert "is already a contributor" in res.json["errors"][0]["detail"]
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 2
+        assert len(res.json["data"]) == 2
 
     def test_node_contributor_bulk_create_errors(
-            self, app, user, user_two, project_private,
-            payload_one, payload_two, url_public, url_private):
+        self,
+        app,
+        user,
+        user_two,
+        project_private,
+        payload_one,
+        payload_two,
+        url_public,
+        url_private,
+    ):
 
         #   test_bulk_create_contributors_blank_request
         res = app.post_json_api(
-            url_public, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
-    #   test_node_contributor_bulk_create_logged_out_public_project
+        #   test_node_contributor_bulk_create_logged_out_public_project
         res = app.post_json_api(
             url_public,
-            {'data': [payload_one, payload_two]},
-            expect_errors=True, bulk=True)
+            {"data": [payload_one, payload_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
-    #   test_node_contributor_bulk_create_logged_out_private_project
+        #   test_node_contributor_bulk_create_logged_out_private_project
         res = app.post_json_api(
             url_private,
-            {'data': [payload_one, payload_two]},
-            expect_errors=True, bulk=True)
+            {"data": [payload_one, payload_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
-    #   test_node_contributor_bulk_create_logged_in_non_contrib_private_project
-        res = app.post_json_api(url_private, {'data': [payload_one, payload_two]},
-                                auth=user_two.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 403
-
-        res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
-
-    #   test_node_contributor_bulk_create_logged_in_read_only_contrib_private_project
-        project_private.add_contributor(
-            user_two, permissions=permissions.READ, save=True)
+        #   test_node_contributor_bulk_create_logged_in_non_contrib_private_project
         res = app.post_json_api(
             url_private,
-            {'data': [payload_two]},
+            {"data": [payload_one, payload_two]},
             auth=user_two.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
+
+        #   test_node_contributor_bulk_create_logged_in_read_only_contrib_private_project
+        project_private.add_contributor(
+            user_two, permissions=permissions.READ, save=True
+        )
+        res = app.post_json_api(
+            url_private,
+            {"data": [payload_two]},
+            auth=user_two.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 403
+
+        res = app.get(url_public, auth=user.auth)
+        assert len(res.json["data"]) == 1
 
     def test_node_contributor_bulk_create_logged_in_public_project_project(
-            self, app, user, payload_one, payload_two, url_public):
+        self, app, user, payload_one, payload_two, url_public
+    ):
         res = app.post_json_api(
-            url_public,
-            {'data': [payload_one, payload_two]},
-            auth=user.auth, bulk=True)
+            url_public, {"data": [payload_one, payload_two]}, auth=user.auth, bulk=True
+        )
         assert res.status_code == 201
-        assert_equals([res.json['data'][0]['attributes']['bibliographic'],
-                            res.json['data'][1]['attributes']['bibliographic']], [True, False])
-        assert_equals([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
-        assert res.content_type == 'application/vnd.api+json'
+        assert [
+            res.json["data"][0]["attributes"]["bibliographic"],
+            res.json["data"][1]["attributes"]["bibliographic"],
+        ] == [True, False]
+        assert [
+            res.json["data"][0]["attributes"]["permission"],
+            res.json["data"][1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ]
+        assert res.content_type == "application/vnd.api+json"
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
     def test_node_contributor_bulk_create_logged_in_contrib_private_project(
-            self, app, user, payload_one, payload_two, url_private):
-        res = app.post_json_api(url_private, {'data': [payload_one, payload_two]},
-                                auth=user.auth, expect_errors=True, bulk=True)
+        self, app, user, payload_one, payload_two, url_private
+    ):
+        res = app.post_json_api(
+            url_private,
+            {"data": [payload_one, payload_two]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 201
-        assert len(res.json['data']) == 2
-        assert_equals([res.json['data'][0]['attributes']['bibliographic'],
-                            res.json['data'][1]['attributes']['bibliographic']], [True, False])
-        assert_equals([res.json['data'][0]['attributes']['permission'],
-                            res.json['data'][1]['attributes']['permission']], [permissions.ADMIN, permissions.READ])
-        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json["data"]) == 2
+        assert [
+            res.json["data"][0]["attributes"]["bibliographic"],
+            res.json["data"][1]["attributes"]["bibliographic"],
+        ] == [True, False]
+        assert [
+            res.json["data"][0]["attributes"]["permission"],
+            res.json["data"][1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ]
+        assert res.content_type == "application/vnd.api+json"
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
     def test_node_contributor_bulk_create_payload_errors(
-            self, app, user, user_two, payload_one, payload_two, url_public):
+        self, app, user, user_two, payload_one, payload_two, url_public
+    ):
 
         #   test_node_contributor_bulk_create_all_or_nothing
         invalid_id_payload = {
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True
-            },
-            'relationships': {
-                'users': {
-                    'data': {
-                        'type': 'users',
-                        'id': '12345'
-                    }
-                }
-            }
+            "type": "contributors",
+            "attributes": {"bibliographic": True},
+            "relationships": {"users": {"data": {"type": "users", "id": "12345"}}},
         }
         res = app.post_json_api(
             url_public,
-            {'data': [payload_one, invalid_id_payload]},
+            {"data": [payload_one, invalid_id_payload]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 404
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
-    #   test_node_contributor_bulk_create_limits
-        node_contrib_create_list = {'data': [payload_one] * 101}
-        res = app.post_json_api(url_public, node_contrib_create_list,
-                                auth=user.auth, expect_errors=True, bulk=True)
-        assert res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data'
-
-    #   test_node_contributor_ugly_payload
-        payload = 'sdf;jlasfd'
+        #   test_node_contributor_bulk_create_limits
+        node_contrib_create_list = {"data": [payload_one] * 101}
         res = app.post_json_api(
-            url_public, payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public,
+            node_contrib_create_list,
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert (
+            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+        )
+        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+
+        #   test_node_contributor_ugly_payload
+        payload = "sdf;jlasfd"
+        res = app.post_json_api(
+            url_public, payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
+        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
 
-    #   test_node_contributor_bulk_create_invalid_permissions_all_or_nothing
+        #   test_node_contributor_bulk_create_invalid_permissions_all_or_nothing
         payload = {
-            'type': 'contributors',
-            'attributes': {
-                'permission': 'super-user',
-                'bibliographic': True
-            },
-            'relationships': {
-                'users': {
-                    'data': {
-                        'type': 'users',
-                        'id': user_two._id
-                    }
-                }
-            }
+            "type": "contributors",
+            "attributes": {"permission": "super-user", "bibliographic": True},
+            "relationships": {"users": {"data": {"type": "users", "id": user_two._id}}},
         }
-        payload = {'data': [payload_two, payload]}
+        payload = {"data": [payload_two, payload]}
         res = app.post_json_api(
-            url_public, payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
 
 @pytest.mark.django_db
@@ -1771,438 +1669,445 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         return AuthUserFactory()
 
     @pytest.fixture()
-    def project_public(
-            self, user, user_two, user_three, title,
-            description, category):
+    def project_public(self, user, user_two, user_three, title, description, category):
         project_public = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=True,
-            creator=user
+            creator=user,
         )
         project_public.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         project_public.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_three, permissions=permissions.READ, visible=True, save=True
+        )
         return project_public
 
     @pytest.fixture()
-    def project_private(
-            self, user, user_two, user_three,
-            title, description, category):
+    def project_private(self, user, user_two, user_three, title, description, category):
         project_private = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=False,
-            creator=user
+            creator=user,
         )
         project_private.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         project_private.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_three, permissions=permissions.READ, visible=True, save=True
+        )
         return project_private
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
+        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_two._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True,
-                'permission': permissions.ADMIN
-            }
+            "id": make_contrib_id(project_public._id, user_two._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_two._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True,
-                'permission': permissions.ADMIN
-            }
+            "id": make_contrib_id(project_private._id, user_two._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_three._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': False,
-                'permission': permissions.WRITE
-            }
+            "id": make_contrib_id(project_public._id, user_three._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
         }
 
     @pytest.fixture()
-    def payload_private_two(
-            self, user_three, project_private, make_contrib_id):
+    def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_three._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': False,
-                'permission': permissions.WRITE
-            }
+            "id": make_contrib_id(project_private._id, user_three._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
         }
 
     def test_bulk_update_contributors_errors(
-            self, app, user, user_two, user_four, project_public,
-            payload_public_one, payload_public_two,
-            payload_private_one, payload_private_two,
-            url_public, url_private, make_contrib_id):
+        self,
+        app,
+        user,
+        user_two,
+        user_four,
+        project_public,
+        payload_public_one,
+        payload_public_two,
+        payload_private_one,
+        payload_private_two,
+        url_public,
+        url_private,
+        make_contrib_id,
+    ):
 
         #   test_bulk_update_contributors_blank_request
         res = app.patch_json_api(
-            url_public, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
-    #   test_bulk_update_contributors_dict_instead_of_list
+        #   test_bulk_update_contributors_dict_instead_of_list
         res = app.put_json_api(
             url_public,
-            {'data': payload_public_one},
+            {"data": payload_public_one},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
 
-    #   test_bulk_update_contributors_public_project_one_not_found
-        invalid_id = {
-            'id': '12345-abcde',
-            'type': 'contributors',
-            'attributes': {}
-        }
-        empty_payload = {'data': [invalid_id, payload_public_one]}
+        #   test_bulk_update_contributors_public_project_one_not_found
+        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
+        empty_payload = {"data": [invalid_id, payload_public_one]}
         res = app.put_json_api(
-            url_public, empty_payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, empty_payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
-
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to update."
         )
 
-    #   test_bulk_update_contributors_public_projects_logged_out
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_update_contributors_public_projects_logged_out
         res = app.put_json_api(
             url_public,
-            {
-                'data': [payload_public_one,
-                         payload_public_two]
-            },
-            expect_errors=True, bulk=True)
+            {"data": [payload_public_one, payload_public_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
-        )
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_update_contributors_private_projects_logged_out
+        #   test_bulk_update_contributors_private_projects_logged_out
         res = app.put_json_api(
             url_private,
-            {
-                'data': [payload_private_one,
-                         payload_private_two]
-            },
-            expect_errors=True, bulk=True)
+            {"data": [payload_private_one, payload_private_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_update_contributors_private_projects_logged_in_non_contrib
+        #   test_bulk_update_contributors_private_projects_logged_in_non_contrib
         res = app.put_json_api(
             url_private,
-            {
-                'data': [payload_private_one,
-                         payload_private_two]
-            },
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_four.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_update_contributors_private_projects_logged_in_read_only_contrib
+        #   test_bulk_update_contributors_private_projects_logged_in_read_only_contrib
         res = app.put_json_api(
             url_private,
-            {
-                'data': [payload_private_one,
-                         payload_private_two]
-            },
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_two.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_update_contributors_projects_send_dictionary_not_list
+        res = app.put_json_api(
+            url_public,
+            {"data": payload_public_one},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"]
+            == 'Expected a list of items but got type "dict".'
         )
 
-    #   test_bulk_update_contributors_projects_send_dictionary_not_list
+        #   test_bulk_update_contributors_id_not_supplied
         res = app.put_json_api(
             url_public,
-            {'data': payload_public_one},
+            {"data": [{"type": "contributors", "attributes": {}}]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Expected a list of items but got type "dict".'
+        assert len(res.json["errors"]) == 1
+        assert res.json["errors"][0]["detail"] == "Contributor identifier not provided."
 
-    #   test_bulk_update_contributors_id_not_supplied
+        #   test_bulk_update_contributors_type_not_supplied
         res = app.put_json_api(
             url_public,
-            {'data': [{
-                'type': 'contributors',
-                'attributes': {}
-            }]},
+            {
+                "data": [
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "attributes": {},
+                    }
+                ]
+            },
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert len(res.json['errors']) == 1
-        assert res.json['errors'][0]['detail'] == 'Contributor identifier not provided.'
+        assert len(res.json["errors"]) == 1
+        assert res.json["errors"][0]["source"]["pointer"] == "/data/0/type"
+        assert res.json["errors"][0]["detail"] == "This field may not be null."
 
-    #   test_bulk_update_contributors_type_not_supplied
-        res = app.put_json_api(
-            url_public,
-            {'data': [{
-                'id': make_contrib_id(
-                    project_public._id, user_two._id
-                ),
-                'attributes': {}
-            }]},
-            auth=user.auth,
-            expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert len(res.json['errors']) == 1
-        assert res.json['errors'][0]['source']['pointer'] == '/data/0/type'
-        assert res.json['errors'][0]['detail'] == 'This field may not be null.'
-
-    #   test_bulk_update_contributors_wrong_type
+        #   test_bulk_update_contributors_wrong_type
         invalid_type = {
-            'id': make_contrib_id(project_public._id, user_two._id),
-            'type': 'Wrong type.',
-            'attributes': {}
+            "id": make_contrib_id(project_public._id, user_two._id),
+            "type": "Wrong type.",
+            "attributes": {},
         }
-        res = app.put_json_api(url_public, {'data': [invalid_type]},
-                               auth=user.auth, expect_errors=True, bulk=True)
+        res = app.put_json_api(
+            url_public,
+            {"data": [invalid_type]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 409
 
-    #   test_bulk_update_contributors_invalid_id_format
-        invalid_id = {
-            'id': '12345',
-            'type': 'contributors',
-            'attributes': {}
-
-        }
-        res = app.put_json_api(url_public, {'data': [invalid_id]},
-                               auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Contributor identifier incorrectly formatted.'
-
-    #   test_bulk_update_contributors_wrong_id
-        invalid_id = {
-            'id': '12345-abcde',
-            'type': 'contributors',
-            'attributes': {}
-        }
-        res = app.put_json_api(
-            url_public, {'data': [invalid_id]},
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
-
-    #   test_bulk_update_contributors_limits
-        contrib_update_list = {'data': [payload_public_one] * 101}
-        res = app.put_json_api(
-            url_public, contrib_update_list,
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data'
-
-    #   test_bulk_update_contributors_invalid_permissions
+        #   test_bulk_update_contributors_invalid_id_format
+        invalid_id = {"id": "12345", "type": "contributors", "attributes": {}}
         res = app.put_json_api(
             url_public,
-            {
-                'data': [
-                    payload_public_two, {
-                        'id': make_contrib_id(
-                            project_public._id, user_two._id
-                        ),
-                        'type': 'contributors',
-                        'attributes': {
-                            'permission': 'super-user'}
-                    }
-                ]
-            },
+            {"data": [invalid_id]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"super-user" is not a valid choice.'
-
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Contributor identifier incorrectly formatted."
         )
 
-    #   test_bulk_update_contributors_invalid_bibliographic
+        #   test_bulk_update_contributors_wrong_id
+        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
         res = app.put_json_api(
             url_public,
-            {
-                'data': [
-                    payload_public_two, {
-                        'id': make_contrib_id(
-                            project_public._id, user_two._id
-                        ),
-                        'type': 'contributors',
-                        'attributes': {
-                            'bibliographic': 'true and false'
-                        }
-                    }
-                ]
-            },
+            {"data": [invalid_id]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
-
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to update."
         )
 
-    #   test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor
+        #   test_bulk_update_contributors_limits
+        contrib_update_list = {"data": [payload_public_one] * 101}
+        res = app.put_json_api(
+            url_public,
+            contrib_update_list,
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert (
+            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+        )
+        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+
+        #   test_bulk_update_contributors_invalid_permissions
         res = app.put_json_api(
             url_public,
             {
-                'data': [
-                    payload_public_two, {
-                        'id': make_contrib_id(
-                            project_public._id, user._id
-                        ),
-                        'type': 'contributors',
-                        'attributes': {
-                            'permission': permissions.ADMIN,
-                            'bibliographic': False
-                        }
-                    }, {
-                        'id': make_contrib_id(
-                            project_public._id, user_two._id
-                        ),
-                        'type': 'contributors',
-                        'attributes': {
-                            'bibliographic': False
-                        }
-                    }
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "type": "contributors",
+                        "attributes": {"permission": "super-user"},
+                    },
                 ]
             },
             auth=user.auth,
-            expect_errors=True, bulk=True)
-
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must have at least one visible contributor'
+        assert res.json["errors"][0]["detail"] == '"super-user" is not a valid choice.'
 
-    #   test_bulk_update_contributors_must_have_at_least_one_admin
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_update_contributors_invalid_bibliographic
         res = app.put_json_api(
             url_public,
-            {'data': [
-                payload_public_two, {
-                    'id': make_contrib_id(
-                        project_public._id, user._id
-                    ),
-                    'type': 'contributors',
-                    'attributes': {
-                            'permission': permissions.READ
-                    }
-                }
-            ]},
+            {
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "type": "contributors",
+                        "attributes": {"bibliographic": "true and false"},
+                    },
+                ]
+            },
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '{} is the only admin.'.format(
-            user.fullname)
+        assert res.json["errors"][0]["detail"] == "Must be a valid boolean."
+
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor
+        res = app.put_json_api(
+            url_public,
+            {
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user._id),
+                        "type": "contributors",
+                        "attributes": {
+                            "permission": permissions.ADMIN,
+                            "bibliographic": False,
+                        },
+                    },
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "type": "contributors",
+                        "attributes": {"bibliographic": False},
+                    },
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Must have at least one visible contributor"
+        )
+
+        #   test_bulk_update_contributors_must_have_at_least_one_admin
+        res = app.put_json_api(
+            url_public,
+            {
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user._id),
+                        "type": "contributors",
+                        "attributes": {"permission": permissions.READ},
+                    },
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] == "{} is the only admin.".format(
+            user.fullname
+        )
 
     def test_bulk_update_contributors_public_projects_logged_in(
-            self, app, user, payload_public_one, payload_public_two, url_public):
+        self, app, user, payload_public_one, payload_public_two, url_public
+    ):
         res = app.put_json_api(
             url_public,
-            {'data': [payload_public_one, payload_public_two]},
-            auth=user.auth, bulk=True
+            {"data": [payload_public_one, payload_public_two]},
+            auth=user.auth,
+            bulk=True,
         )
         assert res.status_code == 200
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission']],
-            [permissions.ADMIN, permissions.WRITE]
-        )
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.WRITE]
 
     def test_bulk_update_contributors_private_projects_logged_in_contrib(
-            self, app, user, payload_private_one, payload_private_two, url_private):
+        self, app, user, payload_private_one, payload_private_two, url_private
+    ):
         res = app.put_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
-            auth=user.auth, bulk=True
+            {"data": [payload_private_one, payload_private_two]},
+            auth=user.auth,
+            bulk=True,
         )
         assert res.status_code == 200
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission']],
-            [permissions.ADMIN, permissions.WRITE]
-        )
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.WRITE]
 
 
 @pytest.mark.django_db
@@ -2217,354 +2122,368 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         return AuthUserFactory()
 
     @pytest.fixture()
-    def project_public(
-            self, user, user_two, user_three, title,
-            description, category):
+    def project_public(self, user, user_two, user_three, title, description, category):
         project_public = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=True,
-            creator=user
+            creator=user,
         )
         project_public.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True
+            user_two, permissions=permissions.READ, visible=True, save=True
         )
         project_public.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True
+            user_three, permissions=permissions.READ, visible=True, save=True
         )
         return project_public
 
     @pytest.fixture()
-    def project_private(
-            self, user, user_two, user_three, title,
-            description, category):
+    def project_private(self, user, user_two, user_three, title, description, category):
         project_private = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=False,
-            creator=user
+            creator=user,
         )
         project_private.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         project_private.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_three, permissions=permissions.READ, visible=True, save=True
+        )
         return project_private
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
+        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_two._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True,
-                'permission': permissions.ADMIN
-            }
+            "id": make_contrib_id(project_public._id, user_two._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_three._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': False,
-                'permission': permissions.WRITE
-            }
+            "id": make_contrib_id(project_public._id, user_three._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_two._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': True,
-                'permission': permissions.ADMIN
-            }
+            "id": make_contrib_id(project_private._id, user_two._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
         }
 
     @pytest.fixture()
-    def payload_private_two(
-            self, user_three, project_private, make_contrib_id):
+    def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_three._id),
-            'type': 'contributors',
-            'attributes': {
-                'bibliographic': False,
-                'permission': permissions.WRITE
-            }
+            "id": make_contrib_id(project_private._id, user_three._id),
+            "type": "contributors",
+            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
         }
 
     def test_bulk_partial_update_errors(
-            self, app, user, user_two, user_four,
-            project_public, payload_public_one,
-            payload_public_two, payload_private_one,
-            payload_private_two, url_public,
-            url_private, make_contrib_id):
+        self,
+        app,
+        user,
+        user_two,
+        user_four,
+        project_public,
+        payload_public_one,
+        payload_public_two,
+        payload_private_one,
+        payload_private_two,
+        url_public,
+        url_private,
+        make_contrib_id,
+    ):
 
         #   test_bulk_partial_update_contributors_blank_request
         res = app.patch_json_api(
-            url_public, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
-    #   test_bulk_partial_update_contributors_public_project_one_not_found
-        invalid_id = {
-            'id': '12345-abcde',
-            'type': 'contributors',
-            'attributes': {}
-        }
+        #   test_bulk_partial_update_contributors_public_project_one_not_found
+        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
 
-        empty_payload = {'data': [invalid_id, payload_public_one]}
+        empty_payload = {"data": [invalid_id, payload_public_one]}
         res = app.patch_json_api(
-            url_public, empty_payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, empty_payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
-
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to update."
         )
 
-    #   test_bulk_partial_update_contributors_public_projects_logged_out
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_partial_update_contributors_public_projects_logged_out
         res = app.patch_json_api(
             url_public,
-            {'data': [payload_public_one, payload_public_two]},
-            bulk=True, expect_errors=True)
+            {"data": [payload_public_one, payload_public_two]},
+            bulk=True,
+            expect_errors=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
-        )
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_partial_update_contributors_private_projects_logged_out
+        #   test_bulk_partial_update_contributors_private_projects_logged_out
         res = app.patch_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
-            expect_errors=True, bulk=True
+            {"data": [payload_private_one, payload_private_two]},
+            expect_errors=True,
+            bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_partial_update_contributors_private_projects_logged_in_non_contrib
+        #   test_bulk_partial_update_contributors_private_projects_logged_in_non_contrib
         res = app.patch_json_api(
             url_private,
-            {'data': [payload_private_one,
-                      payload_private_two]},
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_four.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ]
-        )
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_partial_update_contributors_private_projects_logged_in_read_only_contrib
+        #   test_bulk_partial_update_contributors_private_projects_logged_in_read_only_contrib
         res = app.patch_json_api(
             url_private,
-            {'data': [payload_private_one,
-                      payload_private_two]},
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_two.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
-    #   test_bulk_partial_update_contributors_projects_send_dictionary_not_list
+        #   test_bulk_partial_update_contributors_projects_send_dictionary_not_list
         res = app.patch_json_api(
             url_public,
-            {'data': payload_public_one},
+            {"data": payload_public_one},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Expected a list of items but got type "dict".'
+        assert (
+            res.json["errors"][0]["detail"]
+            == 'Expected a list of items but got type "dict".'
+        )
 
-    #   test_bulk_partial_update_contributors_id_not_supplied
+        #   test_bulk_partial_update_contributors_id_not_supplied
         res = app.patch_json_api(
             url_public,
-            {'data': [{
-                'type': 'contributors',
-                'attributes': {}
-            }]},
+            {"data": [{"type": "contributors", "attributes": {}}]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert len(res.json['errors']) == 1
-        assert res.json['errors'][0]['detail'] == 'Contributor identifier not provided.'
+        assert len(res.json["errors"]) == 1
+        assert res.json["errors"][0]["detail"] == "Contributor identifier not provided."
 
-    #   test_bulk_partial_update_contributors_type_not_supplied
-        res = app.patch_json_api(
-            url_public,
-            {'data': [{
-                'id': make_contrib_id(
-                    project_public._id,
-                    user_two._id
-                ),
-                'attributes': {}
-            }]},
-            auth=user.auth,
-            expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert len(res.json['errors']) == 1
-        assert res.json['errors'][0]['source']['pointer'] == '/data/0/type'
-        assert res.json['errors'][0]['detail'] == 'This field may not be null.'
-
-    #   test_bulk_partial_update_contributors_wrong_type
-        invalid_type = {
-            'id': make_contrib_id(project_public._id, user_two._id),
-            'type': 'Wrong type.',
-            'attributes': {}
-        }
-        res = app.patch_json_api(
-            url_public, {'data': [invalid_type]},
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 409
-
-    #   test_bulk_partial_update_contributors_wrong_id
-        invalid_id = {
-            'id': '12345-abcde',
-            'type': 'contributors',
-            'attributes': {}
-        }
-
-        res = app.patch_json_api(
-            url_public, {'data': [invalid_id]},
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
-
-    #   test_bulk_partial_update_contributors_limits
-        contrib_update_list = {'data': [payload_public_one] * 101}
-        res = app.patch_json_api(
-            url_public, contrib_update_list,
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data'
-
-    #   test_bulk_partial_update_invalid_permissions
+        #   test_bulk_partial_update_contributors_type_not_supplied
         res = app.patch_json_api(
             url_public,
             {
-                'data': [
-                    payload_public_two, {
-                        'id': make_contrib_id(
-                            project_public._id,
-                            user_two._id
-                        ),
-                        'type': 'contributors',
-                        'attributes': {'permission': 'super-user'}
-                    }]
-            },
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == '"super-user" is not a valid choice.'
-
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
-
-    #   test_bulk_partial_update_invalid_bibliographic
-        res = app.patch_json_api(
-            url_public,
-            {
-                'data': [
-                    payload_public_two, {
-                        'id': make_contrib_id(
-                            project_public._id, user_two._id),
-                        'type': 'contributors',
-                        'attributes': {'bibliographic': 'true and false'}
+                "data": [
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "attributes": {},
                     }
                 ]
             },
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
+        assert len(res.json["errors"]) == 1
+        assert res.json["errors"][0]["source"]["pointer"] == "/data/0/type"
+        assert res.json["errors"][0]["detail"] == "This field may not be null."
 
-        res = app.get(url_public, auth=user.auth)
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission'],
-             data[2]['attributes']['permission']],
-            [permissions.ADMIN, permissions.READ, permissions.READ])
-
-    def test_bulk_partial_update_contributors_public_projects_logged_in(
-            self, app, user, payload_public_one, payload_public_two, url_public):
+        #   test_bulk_partial_update_contributors_wrong_type
+        invalid_type = {
+            "id": make_contrib_id(project_public._id, user_two._id),
+            "type": "Wrong type.",
+            "attributes": {},
+        }
         res = app.patch_json_api(
             url_public,
-            {'data': [payload_public_one, payload_public_two]},
-            auth=user.auth, bulk=True)
+            {"data": [invalid_type]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 409
+
+        #   test_bulk_partial_update_contributors_wrong_id
+        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
+
+        res = app.patch_json_api(
+            url_public,
+            {"data": [invalid_id]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to update."
+        )
+
+        #   test_bulk_partial_update_contributors_limits
+        contrib_update_list = {"data": [payload_public_one] * 101}
+        res = app.patch_json_api(
+            url_public,
+            contrib_update_list,
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert (
+            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+        )
+        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+
+        #   test_bulk_partial_update_invalid_permissions
+        res = app.patch_json_api(
+            url_public,
+            {
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "type": "contributors",
+                        "attributes": {"permission": "super-user"},
+                    },
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] == '"super-user" is not a valid choice.'
+
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+        #   test_bulk_partial_update_invalid_bibliographic
+        res = app.patch_json_api(
+            url_public,
+            {
+                "data": [
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                        "type": "contributors",
+                        "attributes": {"bibliographic": "true and false"},
+                    },
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] == "Must be a valid boolean."
+
+        res = app.get(url_public, auth=user.auth)
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+            data[2]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.READ, permissions.READ]
+
+    def test_bulk_partial_update_contributors_public_projects_logged_in(
+        self, app, user, payload_public_one, payload_public_two, url_public
+    ):
+        res = app.patch_json_api(
+            url_public,
+            {"data": [payload_public_one, payload_public_two]},
+            auth=user.auth,
+            bulk=True,
+        )
         assert res.status_code == 200
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission']],
-            [permissions.ADMIN, permissions.WRITE])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.WRITE]
 
     def test_bulk_partial_update_contributors_private_projects_logged_in_contrib(
-            self, app, user, payload_private_one, payload_private_two, url_private):
+        self, app, user, payload_private_one, payload_private_two, url_private
+    ):
         res = app.patch_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
-            auth=user.auth, bulk=True)
+            {"data": [payload_private_one, payload_private_two]},
+            auth=user.auth,
+            bulk=True,
+        )
         assert res.status_code == 200
-        data = res.json['data']
-        assert_equals(
-            [data[0]['attributes']['permission'],
-             data[1]['attributes']['permission']],
-            [permissions.ADMIN, permissions.WRITE])
+        data = res.json["data"]
+        assert [
+            data[0]["attributes"]["permission"],
+            data[1]["attributes"]["permission"],
+        ] == [permissions.ADMIN, permissions.WRITE]
 
 
 class TestNodeContributorBulkDelete(NodeCRUDTestCase):
@@ -2578,323 +2497,363 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         return AuthUserFactory()
 
     @pytest.fixture()
-    def project_public(
-            self, user, user_two, user_three, title,
-            description, category):
+    def project_public(self, user, user_two, user_three, title, description, category):
         project_public = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=True,
-            creator=user
+            creator=user,
         )
         project_public.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         project_public.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_three, permissions=permissions.READ, visible=True, save=True
+        )
         return project_public
 
     @pytest.fixture()
-    def project_private(
-            self, user, user_two, user_three, title,
-            description, category):
+    def project_private(self, user, user_two, user_three, title, description, category):
         project_private = ProjectFactory(
             title=title,
             description=description,
             category=category,
             is_public=False,
-            creator=user
+            creator=user,
         )
         project_private.add_contributor(
-            user_two,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_two, permissions=permissions.READ, visible=True, save=True
+        )
         project_private.add_contributor(
-            user_three,
-            permissions=permissions.READ,
-            visible=True, save=True)
+            user_three, permissions=permissions.READ, visible=True, save=True
+        )
         return project_private
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
+        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return '/{}nodes/{}/contributors/'.format(
-            API_BASE, project_private._id)
+        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_two._id),
-            'type': 'contributors'
+            "id": make_contrib_id(project_public._id, user_two._id),
+            "type": "contributors",
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            'id': make_contrib_id(project_public._id, user_three._id),
-            'type': 'contributors'
+            "id": make_contrib_id(project_public._id, user_three._id),
+            "type": "contributors",
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_two._id),
-            'type': 'contributors',
+            "id": make_contrib_id(project_private._id, user_two._id),
+            "type": "contributors",
         }
 
     @pytest.fixture()
-    def payload_private_two(
-            self, user_three, project_private, make_contrib_id):
+    def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            'id': make_contrib_id(project_private._id, user_three._id),
-            'type': 'contributors',
+            "id": make_contrib_id(project_private._id, user_three._id),
+            "type": "contributors",
         }
 
     def test_bulk_delete_contributors_errors(
-            self, app, user, user_two, user_four,
-            project_public, payload_public_one,
-            payload_public_two, payload_private_one,
-            payload_private_two, url_public,
-            url_private, make_contrib_id):
+        self,
+        app,
+        user,
+        user_two,
+        user_four,
+        project_public,
+        payload_public_one,
+        payload_public_two,
+        payload_private_one,
+        payload_private_two,
+        url_public,
+        url_private,
+        make_contrib_id,
+    ):
 
         #   test_bulk_delete_contributors_blank_request
         res = app.delete_json_api(
-            url_public, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
-    #   test_bulk_delete_invalid_id_format
+        #   test_bulk_delete_invalid_id_format
         res = app.delete_json_api(
             url_public,
-            {'data': [{
-                'id': '12345',
-                'type': 'contributors'
-            }]},
+            {"data": [{"id": "12345", "type": "contributors"}]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Contributor identifier incorrectly formatted.'
+        assert (
+            res.json["errors"][0]["detail"]
+            == "Contributor identifier incorrectly formatted."
+        )
 
-    #   test_bulk_delete_invalid_id
+        #   test_bulk_delete_invalid_id
         res = app.delete_json_api(
             url_public,
-            {'data': [{
-                'id': '12345-abcde',
-                'type': 'contributors'
-            }]},
+            {"data": [{"id": "12345-abcde", "type": "contributors"}]},
             auth=user.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to delete."
+        )
 
-    #   test_bulk_delete_non_contributor
-        res = app.delete_json_api(
-            url_public,
-            {'data': [{
-                'id': make_contrib_id(
-                    project_public._id, user_four._id
-                ),
-                'type': 'contributors'
-            }]},
-            auth=user.auth,
-            expect_errors=True, bulk=True)
-        assert res.status_code == 404
-
-    #   test_bulk_delete_all_contributors
-        res = app.delete_json_api(
-            url_public,
-            {'data': [
-                payload_public_one,
-                payload_public_two,
-                {
-                    'id': make_contrib_id(
-                        project_public._id, user._id
-                    ),
-                    'type': 'contributors'
-                }
-            ]},
-            auth=user.auth,
-            expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] in [
-            'Must have at least one registered admin contributor',
-            'Must have at least one visible contributor']
-        project_public.reload()
-        assert len(project_public.contributors) == 3
-
-    #   test_bulk_delete_contributors_no_id
-        res = app.delete_json_api(
-            url_public,
-            {'data': [{'type': 'contributors'}]},
-            auth=user.auth,
-            expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /data/id.'
-
-    #   test_bulk_delete_contributors_no_type
-        res = app.delete_json_api(
-            url_public,
-            {'data': [{'id': make_contrib_id(
-                project_public._id, user_two._id
-            )}]},
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Request must include /type.'
-
-    #   test_bulk_delete_contributors_invalid_type
-        res = app.delete_json_api(
-            url_public,
-            {'data': [{
-                'type': 'Wrong type',
-                'id': make_contrib_id(
-                    project_public._id, user_two._id)
-            }]},
-            auth=user.auth, expect_errors=True, bulk=True)
-        assert res.status_code == 409
-
-    #   test_bulk_delete_dict_inside_data
+        #   test_bulk_delete_non_contributor
         res = app.delete_json_api(
             url_public,
             {
-                'data': {
-                    'id': make_contrib_id(
-                        project_public._id,
-                        user_two._id),
-                    'type': 'contributors'}},
+                "data": [
+                    {
+                        "id": make_contrib_id(project_public._id, user_four._id),
+                        "type": "contributors",
+                    }
+                ]
+            },
             auth=user.auth,
             expect_errors=True,
-            bulk=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Expected a list of items but got type "dict".'
+            bulk=True,
+        )
+        assert res.status_code == 404
 
-    #   test_bulk_delete_contributors_public_projects_logged_out
+        #   test_bulk_delete_all_contributors
+        res = app.delete_json_api(
+            url_public,
+            {
+                "data": [
+                    payload_public_one,
+                    payload_public_two,
+                    {
+                        "id": make_contrib_id(project_public._id, user._id),
+                        "type": "contributors",
+                    },
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] in [
+            "Must have at least one registered admin contributor",
+            "Must have at least one visible contributor",
+        ]
+        project_public.reload()
+        assert len(project_public.contributors) == 3
+
+        #   test_bulk_delete_contributors_no_id
+        res = app.delete_json_api(
+            url_public,
+            {"data": [{"type": "contributors"}]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] == "Request must include /data/id."
+
+        #   test_bulk_delete_contributors_no_type
+        res = app.delete_json_api(
+            url_public,
+            {"data": [{"id": make_contrib_id(project_public._id, user_two._id)}]},
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert res.json["errors"][0]["detail"] == "Request must include /type."
+
+        #   test_bulk_delete_contributors_invalid_type
+        res = app.delete_json_api(
+            url_public,
+            {
+                "data": [
+                    {
+                        "type": "Wrong type",
+                        "id": make_contrib_id(project_public._id, user_two._id),
+                    }
+                ]
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 409
+
+        #   test_bulk_delete_dict_inside_data
+        res = app.delete_json_api(
+            url_public,
+            {
+                "data": {
+                    "id": make_contrib_id(project_public._id, user_two._id),
+                    "type": "contributors",
+                }
+            },
+            auth=user.auth,
+            expect_errors=True,
+            bulk=True,
+        )
+        assert res.status_code == 400
+        assert (
+            res.json["errors"][0]["detail"]
+            == 'Expected a list of items but got type "dict".'
+        )
+
+        #   test_bulk_delete_contributors_public_projects_logged_out
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         res = app.delete_json_api(
             url_public,
-            {'data': [payload_public_one, payload_public_two]},
-            expect_errors=True, bulk=True)
+            {"data": [payload_public_one, payload_public_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_bulk_delete_contributors_private_projects_logged_out
+        #   test_bulk_delete_contributors_private_projects_logged_out
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         res = app.delete_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
-            expect_errors=True, bulk=True)
+            {"data": [payload_private_one, payload_private_two]},
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_bulk_delete_contributors_private_projects_logged_in_non_contributor
+        #   test_bulk_delete_contributors_private_projects_logged_in_non_contributor
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         res = app.delete_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_four.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_bulk_delete_contributors_private_projects_logged_in_read_only_contributor
+        #   test_bulk_delete_contributors_private_projects_logged_in_read_only_contributor
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         res = app.delete_json_api(
             url_private,
-            {'data': [payload_private_one, payload_private_two]},
+            {"data": [payload_private_one, payload_private_two]},
             auth=user_two.auth,
-            expect_errors=True, bulk=True)
+            expect_errors=True,
+            bulk=True,
+        )
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_bulk_delete_contributors_all_or_nothing
+        #   test_bulk_delete_contributors_all_or_nothing
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
         invalid_id = {
-            'id': '12345-abcde',
-            'type': 'contributors',
+            "id": "12345-abcde",
+            "type": "contributors",
         }
 
-        new_payload = {'data': [payload_public_one, invalid_id]}
+        new_payload = {"data": [payload_public_one, invalid_id]}
 
         res = app.delete_json_api(
-            url_public, new_payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, new_payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
+        assert (
+            res.json["errors"][0]["detail"] == "Could not find all objects to delete."
+        )
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_bulk_delete_contributors_limits
-        new_payload = {'data': [payload_public_one] * 101}
+        #   test_bulk_delete_contributors_limits
+        new_payload = {"data": [payload_public_one] * 101}
         res = app.delete_json_api(
-            url_public, new_payload, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, new_payload, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
-        assert res.json['errors'][0]['source']['pointer'] == '/data'
+        assert (
+            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+        )
+        assert res.json["errors"][0]["source"]["pointer"] == "/data"
 
-    #   test_bulk_delete_contributors_no_payload
+        #   test_bulk_delete_contributors_no_payload
         res = app.delete_json_api(
-            url_public, auth=user.auth,
-            expect_errors=True, bulk=True)
+            url_public, auth=user.auth, expect_errors=True, bulk=True
+        )
         assert res.status_code == 400
 
     def test_bulk_delete_contributors_public_project_logged_in(
-            self, app, user, payload_public_one, payload_public_two, url_public):
+        self, app, user, payload_public_one, payload_public_two, url_public
+    ):
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         # Disconnect contributor_removed so that we don't check in files
         # We can remove this when StoredFileNode is implemented in osf-models
         with disconnected_from_listeners(contributor_removed):
             res = app.delete_json_api(
                 url_public,
-                {'data': [payload_public_one, payload_public_two]},
-                auth=user.auth, bulk=True)
+                {"data": [payload_public_one, payload_public_two]},
+                auth=user.auth,
+                bulk=True,
+            )
         assert res.status_code == 204
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
     def test_bulk_delete_contributors_private_projects_logged_in_contributor(
-            self, app, user, payload_private_one, payload_private_two, url_private):
+        self, app, user, payload_private_one, payload_private_two, url_private
+    ):
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         # Disconnect contributor_removed so that we don't check in files
         # We can remove this when StoredFileNode is implemented in osf-models
         with disconnected_from_listeners(contributor_removed):
             res = app.delete_json_api(
                 url_private,
-                {'data': [payload_private_one, payload_private_two]},
-                auth=user.auth, bulk=True)
+                {"data": [payload_private_one, payload_private_two]},
+                auth=user.auth,
+                bulk=True,
+            )
         assert res.status_code == 204
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
 
 @pytest.mark.django_db
@@ -2907,70 +2866,74 @@ class TestNodeContributorFiltering:
 
     @pytest.fixture()
     def url(self, project):
-        return '/{}nodes/{}/contributors/'.format(
-            API_BASE, project._id)
+        return "/{}nodes/{}/contributors/".format(API_BASE, project._id)
 
     def test_filtering(self, app, user, url, project):
 
         #   test_filtering_full_name_field
-        filter_url = f'{url}?filter[full_name]=Freddie'
+        filter_url = f"{url}?filter[full_name]=Freddie"
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json['errors']
+        errors = res.json["errors"]
         assert len(errors) == 1
-        assert errors[0]['detail'] == '\'full_name\' is not a valid field for this endpoint.'
+        assert (
+            errors[0]["detail"] == "'full_name' is not a valid field for this endpoint."
+        )
 
         user_two = AuthUserFactory()
         user_three = AuthUserFactory()
         project.add_contributor(user_two, permissions.WRITE)
         project.add_contributor(user_three, permissions.READ, visible=False)
-    #   test_filtering_permission_field_admin
-        filter_url = f'{url}?filter[permission]=admin'
+        #   test_filtering_permission_field_admin
+        filter_url = f"{url}?filter[permission]=admin"
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get('permission') == permissions.ADMIN
+        assert len(res.json["data"]) == 1
+        assert res.json["data"][0]["attributes"].get("permission") == permissions.ADMIN
 
-    #   test_filtering_permission_field_write
-        filter_url = f'{url}?filter[permission]=write'
+        #   test_filtering_permission_field_write
+        filter_url = f"{url}?filter[permission]=write"
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 2
+        assert len(res.json["data"]) == 2
 
-    #   test_filtering_permission_field_read
-        filter_url = f'{url}?filter[permission]=read'
+        #   test_filtering_permission_field_read
+        filter_url = f"{url}?filter[permission]=read"
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
-    #   test_filtering_node_with_only_bibliographic_contributors
+        #   test_filtering_node_with_only_bibliographic_contributors
         # no filter
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 3
+        assert len(res.json["data"]) == 3
 
         # filter for bibliographic contributors
-        filter_url = url + '?filter[bibliographic]=True'
+        filter_url = url + "?filter[bibliographic]=True"
         res = app.get(filter_url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 2
-        assert res.json['data'][0]['attributes'].get('bibliographic', None)
+        assert len(res.json["data"]) == 2
+        assert res.json["data"][0]["attributes"].get("bibliographic", None)
 
         # filter for non-bibliographic contributors
-        filter_url = url + '?filter[bibliographic]=False'
+        filter_url = url + "?filter[bibliographic]=False"
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json['data']) == 1
+        assert len(res.json["data"]) == 1
 
-    #   test_filtering_on_invalid_field
-        filter_url = f'{url}?filter[invalid]=foo'
+        #   test_filtering_on_invalid_field
+        filter_url = f"{url}?filter[invalid]=foo"
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json['errors']
+        errors = res.json["errors"]
         assert len(errors) == 1
-        assert errors[0]['detail'] == '\'invalid\' is not a valid field for this endpoint.'
+        assert (
+            errors[0]["detail"] == "'invalid' is not a valid field for this endpoint."
+        )
 
     def test_filtering_node_with_non_bibliographic_contributor(
-            self, app, user, project, url):
+        self, app, user, project, url
+    ):
         non_bibliographic_contrib = UserFactory()
         project.add_contributor(non_bibliographic_contrib, visible=False)
         project.save()
@@ -2978,16 +2941,16 @@ class TestNodeContributorFiltering:
         # no filter
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 2
+        assert len(res.json["data"]) == 2
 
         # filter for bibliographic contributors
-        filter_url = url + '?filter[bibliographic]=True'
+        filter_url = url + "?filter[bibliographic]=True"
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes'].get('bibliographic', None)
+        assert len(res.json["data"]) == 1
+        assert res.json["data"][0]["attributes"].get("bibliographic", None)
 
         # filter for non-bibliographic contributors
-        filter_url = url + '?filter[bibliographic]=False'
+        filter_url = url + "?filter[bibliographic]=False"
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json['data']) == 1
-        assert not res.json['data'][0]['attributes'].get('bibliographic', None)
+        assert len(res.json["data"]) == 1
+        assert not res.json["data"][0]["attributes"].get("bibliographic", None)

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -40,27 +40,27 @@ class NodeCRUDTestCase:
 
     @pytest.fixture()
     def title(self):
-        return "Cool Project"
+        return 'Cool Project'
 
     @pytest.fixture()
     def title_new(self):
-        return "Super Cool Project"
+        return 'Super Cool Project'
 
     @pytest.fixture()
     def description(self):
-        return "A Properly Cool Project"
+        return 'A Properly Cool Project'
 
     @pytest.fixture()
     def description_new(self):
-        return "An even cooler project"
+        return 'An even cooler project'
 
     @pytest.fixture()
     def category(self):
-        return "data"
+        return 'data'
 
     @pytest.fixture()
     def category_new(self):
-        return "project"
+        return 'project'
 
     @pytest.fixture()
     def project_public(self, user, title, description, category):
@@ -84,20 +84,20 @@ class NodeCRUDTestCase:
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/"
+        return f'/{API_BASE}nodes/{project_public._id}/'
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return f"/{API_BASE}nodes/{project_private._id}/"
+        return f'/{API_BASE}nodes/{project_private._id}/'
 
     @pytest.fixture()
     def url_fake(self):
-        return "/{}nodes/{}/".format(API_BASE, "12345")
+        return '/{}nodes/{}/'.format(API_BASE, '12345')
 
     @pytest.fixture()
     def make_contrib_id(self):
         def contrib_id(node_id, user_id):
-            return f"{node_id}-{user_id}"
+            return f'{node_id}-{user_id}'
 
         return contrib_id
 
@@ -108,18 +108,18 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
+        return '/{}nodes/{}/contributors/'.format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
+        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
 
     def test_concatenated_id(self, app, user, project_public, url_public):
         res = app.get(url_public)
         assert res.status_code == 200
 
-        assert res.json["data"][0]["id"].split("-")[0] == project_public._id
-        assert res.json["data"][0]["id"] == "{}-{}".format(project_public._id, user._id)
+        assert res.json['data'][0]['id'].split('-')[0] == project_public._id
+        assert res.json['data'][0]['id'] == '{}-{}'.format(project_public._id, user._id)
 
     def test_permissions_work_with_many_users(
         self, app, user, project_private, url_private
@@ -137,13 +137,13 @@ class TestNodeContributorList(NodeCRUDTestCase):
             users[perm].append(user._id)
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         for user in data:
-            api_perm = user["attributes"]["permission"]
-            user_id = user["id"].split("-")[1]
+            api_perm = user['attributes']['permission']
+            user_id = user['id'].split('-')[1]
             assert (
                 user_id in users[api_perm]
-            ), "Permissions incorrect for {}. Should not have {} permission.".format(
+            ), 'Permissions incorrect for {}. Should not have {} permission.'.format(
                 user_id, api_perm
             )
 
@@ -162,21 +162,21 @@ class TestNodeContributorList(NodeCRUDTestCase):
         #   test_return_public_contributor_list_logged_in
         res = app.get(url_public, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
-        assert len(res.json["data"]) == 1
-        assert res.json["data"][0]["id"] == make_contrib_id(
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == make_contrib_id(
             project_public._id, user._id
         )
 
         #   test_return_private_contributor_list_logged_out
         res = app.get(url_private, expect_errors=True)
         assert res.status_code == 401
-        assert "detail" in res.json["errors"][0]
+        assert 'detail' in res.json['errors'][0]
 
         #   test_return_private_contributor_list_logged_in_non_contributor
         res = app.get(url_private, auth=user_two.auth, expect_errors=True)
         assert res.status_code == 403
-        assert "detail" in res.json["errors"][0]
+        assert 'detail' in res.json['errors'][0]
 
         #   test_return_private_contributor_list_logged_in_osf_group_member
         res = app.get(url_private, auth=user_two.auth, expect_errors=True)
@@ -184,9 +184,9 @@ class TestNodeContributorList(NodeCRUDTestCase):
         project_private.add_osf_group(osf_group, permissions.READ)
         res = app.get(url_private, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
-        assert len(res.json["data"]) == 1
-        assert res.json["data"][0]["id"] == make_contrib_id(
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == make_contrib_id(
             project_private._id, user._id
         )
 
@@ -197,12 +197,12 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
         res = app.get(url_public)
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
-        assert len(res.json["data"]) == 2
-        assert res.json["data"][0]["id"] == make_contrib_id(
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['id'] == make_contrib_id(
             project_public._id, user._id
         )
-        assert res.json["data"][1]["id"] == make_contrib_id(
+        assert res.json['data'][1]['id'] == make_contrib_id(
             project_public._id, user_two._id
         )
 
@@ -214,34 +214,34 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
         res = app.get(url_private, auth=user.auth)
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
-        assert len(res.json["data"]) == 2
-        assert res.json["data"][0]["id"] == make_contrib_id(
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['id'] == make_contrib_id(
             project_private._id, user._id
         )
-        assert res.json["data"][1]["id"] == make_contrib_id(
+        assert res.json['data'][1]['id'] == make_contrib_id(
             project_private._id, user_two._id
         )
 
     def test_filtering_on_obsolete_fields(self, app, user, url_public):
         # regression test for changes in filter fields
-        url_fullname = f"{url_public}?filter[fullname]=foo"
+        url_fullname = f'{url_public}?filter[fullname]=foo'
         res = app.get(url_fullname, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json["errors"]
+        errors = res.json['errors']
         assert len(errors) == 1
         assert (
-            errors[0]["detail"] == "'fullname' is not a valid field for this endpoint."
+            errors[0]['detail'] == "'fullname' is not a valid field for this endpoint."
         )
 
         # middle_name is now middle_names
-        url_middle_name = f"{url_public}?filter[middle_name]=foo"
+        url_middle_name = f'{url_public}?filter[middle_name]=foo'
         res = app.get(url_middle_name, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json["errors"]
+        errors = res.json['errors']
         assert len(errors) == 1
         assert (
-            errors[0]["detail"]
+            errors[0]['detail']
             == "'middle_name' is not a valid field for this endpoint."
         )
 
@@ -255,21 +255,21 @@ class TestNodeContributorList(NodeCRUDTestCase):
 
         res = app.get(url_public)
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
-        assert len(res.json["data"]) == 2
-        assert res.json["data"][0]["id"] == make_contrib_id(
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['id'] == make_contrib_id(
             project_public._id, user._id
         )
-        assert res.json["data"][1]["id"] == make_contrib_id(
+        assert res.json['data'][1]['id'] == make_contrib_id(
             project_public._id, user_two._id
         )
         assert (
-            res.json["data"][1]["embeds"]["users"]["errors"][0]["meta"]["full_name"]
+            res.json['data'][1]['embeds']['users']['errors'][0]['meta']['full_name']
             == user_two.fullname
         )
         assert (
-            res.json["data"][1]["embeds"]["users"]["errors"][0]["detail"]
-            == "The requested user is no longer available."
+            res.json['data'][1]['embeds']['users']['errors'][0]['detail']
+            == 'The requested user is no longer available.'
         )
 
     def test_total_bibliographic_contributor_count_returned_in_metadata(
@@ -282,61 +282,61 @@ class TestNodeContributorList(NodeCRUDTestCase):
         project_public.save()
         res = app.get(url_public, auth=user_two.auth)
         assert res.status_code == 200
-        assert res.json["links"]["meta"]["total_bibliographic"] == len(
+        assert res.json['links']['meta']['total_bibliographic'] == len(
             project_public.visible_contributor_ids
         )
 
     def test_unregistered_contributor_field_is_null_if_account_claimed(self, app, user):
         project = ProjectFactory(creator=user, is_public=True)
-        url = f"/{API_BASE}nodes/{project._id}/contributors/"
+        url = f'/{API_BASE}nodes/{project._id}/contributors/'
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 1
-        assert res.json["data"][0]["attributes"].get("unregistered_contributor") is None
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes'].get('unregistered_contributor') is None
 
     def test_unregistered_contributors_show_up_as_name_associated_with_project(
         self, app, user
     ):
         project = ProjectFactory(creator=user, is_public=True)
         project.add_unregistered_contributor(
-            "Robert Jackson", "robert@gmail.com", auth=Auth(user), save=True
+            'Robert Jackson', 'robert@gmail.com', auth=Auth(user), save=True
         )
-        url = f"/{API_BASE}nodes/{project._id}/contributors/"
+        url = f'/{API_BASE}nodes/{project._id}/contributors/'
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
         assert (
-            res.json["data"][1]["embeds"]["users"]["data"]["attributes"]["full_name"]
-            == "Robert Jackson"
+            res.json['data'][1]['embeds']['users']['data']['attributes']['full_name']
+            == 'Robert Jackson'
         )
         assert (
-            res.json["data"][1]["attributes"].get("unregistered_contributor")
-            == "Robert Jackson"
+            res.json['data'][1]['attributes'].get('unregistered_contributor')
+            == 'Robert Jackson'
         )
 
         project_two = ProjectFactory(creator=user, is_public=True)
         project_two.add_unregistered_contributor(
-            "Bob Jackson", "robert@gmail.com", auth=Auth(user), save=True
+            'Bob Jackson', 'robert@gmail.com', auth=Auth(user), save=True
         )
-        url = f"/{API_BASE}nodes/{project_two._id}/contributors/"
+        url = f'/{API_BASE}nodes/{project_two._id}/contributors/'
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
 
         assert (
-            res.json["data"][1]["embeds"]["users"]["data"]["attributes"]["full_name"]
-            == "Robert Jackson"
+            res.json['data'][1]['embeds']['users']['data']['attributes']['full_name']
+            == 'Robert Jackson'
         )
         assert (
-            res.json["data"][1]["attributes"].get("unregistered_contributor")
-            == "Bob Jackson"
+            res.json['data'][1]['attributes'].get('unregistered_contributor')
+            == 'Bob Jackson'
         )
 
     def test_contributors_order_is_the_same_over_multiple_requests(
         self, app, user, project_public, url_public
     ):
         project_public.add_unregistered_contributor(
-            "Robert Jackson", "robert@gmail.com", auth=Auth(user), save=True
+            'Robert Jackson', 'robert@gmail.com', auth=Auth(user), save=True
         )
 
         for i in range(0, 10):
@@ -348,10 +348,10 @@ class TestNodeContributorList(NodeCRUDTestCase):
             project_public.add_contributor(
                 new_user, visible=visible, auth=Auth(project_public.creator), save=True
             )
-        req_one = app.get(f"{url_public}?page=2", auth=Auth(project_public.creator))
-        req_two = app.get(f"{url_public}?page=2", auth=Auth(project_public.creator))
-        id_one = [item["id"] for item in req_one.json["data"]]
-        id_two = [item["id"] for item in req_two.json["data"]]
+        req_one = app.get(f'{url_public}?page=2', auth=Auth(project_public.creator))
+        req_two = app.get(f'{url_public}?page=2', auth=Auth(project_public.creator))
+        id_one = [item['id'] for item in req_one.json['data']]
+        id_two = [item['id'] for item in req_two.json['data']]
         for a, b in zip(id_one, id_two):
             assert a == b
 
@@ -366,29 +366,29 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/?send_email=false".format(
+        return '/{}nodes/{}/contributors/?send_email=false'.format(
             API_BASE, project_private._id
         )
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return "/{}nodes/{}/contributors/?send_email=false".format(
+        return '/{}nodes/{}/contributors/?send_email=false'.format(
             API_BASE, project_public._id
         )
 
     @pytest.fixture()
     def data_user_two(self, user_two):
         return {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "bibliographic": True,
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'bibliographic': True,
                 },
-                "relationships": {
-                    "users": {
-                        "data": {
-                            "type": "users",
-                            "id": user_two._id,
+                'relationships': {
+                    'users': {
+                        'data': {
+                            'type': 'users',
+                            'id': user_two._id,
                         }
                     }
                 },
@@ -398,16 +398,16 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     @pytest.fixture()
     def data_user_three(self, user_three):
         return {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "bibliographic": True,
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'bibliographic': True,
                 },
-                "relationships": {
-                    "users": {
-                        "data": {
-                            "type": "users",
-                            "id": user_three._id,
+                'relationships': {
+                    'users': {
+                        'data': {
+                            'type': 'users',
+                            'id': user_three._id,
                         }
                     }
                 },
@@ -418,97 +418,97 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
         #   test_add_node_contributors_relationships_is_a_list
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": [{"contributor_id": user_three._id}],
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': [{'contributor_id': user_three._id}],
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
+        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
         #   test_add_contributor_no_relationships
-        data = {"data": {"type": "contributors", "attributes": {"bibliographic": True}}}
+        data = {'data': {'type': 'contributors', 'attributes': {'bibliographic': True}}}
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "A user ID or full name must be provided to add a contributor."
+            res.json['errors'][0]['detail']
+            == 'A user ID or full name must be provided to add a contributor.'
         )
 
         #   test_add_contributor_empty_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "A user ID or full name must be provided to add a contributor."
+            res.json['errors'][0]['detail']
+            == 'A user ID or full name must be provided to add a contributor.'
         )
 
         #   test_add_contributor_no_user_key_in_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"id": user_two._id, "type": "users"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'id': user_two._id, 'type': 'users'},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
+        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
         #   test_add_contributor_no_data_in_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"users": {"id": user_two._id}},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'users': {'id': user_two._id}},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Request must include /data."
+        assert res.json['errors'][0]['detail'] == 'Request must include /data.'
 
         #   test_add_contributor_no_target_type_in_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"users": {"data": {"id": user_two._id}}},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'users': {'data': {'id': user_two._id}}},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Request must include /type."
+        assert res.json['errors'][0]['detail'] == 'Request must include /type.'
 
         #   test_add_contributor_no_target_id_in_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"users": {"data": {"type": "users"}}},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'users': {'data': {'type': 'users'}}},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "A user ID or full name must be provided to add a contributor."
+            res.json['errors'][0]['detail']
+            == 'A user ID or full name must be provided to add a contributor.'
         )
 
         #   test_add_contributor_incorrect_target_id_in_relationships
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"users": {"data": {"type": "users", "id": "12345"}}},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'users': {'data': {'type': 'users', 'id': '12345'}}},
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
@@ -516,24 +516,24 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
         #   test_add_contributor_no_type
         data = {
-            "data": {
-                "attributes": {"bibliographic": True},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'attributes': {'bibliographic': True},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["source"]["pointer"] == "/data/type"
+        assert res.json['errors'][0]['source']['pointer'] == '/data/type'
 
         #   test_add_contributor_incorrect_type
         data = {
-            "data": {
-                "type": "Incorrect type",
-                "attributes": {"bibliographic": True},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'Incorrect type',
+                'attributes': {'bibliographic': True},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
@@ -542,34 +542,34 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
         #   test_unregistered_contributor_invalid_email
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "permission": "admin",
-                    "email": "jdoe@example.com",
-                    "full_name": "John Doe",
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'permission': 'admin',
+                    'email': 'jdoe@example.com',
+                    'full_name': 'John Doe',
                 },
             }
         }
         res = app.post_json_api(url_public, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Unregistered contributor email address domain is blocked."
+            res.json['errors'][0]['detail']
+            == 'Unregistered contributor email address domain is blocked.'
         )
 
     def test_contributor_create_invalid_data(self, app, user_three, url_public):
         res = app.post_json_api(
-            url_public, "Incorrect data", auth=user_three.auth, expect_errors=True
+            url_public, 'Incorrect data', auth=user_three.auth, expect_errors=True
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
+        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
         res = app.post_json_api(
-            url_public, ["Incorrect data"], auth=user_three.auth, expect_errors=True
+            url_public, ['Incorrect data'], auth=user_three.auth, expect_errors=True
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
+        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
     def test_add_contributor_dont_expose_email(
         self, app, user, user_two, project_public, data_user_two, url_public
@@ -577,17 +577,17 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
 
         res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["attributes"].get("email") is None
+        assert res.json['data']['attributes'].get('email') is None
 
     def test_add_contributor_is_visible_by_default(
         self, app, user, user_two, project_public, data_user_two, url_public
     ):
-        del data_user_two["data"]["attributes"]["bibliographic"]
+        del data_user_two['data']['attributes']['bibliographic']
         res = app.post_json_api(
             url_public, data_user_two, auth=user.auth, expect_errors=True
         )
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_public._id, user_two._id
         )
 
@@ -600,7 +600,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     ):
         res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_public._id, user_two._id
         )
 
@@ -611,20 +611,20 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": False},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': False},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
-        assert res.json["data"]["attributes"]["bibliographic"] is False
+        assert res.json['data']['attributes']['bibliographic'] is False
 
         project_private.reload()
         assert user_two in project_private.contributors
@@ -690,7 +690,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     ):
         res = app.post_json_api(url_private, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
 
@@ -711,7 +711,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         project_private.add_osf_group(osf_group, permissions.ADMIN)
         res = app.post_json_api(url_private, data_user_two, auth=user_three.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
 
@@ -722,11 +722,11 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
@@ -740,17 +740,17 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
 
@@ -766,17 +766,17 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True, "permission": permissions.WRITE},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True, 'permission': permissions.WRITE},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
 
@@ -791,17 +791,17 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True, "permission": permissions.READ},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True, 'permission': permissions.READ},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["id"] == "{}-{}".format(
+        assert res.json['data']['id'] == '{}-{}'.format(
             project_private._id, user_two._id
         )
 
@@ -813,14 +813,14 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "bibliographic": True,
-                    "permission": "invalid",
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'bibliographic': True,
+                    'permission': 'invalid',
                 },
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
@@ -834,11 +834,11 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, user_two, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True, "permission": None},
-                "relationships": {
-                    "users": {"data": {"id": user_two._id, "type": "users"}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True, 'permission': None},
+                'relationships': {
+                    'users': {'data': {'id': user_two._id, 'type': 'users'}}
                 },
             }
         }
@@ -864,10 +864,10 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, project_private, url_private
     ):
         data = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"bibliographic": True},
-                "relationships": {"users": {"data": {"id": "FAKE", "type": "users"}}},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'bibliographic': True},
+                'relationships': {'users': {'data': {'id': 'FAKE', 'type': 'users'}}},
             }
         }
         res = app.post_json_api(url_private, data, auth=user.auth, expect_errors=True)
@@ -921,88 +921,88 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         self, app, user, project_public, url_public
     ):
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "full_name": "John Doe",
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': 'John Doe',
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
-        assert res.json["data"]["attributes"].get("email") is None
-        assert res.json["data"]["embeds"]["users"]["data"][
-            "id"
-        ] in project_public.contributors.values_list("guids___id", flat=True)
+        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
+        assert res.json['data']['attributes'].get('email') is None
+        assert res.json['data']['embeds']['users']['data'][
+            'id'
+        ] in project_public.contributors.values_list('guids___id', flat=True)
 
     def test_add_contributor_with_fullname_and_email_unregistered_user(
         self, app, user, project_public, url_public
     ):
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "John Doe", "email": "john@doe.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'John Doe', 'email': 'john@doe.com'},
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
-        assert res.json["data"]["attributes"].get("email") is None
-        assert res.json["data"]["attributes"]["bibliographic"] is True
-        assert res.json["data"]["attributes"]["permission"] == permissions.WRITE
-        assert res.json["data"]["embeds"]["users"]["data"][
-            "id"
-        ] in project_public.contributors.values_list("guids___id", flat=True)
+        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
+        assert res.json['data']['attributes'].get('email') is None
+        assert res.json['data']['attributes']['bibliographic'] is True
+        assert res.json['data']['attributes']['permission'] == permissions.WRITE
+        assert res.json['data']['embeds']['users']['data'][
+            'id'
+        ] in project_public.contributors.values_list('guids___id', flat=True)
 
     def test_add_contributor_with_fullname_and_email_unregistered_user_set_attributes(
         self, app, user, project_public, url_public
     ):
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "full_name": "John Doe",
-                    "email": "john@doe.com",
-                    "bibliographic": False,
-                    "permission": permissions.READ,
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': 'John Doe',
+                    'email': 'john@doe.com',
+                    'bibliographic': False,
+                    'permission': permissions.READ,
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["unregistered_contributor"] == "John Doe"
-        assert res.json["data"]["attributes"].get("email") is None
-        assert res.json["data"]["attributes"]["bibliographic"] is False
-        assert res.json["data"]["attributes"]["permission"] == permissions.READ
-        assert res.json["data"]["embeds"]["users"]["data"][
-            "id"
-        ] in project_public.contributors.values_list("guids___id", flat=True)
+        assert res.json['data']['attributes']['unregistered_contributor'] == 'John Doe'
+        assert res.json['data']['attributes'].get('email') is None
+        assert res.json['data']['attributes']['bibliographic'] is False
+        assert res.json['data']['attributes']['permission'] == permissions.READ
+        assert res.json['data']['embeds']['users']['data'][
+            'id'
+        ] in project_public.contributors.values_list('guids___id', flat=True)
 
     def test_add_contributor_with_fullname_and_email_registered_user(
         self, app, user, project_public, url_public
     ):
         user_contrib = UserFactory()
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "full_name": user_contrib.fullname,
-                    "email": user_contrib.username,
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': user_contrib.fullname,
+                    'email': user_contrib.username,
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth)
         project_public.reload()
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["unregistered_contributor"] is None
-        assert res.json["data"]["attributes"].get("email") is None
-        assert res.json["data"]["embeds"]["users"]["data"][
-            "id"
-        ] in project_public.contributors.values_list("guids___id", flat=True)
+        assert res.json['data']['attributes']['unregistered_contributor'] is None
+        assert res.json['data']['attributes'].get('email') is None
+        assert res.json['data']['embeds']['users']['data'][
+            'id'
+        ] in project_public.contributors.values_list('guids___id', flat=True)
 
     def test_add_unregistered_contributor_already_contributor(
         self, app, user, project_public, url_public
@@ -1012,15 +1012,15 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             auth=Auth(user), fullname=name, email=email
         )
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Doesn't Matter", "email": email},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': "Doesn't Matter", 'email': email},
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         project_public.reload()
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "{} is already a contributor.".format(
+        assert res.json['errors'][0]['detail'] == '{} is already a contributor.'.format(
             name
         )
 
@@ -1031,19 +1031,19 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         user_contrib.date_disabled = datetime.utcnow()
         user_contrib.save()
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_contrib._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_contrib._id}}
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Deactivated users cannot be added as contributors."
+            res.json['errors'][0]['detail']
+            == 'Deactivated users cannot be added as contributors.'
         )
 
     def test_add_contributor_user_is_deactivated_unregistered_payload(
@@ -1053,19 +1053,19 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         user_contrib.date_disabled = datetime.utcnow()
         user_contrib.save()
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "full_name": user_contrib.fullname,
-                    "email": user_contrib.username,
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': user_contrib.fullname,
+                    'email': user_contrib.username,
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Deactivated users cannot be added as contributors."
+            res.json['errors'][0]['detail']
+            == 'Deactivated users cannot be added as contributors.'
         )
 
     def test_add_contributor_index_returned(
@@ -1073,11 +1073,11 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     ):
         res = app.post_json_api(url_public, data_user_two, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["index"] == 1
+        assert res.json['data']['attributes']['index'] == 1
 
         res = app.post_json_api(url_public, data_user_three, auth=user.auth)
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["index"] == 2
+        assert res.json['data']['attributes']['index'] == 2
 
     def test_add_contributor_set_index_out_of_range(
         self, app, user, user_two, project_public, url_public
@@ -1087,19 +1087,19 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"index": 4},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'index': 4},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0][
-            "detail"
-        ] == "4 is not a valid contributor index for node with id {}".format(
+        assert res.json['errors'][0][
+            'detail'
+        ] == '4 is not a valid contributor index for node with id {}'.format(
             project_public._id
         )
 
@@ -1111,11 +1111,11 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"index": 0},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'index': 0},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
@@ -1134,11 +1134,11 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         user_contrib_two = UserFactory()
         project_public.add_contributor(user_contrib_two, save=True)
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"index": 3},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {'index': 3},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
@@ -1154,46 +1154,46 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         merged_user = UserFactory(merged_by=primary_user)
 
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": merged_user._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': merged_user._id}}
                 },
             }
         }
 
         res = app.post_json_api(url_public, payload, auth=user.auth)
         assert res.status_code == 201
-        contributor_added = res.json["data"]["embeds"]["users"]["data"]["id"]
+        contributor_added = res.json['data']['embeds']['users']['data']['id']
         assert contributor_added == primary_user._id
 
     def test_add_unconfirmed_user_by_guid(self, app, user, project_public, url_public):
         unconfirmed_user = UnconfirmedUserFactory()
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": unconfirmed_user._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': unconfirmed_user._id}}
                 },
             }
         }
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
         # if adding unregistered contrib by guid, fullname must be supplied
-        assert res.json["errors"][0][
-            "detail"
-        ] == "Cannot add unconfirmed user {} to resource {}. You need to provide a full_name.".format(
+        assert res.json['errors'][0][
+            'detail'
+        ] == 'Cannot add unconfirmed user {} to resource {}. You need to provide a full_name.'.format(
             unconfirmed_user._id, project_public._id
         )
 
-        payload["data"]["attributes"]["full_name"] = "Susan B. Anthony"
+        payload['data']['attributes']['full_name'] = 'Susan B. Anthony'
         res = app.post_json_api(url_public, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 201
         assert (
-            res.json["data"]["attributes"]["unregistered_contributor"]
-            == "Susan B. Anthony"
+            res.json['data']['attributes']['unregistered_contributor']
+            == 'Susan B. Anthony'
         )
 
 
@@ -1214,11 +1214,11 @@ class TestNodeContributorCreateValidation(NodeCRUDTestCase):
     ):
 
         #   test_add_contributor_validation_user_id
-        validate_data(create_serializer(), project_public, user_id="abcde")
+        validate_data(create_serializer(), project_public, user_id='abcde')
 
         #   test_add_contributor_validation_user_id_fullname
         validate_data(
-            create_serializer(), project_public, user_id="abcde", full_name="Kanye"
+            create_serializer(), project_public, user_id='abcde', full_name='Kanye'
         )
 
         #   test_add_contributor_validation_user_id_email
@@ -1226,8 +1226,8 @@ class TestNodeContributorCreateValidation(NodeCRUDTestCase):
             validate_data(
                 create_serializer(),
                 project_public,
-                user_id="abcde",
-                email="kanye@west.com",
+                user_id='abcde',
+                email='kanye@west.com',
             )
 
         #   test_add_contributor_validation_user_id_fullname_email
@@ -1235,24 +1235,24 @@ class TestNodeContributorCreateValidation(NodeCRUDTestCase):
             validate_data(
                 create_serializer(),
                 project_public,
-                user_id="abcde",
-                full_name="Kanye",
-                email="kanye@west.com",
+                user_id='abcde',
+                full_name='Kanye',
+                email='kanye@west.com',
             )
 
         #   test_add_contributor_validation_fullname
-        validate_data(create_serializer(), project_public, full_name="Kanye")
+        validate_data(create_serializer(), project_public, full_name='Kanye')
 
         #   test_add_contributor_validation_email
         with pytest.raises(exceptions.ValidationError):
-            validate_data(create_serializer(), project_public, email="kanye@west.com")
+            validate_data(create_serializer(), project_public, email='kanye@west.com')
 
         #   test_add_contributor_validation_fullname_email
         validate_data(
             create_serializer(),
             project_public,
-            full_name="Kanye",
-            email="kanye@west.com",
+            full_name='Kanye',
+            email='kanye@west.com',
         )
 
 
@@ -1263,34 +1263,34 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_project_contribs(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
+        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
 
-    @mock.patch("framework.auth.views.mails.send_mail")
+    @mock.patch('framework.auth.views.mails.send_mail')
     def test_add_contributor_no_email_if_false(
         self, mock_mail, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=false"
+        url = f'{url_project_contribs}?send_email=false'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'Kanye West', 'email': 'kanye@west.com'},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         assert mock_mail.call_count == 0
 
-    @mock.patch("framework.auth.views.mails.send_mail")
+    @mock.patch('framework.auth.views.mails.send_mail')
     def test_add_contributor_sends_email(
         self, mock_mail, app, user, user_two, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=default"
+        url = f'{url_project_contribs}?send_email=default'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
@@ -1299,121 +1299,121 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
         assert res.status_code == 201
         assert mock_mail.call_count == 1
 
-    @mock.patch("website.project.signals.contributor_added.send")
+    @mock.patch('website.project.signals.contributor_added.send')
     def test_add_contributor_signal_if_default(
         self, mock_send, app, user, user_two, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=default"
+        url = f'{url_project_contribs}?send_email=default'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         args, kwargs = mock_send.call_args
         assert res.status_code == 201
-        assert "default" == kwargs["email_template"]
+        assert 'default' == kwargs['email_template']
 
     def test_add_contributor_signal_preprint_email_disallowed(
         self, app, user, user_two, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=preprint"
+        url = f'{url_project_contribs}?send_email=preprint'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {},
-                "relationships": {
-                    "users": {"data": {"type": "users", "id": user_two._id}}
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {'data': {'type': 'users', 'id': user_two._id}}
                 },
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "preprint is not a valid email preference."
+            res.json['errors'][0]['detail']
+            == 'preprint is not a valid email preference.'
         )
 
-    @mock.patch("framework.auth.views.mails.send_mail")
+    @mock.patch('framework.auth.views.mails.send_mail')
     def test_add_unregistered_contributor_sends_email(
         self, mock_mail, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=default"
+        url = f'{url_project_contribs}?send_email=default'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'Kanye West', 'email': 'kanye@west.com'},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         assert res.status_code == 201
         assert mock_mail.call_count == 1
 
-    @mock.patch("website.project.signals.unreg_contributor_added.send")
+    @mock.patch('website.project.signals.unreg_contributor_added.send')
     def test_add_unregistered_contributor_signal_if_default(
         self, mock_send, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=default"
+        url = f'{url_project_contribs}?send_email=default'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'Kanye West', 'email': 'kanye@west.com'},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth)
         args, kwargs = mock_send.call_args
         assert res.status_code == 201
-        assert "default" == kwargs["email_template"]
+        assert 'default' == kwargs['email_template']
 
     def test_add_unregistered_contributor_signal_preprint_email_disallowed(
         self, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=preprint"
+        url = f'{url_project_contribs}?send_email=preprint'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'Kanye West', 'email': 'kanye@west.com'},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "preprint is not a valid email preference."
+            res.json['errors'][0]['detail']
+            == 'preprint is not a valid email preference.'
         )
 
-    @mock.patch("framework.auth.views.mails.send_mail")
+    @mock.patch('framework.auth.views.mails.send_mail')
     def test_add_contributor_invalid_send_email_param(
         self, mock_mail, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=true"
+        url = f'{url_project_contribs}?send_email=true'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {"full_name": "Kanye West", "email": "kanye@west.com"},
+            'data': {
+                'type': 'contributors',
+                'attributes': {'full_name': 'Kanye West', 'email': 'kanye@west.com'},
             }
         }
         res = app.post_json_api(url, payload, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "true is not a valid email preference."
+            res.json['errors'][0]['detail'] == 'true is not a valid email preference.'
         )
         assert mock_mail.call_count == 0
 
-    @mock.patch("framework.auth.views.mails.send_mail")
+    @mock.patch('framework.auth.views.mails.send_mail')
     def test_add_unregistered_contributor_without_email_no_email(
         self, mock_mail, app, user, url_project_contribs
     ):
-        url = f"{url_project_contribs}?send_email=default"
+        url = f'{url_project_contribs}?send_email=default'
         payload = {
-            "data": {
-                "type": "contributors",
-                "attributes": {
-                    "full_name": "Kanye West",
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': 'Kanye West',
                 },
             }
         }
@@ -1434,31 +1434,31 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return "/{}nodes/{}/contributors/?send_email=false".format(
+        return '/{}nodes/{}/contributors/?send_email=false'.format(
             API_BASE, project_public._id
         )
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/?send_email=false".format(
+        return '/{}nodes/{}/contributors/?send_email=false'.format(
             API_BASE, project_private._id
         )
 
     @pytest.fixture()
     def payload_one(self, user_two):
         return {
-            "type": "contributors",
-            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
-            "relationships": {"users": {"data": {"id": user_two._id, "type": "users"}}},
+            'type': 'contributors',
+            'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
+            'relationships': {'users': {'data': {'id': user_two._id, 'type': 'users'}}},
         }
 
     @pytest.fixture()
     def payload_two(self, user_three):
         return {
-            "type": "contributors",
-            "attributes": {"bibliographic": False, "permission": permissions.READ},
-            "relationships": {
-                "users": {"data": {"id": user_three._id, "type": "users"}}
+            'type': 'contributors',
+            'attributes': {'bibliographic': False, 'permission': permissions.READ},
+            'relationships': {
+                'users': {'data': {'id': user_three._id, 'type': 'users'}}
             },
         }
 
@@ -1470,16 +1470,16 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         )
         res = app.post_json_api(
             url_public,
-            {"data": [payload_two, payload_one]},
+            {'data': [payload_two, payload_one]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
-        assert "is already a contributor" in res.json["errors"][0]["detail"]
+        assert 'is already a contributor' in res.json['errors'][0]['detail']
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
 
     def test_node_contributor_bulk_create_errors(
         self,
@@ -1502,31 +1502,31 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         #   test_node_contributor_bulk_create_logged_out_public_project
         res = app.post_json_api(
             url_public,
-            {"data": [payload_one, payload_two]},
+            {'data': [payload_one, payload_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
         #   test_node_contributor_bulk_create_logged_out_private_project
         res = app.post_json_api(
             url_private,
-            {"data": [payload_one, payload_two]},
+            {'data': [payload_one, payload_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
         #   test_node_contributor_bulk_create_logged_in_non_contrib_private_project
         res = app.post_json_api(
             url_private,
-            {"data": [payload_one, payload_two]},
+            {'data': [payload_one, payload_two]},
             auth=user_two.auth,
             expect_errors=True,
             bulk=True,
@@ -1534,7 +1534,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
         #   test_node_contributor_bulk_create_logged_in_read_only_contrib_private_project
         project_private.add_contributor(
@@ -1542,7 +1542,7 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         )
         res = app.post_json_api(
             url_private,
-            {"data": [payload_two]},
+            {'data': [payload_two]},
             auth=user_two.auth,
             expect_errors=True,
             bulk=True,
@@ -1550,52 +1550,52 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
     def test_node_contributor_bulk_create_logged_in_public_project_project(
         self, app, user, payload_one, payload_two, url_public
     ):
         res = app.post_json_api(
-            url_public, {"data": [payload_one, payload_two]}, auth=user.auth, bulk=True
+            url_public, {'data': [payload_one, payload_two]}, auth=user.auth, bulk=True
         )
         assert res.status_code == 201
         assert [
-            res.json["data"][0]["attributes"]["bibliographic"],
-            res.json["data"][1]["attributes"]["bibliographic"],
+            res.json['data'][0]['attributes']['bibliographic'],
+            res.json['data'][1]['attributes']['bibliographic'],
         ] == [True, False]
         assert [
-            res.json["data"][0]["attributes"]["permission"],
-            res.json["data"][1]["attributes"]["permission"],
+            res.json['data'][0]['attributes']['permission'],
+            res.json['data'][1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ]
-        assert res.content_type == "application/vnd.api+json"
+        assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
     def test_node_contributor_bulk_create_logged_in_contrib_private_project(
         self, app, user, payload_one, payload_two, url_private
     ):
         res = app.post_json_api(
             url_private,
-            {"data": [payload_one, payload_two]},
+            {'data': [payload_one, payload_two]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 201
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
         assert [
-            res.json["data"][0]["attributes"]["bibliographic"],
-            res.json["data"][1]["attributes"]["bibliographic"],
+            res.json['data'][0]['attributes']['bibliographic'],
+            res.json['data'][1]['attributes']['bibliographic'],
         ] == [True, False]
         assert [
-            res.json["data"][0]["attributes"]["permission"],
-            res.json["data"][1]["attributes"]["permission"],
+            res.json['data'][0]['attributes']['permission'],
+            res.json['data'][1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ]
-        assert res.content_type == "application/vnd.api+json"
+        assert res.content_type == 'application/vnd.api+json'
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
     def test_node_contributor_bulk_create_payload_errors(
         self, app, user, user_two, payload_one, payload_two, url_public
@@ -1603,13 +1603,13 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
 
         #   test_node_contributor_bulk_create_all_or_nothing
         invalid_id_payload = {
-            "type": "contributors",
-            "attributes": {"bibliographic": True},
-            "relationships": {"users": {"data": {"type": "users", "id": "12345"}}},
+            'type': 'contributors',
+            'attributes': {'bibliographic': True},
+            'relationships': {'users': {'data': {'type': 'users', 'id': '12345'}}},
         }
         res = app.post_json_api(
             url_public,
-            {"data": [payload_one, invalid_id_payload]},
+            {'data': [payload_one, invalid_id_payload]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
@@ -1617,10 +1617,10 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
         assert res.status_code == 404
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
         #   test_node_contributor_bulk_create_limits
-        node_contrib_create_list = {"data": [payload_one] * 101}
+        node_contrib_create_list = {'data': [payload_one] * 101}
         res = app.post_json_api(
             url_public,
             node_contrib_create_list,
@@ -1629,32 +1629,32 @@ class TestNodeContributorBulkCreate(NodeCRUDTestCase):
             bulk=True,
         )
         assert (
-            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+            res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
         )
-        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+        assert res.json['errors'][0]['source']['pointer'] == '/data'
 
         #   test_node_contributor_ugly_payload
-        payload = "sdf;jlasfd"
+        payload = 'sdf;jlasfd'
         res = app.post_json_api(
             url_public, payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == exceptions.ParseError.default_detail
+        assert res.json['errors'][0]['detail'] == exceptions.ParseError.default_detail
 
         #   test_node_contributor_bulk_create_invalid_permissions_all_or_nothing
         payload = {
-            "type": "contributors",
-            "attributes": {"permission": "super-user", "bibliographic": True},
-            "relationships": {"users": {"data": {"type": "users", "id": user_two._id}}},
+            'type': 'contributors',
+            'attributes': {'permission': 'super-user', 'bibliographic': True},
+            'relationships': {'users': {'data': {'type': 'users', 'id': user_two._id}}},
         }
-        payload = {"data": [payload_two, payload]}
+        payload = {'data': [payload_two, payload]}
         res = app.post_json_api(
             url_public, payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
 
 @pytest.mark.django_db
@@ -1704,42 +1704,42 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
+        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
+        return '/{}nodes/{}/contributors/'.format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_two._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+            'id': make_contrib_id(project_public._id, user_two._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_two._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+            'id': make_contrib_id(project_private._id, user_two._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_three._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
+            'id': make_contrib_id(project_public._id, user_three._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': False, 'permission': permissions.WRITE},
         }
 
     @pytest.fixture()
     def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_three._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
+            'id': make_contrib_id(project_private._id, user_three._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': False, 'permission': permissions.WRITE},
         }
 
     def test_bulk_update_contributors_errors(
@@ -1767,7 +1767,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         #   test_bulk_update_contributors_dict_instead_of_list
         res = app.put_json_api(
             url_public,
-            {"data": payload_public_one},
+            {'data': payload_public_one},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
@@ -1775,62 +1775,62 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert res.status_code == 400
 
         #   test_bulk_update_contributors_public_project_one_not_found
-        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
-        empty_payload = {"data": [invalid_id, payload_public_one]}
+        invalid_id = {'id': '12345-abcde', 'type': 'contributors', 'attributes': {}}
+        empty_payload = {'data': [invalid_id, payload_public_one]}
         res = app.put_json_api(
             url_public, empty_payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to update."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
         )
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_public_projects_logged_out
         res = app.put_json_api(
             url_public,
-            {"data": [payload_public_one, payload_public_two]},
+            {'data': [payload_public_one, payload_public_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_private_projects_logged_out
         res = app.put_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_private_projects_logged_in_non_contrib
         res = app.put_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_four.auth,
             expect_errors=True,
             bulk=True,
@@ -1838,17 +1838,17 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_private_projects_logged_in_read_only_contrib
         res = app.put_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_two.auth,
             expect_errors=True,
             bulk=True,
@@ -1856,47 +1856,47 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_projects_send_dictionary_not_list
         res = app.put_json_api(
             url_public,
-            {"data": payload_public_one},
+            {'data': payload_public_one},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
+            res.json['errors'][0]['detail']
             == 'Expected a list of items but got type "dict".'
         )
 
         #   test_bulk_update_contributors_id_not_supplied
         res = app.put_json_api(
             url_public,
-            {"data": [{"type": "contributors", "attributes": {}}]},
+            {'data': [{'type': 'contributors', 'attributes': {}}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
-        assert len(res.json["errors"]) == 1
-        assert res.json["errors"][0]["detail"] == "Contributor identifier not provided."
+        assert len(res.json['errors']) == 1
+        assert res.json['errors'][0]['detail'] == 'Contributor identifier not provided.'
 
         #   test_bulk_update_contributors_type_not_supplied
         res = app.put_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "attributes": {},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'attributes': {},
                     }
                 ]
             },
@@ -1905,19 +1905,19 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert len(res.json["errors"]) == 1
-        assert res.json["errors"][0]["source"]["pointer"] == "/data/0/type"
-        assert res.json["errors"][0]["detail"] == "This field may not be null."
+        assert len(res.json['errors']) == 1
+        assert res.json['errors'][0]['source']['pointer'] == '/data/0/type'
+        assert res.json['errors'][0]['detail'] == 'This field may not be null.'
 
         #   test_bulk_update_contributors_wrong_type
         invalid_type = {
-            "id": make_contrib_id(project_public._id, user_two._id),
-            "type": "Wrong type.",
-            "attributes": {},
+            'id': make_contrib_id(project_public._id, user_two._id),
+            'type': 'Wrong type.',
+            'attributes': {},
         }
         res = app.put_json_api(
             url_public,
-            {"data": [invalid_type]},
+            {'data': [invalid_type]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
@@ -1925,36 +1925,36 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert res.status_code == 409
 
         #   test_bulk_update_contributors_invalid_id_format
-        invalid_id = {"id": "12345", "type": "contributors", "attributes": {}}
+        invalid_id = {'id': '12345', 'type': 'contributors', 'attributes': {}}
         res = app.put_json_api(
             url_public,
-            {"data": [invalid_id]},
+            {'data': [invalid_id]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Contributor identifier incorrectly formatted."
+            res.json['errors'][0]['detail']
+            == 'Contributor identifier incorrectly formatted.'
         )
 
         #   test_bulk_update_contributors_wrong_id
-        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
+        invalid_id = {'id': '12345-abcde', 'type': 'contributors', 'attributes': {}}
         res = app.put_json_api(
             url_public,
-            {"data": [invalid_id]},
+            {'data': [invalid_id]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to update."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
         )
 
         #   test_bulk_update_contributors_limits
-        contrib_update_list = {"data": [payload_public_one] * 101}
+        contrib_update_list = {'data': [payload_public_one] * 101}
         res = app.put_json_api(
             url_public,
             contrib_update_list,
@@ -1963,20 +1963,20 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert (
-            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+            res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
         )
-        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+        assert res.json['errors'][0]['source']['pointer'] == '/data'
 
         #   test_bulk_update_contributors_invalid_permissions
         res = app.put_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "type": "contributors",
-                        "attributes": {"permission": "super-user"},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'type': 'contributors',
+                        'attributes': {'permission': 'super-user'},
                     },
                 ]
             },
@@ -1985,26 +1985,26 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == '"super-user" is not a valid choice.'
+        assert res.json['errors'][0]['detail'] == '"super-user" is not a valid choice.'
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_invalid_bibliographic
         res = app.put_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "type": "contributors",
-                        "attributes": {"bibliographic": "true and false"},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'type': 'contributors',
+                        'attributes': {'bibliographic': 'true and false'},
                     },
                 ]
             },
@@ -2013,34 +2013,34 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Must be a valid boolean."
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor
         res = app.put_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user._id),
-                        "type": "contributors",
-                        "attributes": {
-                            "permission": permissions.ADMIN,
-                            "bibliographic": False,
+                        'id': make_contrib_id(project_public._id, user._id),
+                        'type': 'contributors',
+                        'attributes': {
+                            'permission': permissions.ADMIN,
+                            'bibliographic': False,
                         },
                     },
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "type": "contributors",
-                        "attributes": {"bibliographic": False},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'type': 'contributors',
+                        'attributes': {'bibliographic': False},
                     },
                 ]
             },
@@ -2051,20 +2051,20 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
 
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Must have at least one visible contributor"
+            res.json['errors'][0]['detail']
+            == 'Must have at least one visible contributor'
         )
 
         #   test_bulk_update_contributors_must_have_at_least_one_admin
         res = app.put_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user._id),
-                        "type": "contributors",
-                        "attributes": {"permission": permissions.READ},
+                        'id': make_contrib_id(project_public._id, user._id),
+                        'type': 'contributors',
+                        'attributes': {'permission': permissions.READ},
                     },
                 ]
             },
@@ -2073,7 +2073,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "{} is the only admin.".format(
+        assert res.json['errors'][0]['detail'] == '{} is the only admin.'.format(
             user.fullname
         )
 
@@ -2082,15 +2082,15 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
     ):
         res = app.put_json_api(
             url_public,
-            {"data": [payload_public_one, payload_public_two]},
+            {'data': [payload_public_one, payload_public_two]},
             auth=user.auth,
             bulk=True,
         )
         assert res.status_code == 200
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.WRITE]
 
     def test_bulk_update_contributors_private_projects_logged_in_contrib(
@@ -2098,15 +2098,15 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
     ):
         res = app.put_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user.auth,
             bulk=True,
         )
         assert res.status_code == 200
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.WRITE]
 
 
@@ -2157,42 +2157,42 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
+        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
+        return '/{}nodes/{}/contributors/'.format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_two._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+            'id': make_contrib_id(project_public._id, user_two._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_three._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
+            'id': make_contrib_id(project_public._id, user_three._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': False, 'permission': permissions.WRITE},
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_two._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": True, "permission": permissions.ADMIN},
+            'id': make_contrib_id(project_private._id, user_two._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': True, 'permission': permissions.ADMIN},
         }
 
     @pytest.fixture()
     def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_three._id),
-            "type": "contributors",
-            "attributes": {"bibliographic": False, "permission": permissions.WRITE},
+            'id': make_contrib_id(project_private._id, user_three._id),
+            'type': 'contributors',
+            'attributes': {'bibliographic': False, 'permission': permissions.WRITE},
         }
 
     def test_bulk_partial_update_errors(
@@ -2218,63 +2218,63 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert res.status_code == 400
 
         #   test_bulk_partial_update_contributors_public_project_one_not_found
-        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
+        invalid_id = {'id': '12345-abcde', 'type': 'contributors', 'attributes': {}}
 
-        empty_payload = {"data": [invalid_id, payload_public_one]}
+        empty_payload = {'data': [invalid_id, payload_public_one]}
         res = app.patch_json_api(
             url_public, empty_payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to update."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
         )
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_contributors_public_projects_logged_out
         res = app.patch_json_api(
             url_public,
-            {"data": [payload_public_one, payload_public_two]},
+            {'data': [payload_public_one, payload_public_two]},
             bulk=True,
             expect_errors=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_contributors_private_projects_logged_out
         res = app.patch_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_contributors_private_projects_logged_in_non_contrib
         res = app.patch_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_four.auth,
             expect_errors=True,
             bulk=True,
@@ -2282,17 +2282,17 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_contributors_private_projects_logged_in_read_only_contrib
         res = app.patch_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_two.auth,
             expect_errors=True,
             bulk=True,
@@ -2300,47 +2300,47 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_contributors_projects_send_dictionary_not_list
         res = app.patch_json_api(
             url_public,
-            {"data": payload_public_one},
+            {'data': payload_public_one},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
+            res.json['errors'][0]['detail']
             == 'Expected a list of items but got type "dict".'
         )
 
         #   test_bulk_partial_update_contributors_id_not_supplied
         res = app.patch_json_api(
             url_public,
-            {"data": [{"type": "contributors", "attributes": {}}]},
+            {'data': [{'type': 'contributors', 'attributes': {}}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
-        assert len(res.json["errors"]) == 1
-        assert res.json["errors"][0]["detail"] == "Contributor identifier not provided."
+        assert len(res.json['errors']) == 1
+        assert res.json['errors'][0]['detail'] == 'Contributor identifier not provided.'
 
         #   test_bulk_partial_update_contributors_type_not_supplied
         res = app.patch_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "attributes": {},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'attributes': {},
                     }
                 ]
             },
@@ -2349,19 +2349,19 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert len(res.json["errors"]) == 1
-        assert res.json["errors"][0]["source"]["pointer"] == "/data/0/type"
-        assert res.json["errors"][0]["detail"] == "This field may not be null."
+        assert len(res.json['errors']) == 1
+        assert res.json['errors'][0]['source']['pointer'] == '/data/0/type'
+        assert res.json['errors'][0]['detail'] == 'This field may not be null.'
 
         #   test_bulk_partial_update_contributors_wrong_type
         invalid_type = {
-            "id": make_contrib_id(project_public._id, user_two._id),
-            "type": "Wrong type.",
-            "attributes": {},
+            'id': make_contrib_id(project_public._id, user_two._id),
+            'type': 'Wrong type.',
+            'attributes': {},
         }
         res = app.patch_json_api(
             url_public,
-            {"data": [invalid_type]},
+            {'data': [invalid_type]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
@@ -2369,22 +2369,22 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
         assert res.status_code == 409
 
         #   test_bulk_partial_update_contributors_wrong_id
-        invalid_id = {"id": "12345-abcde", "type": "contributors", "attributes": {}}
+        invalid_id = {'id': '12345-abcde', 'type': 'contributors', 'attributes': {}}
 
         res = app.patch_json_api(
             url_public,
-            {"data": [invalid_id]},
+            {'data': [invalid_id]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to update."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to update.'
         )
 
         #   test_bulk_partial_update_contributors_limits
-        contrib_update_list = {"data": [payload_public_one] * 101}
+        contrib_update_list = {'data': [payload_public_one] * 101}
         res = app.patch_json_api(
             url_public,
             contrib_update_list,
@@ -2393,20 +2393,20 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert (
-            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+            res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
         )
-        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+        assert res.json['errors'][0]['source']['pointer'] == '/data'
 
         #   test_bulk_partial_update_invalid_permissions
         res = app.patch_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "type": "contributors",
-                        "attributes": {"permission": "super-user"},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'type': 'contributors',
+                        'attributes': {'permission': 'super-user'},
                     },
                 ]
             },
@@ -2415,26 +2415,26 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == '"super-user" is not a valid choice.'
+        assert res.json['errors'][0]['detail'] == '"super-user" is not a valid choice.'
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
         #   test_bulk_partial_update_invalid_bibliographic
         res = app.patch_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user_two._id),
-                        "type": "contributors",
-                        "attributes": {"bibliographic": "true and false"},
+                        'id': make_contrib_id(project_public._id, user_two._id),
+                        'type': 'contributors',
+                        'attributes': {'bibliographic': 'true and false'},
                     },
                 ]
             },
@@ -2443,14 +2443,14 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Must be a valid boolean."
+        assert res.json['errors'][0]['detail'] == 'Must be a valid boolean.'
 
         res = app.get(url_public, auth=user.auth)
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
-            data[2]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
+            data[2]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.READ, permissions.READ]
 
     def test_bulk_partial_update_contributors_public_projects_logged_in(
@@ -2458,15 +2458,15 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
     ):
         res = app.patch_json_api(
             url_public,
-            {"data": [payload_public_one, payload_public_two]},
+            {'data': [payload_public_one, payload_public_two]},
             auth=user.auth,
             bulk=True,
         )
         assert res.status_code == 200
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.WRITE]
 
     def test_bulk_partial_update_contributors_private_projects_logged_in_contrib(
@@ -2474,15 +2474,15 @@ class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
     ):
         res = app.patch_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user.auth,
             bulk=True,
         )
         assert res.status_code == 200
-        data = res.json["data"]
+        data = res.json['data']
         assert [
-            data[0]["attributes"]["permission"],
-            data[1]["attributes"]["permission"],
+            data[0]['attributes']['permission'],
+            data[1]['attributes']['permission'],
         ] == [permissions.ADMIN, permissions.WRITE]
 
 
@@ -2532,38 +2532,38 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
 
     @pytest.fixture()
     def url_public(self, project_public):
-        return f"/{API_BASE}nodes/{project_public._id}/contributors/"
+        return f'/{API_BASE}nodes/{project_public._id}/contributors/'
 
     @pytest.fixture()
     def url_private(self, project_private):
-        return "/{}nodes/{}/contributors/".format(API_BASE, project_private._id)
+        return '/{}nodes/{}/contributors/'.format(API_BASE, project_private._id)
 
     @pytest.fixture()
     def payload_public_one(self, user_two, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_two._id),
-            "type": "contributors",
+            'id': make_contrib_id(project_public._id, user_two._id),
+            'type': 'contributors',
         }
 
     @pytest.fixture()
     def payload_public_two(self, user_three, project_public, make_contrib_id):
         return {
-            "id": make_contrib_id(project_public._id, user_three._id),
-            "type": "contributors",
+            'id': make_contrib_id(project_public._id, user_three._id),
+            'type': 'contributors',
         }
 
     @pytest.fixture()
     def payload_private_one(self, user_two, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_two._id),
-            "type": "contributors",
+            'id': make_contrib_id(project_private._id, user_two._id),
+            'type': 'contributors',
         }
 
     @pytest.fixture()
     def payload_private_two(self, user_three, project_private, make_contrib_id):
         return {
-            "id": make_contrib_id(project_private._id, user_three._id),
-            "type": "contributors",
+            'id': make_contrib_id(project_private._id, user_three._id),
+            'type': 'contributors',
         }
 
     def test_bulk_delete_contributors_errors(
@@ -2591,38 +2591,38 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         #   test_bulk_delete_invalid_id_format
         res = app.delete_json_api(
             url_public,
-            {"data": [{"id": "12345", "type": "contributors"}]},
+            {'data': [{'id': '12345', 'type': 'contributors'}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
-            == "Contributor identifier incorrectly formatted."
+            res.json['errors'][0]['detail']
+            == 'Contributor identifier incorrectly formatted.'
         )
 
         #   test_bulk_delete_invalid_id
         res = app.delete_json_api(
             url_public,
-            {"data": [{"id": "12345-abcde", "type": "contributors"}]},
+            {'data': [{'id': '12345-abcde', 'type': 'contributors'}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to delete."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
         )
 
         #   test_bulk_delete_non_contributor
         res = app.delete_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     {
-                        "id": make_contrib_id(project_public._id, user_four._id),
-                        "type": "contributors",
+                        'id': make_contrib_id(project_public._id, user_four._id),
+                        'type': 'contributors',
                     }
                 ]
             },
@@ -2636,12 +2636,12 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         res = app.delete_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     payload_public_one,
                     payload_public_two,
                     {
-                        "id": make_contrib_id(project_public._id, user._id),
-                        "type": "contributors",
+                        'id': make_contrib_id(project_public._id, user._id),
+                        'type': 'contributors',
                     },
                 ]
             },
@@ -2650,9 +2650,9 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] in [
-            "Must have at least one registered admin contributor",
-            "Must have at least one visible contributor",
+        assert res.json['errors'][0]['detail'] in [
+            'Must have at least one registered admin contributor',
+            'Must have at least one visible contributor',
         ]
         project_public.reload()
         assert len(project_public.contributors) == 3
@@ -2660,33 +2660,33 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         #   test_bulk_delete_contributors_no_id
         res = app.delete_json_api(
             url_public,
-            {"data": [{"type": "contributors"}]},
+            {'data': [{'type': 'contributors'}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Request must include /data/id."
+        assert res.json['errors'][0]['detail'] == 'Request must include /data/id.'
 
         #   test_bulk_delete_contributors_no_type
         res = app.delete_json_api(
             url_public,
-            {"data": [{"id": make_contrib_id(project_public._id, user_two._id)}]},
+            {'data': [{'id': make_contrib_id(project_public._id, user_two._id)}]},
             auth=user.auth,
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Request must include /type."
+        assert res.json['errors'][0]['detail'] == 'Request must include /type.'
 
         #   test_bulk_delete_contributors_invalid_type
         res = app.delete_json_api(
             url_public,
             {
-                "data": [
+                'data': [
                     {
-                        "type": "Wrong type",
-                        "id": make_contrib_id(project_public._id, user_two._id),
+                        'type': 'Wrong type',
+                        'id': make_contrib_id(project_public._id, user_two._id),
                     }
                 ]
             },
@@ -2700,9 +2700,9 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         res = app.delete_json_api(
             url_public,
             {
-                "data": {
-                    "id": make_contrib_id(project_public._id, user_two._id),
-                    "type": "contributors",
+                'data': {
+                    'id': make_contrib_id(project_public._id, user_two._id),
+                    'type': 'contributors',
                 }
             },
             auth=user.auth,
@@ -2711,47 +2711,47 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"]
+            res.json['errors'][0]['detail']
             == 'Expected a list of items but got type "dict".'
         )
 
         #   test_bulk_delete_contributors_public_projects_logged_out
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         res = app.delete_json_api(
             url_public,
-            {"data": [payload_public_one, payload_public_two]},
+            {'data': [payload_public_one, payload_public_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_bulk_delete_contributors_private_projects_logged_out
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         res = app.delete_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             expect_errors=True,
             bulk=True,
         )
         assert res.status_code == 401
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_bulk_delete_contributors_private_projects_logged_in_non_contributor
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         res = app.delete_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_four.auth,
             expect_errors=True,
             bulk=True,
@@ -2759,15 +2759,15 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_bulk_delete_contributors_private_projects_logged_in_read_only_contributor
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         res = app.delete_json_api(
             url_private,
-            {"data": [payload_private_one, payload_private_two]},
+            {'data': [payload_private_one, payload_private_two]},
             auth=user_two.auth,
             expect_errors=True,
             bulk=True,
@@ -2775,39 +2775,39 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         assert res.status_code == 403
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_bulk_delete_contributors_all_or_nothing
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
         invalid_id = {
-            "id": "12345-abcde",
-            "type": "contributors",
+            'id': '12345-abcde',
+            'type': 'contributors',
         }
 
-        new_payload = {"data": [payload_public_one, invalid_id]}
+        new_payload = {'data': [payload_public_one, invalid_id]}
 
         res = app.delete_json_api(
             url_public, new_payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Could not find all objects to delete."
+            res.json['errors'][0]['detail'] == 'Could not find all objects to delete.'
         )
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_bulk_delete_contributors_limits
-        new_payload = {"data": [payload_public_one] * 101}
+        new_payload = {'data': [payload_public_one] * 101}
         res = app.delete_json_api(
             url_public, new_payload, auth=user.auth, expect_errors=True, bulk=True
         )
         assert res.status_code == 400
         assert (
-            res.json["errors"][0]["detail"] == "Bulk operation limit is 100, got 101."
+            res.json['errors'][0]['detail'] == 'Bulk operation limit is 100, got 101.'
         )
-        assert res.json["errors"][0]["source"]["pointer"] == "/data"
+        assert res.json['errors'][0]['source']['pointer'] == '/data'
 
         #   test_bulk_delete_contributors_no_payload
         res = app.delete_json_api(
@@ -2819,41 +2819,41 @@ class TestNodeContributorBulkDelete(NodeCRUDTestCase):
         self, app, user, payload_public_one, payload_public_two, url_public
     ):
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         # Disconnect contributor_removed so that we don't check in files
         # We can remove this when StoredFileNode is implemented in osf-models
         with disconnected_from_listeners(contributor_removed):
             res = app.delete_json_api(
                 url_public,
-                {"data": [payload_public_one, payload_public_two]},
+                {'data': [payload_public_one, payload_public_two]},
                 auth=user.auth,
                 bulk=True,
             )
         assert res.status_code == 204
 
         res = app.get(url_public, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
     def test_bulk_delete_contributors_private_projects_logged_in_contributor(
         self, app, user, payload_private_one, payload_private_two, url_private
     ):
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         # Disconnect contributor_removed so that we don't check in files
         # We can remove this when StoredFileNode is implemented in osf-models
         with disconnected_from_listeners(contributor_removed):
             res = app.delete_json_api(
                 url_private,
-                {"data": [payload_private_one, payload_private_two]},
+                {'data': [payload_private_one, payload_private_two]},
                 auth=user.auth,
                 bulk=True,
             )
         assert res.status_code == 204
 
         res = app.get(url_private, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
 
 @pytest.mark.django_db
@@ -2866,18 +2866,18 @@ class TestNodeContributorFiltering:
 
     @pytest.fixture()
     def url(self, project):
-        return "/{}nodes/{}/contributors/".format(API_BASE, project._id)
+        return '/{}nodes/{}/contributors/'.format(API_BASE, project._id)
 
     def test_filtering(self, app, user, url, project):
 
         #   test_filtering_full_name_field
-        filter_url = f"{url}?filter[full_name]=Freddie"
+        filter_url = f'{url}?filter[full_name]=Freddie'
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json["errors"]
+        errors = res.json['errors']
         assert len(errors) == 1
         assert (
-            errors[0]["detail"] == "'full_name' is not a valid field for this endpoint."
+            errors[0]['detail'] == "'full_name' is not a valid field for this endpoint."
         )
 
         user_two = AuthUserFactory()
@@ -2885,50 +2885,50 @@ class TestNodeContributorFiltering:
         project.add_contributor(user_two, permissions.WRITE)
         project.add_contributor(user_three, permissions.READ, visible=False)
         #   test_filtering_permission_field_admin
-        filter_url = f"{url}?filter[permission]=admin"
+        filter_url = f'{url}?filter[permission]=admin'
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 1
-        assert res.json["data"][0]["attributes"].get("permission") == permissions.ADMIN
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes'].get('permission') == permissions.ADMIN
 
         #   test_filtering_permission_field_write
-        filter_url = f"{url}?filter[permission]=write"
+        filter_url = f'{url}?filter[permission]=write'
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
 
         #   test_filtering_permission_field_read
-        filter_url = f"{url}?filter[permission]=read"
+        filter_url = f'{url}?filter[permission]=read'
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         #   test_filtering_node_with_only_bibliographic_contributors
         # no filter
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 3
+        assert len(res.json['data']) == 3
 
         # filter for bibliographic contributors
-        filter_url = url + "?filter[bibliographic]=True"
+        filter_url = url + '?filter[bibliographic]=True'
         res = app.get(filter_url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 2
-        assert res.json["data"][0]["attributes"].get("bibliographic", None)
+        assert len(res.json['data']) == 2
+        assert res.json['data'][0]['attributes'].get('bibliographic', None)
 
         # filter for non-bibliographic contributors
-        filter_url = url + "?filter[bibliographic]=False"
+        filter_url = url + '?filter[bibliographic]=False'
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
 
         #   test_filtering_on_invalid_field
-        filter_url = f"{url}?filter[invalid]=foo"
+        filter_url = f'{url}?filter[invalid]=foo'
         res = app.get(filter_url, auth=user.auth, expect_errors=True)
         assert res.status_code == 400
-        errors = res.json["errors"]
+        errors = res.json['errors']
         assert len(errors) == 1
         assert (
-            errors[0]["detail"] == "'invalid' is not a valid field for this endpoint."
+            errors[0]['detail'] == "'invalid' is not a valid field for this endpoint."
         )
 
     def test_filtering_node_with_non_bibliographic_contributor(
@@ -2941,16 +2941,16 @@ class TestNodeContributorFiltering:
         # no filter
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
-        assert len(res.json["data"]) == 2
+        assert len(res.json['data']) == 2
 
         # filter for bibliographic contributors
-        filter_url = url + "?filter[bibliographic]=True"
+        filter_url = url + '?filter[bibliographic]=True'
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json["data"]) == 1
-        assert res.json["data"][0]["attributes"].get("bibliographic", None)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes'].get('bibliographic', None)
 
         # filter for non-bibliographic contributors
-        filter_url = url + "?filter[bibliographic]=False"
+        filter_url = url + '?filter[bibliographic]=False'
         res = app.get(filter_url, auth=user.auth)
-        assert len(res.json["data"]) == 1
-        assert not res.json["data"][0]["attributes"].get("bibliographic", None)
+        assert len(res.json['data']) == 1
+        assert not res.json['data'][0]['attributes'].get('bibliographic', None)

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1,7 +1,6 @@
 from django.utils import timezone
 from future.moves.urllib.parse import urlparse
 from unittest import mock
-from nose.tools import *  # noqa:
 import pytest
 from rest_framework import exceptions
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -175,9 +175,7 @@ class TestNodeDetail:
         assert res.json['data']['attributes']['description'] == project_private.description
         assert res.json['data']['attributes']['category'] == project_private.category
         assert res.json['data']['attributes']['current_user_is_contributor'] is True
-        assert_equals(
-            res.json['data']['attributes']['current_user_permissions'],
-            permissions_write)
+        assert res.json['data']['attributes']['current_user_permissions'] == permissions_write
 
     def test_top_level_project_has_no_parent(self, app, url_public):
         res = app.get(url_public)

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -129,25 +129,21 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_public_files_logged_out(self):
         res = self.app.get(self.public_url, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert res.status_code == 200
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_returns_public_files_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
     def test_returns_storage_addons_link(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertIn('storage_addons', res.json['data'][0]['links'])
+        assert 'storage_addons' in res.json['data'][0]['links']
 
     def test_returns_file_data(self):
         fobj = self.project.get_addon(
@@ -155,11 +151,11 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertTrue(isinstance(res.json['data'], dict))
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(res.json['data']['attributes']['kind'], 'file')
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        assert res.status_code == 200
+        assert isinstance(res.json['data'], dict)
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['data']['attributes']['kind'] == 'file'
+        assert res.json['data']['attributes']['name'] == 'NewFile'
 
     def test_returns_osfstorage_folder_version_two(self):
         fobj = self.project.get_addon(
@@ -167,7 +163,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         fobj = self.project.get_addon(
@@ -175,7 +171,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/?version=2.2', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_list_returns_folder_data(self):
         fobj = self.project.get_addon(
@@ -183,10 +179,10 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFolder')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1
+        assert res.content_type == 'application/vnd.api+json'
+        assert res.json['data'][0]['attributes']['name'] == 'NewFolder'
 
     def test_returns_folder_data(self):
         fobj = self.project.get_addon(
@@ -194,32 +190,30 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 0)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 0
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 401
+        assert 'detail' in res.json['errors'][0]
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(
             self.private_url,
             auth=self.user_two.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 403
+        assert 'detail' in res.json['errors'][0]
 
     def test_returns_private_files_logged_in_osf_group_member(self):
         group_mem = AuthUserFactory()
@@ -229,16 +223,14 @@ class TestNodeFilesList(ApiTestCase):
             self.private_url,
             auth=group_mem.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
         self.project.add_addon('github', auth=user_auth)
         addon = self.project.get_addon('github')
@@ -259,9 +251,9 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth)
         data = res.json['data']
         providers = [item['attributes']['provider'] for item in data]
-        self.assertEqual(len(data), 2)
-        self.assertIn('github', providers)
-        self.assertIn('osfstorage', providers)
+        assert len(data) == 2
+        assert 'github' in providers
+        assert 'osfstorage' in providers
 
     @responses.activate
     def test_vol_node_files_list(self):
@@ -275,14 +267,14 @@ class TestNodeFilesList(ApiTestCase):
         wb_request = responses.calls[-1].request
         url = furl.furl(wb_request.url)
 
-        self.assertEqual(url.query, f'meta=True&view_only={str(vol.key)}')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
-        self.assertIn(vol.key, res.json['data'][0]['links']['info'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['move'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['upload'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['download'])
-        self.assertIn(vol.key, res.json['data'][0]['links']['delete'])
+        assert url.query == f'meta=True&view_only={str(vol.key)}'
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
+        assert vol.key in res.json['data'][0]['links']['info']
+        assert vol.key in res.json['data'][0]['links']['move']
+        assert vol.key in res.json['data'][0]['links']['upload']
+        assert vol.key in res.json['data'][0]['links']['download']
+        assert vol.key in res.json['data'][0]['links']['delete']
 
     @responses.activate
     def test_returns_node_files_list(self):
@@ -293,13 +285,13 @@ class TestNodeFilesList(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.json['data'][0]['attributes']['name'] == 'NewFile'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_returns_folder_metadata_not_children(self):
@@ -314,10 +306,10 @@ class TestNodeFilesList(ApiTestCase):
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/Folder/'
         res = self.app.get(url, params={'info': ''}, auth=self.user.auth)
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data'][0]['attributes']['kind'], 'folder')
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'Folder')
-        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data'][0]['attributes']['kind'] == 'folder'
+        assert res.json['data'][0]['attributes']['name'] == 'Folder'
+        assert res.json['data'][0]['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_returns_node_file(self):
@@ -331,14 +323,14 @@ class TestNodeFilesList(ApiTestCase):
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         # test create
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['name'] == 'NewFile'
+        assert res.json['data']['attributes']['provider'] == 'github'
 
         # test get
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
-        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['name'] == 'NewFile'
+        assert res.json['data']['attributes']['provider'] == 'github'
 
     @responses.activate
     def test_notfound_node_file_returns_folder(self):
@@ -352,7 +344,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     @responses.activate
     def test_notfound_node_folder_returns_file(self):
@@ -366,7 +358,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     @responses.activate
     def test_waterbutler_server_error_returns_503(self):
@@ -378,7 +370,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        self.assertEqual(res.status_code, 503)
+        assert res.status_code == 503
 
     @responses.activate
     def test_waterbutler_invalid_data_returns_503(self):
@@ -394,7 +386,7 @@ class TestNodeFilesList(ApiTestCase):
         )
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 503)
+        assert res.status_code == 503
 
     @responses.activate
     def test_handles_unauthenticated_waterbutler_request(self):
@@ -402,8 +394,8 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 403
+        assert 'detail' in res.json['errors'][0]
 
     @responses.activate
     def test_handles_notfound_waterbutler_request(self):
@@ -413,19 +405,18 @@ class TestNodeFilesList(ApiTestCase):
         url = '/{}nodes/{}/files/{}/'.format(API_BASE,
                                              self.project._id, invalid_provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 404
+        assert 'detail' in res.json['errors'][0]
 
     def test_handles_request_to_provider_not_configured_on_project(self):
         provider = 'box'
         url = '/{}nodes/{}/files/{}/'.format(
             API_BASE, self.project._id, provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertFalse(self.project.get_addon(provider))
-        self.assertEqual(res.status_code, 404)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            f'The {provider} provider is not configured for this project.')
+        assert not self.project.get_addon(provider)
+        assert res.status_code == 404
+        assert res.json['errors'][0]['detail'] == \
+            f'The {provider} provider is not configured for this project.'
 
     @responses.activate
     def test_handles_bad_waterbutler_request(self):
@@ -441,12 +432,12 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 503)
-        self.assertIn('detail', res.json['errors'][0])
+        assert res.status_code == 503
+        assert 'detail' in res.json['errors'][0]
 
     def test_files_list_contains_relationships_object(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         assert 'relationships' in res.json['data'][0]
 
 
@@ -492,15 +483,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'abc'
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'abc'
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
     @responses.activate
     def test_node_files_filter_by_name_case_insensitive(self):
@@ -510,17 +501,17 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         # filters out 'abc', but finds 'xyz'
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         # filters out 'abc', but finds 'xyz'
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['name'] == 'xyz'
 
     @responses.activate
     def test_node_files_are_filterable_by_path(self):
@@ -530,15 +521,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
     @responses.activate
     def test_node_files_are_filterable_by_kind(self):
@@ -548,15 +539,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
-        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1  # filters out 'xyz'
+        assert res.json['data'][0]['attributes']['name'] == 'abc'
 
     @responses.activate
     def test_node_files_external_provider_can_filter_by_last_touched(self):
@@ -566,13 +557,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
             API_BASE, self.project._id, yesterday_stamp.isoformat())
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 2)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 2)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
         yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
@@ -583,13 +574,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(len(res.json['errors']), 1)
+        assert res.status_code == 400
+        assert len(res.json['errors']) == 1
 
         # test get
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(len(res.json['errors']), 1)
+        assert res.status_code == 400
+        assert len(res.json['errors']) == 1
 
 
 class TestNodeFilesListPagination(ApiTestCase):
@@ -707,31 +698,23 @@ class TestNodeStorageProviderDetail(ApiTestCase):
 
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['id'],
+        assert res.status_code == 200
+        assert res.json['data']['id'] == \
             f'{self.private_project._id}:osfstorage'
-        )
-        self.assertEqual(
-            res.json['data']['relationships']['target']['links']['related']['href'],
+        assert res.json['data']['relationships']['target']['links']['related']['href'] == \
             f'{settings.API_DOMAIN}v2/nodes/{self.private_project._id}/'
-        )
 
     def test_can_view_if_public(self):
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['id'],
+        assert res.status_code == 200
+        assert res.json['data']['id'] == \
             f'{self.public_project._id}:osfstorage'
-        )
-        self.assertEqual(
-            res.json['data']['relationships']['target']['links']['related']['href'],
+        assert res.json['data']['relationships']['target']['links']['related']['href'] == \
             f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
-        )
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
 
 class TestShowAsUnviewed(ApiTestCase):

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -4,7 +4,6 @@ import json
 import furl
 import responses
 from django.utils import timezone
-from nose.tools import *  # noqa:
 
 from framework.auth.core import Auth
 
@@ -130,25 +129,25 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_public_files_logged_out(self):
         res = self.app.get(self.public_url, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
     def test_returns_public_files_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
 
     def test_returns_storage_addons_link(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_in('storage_addons', res.json['data'][0]['links'])
+        self.assertIn('storage_addons', res.json['data'][0]['links'])
 
     def test_returns_file_data(self):
         fobj = self.project.get_addon(
@@ -156,11 +155,11 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_true(isinstance(res.json['data'], dict))
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['kind'], 'file')
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(isinstance(res.json['data'], dict))
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.json['data']['attributes']['kind'], 'file')
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
 
     def test_returns_osfstorage_folder_version_two(self):
         fobj = self.project.get_addon(
@@ -168,7 +167,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         fobj = self.project.get_addon(
@@ -176,7 +175,7 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/?version=2.2', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_list_returns_folder_data(self):
         fobj = self.project.get_addon(
@@ -184,10 +183,10 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFolder')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFolder')
 
     def test_returns_folder_data(self):
         fobj = self.project.get_addon(
@@ -195,21 +194,21 @@ class TestNodeFilesList(ApiTestCase):
         fobj.save()
         res = self.app.get(
             f'{self.private_url}osfstorage/{fobj._id}/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 0)
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 0)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 401)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
@@ -219,8 +218,8 @@ class TestNodeFilesList(ApiTestCase):
             self.private_url,
             auth=self.user_two.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 403)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_returns_private_files_logged_in_osf_group_member(self):
         group_mem = AuthUserFactory()
@@ -230,13 +229,13 @@ class TestNodeFilesList(ApiTestCase):
             self.private_url,
             auth=group_mem.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
@@ -260,9 +259,9 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth)
         data = res.json['data']
         providers = [item['attributes']['provider'] for item in data]
-        assert_equal(len(data), 2)
-        assert_in('github', providers)
-        assert_in('osfstorage', providers)
+        self.assertEqual(len(data), 2)
+        self.assertIn('github', providers)
+        self.assertIn('osfstorage', providers)
 
     @responses.activate
     def test_vol_node_files_list(self):
@@ -276,14 +275,14 @@ class TestNodeFilesList(ApiTestCase):
         wb_request = responses.calls[-1].request
         url = furl.furl(wb_request.url)
 
-        assert_equal(url.query, f'meta=True&view_only={str(vol.key)}')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
-        assert_in(vol.key, res.json['data'][0]['links']['info'])
-        assert_in(vol.key, res.json['data'][0]['links']['move'])
-        assert_in(vol.key, res.json['data'][0]['links']['upload'])
-        assert_in(vol.key, res.json['data'][0]['links']['download'])
-        assert_in(vol.key, res.json['data'][0]['links']['delete'])
+        self.assertEqual(url.query, f'meta=True&view_only={str(vol.key)}')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertIn(vol.key, res.json['data'][0]['links']['info'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['move'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['upload'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['download'])
+        self.assertIn(vol.key, res.json['data'][0]['links']['delete'])
 
     @responses.activate
     def test_returns_node_files_list(self):
@@ -294,13 +293,13 @@ class TestNodeFilesList(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
     @responses.activate
     def test_returns_folder_metadata_not_children(self):
@@ -315,10 +314,10 @@ class TestNodeFilesList(ApiTestCase):
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/Folder/'
         res = self.app.get(url, params={'info': ''}, auth=self.user.auth)
 
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['attributes']['kind'], 'folder')
-        assert_equal(res.json['data'][0]['attributes']['name'], 'Folder')
-        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data'][0]['attributes']['kind'], 'folder')
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'Folder')
+        self.assertEqual(res.json['data'][0]['attributes']['provider'], 'github')
 
     @responses.activate
     def test_returns_node_file(self):
@@ -332,14 +331,14 @@ class TestNodeFilesList(ApiTestCase):
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         # test create
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data']['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
 
         # test get
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
-        assert_equal(res.json['data']['attributes']['provider'], 'github')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['attributes']['name'], 'NewFile')
+        self.assertEqual(res.json['data']['attributes']['provider'], 'github')
 
     @responses.activate
     def test_notfound_node_file_returns_folder(self):
@@ -353,7 +352,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     @responses.activate
     def test_notfound_node_folder_returns_file(self):
@@ -367,7 +366,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     @responses.activate
     def test_waterbutler_server_error_returns_503(self):
@@ -379,7 +378,7 @@ class TestNodeFilesList(ApiTestCase):
             expect_errors=True,
             headers={'COOKIE': 'foo=bar;'}  # Webtests doesnt support cookies?
         )
-        assert_equal(res.status_code, 503)
+        self.assertEqual(res.status_code, 503)
 
     @responses.activate
     def test_waterbutler_invalid_data_returns_503(self):
@@ -395,7 +394,7 @@ class TestNodeFilesList(ApiTestCase):
         )
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 503)
+        self.assertEqual(res.status_code, 503)
 
     @responses.activate
     def test_handles_unauthenticated_waterbutler_request(self):
@@ -403,8 +402,8 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 403)
+        self.assertIn('detail', res.json['errors'][0])
 
     @responses.activate
     def test_handles_notfound_waterbutler_request(self):
@@ -414,17 +413,17 @@ class TestNodeFilesList(ApiTestCase):
         url = '/{}nodes/{}/files/{}/'.format(API_BASE,
                                              self.project._id, invalid_provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 404)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_handles_request_to_provider_not_configured_on_project(self):
         provider = 'box'
         url = '/{}nodes/{}/files/{}/'.format(
             API_BASE, self.project._id, provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_false(self.project.get_addon(provider))
-        assert_equal(res.status_code, 404)
-        assert_equal(
+        self.assertFalse(self.project.get_addon(provider))
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             f'The {provider} provider is not configured for this project.')
 
@@ -442,12 +441,12 @@ class TestNodeFilesList(ApiTestCase):
         self.add_github()
         url = f'/{API_BASE}nodes/{self.project._id}/files/github/'
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 503)
-        assert_in('detail', res.json['errors'][0])
+        self.assertEqual(res.status_code, 503)
+        self.assertIn('detail', res.json['errors'][0])
 
     def test_files_list_contains_relationships_object(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         assert 'relationships' in res.json['data'][0]
 
 
@@ -493,15 +492,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'abc'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'abc'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'abc'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
     @responses.activate
     def test_node_files_filter_by_name_case_insensitive(self):
@@ -511,17 +510,17 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         # filters out 'abc', but finds 'xyz'
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         # filters out 'abc', but finds 'xyz'
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'xyz')
 
     @responses.activate
     def test_node_files_are_filterable_by_path(self):
@@ -531,15 +530,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
     @responses.activate
     def test_node_files_are_filterable_by_kind(self):
@@ -549,15 +548,15 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
-        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)  # filters out 'xyz'
+        self.assertEqual(res.json['data'][0]['attributes']['name'], 'abc')
 
     @responses.activate
     def test_node_files_external_provider_can_filter_by_last_touched(self):
@@ -567,13 +566,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
             API_BASE, self.project._id, yesterday_stamp.isoformat())
         # test create
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
 
         # test get
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
         yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
@@ -584,13 +583,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
         # test create
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(len(res.json['errors']), 1)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(len(res.json['errors']), 1)
 
         # test get
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(len(res.json['errors']), 1)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(len(res.json['errors']), 1)
 
 
 class TestNodeFilesListPagination(ApiTestCase):
@@ -708,31 +707,31 @@ class TestNodeStorageProviderDetail(ApiTestCase):
 
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['id'],
             f'{self.private_project._id}:osfstorage'
         )
-        assert_equal(
+        self.assertEqual(
             res.json['data']['relationships']['target']['links']['related']['href'],
             f'{settings.API_DOMAIN}v2/nodes/{self.private_project._id}/'
         )
 
     def test_can_view_if_public(self):
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['id'],
             f'{self.public_project._id}:osfstorage'
         )
-        assert_equal(
+        self.assertEqual(
             res.json['data']['relationships']['target']['links']['related']['href'],
             f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
         )
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
 
 class TestShowAsUnviewed(ApiTestCase):

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -705,8 +705,8 @@ class TestNodeStorageProviderDetail(ApiTestCase):
         assert res.status_code == 200
         assert res.json['data']['id'] == f'{self.public_project._id}:osfstorage'
         assert (
-                res.json['data']['relationships']['target']['links']['related']['href'] ==
-                f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
+            res.json['data']['relationships']['target']['links']['related']['href'] ==
+            f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
         )
 
     def test_cannot_view_if_private(self):

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -130,16 +130,14 @@ class TestNodeFilesList(ApiTestCase):
     def test_returns_public_files_logged_out(self):
         res = self.app.get(self.public_url, expect_errors=True)
         assert res.status_code == 200
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
         assert res.content_type == 'application/vnd.api+json'
 
     def test_returns_public_files_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
     def test_returns_storage_addons_link(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
@@ -204,8 +202,7 @@ class TestNodeFilesList(ApiTestCase):
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(
@@ -229,8 +226,7 @@ class TestNodeFilesList(ApiTestCase):
         user_auth = Auth(self.user)
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
         self.project.add_addon('github', auth=user_auth)
         addon = self.project.get_addon('github')
@@ -415,8 +411,7 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert not self.project.get_addon(provider)
         assert res.status_code == 404
-        assert res.json['errors'][0]['detail'] == \
-            f'The {provider} provider is not configured for this project.'
+        assert res.json['errors'][0]['detail'] == f'The {provider} provider is not configured for this project.'
 
     @responses.activate
     def test_handles_bad_waterbutler_request(self):
@@ -699,18 +694,20 @@ class TestNodeStorageProviderDetail(ApiTestCase):
     def test_can_view_if_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert res.status_code == 200
-        assert res.json['data']['id'] == \
-            f'{self.private_project._id}:osfstorage'
-        assert res.json['data']['relationships']['target']['links']['related']['href'] == \
+        assert res.json['data']['id'] == f'{self.private_project._id}:osfstorage'
+        assert (
+            res.json['data']['relationships']['target']['links']['related']['href'] ==
             f'{settings.API_DOMAIN}v2/nodes/{self.private_project._id}/'
+        )
 
     def test_can_view_if_public(self):
         res = self.app.get(self.public_url)
         assert res.status_code == 200
-        assert res.json['data']['id'] == \
-            f'{self.public_project._id}:osfstorage'
-        assert res.json['data']['relationships']['target']['links']['related']['href'] == \
-            f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
+        assert res.json['data']['id'] == f'{self.public_project._id}:osfstorage'
+        assert (
+                res.json['data']['relationships']['target']['links']['related']['href'] ==
+                f'{settings.API_DOMAIN}v2/nodes/{self.public_project._id}/'
+        )
 
     def test_cannot_view_if_private(self):
         res = self.app.get(self.private_url, expect_errors=True)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -11,7 +11,7 @@ from framework.auth.core import Auth
 from osf.models import AbstractNode, Node, NodeLog
 from osf.models.licenses import NodeLicense
 from osf.utils.sanitize import strip_html
-from osf.utils import permissionsF
+from osf.utils import permissions
 from osf_tests.factories import (
     CollectionFactory,
     ProjectFactory,

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1,5 +1,4 @@
 import pytest
-from nose.tools import *  # noqa:
 
 from django.utils import timezone
 from api.base.settings.defaults import API_BASE, MAX_PAGE_SIZE
@@ -12,7 +11,7 @@ from framework.auth.core import Auth
 from osf.models import AbstractNode, Node, NodeLog
 from osf.models.licenses import NodeLicense
 from osf.utils.sanitize import strip_html
-from osf.utils import permissions
+from osf.utils import permissionsF
 from osf_tests.factories import (
     CollectionFactory,
     ProjectFactory,

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -19,28 +19,28 @@ class PreprintCitationsMixin:
 
     def test_unauthenticated_can_view_published_preprint_citations(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_unauthenticated_cannot_view_unpublished_preprint_citations(self):
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_preprint_citations_are_read_only(self):
         post_res = self.app.post_json_api(
             self.published_preprint_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(post_res.status_code, 405)
+        assert post_res.status_code == 405
         put_res = self.app.put_json_api(
             self.published_preprint_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(put_res.status_code, 405)
+        assert put_res.status_code == 405
         delete_res = self.app.delete_json_api(
             self.published_preprint_url,
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(delete_res.status_code, 405)
+        assert delete_res.status_code == 405
 
 
 class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
@@ -55,18 +55,15 @@ class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
 
     def test_citation_publisher_is_preprint_provider(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['attributes']['publisher'],
-            self.published_preprint.provider.name)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['publisher'] == \
+            self.published_preprint.provider.name
 
     def test_citation_url_is_preprint_url_not_project(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            res.json['data']['links']['self'],
+        assert res.status_code == 200
+        assert res.json['data']['links']['self'] == \
             self.published_preprint.display_absolute_url
-        )
 
 class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
@@ -81,21 +78,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
     def test_unpublished_preprint_citations(self):
         # Unauthenticated
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Admin contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_private_preprint_citations(self):
         self.published_preprint.is_public = False
@@ -103,21 +100,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_deleted_preprint_citations(self):
         self.published_preprint.deleted = timezone.now()
@@ -125,21 +122,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_abandoned_preprint_citations(self):
         self.published_preprint.machine_state = DefaultStates.INITIAL.value
@@ -147,21 +144,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
 
 class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
@@ -175,20 +172,18 @@ class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
 
     def test_citation_contains_correct_date(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         expected_date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertTrue(
-            expected_date in res.json['data']['attributes']['citation'])
+        assert expected_date in res.json['data']['attributes']['citation']
 
     def test_citation_no_date(self):
         self.published_preprint.date_published = None
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         expected_date = 'n.d.'
-        self.assertTrue(
-            expected_date in res.json['data']['attributes']['citation'])
+        assert expected_date in res.json['data']['attributes']['citation']
 
 
 class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCase):
@@ -204,21 +199,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
     def test_unpublished_preprint_citations(self):
         # Unauthenticated
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Admin contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_private_preprint_citations(self):
         self.published_preprint.is_public = False
@@ -226,21 +221,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_deleted_preprint_citations(self):
         self.published_preprint.deleted = timezone.now()
@@ -248,21 +243,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_abandoned_preprint_citations(self):
         self.published_preprint.machine_state = DefaultStates.INITIAL.value
@@ -270,21 +265,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
 
 class TestPreprintCitationContentMLA(ApiTestCase):
@@ -321,44 +316,43 @@ class TestPreprintCitationContentMLA(ApiTestCase):
         self.published_preprint.date_published = None
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, 'McGee, Grapes C. B. “{}.” {}, {} Web.'.format(
+        assert citation == 'McGee, Grapes C. B. “{}.” {}, {} Web.'.format(
             self.published_preprint.title,
             self.published_preprint.provider.name,
             'n.d.')
-        )
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
         # test_suffix
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
         # test_no_middle_names
         self.admin_contributor.suffix = ''
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
     def test_citation_no_repeated_periods(self):
         self.published_preprint.title = 'A Study of Coffee.'
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
     def test_citation_osf_provider(self):
         self.published_preprint.title = 'A Study of Coffee.'
@@ -366,34 +360,34 @@ class TestPreprintCitationContentMLA(ApiTestCase):
         self.published_preprint.provider.name = 'Open Science Framework'
         self.published_preprint.provider.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
     def test_two_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
     def test_three_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.add_contributor(self.third_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
         # first name suffix
         self.admin_contributor.suffix = 'Jr.'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        assert citation == render_citation(self.published_preprint, 'modern-language-association')
 
 
 class TestPreprintCitationContentAPA(ApiTestCase):
@@ -434,74 +428,69 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B., & Jenkins, D. T. T., Junior. ({}). {}. {}'.format(
                 'n.d.',
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
         # test_suffix
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B., Junior. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
         # test_no_middle_names
         self.admin_contributor.suffix = ''
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
     def test_two_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B., & Jenkins, D. T. T., Junior. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
     def test_three_authors_and_title_with_period(self):
         self.published_preprint.title = 'This Title Ends in a Period.'
@@ -509,14 +498,13 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.add_contributor(self.third_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation, 'McGee, G. C. B., Jenkins, D. T. T., Junior, & Schematics, L. R. ({}). {}. {}'.format(
+        assert citation == 'McGee, G. C. B., Jenkins, D. T. T., Junior, & Schematics, L. R. ({}). {}. {}'.format(
             date,
             'This Title Ends in a Period',
             'https://doi.org/' + self.published_preprint.article_doi)
-        )
 
     def test_seven_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
@@ -530,16 +518,15 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B., Jenkins, D. T. T., Junior, Schematics, L. R., Taylor1, J., Taylor2, J., Taylor3, J., & Taylor4, J. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
     def test_eight_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
@@ -553,16 +540,15 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, G. C. B., Jenkins, D. T. T., Junior, Schematics, L. R., Taylor1, J., Taylor2, J., Taylor3, J., … Taylor5, J. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
                 'https://doi.org/' + self.published_preprint.article_doi
             )
-        )
 
 
 class TestPreprintCitationContentChicago(ApiTestCase):
@@ -599,23 +585,22 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.published_preprint.date_published = None
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes C. B. {} “{}.” {}. {}.'.format(
                 'n.d.',
                 self.published_preprint.title,
                 self.published_preprint.provider.name,
                 'doi:' + self.published_preprint.article_doi,
             )
-        )
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes C. B. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -623,16 +608,15 @@ class TestPreprintCitationContentChicago(ApiTestCase):
                 date.strftime('%B %-d'),
                 'doi:' + self.published_preprint.article_doi
             )
-        )
 
         # test_suffix
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes C. B., Junior. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -640,17 +624,16 @@ class TestPreprintCitationContentChicago(ApiTestCase):
                 date.strftime('%B %-d'),
                 'doi:' + self.published_preprint.article_doi
             )
-        )
 
         # test_no_middle_names
         self.admin_contributor.suffix = ''
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -658,16 +641,15 @@ class TestPreprintCitationContentChicago(ApiTestCase):
                 date.strftime('%B %-d'),
                 'doi:' + self.published_preprint.article_doi
             )
-        )
 
     def test_two_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes C. B., and Darla T. T. Jenkins, Junior. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -675,7 +657,6 @@ class TestPreprintCitationContentChicago(ApiTestCase):
                 date.strftime('%B %-d'),
                 'doi:' + self.published_preprint.article_doi
             )
-        )
 
     def test_three_authors_and_title_with_period(self):
         self.published_preprint.add_contributor(self.second_contrib)
@@ -683,16 +664,15 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.published_preprint.title = 'This Preprint ends in a Period.'
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation, 'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, and Lilith R. Schematics. {}. “{}.” {}. {}. {}.'.format(
+        assert citation == 'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, and Lilith R. Schematics. {}. “{}.” {}. {}. {}.'.format(
             date.strftime('%Y'),
             'This Preprint Ends in a Period',
             self.published_preprint.provider.name,
             date.strftime('%B %-d'),
             'doi:' + self.published_preprint.article_doi)
-        )
 
     def test_eleven_contributors(self):
         self.published_preprint.add_contributor(self.second_contrib)
@@ -705,10 +685,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
             self.published_preprint.add_contributor(new_user)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        self.assertEqual(citation,
+        assert citation == \
             'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, Lilith R. Schematics, James Taylor1, James Taylor2, James Taylor3, James Taylor4, et al. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -716,4 +696,3 @@ class TestPreprintCitationContentChicago(ApiTestCase):
                 date.strftime('%B %-d'),
                 'doi:' + self.published_preprint.article_doi
             )
-        )

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -1,7 +1,6 @@
 from api.base.settings.defaults import API_BASE
 from api.citations.utils import render_citation
 from django.utils import timezone
-from nose.tools import *  # noqa:
 from osf_tests.factories import AuthUserFactory, PreprintFactory
 from tests.base import ApiTestCase
 from osf.utils.permissions import WRITE
@@ -20,28 +19,28 @@ class PreprintCitationsMixin:
 
     def test_unauthenticated_can_view_published_preprint_citations(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_unauthenticated_cannot_view_unpublished_preprint_citations(self):
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
     def test_preprint_citations_are_read_only(self):
         post_res = self.app.post_json_api(
             self.published_preprint_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(post_res.status_code, 405)
+        self.assertEqual(post_res.status_code, 405)
         put_res = self.app.put_json_api(
             self.published_preprint_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(put_res.status_code, 405)
+        self.assertEqual(put_res.status_code, 405)
         delete_res = self.app.delete_json_api(
             self.published_preprint_url,
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(delete_res.status_code, 405)
+        self.assertEqual(delete_res.status_code, 405)
 
 
 class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
@@ -56,15 +55,15 @@ class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
 
     def test_citation_publisher_is_preprint_provider(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['attributes']['publisher'],
             self.published_preprint.provider.name)
 
     def test_citation_url_is_preprint_url_not_project(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
             res.json['data']['links']['self'],
             self.published_preprint.display_absolute_url
         )
@@ -82,21 +81,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
     def test_unpublished_preprint_citations(self):
         # Unauthenticated
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Admin contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_private_preprint_citations(self):
         self.published_preprint.is_public = False
@@ -104,21 +103,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_deleted_preprint_citations(self):
         self.published_preprint.deleted = timezone.now()
@@ -126,21 +125,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_abandoned_preprint_citations(self):
         self.published_preprint.machine_state = DefaultStates.INITIAL.value
@@ -148,21 +147,21 @@ class TestPreprintCitationsPermissions(PreprintCitationsMixin, ApiTestCase):
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
 
 class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
@@ -176,9 +175,9 @@ class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
 
     def test_citation_contains_correct_date(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         expected_date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_true(
+        self.assertTrue(
             expected_date in res.json['data']['attributes']['citation'])
 
     def test_citation_no_date(self):
@@ -186,9 +185,9 @@ class TestPreprintCitationContent(PreprintCitationsMixin, ApiTestCase):
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         expected_date = 'n.d.'
-        assert_true(
+        self.assertTrue(
             expected_date in res.json['data']['attributes']['citation'])
 
 
@@ -205,21 +204,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
     def test_unpublished_preprint_citations(self):
         # Unauthenticated
         res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.unpublished_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.unpublished_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state, not because of published flag
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Admin contrib
         res = self.app.get(self.unpublished_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_private_preprint_citations(self):
         self.published_preprint.is_public = False
@@ -227,21 +226,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_deleted_preprint_citations(self):
         self.published_preprint.deleted = timezone.now()
@@ -249,21 +248,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_abandoned_preprint_citations(self):
         self.published_preprint.machine_state = DefaultStates.INITIAL.value
@@ -271,21 +270,21 @@ class TestPreprintCitationsContentPermissions(PreprintCitationsMixin, ApiTestCas
 
         # Unauthenticated
         res = self.app.get(self.published_preprint_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
         # Non contrib
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Write contrib
         self.published_preprint.add_contributor(self.other_contrib, WRITE, save=True)
         res = self.app.get(self.published_preprint_url, auth=self.other_contrib.auth, expect_errors=True)
         # Really because preprint is in initial machine state
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
         # Admin contrib
         res = self.app.get(self.published_preprint_url, auth=self.admin_contributor.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
 
 class TestPreprintCitationContentMLA(ApiTestCase):
@@ -322,9 +321,9 @@ class TestPreprintCitationContentMLA(ApiTestCase):
         self.published_preprint.date_published = None
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, 'McGee, Grapes C. B. “{}.” {}, {} Web.'.format(
+        self.assertEqual(citation, 'McGee, Grapes C. B. “{}.” {}, {} Web.'.format(
             self.published_preprint.title,
             self.published_preprint.provider.name,
             'n.d.')
@@ -332,34 +331,34 @@ class TestPreprintCitationContentMLA(ApiTestCase):
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
         # test_suffix
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
         # test_no_middle_names
         self.admin_contributor.suffix = ''
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
     def test_citation_no_repeated_periods(self):
         self.published_preprint.title = 'A Study of Coffee.'
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
     def test_citation_osf_provider(self):
         self.published_preprint.title = 'A Study of Coffee.'
@@ -367,34 +366,34 @@ class TestPreprintCitationContentMLA(ApiTestCase):
         self.published_preprint.provider.name = 'Open Science Framework'
         self.published_preprint.provider.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
     def test_two_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
     def test_three_authors(self):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.add_contributor(self.third_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
         # first name suffix
         self.admin_contributor.suffix = 'Jr.'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation, render_citation(self.published_preprint, 'modern-language-association'))
+        self.assertEqual(citation, render_citation(self.published_preprint, 'modern-language-association'))
 
 
 class TestPreprintCitationContentAPA(ApiTestCase):
@@ -435,9 +434,9 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B., & Jenkins, D. T. T., Junior. ({}). {}. {}'.format(
                 'n.d.',
                 self.published_preprint.title,
@@ -447,10 +446,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -462,10 +461,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B., Junior. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -478,10 +477,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -493,10 +492,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B., & Jenkins, D. T. T., Junior. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -510,10 +509,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.add_contributor(self.third_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation, 'McGee, G. C. B., Jenkins, D. T. T., Junior, & Schematics, L. R. ({}). {}. {}'.format(
+        self.assertEqual(citation, 'McGee, G. C. B., Jenkins, D. T. T., Junior, & Schematics, L. R. ({}). {}. {}'.format(
             date,
             'This Title Ends in a Period',
             'https://doi.org/' + self.published_preprint.article_doi)
@@ -531,10 +530,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B., Jenkins, D. T. T., Junior, Schematics, L. R., Taylor1, J., Taylor2, J., Taylor3, J., & Taylor4, J. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -554,10 +553,10 @@ class TestPreprintCitationContentAPA(ApiTestCase):
         self.published_preprint.save()
 
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published.strftime('%Y, %B %-d')
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, G. C. B., Jenkins, D. T. T., Junior, Schematics, L. R., Taylor1, J., Taylor2, J., Taylor3, J., … Taylor5, J. ({}). {}. {}'.format(
                 date,
                 self.published_preprint.title,
@@ -600,9 +599,9 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.published_preprint.date_published = None
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes C. B. {} “{}.” {}. {}.'.format(
                 'n.d.',
                 self.published_preprint.title,
@@ -613,10 +612,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
 
     def test_one_author(self):
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes C. B. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -630,10 +629,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.admin_contributor.suffix = 'Junior'
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes C. B., Junior. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -648,10 +647,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.admin_contributor.middle_names = ''
         self.admin_contributor.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -665,10 +664,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.published_preprint.add_contributor(self.second_contrib)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes C. B., and Darla T. T. Jenkins, Junior. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,
@@ -684,10 +683,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
         self.published_preprint.title = 'This Preprint ends in a Period.'
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation, 'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, and Lilith R. Schematics. {}. “{}.” {}. {}. {}.'.format(
+        self.assertEqual(citation, 'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, and Lilith R. Schematics. {}. “{}.” {}. {}. {}.'.format(
             date.strftime('%Y'),
             'This Preprint Ends in a Period',
             self.published_preprint.provider.name,
@@ -706,10 +705,10 @@ class TestPreprintCitationContentChicago(ApiTestCase):
             self.published_preprint.add_contributor(new_user)
         self.published_preprint.save()
         res = self.app.get(self.published_preprint_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         citation = res.json['data']['attributes']['citation']
         date = self.published_preprint.date_published
-        assert_equal(citation,
+        self.assertEqual(citation,
             'McGee, Grapes C. B., Darla T. T. Jenkins, Junior, Lilith R. Schematics, James Taylor1, James Taylor2, James Taylor3, James Taylor4, et al. {}. “{}.” {}. {}. {}.'.format(
                 date.strftime('%Y'),
                 self.published_preprint.title,

--- a/api_tests/preprints/views/test_preprint_files_list.py
+++ b/api_tests/preprints/views/test_preprint_files_list.py
@@ -146,52 +146,48 @@ class TestPreprintProvidersList(ApiTestCase):
 
     def test_return_published_files_logged_out(self):
         res = self.app.get(self.url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(
-            res.json['data'][0]['attributes']['provider'],
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['provider'] == \
             'osfstorage'
-        )
 
     def test_does_not_return_storage_addons_link(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertNotIn('storage_addons', res.json['data'][0]['links'])
+        assert 'storage_addons' not in res.json['data'][0]['links']
 
     def test_does_not_return_new_folder_link(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertNotIn('new_folder', res.json['data'][0]['links'])
+        assert 'new_folder' not in res.json['data'][0]['links']
 
     def test_returns_provider_data(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertTrue(isinstance(res.json['data'], list))
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.status_code == 200
+        assert isinstance(res.json['data'], list)
+        assert res.content_type == 'application/vnd.api+json'
         data = res.json['data'][0]
-        self.assertEqual(data['attributes']['kind'], 'folder')
-        self.assertEqual(data['attributes']['name'], 'osfstorage')
-        self.assertEqual(data['attributes']['provider'], 'osfstorage')
-        self.assertEqual(data['attributes']['preprint'], self.preprint._id)
-        self.assertEqual(data['attributes']['path'], '/')
-        self.assertEqual(data['attributes']['node'], None)
-        self.assertEqual(
-            data['relationships']['target']['links']['related']['href'],
+        assert data['attributes']['kind'] == 'folder'
+        assert data['attributes']['name'] == 'osfstorage'
+        assert data['attributes']['provider'] == 'osfstorage'
+        assert data['attributes']['preprint'] == self.preprint._id
+        assert data['attributes']['path'] == '/'
+        assert data['attributes']['node'] == None
+        assert data['relationships']['target']['links']['related']['href'] == \
             f'{settings.API_DOMAIN}v2/preprints/{self.preprint._id}/'
-        )
 
     def test_osfstorage_file_data_not_found(self):
         res = self.app.get(
             f'{self.url}osfstorage/{self.preprint.primary_file._id}', auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_returns_osfstorage_folder_version_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_osfstorage_folder_data_not_found(self):
         fobj = self.preprint.root_folder.append_folder('NewFolder')
@@ -199,7 +195,7 @@ class TestPreprintProvidersList(ApiTestCase):
 
         res = self.app.get(
             f'{self.url}osfstorage/{fobj._id}', auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
 
 class TestPreprintFilesList(ApiTestCase):
@@ -374,8 +370,8 @@ class TestPreprintFilesList(ApiTestCase):
         primary_file.move_under(subfolder)
         primary_file.save()
 
-        self.assertEqual(subfolder.children[0], primary_file)
-        self.assertEqual(primary_file.parent, subfolder)
+        assert subfolder.children[0] == primary_file
+        assert primary_file.parent == subfolder
 
         res = self.app.get(self.url, auth=self.user.auth)
         assert len(res.json['data']) == 1

--- a/api_tests/preprints/views/test_preprint_files_list.py
+++ b/api_tests/preprints/views/test_preprint_files_list.py
@@ -148,8 +148,7 @@ class TestPreprintProvidersList(ApiTestCase):
         res = self.app.get(self.url)
         assert res.status_code == 200
         assert len(res.json['data']) == 1
-        assert res.json['data'][0]['attributes']['provider'] == \
-            'osfstorage'
+        assert res.json['data'][0]['attributes']['provider'] == 'osfstorage'
 
     def test_does_not_return_storage_addons_link(self):
         res = self.app.get(self.url, auth=self.user.auth)
@@ -170,9 +169,11 @@ class TestPreprintProvidersList(ApiTestCase):
         assert data['attributes']['provider'] == 'osfstorage'
         assert data['attributes']['preprint'] == self.preprint._id
         assert data['attributes']['path'] == '/'
-        assert data['attributes']['node'] == None
-        assert data['relationships']['target']['links']['related']['href'] == \
+        assert data['attributes']['node'] is None
+        assert (
+            data['relationships']['target']['links']['related']['href'] ==
             f'{settings.API_DOMAIN}v2/preprints/{self.preprint._id}/'
+        )
 
     def test_osfstorage_file_data_not_found(self):
         res = self.app.get(

--- a/api_tests/preprints/views/test_preprint_files_list.py
+++ b/api_tests/preprints/views/test_preprint_files_list.py
@@ -1,8 +1,6 @@
 from django.utils import timezone
 from django.contrib.contenttypes.models import ContentType
 
-from nose.tools import *  # noqa: F403
-
 from api.base.settings.defaults import API_BASE
 from tests.base import ApiTestCase
 from osf_tests.factories import (
@@ -148,34 +146,34 @@ class TestPreprintProvidersList(ApiTestCase):
 
     def test_return_published_files_logged_out(self):
         res = self.app.get(self.url)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(
             res.json['data'][0]['attributes']['provider'],
             'osfstorage'
         )
 
     def test_does_not_return_storage_addons_link(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_not_in('storage_addons', res.json['data'][0]['links'])
+        self.assertNotIn('storage_addons', res.json['data'][0]['links'])
 
     def test_does_not_return_new_folder_link(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_not_in('new_folder', res.json['data'][0]['links'])
+        self.assertNotIn('new_folder', res.json['data'][0]['links'])
 
     def test_returns_provider_data(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_true(isinstance(res.json['data'], list))
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(isinstance(res.json['data'], list))
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
         data = res.json['data'][0]
-        assert_equal(data['attributes']['kind'], 'folder')
-        assert_equal(data['attributes']['name'], 'osfstorage')
-        assert_equal(data['attributes']['provider'], 'osfstorage')
-        assert_equal(data['attributes']['preprint'], self.preprint._id)
-        assert_equal(data['attributes']['path'], '/')
-        assert_equal(data['attributes']['node'], None)
-        assert_equal(
+        self.assertEqual(data['attributes']['kind'], 'folder')
+        self.assertEqual(data['attributes']['name'], 'osfstorage')
+        self.assertEqual(data['attributes']['provider'], 'osfstorage')
+        self.assertEqual(data['attributes']['preprint'], self.preprint._id)
+        self.assertEqual(data['attributes']['path'], '/')
+        self.assertEqual(data['attributes']['node'], None)
+        self.assertEqual(
             data['relationships']['target']['links']['related']['href'],
             f'{settings.API_DOMAIN}v2/preprints/{self.preprint._id}/'
         )
@@ -183,17 +181,17 @@ class TestPreprintProvidersList(ApiTestCase):
     def test_osfstorage_file_data_not_found(self):
         res = self.app.get(
             f'{self.url}osfstorage/{self.preprint.primary_file._id}', auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_returns_osfstorage_folder_version_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_returns_osf_storage_folder_version_two_point_two(self):
         res = self.app.get(
             f'{self.url}osfstorage/?version=2.2', auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_osfstorage_folder_data_not_found(self):
         fobj = self.preprint.root_folder.append_folder('NewFolder')
@@ -201,7 +199,7 @@ class TestPreprintProvidersList(ApiTestCase):
 
         res = self.app.get(
             f'{self.url}osfstorage/{fobj._id}', auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
 
 class TestPreprintFilesList(ApiTestCase):
@@ -376,8 +374,8 @@ class TestPreprintFilesList(ApiTestCase):
         primary_file.move_under(subfolder)
         primary_file.save()
 
-        assert_equal(subfolder.children[0], primary_file)
-        assert_equal(primary_file.parent, subfolder)
+        self.assertEqual(subfolder.children[0], primary_file)
+        self.assertEqual(primary_file.parent, subfolder)
 
         res = self.app.get(self.url, auth=self.user.auth)
         assert len(res.json['data']) == 1

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -33,30 +33,30 @@ from website.project import signals as project_signals
 
 def build_preprint_update_payload(preprint_id, primary_file_id, is_published=True):
     return {
-        "data": {
-            "id": preprint_id,
-            "type": "preprints",
-            "attributes": {
-                "is_published": is_published,
-                "subjects": [[SubjectFactory()._id]],
+        'data': {
+            'id': preprint_id,
+            'type': 'preprints',
+            'attributes': {
+                'is_published': is_published,
+                'subjects': [[SubjectFactory()._id]],
             },
-            "relationships": {"primary_file": {"data": {"type": "primary_file", "id": primary_file_id}}},
+            'relationships': {'primary_file': {'data': {'type': 'primary_file', 'id': primary_file_id}}},
         }
     }
 
 
 def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, attrs={}):
 
-    attrs["title"] = "A Study of Coffee and Productivity"
-    attrs["description"] = "The more the better"
+    attrs['title'] = 'A Study of Coffee and Productivity'
+    attrs['description'] = 'The more the better'
 
-    payload = {"data": {"attributes": attrs, "relationships": {}, "type": "preprints"}}
+    payload = {'data': {'attributes': attrs, 'relationships': {}, 'type': 'preprints'}}
     if node_id:
-        payload["data"]["relationships"]["node"] = {"data": {"type": "node", "id": node_id}}
+        payload['data']['relationships']['node'] = {'data': {'type': 'node', 'id': node_id}}
     if provider_id:
-        payload["data"]["relationships"]["provider"] = {"data": {"type": "provider", "id": provider_id}}
+        payload['data']['relationships']['provider'] = {'data': {'type': 'provider', 'id': provider_id}}
     if file_id:
-        payload["data"]["relationships"]["primary_file"] = {"data": {"type": "primary_file", "id": file_id}}
+        payload['data']['relationships']['primary_file'] = {'data': {'type': 'primary_file', 'id': file_id}}
     return payload
 
 
@@ -82,7 +82,7 @@ class TestPreprintCreateWithoutNode:
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/"
+        return f'/{API_BASE}preprints/'
 
     @pytest.fixture()
     def supplementary_project(self, user_one):
@@ -91,14 +91,14 @@ class TestPreprintCreateWithoutNode:
     @pytest.fixture()
     def preprint_payload(self, provider):
         return {
-            "data": {
-                "type": "preprints",
-                "attributes": {
-                    "title": "Greatest Wrestlemania Moment Vol IX",
-                    "description": "Crush VS Doink the Clown in an epic battle during WrestleMania IX",
-                    "public": False,
+            'data': {
+                'type': 'preprints',
+                'attributes': {
+                    'title': 'Greatest Wrestlemania Moment Vol IX',
+                    'description': 'Crush VS Doink the Clown in an epic battle during WrestleMania IX',
+                    'public': False,
                 },
-                "relationships": {"provider": {"data": {"id": provider._id, "type": "providers"}}},
+                'relationships': {'provider': {'data': {'id': provider._id, 'type': 'providers'}}},
             }
         }
 
@@ -106,38 +106,38 @@ class TestPreprintCreateWithoutNode:
         res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 201
-        assert res.json["data"]["attributes"]["title"] == preprint_payload["data"]["attributes"]["title"]
-        assert res.json["data"]["attributes"]["description"] == preprint_payload["data"]["attributes"]["description"]
-        assert res.content_type == "application/vnd.api+json"
+        assert res.json['data']['attributes']['title'] == preprint_payload['data']['attributes']['title']
+        assert res.json['data']['attributes']['description'] == preprint_payload['data']['attributes']['description']
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_create_preprint_does_not_create_a_node(self, app, user_one, provider, url, preprint_payload):
         # Assume that if a supplemental node is being created, will be a separate POST to nodes?
         res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 201
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         assert preprint.node is None
-        assert not Node.objects.filter(preprints__guids___id=res.json["data"]["id"]).exists()
+        assert not Node.objects.filter(preprints__guids___id=res.json['data']['id']).exists()
 
     def test_create_preprint_with_supplementary_node(
         self, app, user_one, provider, url, preprint_payload, supplementary_project
     ):
-        preprint_payload["data"]["relationships"]["node"] = {"data": {"id": supplementary_project._id, "type": "nodes"}}
+        preprint_payload['data']['relationships']['node'] = {'data': {'id': supplementary_project._id, 'type': 'nodes'}}
         res = app.post_json_api(url, preprint_payload, auth=user_one.auth)
 
         assert res.status_code == 201
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         assert preprint.node == supplementary_project
-        assert Node.objects.filter(preprints__guids___id=res.json["data"]["id"]).exists()
+        assert Node.objects.filter(preprints__guids___id=res.json['data']['id']).exists()
 
     def test_create_preprint_with_incorrectly_specified_node(
         self, app, user_one, provider, url, preprint_payload, supplementary_project
     ):
-        preprint_payload["data"]["relationships"]["node"] = {"data": {"id": supplementary_project.id, "type": "nodes"}}
+        preprint_payload['data']['relationships']['node'] = {'data': {'id': supplementary_project.id, 'type': 'nodes'}}
         res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Node not correctly specified."
+        assert res.json['errors'][0]['detail'] == 'Node not correctly specified.'
 
 
 class TestPreprintList(ApiTestCase):
@@ -147,28 +147,28 @@ class TestPreprintList(ApiTestCase):
         self.user = AuthUserFactory()
 
         self.preprint = PreprintFactory(creator=self.user)
-        self.url = f"/{API_BASE}preprints/"
+        self.url = f'/{API_BASE}preprints/'
 
         self.project = ProjectFactory(creator=self.user)
 
     def test_return_preprints_logged_out(self):
         res = self.app.get(self.url)
-        assert len(res.json["data"]) == 1
+        assert len(res.json['data']) == 1
         assert res.status_code == 200
         assert res.status_code == 200
-        assert res.content_type == "application/vnd.api+json"
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_exclude_nodes_from_preprints_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        ids = [each["id"] for each in res.json["data"]]
+        ids = [each['id'] for each in res.json['data']]
         assert self.preprint._id in ids
         assert self.project._id not in ids
 
     def test_withdrawn_preprints_list(self):
-        pp = PreprintFactory(reviews_workflow="pre-moderation", is_published=False, creator=self.user)
-        pp.machine_state = "pending"
+        pp = PreprintFactory(reviews_workflow='pre-moderation', is_published=False, creator=self.user)
+        pp.machine_state = 'pending'
         mod = AuthUserFactory()
-        pp.provider.get_group("moderator").user_set.add(mod)
+        pp.provider.get_group('moderator').user_set.add(mod)
         pp.date_withdrawn = timezone.now()
         pp.save()
 
@@ -177,9 +177,9 @@ class TestPreprintList(ApiTestCase):
         unauth_res = self.app.get(self.url)
         user_res = self.app.get(self.url, auth=self.user.auth)
         mod_res = self.app.get(self.url, auth=mod.auth)
-        unauth_res_ids = [each["id"] for each in unauth_res.json["data"]]
-        user_res_ids = [each["id"] for each in user_res.json["data"]]
-        mod_res_ids = [each["id"] for each in mod_res.json["data"]]
+        unauth_res_ids = [each['id'] for each in unauth_res.json['data']]
+        user_res_ids = [each['id'] for each in user_res.json['data']]
+        mod_res_ids = [each['id'] for each in mod_res.json['data']]
         assert pp._id not in unauth_res_ids
         assert pp._id not in user_res_ids
         assert pp._id in mod_res_ids
@@ -193,11 +193,11 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(name="Sockarxiv")
+        return PreprintProviderFactory(name='Sockarxiv')
 
     @pytest.fixture()
     def provider_two(self):
-        return PreprintProviderFactory(name="Piratearxiv")
+        return PreprintProviderFactory(name='Piratearxiv')
 
     @pytest.fixture()
     def provider_three(self, provider_one):
@@ -217,15 +217,15 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
-    @mock.patch("website.identifiers.clients.crossref.CrossRefClient.update_identifier")
+    @mock.patch('website.identifiers.clients.crossref.CrossRefClient.update_identifier')
     def test_provider_filter_equals_returns_one(
         self, mock_change_identifier, app, user, provider_two, preprint_two, provider_url
     ):
         expected = [preprint_two._id]
-        res = app.get("{}{}".format(provider_url, provider_two._id), auth=user.auth)
-        actual = [preprint["id"] for preprint in res.json["data"]]
+        res = app.get('{}{}'.format(provider_url, provider_two._id), auth=user.auth)
+        actual = [preprint['id'] for preprint in res.json['data']]
         assert expected == actual
 
     def test_filter_withdrawn_preprint(self, app, url, user):
@@ -234,7 +234,7 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         preprint_one.is_public = True
         preprint_one.is_published = True
         preprint_one.date_published = timezone.now()
-        preprint_one.machine_state = "accepted"
+        preprint_one.machine_state = 'accepted'
         assert preprint_one.ever_public is False
         # Putting this preprint in a weird state, is verified_publishable, but has been
         # withdrawn and ever_public is False.  This is to isolate withdrawal portion of query
@@ -248,14 +248,14 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         # Unauthenticated can only see withdrawn preprints that have been public
         expected = [preprint_two._id]
         res = app.get(url)
-        actual = [preprint["id"] for preprint in res.json["data"]]
+        actual = [preprint['id'] for preprint in res.json['data']]
         assert set(expected) == set(actual)
 
         # Noncontribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
-        actual = [preprint["id"] for preprint in res.json["data"]]
+        actual = [preprint['id'] for preprint in res.json['data']]
         assert set(expected) == set(actual)
 
         # Read contribs can only see withdrawn preprints that have been public
@@ -264,12 +264,12 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         preprint_two.add_contributor(user2, permissions.READ)
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
-        actual = [preprint["id"] for preprint in res.json["data"]]
+        actual = [preprint['id'] for preprint in res.json['data']]
         assert set(expected) == set(actual)
 
         # Admin contribs can only see withdrawn preprints that have been public
         res = app.get(url, auth=user.auth)
-        actual = [preprint["id"] for preprint in res.json["data"]]
+        actual = [preprint['id'] for preprint in res.json['data']]
         assert set(expected) == set(actual)
 
 
@@ -284,26 +284,26 @@ class TestPreprintSubjectFiltering(SubjectsFilterMixin):
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/"
+        return f'/{API_BASE}preprints/'
 
 
 class TestPreprintListFilteringByReviewableFields(ReviewableFilterMixin):
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/"
+        return f'/{API_BASE}preprints/'
 
     @pytest.fixture()
     def expected_reviewables(self, user):
-        with mock.patch("website.identifiers.utils.request_identifiers"):
+        with mock.patch('website.identifiers.utils.request_identifiers'):
             preprints = [
                 PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
                 PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
                 PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
             ]
             preprints[0].run_submit(user)
-            preprints[0].run_accept(user, "comment")
+            preprints[0].run_accept(user, 'comment')
             preprints[1].run_submit(user)
-            preprints[1].run_reject(user, "comment")
+            preprints[1].run_reject(user, 'comment')
             preprints[2].run_submit(user)
             return preprints
 
@@ -327,15 +327,15 @@ class TestPreprintCreate(ApiTestCase):
         self.provider = PreprintProviderFactory()
 
         self.user_two = AuthUserFactory()
-        self.url = f"/{API_BASE}preprints/"
+        self.url = f'/{API_BASE}preprints/'
 
     def publish_preprint(self, preprint, user, expect_errors=False):
-        preprint_file = test_utils.create_test_preprint_file(preprint, user, "coffee_manuscript.pdf")
+        preprint_file = test_utils.create_test_preprint_file(preprint, user, 'coffee_manuscript.pdf')
 
         update_payload = build_preprint_update_payload(preprint._id, preprint_file._id)
 
         res = self.app.patch_json_api(
-            self.url + f"{preprint._id}/", update_payload, auth=user.auth, expect_errors=expect_errors
+            self.url + f'{preprint._id}/', update_payload, auth=user.auth, expect_errors=expect_errors
         )
         return res
 
@@ -344,10 +344,10 @@ class TestPreprintCreate(ApiTestCase):
 
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
 
-        data = res.json["data"]
-        preprint = Preprint.load(data["id"])
+        data = res.json['data']
+        preprint = Preprint.load(data['id'])
         assert res.status_code == 201
-        assert data["attributes"]["is_published"] == False
+        assert not data['attributes']['is_published']
         assert preprint.node == self.public_project
 
     def test_create_preprint_with_supplemental_private_project(self):
@@ -355,7 +355,7 @@ class TestPreprintCreate(ApiTestCase):
             self.private_project._id,
             self.provider._id,
             attrs={
-                "subjects": [[SubjectFactory()._id]],
+                'subjects': [[SubjectFactory()._id]],
             },
         )
         res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
@@ -364,7 +364,7 @@ class TestPreprintCreate(ApiTestCase):
         self.private_project.reload()
         assert not self.private_project.is_public
 
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         res = self.publish_preprint(preprint, self.user)
         preprint.reload()
         assert res.status_code == 200
@@ -394,7 +394,7 @@ class TestPreprintCreate(ApiTestCase):
         assert res.status_code == 403
 
     def test_file_is_not_in_node(self):
-        file_one_project = test_utils.create_test_file(self.public_project, self.user, "openupthatwindow.pdf")
+        file_one_project = test_utils.create_test_file(self.public_project, self.user, 'openupthatwindow.pdf')
         assert file_one_project.target == self.public_project
         wrong_project_payload = build_preprint_create_payload(
             self.public_project._id, self.provider._id, file_one_project._id
@@ -403,7 +403,7 @@ class TestPreprintCreate(ApiTestCase):
 
         assert res.status_code == 400
         # File which is targeted towards the project instead of the preprint is invalid
-        assert res.json["errors"][0]["detail"] == "This file is not a valid primary file for this preprint."
+        assert res.json['errors'][0]['detail'] == 'This file is not a valid primary file for this preprint.'
 
     def test_already_has_supplemental_node_on_another_preprint(self):
         preprint = PreprintFactory(creator=self.user, project=self.public_project)
@@ -427,71 +427,71 @@ class TestPreprintCreate(ApiTestCase):
             provider_id=self.provider._id,
             file_id=None,
             attrs={
-                "is_published": True,
-                "subjects": [[SubjectFactory()._id]],
+                'is_published': True,
+                'subjects': [[SubjectFactory()._id]],
             },
         )
         res = self.app.post_json_api(self.url, no_file_payload, auth=self.user.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "A valid primary_file must be set before publishing a preprint."
+        assert res.json['errors'][0]['detail'] == 'A valid primary_file must be set before publishing a preprint.'
 
     def test_publish_preprint_fails_with_invalid_primary_file(self):
         no_file_payload = build_preprint_create_payload(
             node_id=self.public_project._id,
             provider_id=self.provider._id,
             attrs={
-                "subjects": [[SubjectFactory()._id]],
+                'subjects': [[SubjectFactory()._id]],
             },
         )
         res = self.app.post_json_api(self.url, no_file_payload, auth=self.user.auth, expect_errors=True)
 
         assert res.status_code == 201
-        preprint = Preprint.load(res.json["data"]["id"])
-        update_payload = build_preprint_update_payload(preprint._id, "fakefileid")
+        preprint = Preprint.load(res.json['data']['id'])
+        update_payload = build_preprint_update_payload(preprint._id, 'fakefileid')
 
         res = self.app.patch_json_api(
-            self.url + f"{preprint._id}/", update_payload, auth=self.user.auth, expect_errors=True
+            self.url + f'{preprint._id}/', update_payload, auth=self.user.auth, expect_errors=True
         )
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "A valid primary_file must be set before publishing a preprint."
+        assert res.json['errors'][0]['detail'] == 'A valid primary_file must be set before publishing a preprint.'
 
     def test_no_provider_given(self):
         no_providers_payload = build_preprint_create_payload()
         res = self.app.post_json_api(self.url, no_providers_payload, auth=self.user.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "You must specify a valid provider to create a preprint."
+        assert res.json['errors'][0]['detail'] == 'You must specify a valid provider to create a preprint.'
 
     def test_invalid_provider_given(self):
-        wrong_provider_payload = build_preprint_create_payload(provider_id="jobbers")
+        wrong_provider_payload = build_preprint_create_payload(provider_id='jobbers')
 
         res = self.app.post_json_api(self.url, wrong_provider_payload, auth=self.user.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "You must specify a valid provider to create a preprint."
+        assert res.json['errors'][0]['detail'] == 'You must specify a valid provider to create a preprint.'
 
     def test_file_not_osfstorage(self):
         public_project_payload = build_preprint_create_payload(provider_id=self.provider._id)
 
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
 
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         assert res.status_code == 201
 
-        github_file = test_utils.create_test_preprint_file(preprint, self.user, "coffee_manuscript.pdf")
+        github_file = test_utils.create_test_preprint_file(preprint, self.user, 'coffee_manuscript.pdf')
         github_file.recast(GithubFile._typedmodels_type)
         github_file.save()
 
         update_payload = build_preprint_update_payload(preprint._id, github_file._id)
 
         res = self.app.patch_json_api(
-            self.url + f"{preprint._id}/", update_payload, auth=self.user.auth, expect_errors=True
+            self.url + f'{preprint._id}/', update_payload, auth=self.user.auth, expect_errors=True
         )
 
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "This file is not a valid primary file for this preprint."
+        assert res.json['errors'][0]['detail'] == 'This file is not a valid primary file for this preprint.'
 
     def test_preprint_contributor_signal_sent_on_creation(self):
         # Signal sent but bails out early without sending email
@@ -509,7 +509,7 @@ class TestPreprintCreate(ApiTestCase):
         public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json["errors"][0]["detail"] == "Cannot attach a deleted project to a preprint."
+        assert res.json['errors'][0]['detail'] == 'Cannot attach a deleted project to a preprint.'
 
     def test_create_preprint_with_no_permissions_to_node(self):
         project = ProjectFactory()
@@ -524,33 +524,33 @@ class TestPreprintCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
         assert res.status_code == 201
 
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         res = self.publish_preprint(preprint, self.user)
 
         log = preprint.logs.latest()
-        assert log.action == "published"
-        assert log.params.get("preprint") == preprint._id
+        assert log.action == 'published'
+        assert log.params.get('preprint') == preprint._id
 
-    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
     def test_create_preprint_from_project_published_hits_update(self, mock_on_preprint_updated):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id)
         res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
 
         assert not mock_on_preprint_updated.called
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         self.publish_preprint(preprint, self.user)
 
         assert mock_on_preprint_updated.called
 
-    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
     def test_create_preprint_from_project_unpublished_does_not_hit_update(self, mock_on_preprint_updated):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id)
         self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
         assert not mock_on_preprint_updated.called
 
-    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
     def test_setting_is_published_with_moderated_provider_fails(self, mock_on_preprint_updated):
-        self.provider.reviews_workflow = "pre-moderation"
+        self.provider.reviews_workflow = 'pre-moderation'
         self.provider.save()
         public_project_payload = build_preprint_create_payload(
             self.public_project._id,
@@ -558,7 +558,7 @@ class TestPreprintCreate(ApiTestCase):
         )
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
         assert res.status_code == 201
-        preprint = Preprint.load(res.json["data"]["id"])
+        preprint = Preprint.load(res.json['data']['id'])
         res = self.publish_preprint(preprint, self.user, expect_errors=True)
         assert res.status_code == 409
         assert not mock_on_preprint_updated.called
@@ -588,17 +588,17 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
-            machine_state="pending",
+            machine_state='pending',
             is_published=False,
         )
         preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
@@ -608,25 +608,25 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_unpublished_visible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_unpublished_invisible_to_noncontribs(self, app, preprint_unpublished, preprint_published, url):
         noncontrib = AuthUserFactory()
         res = app.get(url, auth=noncontrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 1
+        res = app.get(f'{url}filter[is_published]=false', auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
 
 
 class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
@@ -637,7 +637,7 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow="pre-moderation")
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -653,13 +653,13 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
@@ -673,19 +673,19 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_unpublished_visible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 1
+        res = app.get(f'{url}filter[is_published]=false', auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
 
 
 class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
@@ -696,7 +696,7 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow="pre-moderation")
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -712,13 +712,13 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, user_write_contrib, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
@@ -732,26 +732,26 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
     def test_unpublished_invisible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 0
+        res = app.get(f'{url}filter[is_published]=false', auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
 
     def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, url):
 
-        res = app.get(f"{url}filter[is_published]=false", auth=user_admin_contrib.auth)
+        res = app.get(f'{url}filter[is_published]=false', auth=user_admin_contrib.auth)
         # initial state now visible to no one
-        assert len(res.json["data"]) == 0
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 0
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
 
 class TestPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
@@ -780,7 +780,7 @@ class TestPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetail
     def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
@@ -791,28 +791,28 @@ class TestPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetail
 
     @pytest.fixture()
     def list_url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
+        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
 
     def test_unpublished_not_visible_to_admins(
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json["data"]["id"] == preprint_unpublished._id
+        assert res.json['data']['id'] == preprint_unpublished._id
 
     def test_unpublished_invisible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
@@ -826,7 +826,7 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(PreprintListMatches
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow="pre-moderation")
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -844,7 +844,7 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(PreprintListMatches
     def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
@@ -856,28 +856,28 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(PreprintListMatches
 
     @pytest.fixture()
     def list_url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
+        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
 
     def test_unpublished_not_visible_to_admins(
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json["data"]["id"] == preprint_unpublished._id
+        assert res.json['data']['id'] == preprint_unpublished._id
 
     def test_unpublished_invisible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 1
-        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
@@ -891,7 +891,7 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(PreprintListMatches
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow="pre-moderation")
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -909,7 +909,7 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(PreprintListMatches
     def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
         preprint = PreprintFactory(
             creator=user_admin_contrib,
-            filename="mgla.pdf",
+            filename='mgla.pdf',
             provider=provider_one,
             subjects=[[subject._id]],
             project=project_public,
@@ -921,31 +921,31 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(PreprintListMatches
 
     @pytest.fixture()
     def list_url(self):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
+        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
 
     def test_unpublished_visible_to_admins(
         self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json["data"]["id"] == preprint_unpublished._id
+        assert res.json['data']['id'] == preprint_unpublished._id
 
     def test_unpublished_visible_to_write_contribs(
         self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
     ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json["data"]) == 2
-        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
         res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
-        assert res.json["data"]["id"] == preprint_unpublished._id
+        assert res.json['data']['id'] == preprint_unpublished._id
 
 
 class TestPreprintIsValidList(PreprintIsValidListMixin):
@@ -964,7 +964,7 @@ class TestPreprintIsValidList(PreprintIsValidListMixin):
 
     @pytest.fixture()
     def url(self, project):
-        return f"/{API_BASE}preprints/?version=2.2&"
+        return f'/{API_BASE}preprints/?version=2.2&'
 
 
 @pytest.mark.django_db
@@ -977,41 +977,41 @@ class TestPreprintListWithMetrics:
             yield
 
     @pytest.mark.parametrize(
-        ("metric_name", "metric_class_name"),
+        ('metric_name', 'metric_class_name'),
         [
-            ("downloads", "PreprintDownload"),
-            ("views", "PreprintView"),
+            ('downloads', 'PreprintDownload'),
+            ('views', 'PreprintView'),
         ],
     )
     def test_preprint_list_with_metrics(self, app, metric_name, metric_class_name):
-        url = f"/{API_BASE}preprints/?metrics[{metric_name}]=total"
+        url = f'/{API_BASE}preprints/?metrics[{metric_name}]=total'
         preprint1 = PreprintFactory()
         preprint1.downloads = 41
         preprint2 = PreprintFactory()
         preprint2.downloads = 42
 
-        with mock.patch(f"api.preprints.views.{metric_class_name}.get_top_by_count") as mock_get_top_by_count:
+        with mock.patch(f'api.preprints.views.{metric_class_name}.get_top_by_count') as mock_get_top_by_count:
             mock_get_top_by_count.return_value = [preprint2, preprint1]
             res = app.get(url)
         assert res.status_code == 200
 
-        preprint_2_data = res.json["data"][0]
-        assert preprint_2_data["meta"]["metrics"]["downloads"] == 42
+        preprint_2_data = res.json['data'][0]
+        assert preprint_2_data['meta']['metrics']['downloads'] == 42
 
-        preprint_1_data = res.json["data"][1]
-        assert preprint_1_data["meta"]["metrics"]["downloads"] == 41
+        preprint_1_data = res.json['data'][1]
+        assert preprint_1_data['meta']['metrics']['downloads'] == 41
 
-    @mock.patch("django.utils.timezone.now")
+    @mock.patch('django.utils.timezone.now')
     @pytest.mark.parametrize(
-        ("query_value", "timedelta"),
+        ('query_value', 'timedelta'),
         [
-            ("daily", dt.timedelta(days=1)),
-            ("weekly", dt.timedelta(days=7)),
-            ("yearly", dt.timedelta(days=365)),
+            ('daily', dt.timedelta(days=1)),
+            ('weekly', dt.timedelta(days=7)),
+            ('yearly', dt.timedelta(days=365)),
         ],
     )
     def test_preprint_list_filter_metric_by_time_period(self, mock_timezone_now, app, settings, query_value, timedelta):
-        url = f"/{API_BASE}preprints/?metrics[views]={query_value}"
+        url = f'/{API_BASE}preprints/?metrics[views]={query_value}'
         mock_now = dt.datetime.utcnow().replace(tzinfo=timezone.utc)
         mock_timezone_now.return_value = mock_now
 
@@ -1020,10 +1020,10 @@ class TestPreprintListWithMetrics:
         preprint2 = PreprintFactory()
         preprint2.views = 42
 
-        with mock.patch("api.preprints.views.PreprintView.get_top_by_count") as mock_get_top_by_count:
+        with mock.patch('api.preprints.views.PreprintView.get_top_by_count') as mock_get_top_by_count:
             mock_get_top_by_count.return_value = [preprint2, preprint1]
             res = app.get(url)
 
         assert res.status_code == 200
         call_kwargs = mock_get_top_by_count.call_args[1]
-        assert call_kwargs["after"] == mock_now - timedelta
+        assert call_kwargs['after'] == mock_now - timedelta

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -1,7 +1,6 @@
 from unittest import mock
 import datetime as dt
 
-from nose.tools import *  # noqa:
 import pytest
 from django.utils import timezone
 from waffle.testutils import override_switch
@@ -32,76 +31,38 @@ from tests.base import ApiTestCase, capture_signals
 from website.project import signals as project_signals
 
 
-def build_preprint_update_payload(
-    preprint_id, primary_file_id, is_published=True
-):
+def build_preprint_update_payload(preprint_id, primary_file_id, is_published=True):
     return {
-        'data': {
-            'id': preprint_id,
-            'type': 'preprints',
-            'attributes': {
-                'is_published': is_published,
-                'subjects': [[SubjectFactory()._id]],
+        "data": {
+            "id": preprint_id,
+            "type": "preprints",
+            "attributes": {
+                "is_published": is_published,
+                "subjects": [[SubjectFactory()._id]],
             },
-            'relationships': {
-                'primary_file': {
-                    'data': {
-                        'type': 'primary_file',
-                        'id': primary_file_id
-                    }
-                }
-            }
+            "relationships": {"primary_file": {"data": {"type": "primary_file", "id": primary_file_id}}},
         }
     }
 
-def build_preprint_create_payload(
-        node_id=None,
-        provider_id=None,
-        file_id=None,
-        attrs={}):
 
-    attrs['title'] = 'A Study of Coffee and Productivity'
-    attrs['description'] = 'The more the better'
+def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, attrs={}):
 
-    payload = {
-        'data': {
-            'attributes': attrs,
-            'relationships': {},
-            'type': 'preprints'
-        }
-    }
+    attrs["title"] = "A Study of Coffee and Productivity"
+    attrs["description"] = "The more the better"
+
+    payload = {"data": {"attributes": attrs, "relationships": {}, "type": "preprints"}}
     if node_id:
-        payload['data']['relationships']['node'] = {
-            'data': {
-                'type': 'node',
-                'id': node_id
-            }
-        }
+        payload["data"]["relationships"]["node"] = {"data": {"type": "node", "id": node_id}}
     if provider_id:
-        payload['data']['relationships']['provider'] = {
-            'data': {
-                'type': 'provider',
-                'id': provider_id
-            }
-        }
+        payload["data"]["relationships"]["provider"] = {"data": {"type": "provider", "id": provider_id}}
     if file_id:
-        payload['data']['relationships']['primary_file'] = {
-            'data': {
-                'type': 'primary_file',
-                'id': file_id
-            }
-        }
+        payload["data"]["relationships"]["primary_file"] = {"data": {"type": "primary_file", "id": file_id}}
     return payload
 
 
-def build_preprint_create_payload_without_node(
-        provider_id=None, file_id=None, attrs=None):
+def build_preprint_create_payload_without_node(provider_id=None, file_id=None, attrs=None):
     attrs = attrs or {}
-    return build_preprint_create_payload(
-        node_id=None,
-        provider_id=provider_id,
-        file_id=file_id,
-        attrs=attrs)
+    return build_preprint_create_payload(node_id=None, provider_id=provider_id, file_id=file_id, attrs=attrs)
 
 
 @pytest.mark.django_db
@@ -121,7 +82,7 @@ class TestPreprintCreateWithoutNode:
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/'
+        return f"/{API_BASE}preprints/"
 
     @pytest.fixture()
     def supplementary_project(self, user_one):
@@ -130,85 +91,53 @@ class TestPreprintCreateWithoutNode:
     @pytest.fixture()
     def preprint_payload(self, provider):
         return {
-            'data': {
-                'type': 'preprints',
-                'attributes': {
-                    'title': 'Greatest Wrestlemania Moment Vol IX',
-                    'description': 'Crush VS Doink the Clown in an epic battle during WrestleMania IX',
-                    'public': False,
+            "data": {
+                "type": "preprints",
+                "attributes": {
+                    "title": "Greatest Wrestlemania Moment Vol IX",
+                    "description": "Crush VS Doink the Clown in an epic battle during WrestleMania IX",
+                    "public": False,
                 },
-                'relationships': {
-                    'provider': {
-                        'data': {
-                            'id': provider._id,
-                            'type': 'providers'}}}}}
+                "relationships": {"provider": {"data": {"id": provider._id, "type": "providers"}}},
+            }
+        }
 
-    def test_create_preprint_logged_in(
-            self, app, user_one, url, preprint_payload):
-        res = app.post_json_api(
-            url,
-            preprint_payload,
-            auth=user_one.auth,
-            expect_errors=True)
+    def test_create_preprint_logged_in(self, app, user_one, url, preprint_payload):
+        res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 201
-        assert res.json['data']['attributes']['title'] == preprint_payload['data']['attributes']['title']
-        assert res.json['data']['attributes']['description'] == preprint_payload['data']['attributes']['description']
-        assert res.content_type == 'application/vnd.api+json'
+        assert res.json["data"]["attributes"]["title"] == preprint_payload["data"]["attributes"]["title"]
+        assert res.json["data"]["attributes"]["description"] == preprint_payload["data"]["attributes"]["description"]
+        assert res.content_type == "application/vnd.api+json"
 
-    def test_create_preprint_does_not_create_a_node(
-            self, app, user_one, provider, url, preprint_payload):
+    def test_create_preprint_does_not_create_a_node(self, app, user_one, provider, url, preprint_payload):
         # Assume that if a supplemental node is being created, will be a separate POST to nodes?
-        res = app.post_json_api(
-            url,
-            preprint_payload,
-            auth=user_one.auth,
-            expect_errors=True)
+        res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 201
-        preprint = Preprint.load(res.json['data']['id'])
+        preprint = Preprint.load(res.json["data"]["id"])
         assert preprint.node is None
-        assert not Node.objects.filter(
-            preprints__guids___id=res.json['data']['id']).exists()
+        assert not Node.objects.filter(preprints__guids___id=res.json["data"]["id"]).exists()
 
     def test_create_preprint_with_supplementary_node(
-            self, app, user_one, provider, url, preprint_payload, supplementary_project):
-        preprint_payload['data']['relationships']['node'] = {
-            'data': {
-                'id': supplementary_project._id,
-                'type': 'nodes'
-            }
-        }
-        res = app.post_json_api(
-            url,
-            preprint_payload,
-            auth=user_one.auth)
+        self, app, user_one, provider, url, preprint_payload, supplementary_project
+    ):
+        preprint_payload["data"]["relationships"]["node"] = {"data": {"id": supplementary_project._id, "type": "nodes"}}
+        res = app.post_json_api(url, preprint_payload, auth=user_one.auth)
 
         assert res.status_code == 201
-        preprint = Preprint.load(res.json['data']['id'])
+        preprint = Preprint.load(res.json["data"]["id"])
         assert preprint.node == supplementary_project
-        assert Node.objects.filter(
-            preprints__guids___id=res.json['data']['id']).exists()
+        assert Node.objects.filter(preprints__guids___id=res.json["data"]["id"]).exists()
 
     def test_create_preprint_with_incorrectly_specified_node(
-            self, app, user_one, provider, url, preprint_payload, supplementary_project):
-        preprint_payload['data']['relationships']['node'] = {
-            'data': {
-                'id': supplementary_project.id,
-                'type': 'nodes'
-            }
-        }
-        res = app.post_json_api(
-            url,
-            preprint_payload,
-            auth=user_one.auth,
-            expect_errors=True
-        )
+        self, app, user_one, provider, url, preprint_payload, supplementary_project
+    ):
+        preprint_payload["data"]["relationships"]["node"] = {"data": {"id": supplementary_project.id, "type": "nodes"}}
+        res = app.post_json_api(url, preprint_payload, auth=user_one.auth, expect_errors=True)
 
         assert res.status_code == 400
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'Node not correctly specified.')
+        assert res.json["errors"][0]["detail"] == "Node not correctly specified."
 
 
 class TestPreprintList(ApiTestCase):
@@ -218,28 +147,28 @@ class TestPreprintList(ApiTestCase):
         self.user = AuthUserFactory()
 
         self.preprint = PreprintFactory(creator=self.user)
-        self.url = f'/{API_BASE}preprints/'
+        self.url = f"/{API_BASE}preprints/"
 
         self.project = ProjectFactory(creator=self.user)
 
     def test_return_preprints_logged_out(self):
         res = self.app.get(self.url)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(len(res.json["data"]), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, "application/vnd.api+json")
 
     def test_exclude_nodes_from_preprints_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        ids = [each['id'] for each in res.json['data']]
-        assert_in(self.preprint._id, ids)
-        assert_not_in(self.project._id, ids)
+        ids = [each["id"] for each in res.json["data"]]
+        self.assertIn(self.preprint._id, ids)
+        self.assertNotIn(self.project._id, ids)
 
     def test_withdrawn_preprints_list(self):
-        pp = PreprintFactory(reviews_workflow='pre-moderation', is_published=False, creator=self.user)
-        pp.machine_state = 'pending'
+        pp = PreprintFactory(reviews_workflow="pre-moderation", is_published=False, creator=self.user)
+        pp.machine_state = "pending"
         mod = AuthUserFactory()
-        pp.provider.get_group('moderator').user_set.add(mod)
+        pp.provider.get_group("moderator").user_set.add(mod)
         pp.date_withdrawn = timezone.now()
         pp.save()
 
@@ -248,9 +177,9 @@ class TestPreprintList(ApiTestCase):
         unauth_res = self.app.get(self.url)
         user_res = self.app.get(self.url, auth=self.user.auth)
         mod_res = self.app.get(self.url, auth=mod.auth)
-        unauth_res_ids = [each['id'] for each in unauth_res.json['data']]
-        user_res_ids = [each['id'] for each in user_res.json['data']]
-        mod_res_ids = [each['id'] for each in mod_res.json['data']]
+        unauth_res_ids = [each["id"] for each in unauth_res.json["data"]]
+        user_res_ids = [each["id"] for each in user_res.json["data"]]
+        mod_res_ids = [each["id"] for each in mod_res.json["data"]]
         assert pp._id not in unauth_res_ids
         assert pp._id not in user_res_ids
         assert pp._id in mod_res_ids
@@ -264,11 +193,11 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(name='Sockarxiv')
+        return PreprintProviderFactory(name="Sockarxiv")
 
     @pytest.fixture()
     def provider_two(self):
-        return PreprintProviderFactory(name='Piratearxiv')
+        return PreprintProviderFactory(name="Piratearxiv")
 
     @pytest.fixture()
     def provider_three(self, provider_one):
@@ -288,24 +217,15 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
-    @mock.patch('website.identifiers.clients.crossref.CrossRefClient.update_identifier')
+    @mock.patch("website.identifiers.clients.crossref.CrossRefClient.update_identifier")
     def test_provider_filter_equals_returns_one(
-            self,
-            mock_change_identifier,
-            app,
-            user,
-            provider_two,
-            preprint_two,
-            provider_url):
+        self, mock_change_identifier, app, user, provider_two, preprint_two, provider_url
+    ):
         expected = [preprint_two._id]
-        res = app.get(
-            '{}{}'.format(
-                provider_url,
-                provider_two._id),
-            auth=user.auth)
-        actual = [preprint['id'] for preprint in res.json['data']]
+        res = app.get("{}{}".format(provider_url, provider_two._id), auth=user.auth)
+        actual = [preprint["id"] for preprint in res.json["data"]]
         assert expected == actual
 
     def test_filter_withdrawn_preprint(self, app, url, user):
@@ -314,7 +234,7 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         preprint_one.is_public = True
         preprint_one.is_published = True
         preprint_one.date_published = timezone.now()
-        preprint_one.machine_state = 'accepted'
+        preprint_one.machine_state = "accepted"
         assert preprint_one.ever_public is False
         # Putting this preprint in a weird state, is verified_publishable, but has been
         # withdrawn and ever_public is False.  This is to isolate withdrawal portion of query
@@ -328,14 +248,14 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         # Unauthenticated can only see withdrawn preprints that have been public
         expected = [preprint_two._id]
         res = app.get(url)
-        actual = [preprint['id'] for preprint in res.json['data']]
+        actual = [preprint["id"] for preprint in res.json["data"]]
         assert set(expected) == set(actual)
 
         # Noncontribs can only see withdrawn preprints that have been public
         user2 = AuthUserFactory()
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
-        actual = [preprint['id'] for preprint in res.json['data']]
+        actual = [preprint["id"] for preprint in res.json["data"]]
         assert set(expected) == set(actual)
 
         # Read contribs can only see withdrawn preprints that have been public
@@ -344,12 +264,12 @@ class TestPreprintsListFiltering(PreprintsListFilteringMixin):
         preprint_two.add_contributor(user2, permissions.READ)
         expected = [preprint_two._id]
         res = app.get(url, auth=user2.auth)
-        actual = [preprint['id'] for preprint in res.json['data']]
+        actual = [preprint["id"] for preprint in res.json["data"]]
         assert set(expected) == set(actual)
 
         # Admin contribs can only see withdrawn preprints that have been public
         res = app.get(url, auth=user.auth)
-        actual = [preprint['id'] for preprint in res.json['data']]
+        actual = [preprint["id"] for preprint in res.json["data"]]
         assert set(expected) == set(actual)
 
 
@@ -364,29 +284,26 @@ class TestPreprintSubjectFiltering(SubjectsFilterMixin):
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/'
+        return f"/{API_BASE}preprints/"
 
 
 class TestPreprintListFilteringByReviewableFields(ReviewableFilterMixin):
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/'
+        return f"/{API_BASE}preprints/"
 
     @pytest.fixture()
     def expected_reviewables(self, user):
-        with mock.patch('website.identifiers.utils.request_identifiers'):
+        with mock.patch("website.identifiers.utils.request_identifiers"):
             preprints = [
-                PreprintFactory(
-                    is_published=False, project=ProjectFactory(
-                        is_public=True)), PreprintFactory(
-                    is_published=False, project=ProjectFactory(
-                        is_public=True)), PreprintFactory(
-                            is_published=False, project=ProjectFactory(
-                                is_public=True)), ]
+                PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
+                PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
+                PreprintFactory(is_published=False, project=ProjectFactory(is_public=True)),
+            ]
             preprints[0].run_submit(user)
-            preprints[0].run_accept(user, 'comment')
+            preprints[0].run_accept(user, "comment")
             preprints[1].run_submit(user)
-            preprints[1].run_reject(user, 'comment')
+            preprints[1].run_reject(user, "comment")
             preprints[2].run_submit(user)
             return preprints
 
@@ -404,42 +321,33 @@ class TestPreprintCreate(ApiTestCase):
         self.private_project = ProjectFactory(creator=self.user)
         self.public_project = ProjectFactory(creator=self.user, is_public=True)
         self.public_project.add_contributor(
-            self.other_user,
-            permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS,
-            save=True)
+            self.other_user, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True
+        )
         self.subject = SubjectFactory()
         self.provider = PreprintProviderFactory()
 
         self.user_two = AuthUserFactory()
-        self.url = f'/{API_BASE}preprints/'
+        self.url = f"/{API_BASE}preprints/"
 
     def publish_preprint(self, preprint, user, expect_errors=False):
-        preprint_file = test_utils.create_test_preprint_file(
-            preprint, user, 'coffee_manuscript.pdf')
+        preprint_file = test_utils.create_test_preprint_file(preprint, user, "coffee_manuscript.pdf")
 
         update_payload = build_preprint_update_payload(preprint._id, preprint_file._id)
 
         res = self.app.patch_json_api(
-            self.url + f'{preprint._id}/',
-            update_payload,
-            auth=user.auth,
-            expect_errors=expect_errors
+            self.url + f"{preprint._id}/", update_payload, auth=user.auth, expect_errors=expect_errors
         )
         return res
 
     def test_create_preprint_with_supplemental_public_project(self):
-        public_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id)
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
 
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
 
-        data = res.json['data']
-        preprint = Preprint.load(data['id'])
-        assert_equal(res.status_code, 201)
-        assert_equal(data['attributes']['is_published'], False)
+        data = res.json["data"]
+        preprint = Preprint.load(data["id"])
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(data["attributes"]["is_published"], False)
         assert preprint.node == self.public_project
 
     def test_create_preprint_with_supplemental_private_project(self):
@@ -447,107 +355,71 @@ class TestPreprintCreate(ApiTestCase):
             self.private_project._id,
             self.provider._id,
             attrs={
-                'subjects': [
-                    [
-                        SubjectFactory()._id]],
-            })
-        res = self.app.post_json_api(
-            self.url,
-            private_project_payload,
-            auth=self.user.auth)
+                "subjects": [[SubjectFactory()._id]],
+            },
+        )
+        res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
 
-        assert_equal(res.status_code, 201)
+        self.assertEqual(res.status_code, 201)
         self.private_project.reload()
-        assert_false(self.private_project.is_public)
+        self.assertFalse(self.private_project.is_public)
 
-        preprint = Preprint.load(res.json['data']['id'])
+        preprint = Preprint.load(res.json["data"]["id"])
         res = self.publish_preprint(preprint, self.user)
         preprint.reload()
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         self.private_project.reload()
-        assert_false(self.private_project.is_public)
-        assert_true(preprint.is_public)
-        assert_true(preprint.is_published)
+        self.assertFalse(self.private_project.is_public)
+        self.assertTrue(preprint.is_public)
+        self.assertTrue(preprint.is_published)
 
     def test_non_authorized_user_on_supplemental_node(self):
-        public_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user_two.auth,
-            expect_errors=True)
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user_two.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_write_user_on_supplemental_node(self):
-        assert_in(self.other_user, self.public_project.contributors)
-        public_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.other_user.auth,
-            expect_errors=True)
+        self.assertIn(self.other_user, self.public_project.contributors)
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.other_user.auth, expect_errors=True)
         # Users can create a preprint with a supplemental node that they have write perms to
-        assert_equal(res.status_code, 201)
+        self.assertEqual(res.status_code, 201)
 
     def test_read_user_on_supplemental_node(self):
         self.public_project.set_permissions(self.other_user, permissions.READ, save=True)
-        assert_in(self.other_user, self.public_project.contributors)
-        public_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.other_user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertIn(self.other_user, self.public_project.contributors)
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.other_user.auth, expect_errors=True)
+        self.assertEqual(res.status_code, 403)
 
     def test_file_is_not_in_node(self):
-        file_one_project = test_utils.create_test_file(
-            self.public_project, self.user, 'openupthatwindow.pdf')
-        assert_equal(file_one_project.target, self.public_project)
+        file_one_project = test_utils.create_test_file(self.public_project, self.user, "openupthatwindow.pdf")
+        self.assertEqual(file_one_project.target, self.public_project)
         wrong_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id, file_one_project._id)
-        res = self.app.post_json_api(
-            self.url,
-            wrong_project_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+            self.public_project._id, self.provider._id, file_one_project._id
+        )
+        res = self.app.post_json_api(self.url, wrong_project_payload, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
+        self.assertEqual(res.status_code, 400)
         # File which is targeted towards the project instead of the preprint is invalid
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'This file is not a valid primary file for this preprint.')
+        self.assertEqual(res.json["errors"][0]["detail"], "This file is not a valid primary file for this preprint.")
 
     def test_already_has_supplemental_node_on_another_preprint(self):
         preprint = PreprintFactory(creator=self.user, project=self.public_project)
-        already_preprint_payload = build_preprint_create_payload(
-            preprint.node._id, preprint.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            already_preprint_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        already_preprint_payload = build_preprint_create_payload(preprint.node._id, preprint.provider._id)
+        res = self.app.post_json_api(self.url, already_preprint_payload, auth=self.user.auth, expect_errors=True)
         # One preprint per provider per node constraint has been lifted
-        assert_equal(res.status_code, 201)
+        self.assertEqual(res.status_code, 201)
 
-    def test_read_write_user_already_a_preprint_with_same_provider(
-            self):
-        assert_in(self.other_user, self.public_project.contributors)
+    def test_read_write_user_already_a_preprint_with_same_provider(self):
+        self.assertIn(self.other_user, self.public_project.contributors)
 
         preprint = PreprintFactory(creator=self.user, project=self.public_project)
-        already_preprint_payload = build_preprint_create_payload(
-            preprint.node._id, preprint.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            already_preprint_payload,
-            auth=self.other_user.auth,
-            expect_errors=True)
+        already_preprint_payload = build_preprint_create_payload(preprint.node._id, preprint.provider._id)
+        res = self.app.post_json_api(self.url, already_preprint_payload, auth=self.other_user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 201)
+        self.assertEqual(res.status_code, 201)
 
     def test_publish_preprint_fails_with_no_primary_file(self):
         no_file_payload = build_preprint_create_payload(
@@ -555,212 +427,138 @@ class TestPreprintCreate(ApiTestCase):
             provider_id=self.provider._id,
             file_id=None,
             attrs={
-                'is_published': True,
-                'subjects': [[SubjectFactory()._id]],
-            }
+                "is_published": True,
+                "subjects": [[SubjectFactory()._id]],
+            },
         )
-        res = self.app.post_json_api(
-            self.url,
-            no_file_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, no_file_payload, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'A valid primary_file must be set before publishing a preprint.')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "A valid primary_file must be set before publishing a preprint.")
 
     def test_publish_preprint_fails_with_invalid_primary_file(self):
         no_file_payload = build_preprint_create_payload(
             node_id=self.public_project._id,
             provider_id=self.provider._id,
             attrs={
-                'subjects': [[SubjectFactory()._id]],
-            }
+                "subjects": [[SubjectFactory()._id]],
+            },
         )
-        res = self.app.post_json_api(
-            self.url,
-            no_file_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, no_file_payload, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 201)
-        preprint = Preprint.load(res.json['data']['id'])
-        update_payload = build_preprint_update_payload(preprint._id, 'fakefileid')
+        self.assertEqual(res.status_code, 201)
+        preprint = Preprint.load(res.json["data"]["id"])
+        update_payload = build_preprint_update_payload(preprint._id, "fakefileid")
 
         res = self.app.patch_json_api(
-            self.url + f'{preprint._id}/',
-            update_payload,
-            auth=self.user.auth,
-            expect_errors=True
+            self.url + f"{preprint._id}/", update_payload, auth=self.user.auth, expect_errors=True
         )
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'A valid primary_file must be set before publishing a preprint.')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "A valid primary_file must be set before publishing a preprint.")
 
     def test_no_provider_given(self):
         no_providers_payload = build_preprint_create_payload()
-        res = self.app.post_json_api(
-            self.url,
-            no_providers_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, no_providers_payload, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'You must specify a valid provider to create a preprint.')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "You must specify a valid provider to create a preprint.")
 
     def test_invalid_provider_given(self):
-        wrong_provider_payload = build_preprint_create_payload(
-            provider_id='jobbers')
+        wrong_provider_payload = build_preprint_create_payload(provider_id="jobbers")
 
-        res = self.app.post_json_api(
-            self.url,
-            wrong_provider_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, wrong_provider_payload, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'You must specify a valid provider to create a preprint.')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "You must specify a valid provider to create a preprint.")
 
     def test_file_not_osfstorage(self):
-        public_project_payload = build_preprint_create_payload(
-            provider_id=self.provider._id)
+        public_project_payload = build_preprint_create_payload(provider_id=self.provider._id)
 
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
 
-        preprint = Preprint.load(res.json['data']['id'])
-        assert_equal(res.status_code, 201)
+        preprint = Preprint.load(res.json["data"]["id"])
+        self.assertEqual(res.status_code, 201)
 
-        github_file = test_utils.create_test_preprint_file(
-            preprint, self.user, 'coffee_manuscript.pdf')
+        github_file = test_utils.create_test_preprint_file(preprint, self.user, "coffee_manuscript.pdf")
         github_file.recast(GithubFile._typedmodels_type)
         github_file.save()
 
         update_payload = build_preprint_update_payload(preprint._id, github_file._id)
 
         res = self.app.patch_json_api(
-            self.url + f'{preprint._id}/',
-            update_payload,
-            auth=self.user.auth,
-            expect_errors=True
+            self.url + f"{preprint._id}/", update_payload, auth=self.user.auth, expect_errors=True
         )
 
-        assert_equal(res.status_code, 400)
-        assert_equal(
-            res.json['errors'][0]['detail'],
-            'This file is not a valid primary file for this preprint.')
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "This file is not a valid primary file for this preprint.")
 
     def test_preprint_contributor_signal_sent_on_creation(self):
         # Signal sent but bails out early without sending email
         with capture_signals() as mock_signals:
-            payload = build_preprint_create_payload(
-                provider_id=self.provider._id)
-            res = self.app.post_json_api(
-                self.url, payload, auth=self.user.auth)
+            payload = build_preprint_create_payload(provider_id=self.provider._id)
+            res = self.app.post_json_api(self.url, payload, auth=self.user.auth)
 
-            assert_equal(res.status_code, 201)
-            assert_true(len(mock_signals.signals_sent()) == 1)
-            assert_in(
-                project_signals.contributor_added,
-                mock_signals.signals_sent())
+            self.assertEqual(res.status_code, 201)
+            self.assertTrue(len(mock_signals.signals_sent()) == 1)
+            self.assertIn(project_signals.contributor_added, mock_signals.signals_sent())
 
     def test_create_preprint_with_deleted_node_should_fail(self):
         self.public_project.is_deleted = True
         self.public_project.save()
-        public_project_payload = build_preprint_create_payload(
-            self.public_project._id, self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'],
-                     'Cannot attach a deleted project to a preprint.')
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(res.json["errors"][0]["detail"], "Cannot attach a deleted project to a preprint.")
 
     def test_create_preprint_with_no_permissions_to_node(self):
         project = ProjectFactory()
-        public_project_payload = build_preprint_create_payload(
-            project._id, self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        public_project_payload = build_preprint_create_payload(project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
+        self.assertEqual(res.status_code, 403)
 
     def test_create_preprint_adds_log_if_published(self):
         public_project_payload = build_preprint_create_payload(
             provider_id=self.provider._id,
         )
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth)
-        assert_equal(res.status_code, 201)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
+        self.assertEqual(res.status_code, 201)
 
-        preprint = Preprint.load(res.json['data']['id'])
+        preprint = Preprint.load(res.json["data"]["id"])
         res = self.publish_preprint(preprint, self.user)
 
         log = preprint.logs.latest()
-        assert_equal(log.action, 'published')
-        assert_equal(log.params.get('preprint'), preprint._id)
+        self.assertEqual(log.action, "published")
+        self.assertEqual(log.params.get("preprint"), preprint._id)
 
-    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
-    def test_create_preprint_from_project_published_hits_update(
-            self, mock_on_preprint_updated):
-        private_project_payload = build_preprint_create_payload(
-            self.private_project._id,
-            self.provider._id)
-        res = self.app.post_json_api(
-            self.url,
-            private_project_payload,
-            auth=self.user.auth)
+    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    def test_create_preprint_from_project_published_hits_update(self, mock_on_preprint_updated):
+        private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id)
+        res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
 
-        assert_false(mock_on_preprint_updated.called)
-        preprint = Preprint.load(res.json['data']['id'])
+        self.assertFalse(mock_on_preprint_updated.called)
+        preprint = Preprint.load(res.json["data"]["id"])
         self.publish_preprint(preprint, self.user)
 
-        assert_true(mock_on_preprint_updated.called)
+        self.assertTrue(mock_on_preprint_updated.called)
 
-    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
-    def test_create_preprint_from_project_unpublished_does_not_hit_update(
-            self, mock_on_preprint_updated):
-        private_project_payload = build_preprint_create_payload(
-            self.private_project._id,
-            self.provider._id)
-        self.app.post_json_api(
-            self.url,
-            private_project_payload,
-            auth=self.user.auth)
+    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    def test_create_preprint_from_project_unpublished_does_not_hit_update(self, mock_on_preprint_updated):
+        private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id)
+        self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
         assert not mock_on_preprint_updated.called
 
-    @mock.patch('osf.models.preprint.update_or_enqueue_on_preprint_updated')
-    def test_setting_is_published_with_moderated_provider_fails(
-            self, mock_on_preprint_updated):
-        self.provider.reviews_workflow = 'pre-moderation'
+    @mock.patch("osf.models.preprint.update_or_enqueue_on_preprint_updated")
+    def test_setting_is_published_with_moderated_provider_fails(self, mock_on_preprint_updated):
+        self.provider.reviews_workflow = "pre-moderation"
         self.provider.save()
         public_project_payload = build_preprint_create_payload(
             self.public_project._id,
             self.provider._id,
         )
-        res = self.app.post_json_api(
-            self.url,
-            public_project_payload,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
         assert res.status_code == 201
-        preprint = Preprint.load(res.json['data']['id'])
+        preprint = Preprint.load(res.json["data"]["id"])
         res = self.publish_preprint(preprint, self.user, expect_errors=True)
         assert res.status_code == 409
         assert not mock_on_preprint_updated.called
@@ -786,74 +584,49 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib, user_write_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            user_write_contrib,
-            provider_one,
-            project_public,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               machine_state='pending',
-                               is_published=False)
+    def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            machine_state="pending",
+            is_published=False,
+        )
         preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
+    ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
     def test_unpublished_visible_to_write_contribs(
-        self,
-        app,
-        user_write_contrib,
-        preprint_unpublished,
-        preprint_published,
-        url
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, url
     ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [
-            d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
-    def test_unpublished_invisible_to_noncontribs(
-        self,
-        app,
-        preprint_unpublished,
-        preprint_published,
-        url
-    ):
+    def test_unpublished_invisible_to_noncontribs(self, app, preprint_unpublished, preprint_published, url):
         noncontrib = AuthUserFactory()
         res = app.get(url, auth=noncontrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [
-            d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
-    def test_filter_published_false_write_contrib(
-            self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(
-            f'{url}filter[is_published]=false',
-            auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
+        assert len(res.json["data"]) == 1
 
 
 class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
@@ -864,7 +637,7 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+        return PreprintProviderFactory(reviews_workflow="pre-moderation")
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -872,8 +645,7 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
     def project_published(self, user_admin_contrib):
@@ -881,54 +653,39 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            user_write_contrib,
-            provider_one,
-            project_public,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               is_published=False,
-                               machine_state=DefaultStates.PENDING.value)
+    def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            is_published=False,
+            machine_state=DefaultStates.PENDING.value,
+        )
         preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
+    ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
     def test_unpublished_visible_to_write_contribs(
-            self,
-            app,
-            user_write_contrib,
-            preprint_unpublished,
-            preprint_published,
-            url):
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, url
+    ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
-    def test_filter_published_false_write_contrib(
-            self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(
-            f'{url}filter[is_published]=false',
-            auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
+        assert len(res.json["data"]) == 1
 
 
 class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
@@ -939,7 +696,7 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+        return PreprintProviderFactory(reviews_workflow="pre-moderation")
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -947,8 +704,7 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
     def project_published(self, user_admin_contrib):
@@ -956,69 +712,49 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
 
     @pytest.fixture()
     def url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            provider_one,
-            project_public,
-            user_write_contrib,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               is_published=False,
-                               machine_state=DefaultStates.INITIAL.value)
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, user_write_contrib, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            is_published=False,
+            machine_state=DefaultStates.INITIAL.value,
+        )
         preprint.add_contributor(user_write_contrib, permissions=permissions.WRITE, save=True)
         return preprint
 
     def test_unpublished_not_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, url
+    ):
         res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
     def test_unpublished_invisible_to_write_contribs(
-            self,
-            app,
-            user_write_contrib,
-            preprint_unpublished,
-            preprint_published,
-            url):
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, url
+    ):
         res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [
-            d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
-    def test_filter_published_false_write_contrib(
-            self, app, user_write_contrib, preprint_unpublished, url):
-        res = app.get(
-            f'{url}filter[is_published]=false',
-            auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 0
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get(f"{url}filter[is_published]=false", auth=user_write_contrib.auth)
+        assert len(res.json["data"]) == 0
 
-    def test_filter_published_false_admin(
-            self, app, user_admin_contrib, preprint_unpublished, url):
+    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, url):
 
-        res = app.get(
-            f'{url}filter[is_published]=false',
-            auth=user_admin_contrib.auth)
+        res = app.get(f"{url}filter[is_published]=false", auth=user_admin_contrib.auth)
         # initial state now visible to no one
-        assert len(res.json['data']) == 0
-        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 0
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
 
-class TestPreprintIsPublishedListMatchesDetail(
-        PreprintListMatchesPreprintDetailMixin):
+class TestPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
 
     @pytest.fixture()
     def user_admin_contrib(self):
@@ -1038,71 +774,51 @@ class TestPreprintIsPublishedListMatchesDetail(
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            user_write_contrib,
-            provider_one,
-            project_public,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               is_published=False)
+    def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            is_published=False,
+        )
         preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()
     def list_url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
+        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
 
     def test_unpublished_not_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json['data']['id'] == preprint_unpublished._id
+        assert res.json["data"]["id"] == preprint_unpublished._id
 
     def test_unpublished_invisible_to_write_contribs(
-            self,
-            app,
-            user_write_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [
-            d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
-        res = app.get(
-            detail_url,
-            auth=user_write_contrib.auth,
-            expect_errors=True)
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
 
-class TestReviewsInitialPreprintIsPublishedListMatchesDetail(
-        PreprintListMatchesPreprintDetailMixin):
+class TestReviewsInitialPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
 
     @pytest.fixture()
     def user_admin_contrib(self):
@@ -1110,7 +826,7 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+        return PreprintProviderFactory(reviews_workflow="pre-moderation")
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -1122,72 +838,52 @@ class TestReviewsInitialPreprintIsPublishedListMatchesDetail(
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            user_write_contrib,
-            provider_one,
-            project_public,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               is_published=False,
-                               machine_state=DefaultStates.INITIAL.value)
+    def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            is_published=False,
+            machine_state=DefaultStates.INITIAL.value,
+        )
         preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()
     def list_url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
+        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
 
     def test_unpublished_not_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json['data']['id'] == preprint_unpublished._id
+        assert res.json["data"]["id"] == preprint_unpublished._id
 
     def test_unpublished_invisible_to_write_contribs(
-            self,
-            app,
-            user_write_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [
-            d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 1
+        assert preprint_unpublished._id not in [d["id"] for d in res.json["data"]]
 
-        res = app.get(
-            detail_url,
-            auth=user_write_contrib.auth,
-            expect_errors=True)
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
 
-class TestReviewsPendingPreprintIsPublishedListMatchesDetail(
-        PreprintListMatchesPreprintDetailMixin):
+class TestReviewsPendingPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
 
     @pytest.fixture()
     def user_admin_contrib(self):
@@ -1195,7 +891,7 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(
 
     @pytest.fixture()
     def provider_one(self):
-        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+        return PreprintProviderFactory(reviews_workflow="pre-moderation")
 
     @pytest.fixture()
     def provider_two(self, provider_one):
@@ -1207,67 +903,49 @@ class TestReviewsPendingPreprintIsPublishedListMatchesDetail(
 
     @pytest.fixture()
     def project_public(self, user_admin_contrib):
-        return ProjectFactory(
-            creator=user_admin_contrib, is_public=True)
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
 
     @pytest.fixture()
-    def preprint_unpublished(
-            self,
-            user_admin_contrib,
-            user_write_contrib,
-            provider_one,
-            project_public,
-            subject):
-        preprint = PreprintFactory(creator=user_admin_contrib,
-                               filename='mgla.pdf',
-                               provider=provider_one,
-                               subjects=[[subject._id]],
-                               project=project_public,
-                               is_published=False,
-                               machine_state=DefaultStates.PENDING.value)
+    def preprint_unpublished(self, user_admin_contrib, user_write_contrib, provider_one, project_public, subject):
+        preprint = PreprintFactory(
+            creator=user_admin_contrib,
+            filename="mgla.pdf",
+            provider=provider_one,
+            subjects=[[subject._id]],
+            project=project_public,
+            is_published=False,
+            machine_state=DefaultStates.PENDING.value,
+        )
         preprint.add_contributor(user_write_contrib, permissions.WRITE, save=True)
         return preprint
 
     @pytest.fixture()
     def list_url(self):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
     @pytest.fixture()
     def detail_url(self, preprint_unpublished):
-        return f'/{API_BASE}preprints/{preprint_unpublished._id}/'
+        return f"/{API_BASE}preprints/{preprint_unpublished._id}/"
 
     def test_unpublished_visible_to_admins(
-            self,
-            app,
-            user_admin_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
         res = app.get(detail_url, auth=user_admin_contrib.auth)
-        assert res.json['data']['id'] == preprint_unpublished._id
+        assert res.json["data"]["id"] == preprint_unpublished._id
 
     def test_unpublished_visible_to_write_contribs(
-            self,
-            app,
-            user_write_contrib,
-            preprint_unpublished,
-            preprint_published,
-            list_url,
-            detail_url):
+        self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url
+    ):
         res = app.get(list_url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+        assert len(res.json["data"]) == 2
+        assert preprint_unpublished._id in [d["id"] for d in res.json["data"]]
 
-        res = app.get(
-            detail_url,
-            auth=user_write_contrib.auth,
-            expect_errors=True)
-        assert res.json['data']['id'] == preprint_unpublished._id
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
+        assert res.json["data"]["id"] == preprint_unpublished._id
 
 
 class TestPreprintIsValidList(PreprintIsValidListMixin):
@@ -1286,7 +964,7 @@ class TestPreprintIsValidList(PreprintIsValidListMixin):
 
     @pytest.fixture()
     def url(self, project):
-        return f'/{API_BASE}preprints/?version=2.2&'
+        return f"/{API_BASE}preprints/?version=2.2&"
 
 
 @pytest.mark.django_db
@@ -1298,38 +976,42 @@ class TestPreprintListWithMetrics:
         with override_switch(features.ELASTICSEARCH_METRICS, active=True):
             yield
 
-    @pytest.mark.parametrize(('metric_name', 'metric_class_name'),
-    [
-        ('downloads', 'PreprintDownload'),
-        ('views', 'PreprintView'),
-    ])
+    @pytest.mark.parametrize(
+        ("metric_name", "metric_class_name"),
+        [
+            ("downloads", "PreprintDownload"),
+            ("views", "PreprintView"),
+        ],
+    )
     def test_preprint_list_with_metrics(self, app, metric_name, metric_class_name):
-        url = f'/{API_BASE}preprints/?metrics[{metric_name}]=total'
+        url = f"/{API_BASE}preprints/?metrics[{metric_name}]=total"
         preprint1 = PreprintFactory()
         preprint1.downloads = 41
         preprint2 = PreprintFactory()
         preprint2.downloads = 42
 
-        with mock.patch(f'api.preprints.views.{metric_class_name}.get_top_by_count') as mock_get_top_by_count:
+        with mock.patch(f"api.preprints.views.{metric_class_name}.get_top_by_count") as mock_get_top_by_count:
             mock_get_top_by_count.return_value = [preprint2, preprint1]
             res = app.get(url)
         assert res.status_code == 200
 
-        preprint_2_data = res.json['data'][0]
-        assert preprint_2_data['meta']['metrics']['downloads'] == 42
+        preprint_2_data = res.json["data"][0]
+        assert preprint_2_data["meta"]["metrics"]["downloads"] == 42
 
-        preprint_1_data = res.json['data'][1]
-        assert preprint_1_data['meta']['metrics']['downloads'] == 41
+        preprint_1_data = res.json["data"][1]
+        assert preprint_1_data["meta"]["metrics"]["downloads"] == 41
 
-    @mock.patch('django.utils.timezone.now')
-    @pytest.mark.parametrize(('query_value', 'timedelta'),
-    [
-        ('daily', dt.timedelta(days=1)),
-        ('weekly', dt.timedelta(days=7)),
-        ('yearly', dt.timedelta(days=365)),
-    ])
+    @mock.patch("django.utils.timezone.now")
+    @pytest.mark.parametrize(
+        ("query_value", "timedelta"),
+        [
+            ("daily", dt.timedelta(days=1)),
+            ("weekly", dt.timedelta(days=7)),
+            ("yearly", dt.timedelta(days=365)),
+        ],
+    )
     def test_preprint_list_filter_metric_by_time_period(self, mock_timezone_now, app, settings, query_value, timedelta):
-        url = f'/{API_BASE}preprints/?metrics[views]={query_value}'
+        url = f"/{API_BASE}preprints/?metrics[views]={query_value}"
         mock_now = dt.datetime.utcnow().replace(tzinfo=timezone.utc)
         mock_timezone_now.return_value = mock_now
 
@@ -1338,10 +1020,10 @@ class TestPreprintListWithMetrics:
         preprint2 = PreprintFactory()
         preprint2.views = 42
 
-        with mock.patch('api.preprints.views.PreprintView.get_top_by_count') as mock_get_top_by_count:
+        with mock.patch("api.preprints.views.PreprintView.get_top_by_count") as mock_get_top_by_count:
             mock_get_top_by_count.return_value = [preprint2, preprint1]
             res = app.get(url)
 
         assert res.status_code == 200
         call_kwargs = mock_get_top_by_count.call_args[1]
-        assert call_kwargs['after'] == mock_now - timedelta
+        assert call_kwargs["after"] == mock_now - timedelta

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa:
-
 from osf.models import Node, Registration
 from framework.auth.core import Auth
 from osf_tests.factories import (
@@ -45,14 +43,14 @@ class RegistrationListFilteringMixin:
                 self.parent_url),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(set(expected), set(actual))
+        assert set(expected) == set(actual)
 
     def test_parent_filter_ne_null(self):
         expected = list(Registration.objects.exclude(parent_nodes=None).values_list('guids___id', flat=True))
         res = self.app.get(self.parent_url_ne,
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(set(expected), set(actual))
+        assert set(expected) == set(actual)
 
     def test_parent_filter_equals_returns_one(self):
         expected = [n._id for n in self.node_B2.get_nodes()]
@@ -62,8 +60,8 @@ class RegistrationListFilteringMixin:
                 self.node_B2._id),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(len(actual), 1)
-        assert_equal(expected, actual)
+        assert len(actual) == 1
+        assert expected == actual
 
     def test_parent_filter_equals_returns_multiple(self):
         expected = [n._id for n in self.node_A.get_nodes()]
@@ -73,8 +71,8 @@ class RegistrationListFilteringMixin:
                 self.node_A._id),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(len(actual), 2)
-        assert_equal(set(expected), set(actual))
+        assert len(actual) == 2
+        assert set(expected) == set(actual)
 
     def test_root_filter_null(self):
         res = self.app.get(
@@ -82,8 +80,8 @@ class RegistrationListFilteringMixin:
                 self.root_url),
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['source']['parameter'], 'filter')
+        assert res.status_code == 400
+        assert res.json['errors'][0]['source']['parameter'] == 'filter'
 
     def test_root_filter_equals_returns_branch(self):
         expected = [n._id for n in Node.objects.get_children(self.node_B2)]
@@ -94,7 +92,7 @@ class RegistrationListFilteringMixin:
                 self.node_B2._id),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(set(expected), set(actual))
+        assert set(expected) == set(actual)
 
     def test_root_filter_equals_returns_tree(self):
         expected = [n._id for n in Node.objects.get_children(self.node_A)]
@@ -105,19 +103,19 @@ class RegistrationListFilteringMixin:
                 self.node_A._id),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(len(actual), 6)
-        assert_equal(set(expected), set(actual))
+        assert len(actual) == 6
+        assert set(expected) == set(actual)
 
     def test_tag_filter(self):
         self.node_A.add_tag('nerd', auth=Auth(self.node_A.creator), save=True)
         expected = [self.node_A._id]
         res = self.app.get(f'{self.tags_url}nerd', auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(expected, actual)
+        assert expected == actual
 
         res = self.app.get(f'{self.tags_url}bird', auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal([], actual)
+        assert [] == actual
 
     def test_contributor_filter(self):
         expected = [self.node_A._id]
@@ -127,4 +125,4 @@ class RegistrationListFilteringMixin:
                 self.user_two._id),
             auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
-        assert_equal(expected, actual)
+        assert expected == actual

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -1,4 +1,3 @@
-from nose.tools import *  # noqa:
 import functools
 
 from framework.auth.core import Auth
@@ -49,10 +48,10 @@ class TestRegistrationEmbeds(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         json = res.json
         embeds = json['data']['embeds']
-        assert_equal(len(embeds['children']['data']), 2)
+        self.assertEqual(len(embeds['children']['data']), 2)
         titles = [self.child1.title, self.child2.title]
         for child in embeds['children']['data']:
-            assert_in(child['attributes']['title'], titles)
+            self.assertIn(child['attributes']['title'], titles)
 
     def test_embed_contributors(self):
         url = '/{}registrations/{}/?embed=contributors'.format(
@@ -63,22 +62,22 @@ class TestRegistrationEmbeds(ApiTestCase):
         ids = [c._id for c in self.contribs] + [self.user._id]
         ids = [f'{self.registration._id}-{id_}' for id_ in ids]
         for contrib in embeds['contributors']['data']:
-            assert_in(contrib['id'], ids)
+            self.assertIn(contrib['id'], ids)
 
     def test_embed_identifiers(self):
         url = '/{}registrations/{}/?embed=identifiers'.format(
             API_BASE, self.registration._id)
 
         res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_embed_attributes_not_relationships(self):
         url = '/{}registrations/{}/?embed=title'.format(
             API_BASE, self.registration._id)
 
         res = self.app.get(url, auth=self.contrib1.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(
+        self.assertEqual(res.status_code, 400)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'The following fields are not embeddable: title'
         )

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -77,5 +77,4 @@ class TestRegistrationEmbeds(ApiTestCase):
 
         res = self.app.get(url, auth=self.contrib1.auth, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == \
-            'The following fields are not embeddable: title'
+        assert res.json['errors'][0]['detail'] == 'The following fields are not embeddable: title'

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -48,10 +48,10 @@ class TestRegistrationEmbeds(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         json = res.json
         embeds = json['data']['embeds']
-        self.assertEqual(len(embeds['children']['data']), 2)
+        assert len(embeds['children']['data']) == 2
         titles = [self.child1.title, self.child2.title]
         for child in embeds['children']['data']:
-            self.assertIn(child['attributes']['title'], titles)
+            assert child['attributes']['title'] in titles
 
     def test_embed_contributors(self):
         url = '/{}registrations/{}/?embed=contributors'.format(
@@ -62,22 +62,20 @@ class TestRegistrationEmbeds(ApiTestCase):
         ids = [c._id for c in self.contribs] + [self.user._id]
         ids = [f'{self.registration._id}-{id_}' for id_ in ids]
         for contrib in embeds['contributors']['data']:
-            self.assertIn(contrib['id'], ids)
+            assert contrib['id'] in ids
 
     def test_embed_identifiers(self):
         url = '/{}registrations/{}/?embed=identifiers'.format(
             API_BASE, self.registration._id)
 
         res = self.app.get(url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
     def test_embed_attributes_not_relationships(self):
         url = '/{}registrations/{}/?embed=title'.format(
             API_BASE, self.registration._id)
 
         res = self.app.get(url, auth=self.contrib1.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == \
             'The following fields are not embeddable: title'
-        )

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-from nose.tools import *  # noqa:
-
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
 from osf_tests.factories import (
@@ -100,10 +98,10 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
     def test_unauthenticated_can_view_public_registration_linked_registrations(
             self):
         res = self.make_request(registration_id=self.public_registration._id)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -112,10 +110,10 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             auth=self.admin_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -125,10 +123,10 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             auth=self.rw_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -138,10 +136,10 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             auth=self.read_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -152,8 +150,8 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             auth=self.non_contributor.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 403)
-        assert_equal(
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'You do not have permission to perform this action.')
 
@@ -163,8 +161,8 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_equal(
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'Authentication credentials were not provided.')
 
@@ -190,10 +188,10 @@ class TestRegistrationsLinkedRegistrationsRelationship(
     def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship(
             self):
         res = self.make_request(registration_id=self.public_registration._id)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
         assert res.json['data'][0]['type'] == 'linked_registrations'
@@ -201,10 +199,10 @@ class TestRegistrationsLinkedRegistrationsRelationship(
     def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship_2_13(
             self):
         res = self.make_request(registration_id=self.public_registration._id, version='2.13')
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
         assert res.json['data'][0]['type'] == 'registrations'
@@ -215,10 +213,10 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.admin_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -228,10 +226,10 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.rw_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -241,10 +239,10 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.read_contributor.auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        assert_in(self.public_linked_registration._id, linked_registration_ids)
-        assert_not_in(
+        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
+        self.assertNotIn(
             self.private_linked_registration._id,
             linked_registration_ids)
 
@@ -255,8 +253,8 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             auth=self.non_contributor.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 403)
-        assert_equal(
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'You do not have permission to perform this action.')
 
@@ -266,8 +264,8 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             expect_errors=True
         )
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'],
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json['errors'][0]['detail'],
                      'Authentication credentials were not provided.')
 
     def test_cannot_create_linked_registrations_relationship(self):
@@ -275,18 +273,18 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_cannot_update_linked_registrations_relationship(self):
         res = self.app.put_json_api(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)
 
     def test_cannot_delete_linked_registrations_relationship(self):
         res = self.app.delete_json_api(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 405)
+        self.assertEqual(res.status_code, 405)

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -101,8 +101,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
 
     def test_admin_can_view_private_registration_linked_registrations(self):
         res = self.make_request(
@@ -112,8 +111,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
 
     def test_rw_contributor_can_view_private_registration_linked_registrations(
             self):
@@ -124,8 +122,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id in \
-            linked_registration_ids
+        assert self.private_linked_registration._id in linked_registration_ids
 
     def test_read_only_contributor_can_view_private_registration_linked_registrations(
             self):
@@ -136,8 +133,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
 
     def test_non_contributor_cannot_view_private_registration_linked_registrations(
             self):
@@ -147,8 +143,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             expect_errors=True
         )
         assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == \
-            'You do not have permission to perform this action.'
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_unauthenticated_cannot_view_private_registration_linked_registrations(
             self):
@@ -157,8 +152,7 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             expect_errors=True
         )
         assert res.status_code == 401
-        assert res.json['errors'][0]['detail'] == \
-            'Authentication credentials were not provided.'
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
 
 class TestRegistrationsLinkedRegistrationsRelationship(
@@ -185,8 +179,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
         assert res.json['data'][0]['type'] == 'linked_registrations'
 
     def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship_2_13(
@@ -195,8 +188,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
         assert res.json['data'][0]['type'] == 'registrations'
 
     def test_private_registration_admin_contributor_can_view_linked_registrations_relationship(
@@ -208,8 +200,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
 
     def test_private_registration_rw_contributor_can_view_linked_registrations_relationship(
             self):
@@ -220,8 +211,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id in \
-            linked_registration_ids
+        assert self.private_linked_registration._id in linked_registration_ids
 
     def test_private_registration_read_contributor_can_view_linked_registrations_relationship(
             self):
@@ -232,8 +222,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
         assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
         assert self.public_linked_registration._id in linked_registration_ids
-        assert self.private_linked_registration._id not in \
-            linked_registration_ids
+        assert self.private_linked_registration._id not in linked_registration_ids
 
     def test_private_registration_non_contributor_cannot_view_linked_registrations_relationship(
             self):
@@ -243,8 +232,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             expect_errors=True
         )
         assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == \
-            'You do not have permission to perform this action.'
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_registration_unauthenticated_user_cannot_view_linked_registrations_relationship(
             self):
@@ -253,8 +241,7 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             expect_errors=True
         )
         assert res.status_code == 401
-        assert res.json['errors'][0]['detail'] == \
-                     'Authentication credentials were not provided.'
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_cannot_create_linked_registrations_relationship(self):
         res = self.app.post_json_api(

--- a/api_tests/registrations/views/test_registration_linked_registrations.py
+++ b/api_tests/registrations/views/test_registration_linked_registrations.py
@@ -98,24 +98,22 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
     def test_unauthenticated_can_view_public_registration_linked_registrations(
             self):
         res = self.make_request(registration_id=self.public_registration._id)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
 
     def test_admin_can_view_private_registration_linked_registrations(self):
         res = self.make_request(
             registration_id=self.private_registration._id,
             auth=self.admin_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
 
     def test_rw_contributor_can_view_private_registration_linked_registrations(
             self):
@@ -123,12 +121,11 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             auth=self.rw_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id in \
+            linked_registration_ids
 
     def test_read_only_contributor_can_view_private_registration_linked_registrations(
             self):
@@ -136,12 +133,11 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             auth=self.read_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
 
     def test_non_contributor_cannot_view_private_registration_linked_registrations(
             self):
@@ -150,10 +146,9 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             auth=self.non_contributor.auth,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == \
+            'You do not have permission to perform this action.'
 
     def test_unauthenticated_cannot_view_private_registration_linked_registrations(
             self):
@@ -161,10 +156,9 @@ class TestRegistrationLinkedRegistrationsList(LinkedRegistrationsTestCase):
             registration_id=self.private_registration._id,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == \
+            'Authentication credentials were not provided.'
 
 
 class TestRegistrationsLinkedRegistrationsRelationship(
@@ -188,23 +182,21 @@ class TestRegistrationsLinkedRegistrationsRelationship(
     def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship(
             self):
         res = self.make_request(registration_id=self.public_registration._id)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
         assert res.json['data'][0]['type'] == 'linked_registrations'
 
     def test_public_registration_unauthenticated_user_can_view_linked_registrations_relationship_2_13(
             self):
         res = self.make_request(registration_id=self.public_registration._id, version='2.13')
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
         assert res.json['data'][0]['type'] == 'registrations'
 
     def test_private_registration_admin_contributor_can_view_linked_registrations_relationship(
@@ -213,12 +205,11 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.admin_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
 
     def test_private_registration_rw_contributor_can_view_linked_registrations_relationship(
             self):
@@ -226,12 +217,11 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.rw_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id in \
+            linked_registration_ids
 
     def test_private_registration_read_contributor_can_view_linked_registrations_relationship(
             self):
@@ -239,12 +229,11 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             auth=self.read_contributor.auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         linked_registration_ids = [r['id'] for r in res.json['data']]
-        self.assertIn(self.public_linked_registration._id, linked_registration_ids)
-        self.assertNotIn(
-            self.private_linked_registration._id,
-            linked_registration_ids)
+        assert self.public_linked_registration._id in linked_registration_ids
+        assert self.private_linked_registration._id not in \
+            linked_registration_ids
 
     def test_private_registration_non_contributor_cannot_view_linked_registrations_relationship(
             self):
@@ -253,10 +242,9 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             auth=self.non_contributor.auth,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == \
+            'You do not have permission to perform this action.'
 
     def test_private_registration_unauthenticated_user_cannot_view_linked_registrations_relationship(
             self):
@@ -264,27 +252,27 @@ class TestRegistrationsLinkedRegistrationsRelationship(
             registration_id=self.private_registration._id,
             expect_errors=True
         )
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.json['errors'][0]['detail'],
-                     'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == \
+                     'Authentication credentials were not provided.'
 
     def test_cannot_create_linked_registrations_relationship(self):
         res = self.app.post_json_api(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_cannot_update_linked_registrations_relationship(self):
         res = self.app.put_json_api(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405
 
     def test_cannot_delete_linked_registrations_relationship(self):
         res = self.app.delete_json_api(
             self.public_url, {},
             auth=self.admin_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 405)
+        assert res.status_code == 405

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -1,7 +1,6 @@
 import dateutil.relativedelta
 from django.utils import timezone
 from unittest import mock
-from nose.tools import *  # noqa:
 import pytest
 
 from future.moves.urllib.parse import urljoin, urlparse
@@ -57,41 +56,41 @@ class TestRegistrationList(ApiTestCase):
 
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.url)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
         url = res.json['data'][0]['relationships']['registered_from']['links']['related']['href']
-        assert_equal(
+        self.assertEqual(
             urlparse(url).path,
             f'/{API_BASE}nodes/{self.public_project._id}/'
         )
 
     def test_return_registrations_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(len(res.json['data']), 2)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
 
         registered_from_one = urlparse(
             res.json['data'][0]['relationships']['registered_from']['links']['related']['href']).path
         registered_from_two = urlparse(
             res.json['data'][1]['relationships']['registered_from']['links']['related']['href']).path
 
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
         assert [registered_from_one, registered_from_two] == [f'/{API_BASE}nodes/{self.public_project._id}/',
              f'/{API_BASE}nodes/{self.project._id}/']
 
     def test_return_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.url, auth=self.user_two.auth)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.status_code, 200)
         registered_from = urlparse(
             res.json['data'][0]['relationships']['registered_from']['links']['related']['href']).path
 
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
-        assert_equal(
+        self.assertEqual(
             registered_from,
             f'/{API_BASE}nodes/{self.public_project._id}/')
 
@@ -106,20 +105,20 @@ class TestRegistrationList(ApiTestCase):
             API_BASE, registration._id)
 
         res = self.app.get(registration_url)
-        assert_true(
+        self.assertTrue(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
         )
-        assert_equal(
+        self.assertEqual(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2
         )
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
         ids = [each['id'] for each in res.json['data']]
-        assert_in(self.registration_project._id, ids)
-        assert_in(self.public_registration_project._id, ids)
-        assert_not_in(self.public_project._id, ids)
-        assert_not_in(self.project._id, ids)
+        self.assertIn(self.registration_project._id, ids)
+        self.assertIn(self.public_registration_project._id, ids)
+        self.assertNotIn(self.public_project._id, ids)
+        self.assertNotIn(self.project._id, ids)
 
 class TestSparseRegistrationList(ApiTestCase):
 
@@ -139,25 +138,25 @@ class TestSparseRegistrationList(ApiTestCase):
 
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.url)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
         assert 'registered_from' not in res.json['data'][0]['relationships']
 
     def test_return_registrations_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        assert_equal(len(res.json['data']), 2)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 2)
+        self.assertEqual(res.status_code, 200)
         assert 'registered_from' not in res.json['data'][0]['relationships']
         assert 'registered_from' not in res.json['data'][1]['relationships']
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
     def test_return_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.url, auth=self.user_two.auth)
-        assert_equal(len(res.json['data']), 1)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(len(res.json['data']), 1)
+        self.assertEqual(res.status_code, 200)
         assert 'registered_from' not in res.json['data'][0]['relationships']
-        assert_equal(res.content_type, 'application/vnd.api+json')
+        self.assertEqual(res.content_type, 'application/vnd.api+json')
 
     def test_total_biographic_contributor_in_registration(self):
         user3 = AuthUserFactory()
@@ -170,20 +169,20 @@ class TestSparseRegistrationList(ApiTestCase):
             API_BASE, registration._id)
 
         res = self.app.get(registration_url)
-        assert_true(
+        self.assertTrue(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
         )
-        assert_equal(
+        self.assertEqual(
             res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2
         )
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
         ids = [each['id'] for each in res.json['data']]
-        assert_in(self.registration_project._id, ids)
-        assert_in(self.public_registration_project._id, ids)
-        assert_not_in(self.public_project._id, ids)
-        assert_not_in(self.project._id, ids)
+        self.assertIn(self.registration_project._id, ids)
+        self.assertIn(self.public_registration_project._id, ids)
+        self.assertNotIn(self.public_project._id, ids)
+        self.assertNotIn(self.project._id, ids)
 
 
 @pytest.mark.enable_bookmark_creation
@@ -247,11 +246,11 @@ class TestRegistrationFiltering(ApiTestCase):
         registration_json = res.json['data']
         ids = [each['id'] for each in registration_json]
 
-        assert_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
     def test_filtering_by_public(self):
         url = f'/{API_BASE}registrations/?filter[public]=false'
@@ -259,29 +258,29 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         # No public projects returned
-        assert_false(
+        self.assertFalse(
             any([each['attributes']['public'] for each in reg_json])
         )
 
         ids = [each['id'] for each in reg_json]
-        assert_not_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
 
         url = f'/{API_BASE}registrations/?filter[public]=true'
         res = self.app.get(url, auth=self.user_one.auth)
         reg_json = res.json['data']
 
         # No private projects returned
-        assert_true(
+        self.assertTrue(
             all([each['attributes']['public'] for each in reg_json])
         )
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
     def test_filtering_tags(self):
 
@@ -292,11 +291,11 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
         # filtering two tags
         # project_one has both tags; project_two only has one
@@ -307,11 +306,11 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
     def test_filtering_tags_exact(self):
         self.project_one.add_tag('cats', Auth(self.user_one))
@@ -327,7 +326,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 1)
+        self.assertEqual(len(res.json.get('data')), 1)
 
     def test_filtering_tags_capitalized_query(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -339,7 +338,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 1)
+        self.assertEqual(len(res.json.get('data')), 1)
 
     def test_filtering_tags_capitalized_tag(self):
         self.project_one.add_tag('CAT', Auth(self.user_one))
@@ -351,7 +350,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 1)
+        self.assertEqual(len(res.json.get('data')), 1)
 
     def test_filtering_on_multiple_tags(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -364,7 +363,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 1)
+        self.assertEqual(len(res.json.get('data')), 1)
 
     def test_filtering_on_multiple_tags_must_match_both(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -376,7 +375,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 0)
+        self.assertEqual(len(res.json.get('data')), 0)
 
     def test_filtering_tags_returns_distinct(self):
         # regression test for returning multiple of the same file
@@ -392,7 +391,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 1)
+        self.assertEqual(len(res.json.get('data')), 1)
 
     def test_filtering_contributors(self):
         res = self.app.get(
@@ -401,7 +400,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 3)
+        self.assertEqual(len(res.json.get('data')), 3)
 
     def test_filtering_contributors_bad_id(self):
         res = self.app.get(
@@ -410,45 +409,45 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        assert_equal(len(res.json.get('data')), 0)
+        self.assertEqual(len(res.json.get('data')), 0)
 
     def test_get_all_registrations_with_no_filter_logged_in(self):
         res = self.app.get(self.url, auth=self.user_one.auth)
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_in(self.project_three_reg._id, ids)
-        assert_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertIn(self.project_three_reg._id, ids)
+        self.assertIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.project_one._id, ids)
-        assert_not_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project_user_one._id, ids)
-        assert_not_in(self.private_project_user_two._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.project_one._id, ids)
+        self.assertNotIn(self.project_two._id, ids)
+        self.assertNotIn(self.project_three._id, ids)
+        self.assertNotIn(self.private_project_user_one._id, ids)
+        self.assertNotIn(self.private_project_user_two._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_all_registrations_with_no_filter_not_logged_in(self):
         res = self.app.get(self.url)
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.project_one._id, ids)
-        assert_not_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project_user_one._id, ids)
-        assert_not_in(self.private_project_user_two._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.project_one._id, ids)
+        self.assertNotIn(self.project_two._id, ids)
+        self.assertNotIn(self.project_three._id, ids)
+        self.assertNotIn(self.private_project_user_one._id, ids)
+        self.assertNotIn(self.private_project_user_two._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_one_registration_with_exact_filter_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project%20One'
@@ -457,14 +456,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_one_registration_with_exact_filter_not_logged_in(self):
         url = '/{}registrations/?filter[title]=Private%20Project%20User%20One'.format(
@@ -474,14 +473,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_not_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertNotIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_some_registrations_with_substring_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Two'
@@ -490,14 +489,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_not_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertNotIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_some_registrations_with_substring_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=One'
@@ -506,14 +505,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_only_public_or_my_registrations_with_filter_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project'
@@ -522,14 +521,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_get_only_public_registrations_with_filter_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project'
@@ -538,14 +537,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_alternate_filtering_field_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[description]=Three'
@@ -554,14 +553,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_not_in(self.project_one_reg._id, ids)
-        assert_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertNotIn(self.project_one_reg._id, ids)
+        self.assertIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_alternate_filtering_field_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[description]=Two'
@@ -570,23 +569,23 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        assert_in(self.project_one_reg._id, ids)
-        assert_not_in(self.project_two_reg._id, ids)
-        assert_not_in(self.project_three_reg._id, ids)
-        assert_not_in(self.private_project_user_one_reg._id, ids)
-        assert_not_in(self.private_project_user_two_reg._id, ids)
+        self.assertIn(self.project_one_reg._id, ids)
+        self.assertNotIn(self.project_two_reg._id, ids)
+        self.assertNotIn(self.project_three_reg._id, ids)
+        self.assertNotIn(self.private_project_user_one_reg._id, ids)
+        self.assertNotIn(self.private_project_user_two_reg._id, ids)
 
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.bookmark_collection._id, ids)
+        self.assertNotIn(self.folder._id, ids)
+        self.assertNotIn(self.bookmark_collection._id, ids)
 
     def test_incorrect_filtering_field_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[notafield]=bogus'
 
         res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 400)
+        self.assertEqual(res.status_code, 400)
         errors = res.json['errors']
-        assert_equal(len(errors), 1)
-        assert_equal(
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(
             errors[0]['detail'],
             "'notafield' is not a valid field for this endpoint.")
 

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -61,8 +61,7 @@ class TestRegistrationList(ApiTestCase):
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
         url = res.json['data'][0]['relationships']['registered_from']['links']['related']['href']
-        assert urlparse(url).path == \
-            f'/{API_BASE}nodes/{self.public_project._id}/'
+        assert urlparse(url).path == f'/{API_BASE}nodes/{self.public_project._id}/'
 
     def test_return_registrations_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.user.auth)
@@ -88,8 +87,7 @@ class TestRegistrationList(ApiTestCase):
 
         assert res.content_type == 'application/vnd.api+json'
 
-        assert registered_from == \
-            f'/{API_BASE}nodes/{self.public_project._id}/'
+        assert registered_from == f'/{API_BASE}nodes/{self.public_project._id}/'
 
     def test_total_biographic_contributor_in_registration(self):
         user3 = AuthUserFactory()
@@ -570,8 +568,7 @@ class TestRegistrationFiltering(ApiTestCase):
         assert res.status_code == 400
         errors = res.json['errors']
         assert len(errors) == 1
-        assert errors[0]['detail'] == \
-            "'notafield' is not a valid field for this endpoint."
+        assert errors[0]['detail'] == "'notafield' is not a valid field for this endpoint."
 
 
 class TestRegistrationSubjectFiltering(SubjectsFilterMixin):

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -56,43 +56,40 @@ class TestRegistrationList(ApiTestCase):
 
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.url)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert len(res.json['data']) == 1
+        assert res.status_code == 200
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
         url = res.json['data'][0]['relationships']['registered_from']['links']['related']['href']
-        self.assertEqual(
-            urlparse(url).path,
+        assert urlparse(url).path == \
             f'/{API_BASE}nodes/{self.public_project._id}/'
-        )
 
     def test_return_registrations_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(len(res.json['data']), 2)
-        self.assertEqual(res.status_code, 200)
+        assert len(res.json['data']) == 2
+        assert res.status_code == 200
 
         registered_from_one = urlparse(
             res.json['data'][0]['relationships']['registered_from']['links']['related']['href']).path
         registered_from_two = urlparse(
             res.json['data'][1]['relationships']['registered_from']['links']['related']['href']).path
 
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.content_type == 'application/vnd.api+json'
 
         assert [registered_from_one, registered_from_two] == [f'/{API_BASE}nodes/{self.public_project._id}/',
              f'/{API_BASE}nodes/{self.project._id}/']
 
     def test_return_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.url, auth=self.user_two.auth)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.status_code, 200)
+        assert len(res.json['data']) == 1
+        assert res.status_code == 200
         registered_from = urlparse(
             res.json['data'][0]['relationships']['registered_from']['links']['related']['href']).path
 
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.content_type == 'application/vnd.api+json'
 
-        self.assertEqual(
-            registered_from,
-            f'/{API_BASE}nodes/{self.public_project._id}/')
+        assert registered_from == \
+            f'/{API_BASE}nodes/{self.public_project._id}/'
 
     def test_total_biographic_contributor_in_registration(self):
         user3 = AuthUserFactory()
@@ -105,20 +102,16 @@ class TestRegistrationList(ApiTestCase):
             API_BASE, registration._id)
 
         res = self.app.get(registration_url)
-        self.assertTrue(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
-        )
-        self.assertEqual(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2
-        )
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'] == 2
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
         ids = [each['id'] for each in res.json['data']]
-        self.assertIn(self.registration_project._id, ids)
-        self.assertIn(self.public_registration_project._id, ids)
-        self.assertNotIn(self.public_project._id, ids)
-        self.assertNotIn(self.project._id, ids)
+        assert self.registration_project._id in ids
+        assert self.public_registration_project._id in ids
+        assert self.public_project._id not in ids
+        assert self.project._id not in ids
 
 class TestSparseRegistrationList(ApiTestCase):
 
@@ -138,25 +131,25 @@ class TestSparseRegistrationList(ApiTestCase):
 
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.url)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert len(res.json['data']) == 1
+        assert res.status_code == 200
+        assert res.content_type == 'application/vnd.api+json'
         assert 'registered_from' not in res.json['data'][0]['relationships']
 
     def test_return_registrations_logged_in_contributor(self):
         res = self.app.get(self.url, auth=self.user.auth)
-        self.assertEqual(len(res.json['data']), 2)
-        self.assertEqual(res.status_code, 200)
+        assert len(res.json['data']) == 2
+        assert res.status_code == 200
         assert 'registered_from' not in res.json['data'][0]['relationships']
         assert 'registered_from' not in res.json['data'][1]['relationships']
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_return_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.url, auth=self.user_two.auth)
-        self.assertEqual(len(res.json['data']), 1)
-        self.assertEqual(res.status_code, 200)
+        assert len(res.json['data']) == 1
+        assert res.status_code == 200
         assert 'registered_from' not in res.json['data'][0]['relationships']
-        self.assertEqual(res.content_type, 'application/vnd.api+json')
+        assert res.content_type == 'application/vnd.api+json'
 
     def test_total_biographic_contributor_in_registration(self):
         user3 = AuthUserFactory()
@@ -169,20 +162,16 @@ class TestSparseRegistrationList(ApiTestCase):
             API_BASE, registration._id)
 
         res = self.app.get(registration_url)
-        self.assertTrue(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
-        )
-        self.assertEqual(
-            res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2
-        )
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic']
+        assert res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'] == 2
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
         ids = [each['id'] for each in res.json['data']]
-        self.assertIn(self.registration_project._id, ids)
-        self.assertIn(self.public_registration_project._id, ids)
-        self.assertNotIn(self.public_project._id, ids)
-        self.assertNotIn(self.project._id, ids)
+        assert self.registration_project._id in ids
+        assert self.public_registration_project._id in ids
+        assert self.public_project._id not in ids
+        assert self.project._id not in ids
 
 
 @pytest.mark.enable_bookmark_creation
@@ -246,11 +235,11 @@ class TestRegistrationFiltering(ApiTestCase):
         registration_json = res.json['data']
         ids = [each['id'] for each in registration_json]
 
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
     def test_filtering_by_public(self):
         url = f'/{API_BASE}registrations/?filter[public]=false'
@@ -258,29 +247,25 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         # No public projects returned
-        self.assertFalse(
-            any([each['attributes']['public'] for each in reg_json])
-        )
+        assert not any([each['attributes']['public'] for each in reg_json])
 
         ids = [each['id'] for each in reg_json]
-        self.assertNotIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
+        assert self.project_one_reg._id not in ids
+        assert self.project_two_reg._id not in ids
 
         url = f'/{API_BASE}registrations/?filter[public]=true'
         res = self.app.get(url, auth=self.user_one.auth)
         reg_json = res.json['data']
 
         # No private projects returned
-        self.assertTrue(
-            all([each['attributes']['public'] for each in reg_json])
-        )
+        assert all([each['attributes']['public'] for each in reg_json])
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
     def test_filtering_tags(self):
 
@@ -291,11 +276,11 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
         # filtering two tags
         # project_one has both tags; project_two only has one
@@ -306,11 +291,11 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
     def test_filtering_tags_exact(self):
         self.project_one.add_tag('cats', Auth(self.user_one))
@@ -326,7 +311,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 1)
+        assert len(res.json.get('data')) == 1
 
     def test_filtering_tags_capitalized_query(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -338,7 +323,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 1)
+        assert len(res.json.get('data')) == 1
 
     def test_filtering_tags_capitalized_tag(self):
         self.project_one.add_tag('CAT', Auth(self.user_one))
@@ -350,7 +335,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 1)
+        assert len(res.json.get('data')) == 1
 
     def test_filtering_on_multiple_tags(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -363,7 +348,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 1)
+        assert len(res.json.get('data')) == 1
 
     def test_filtering_on_multiple_tags_must_match_both(self):
         self.project_one.add_tag('cat', Auth(self.user_one))
@@ -375,7 +360,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 0)
+        assert len(res.json.get('data')) == 0
 
     def test_filtering_tags_returns_distinct(self):
         # regression test for returning multiple of the same file
@@ -391,7 +376,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 1)
+        assert len(res.json.get('data')) == 1
 
     def test_filtering_contributors(self):
         res = self.app.get(
@@ -400,7 +385,7 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 3)
+        assert len(res.json.get('data')) == 3
 
     def test_filtering_contributors_bad_id(self):
         res = self.app.get(
@@ -409,45 +394,45 @@ class TestRegistrationFiltering(ApiTestCase):
             ),
             auth=self.user_one.auth
         )
-        self.assertEqual(len(res.json.get('data')), 0)
+        assert len(res.json.get('data')) == 0
 
     def test_get_all_registrations_with_no_filter_logged_in(self):
         res = self.app.get(self.url, auth=self.user_one.auth)
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertIn(self.project_three_reg._id, ids)
-        self.assertIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id in ids
+        assert self.private_project_user_one_reg._id in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.project_one._id, ids)
-        self.assertNotIn(self.project_two._id, ids)
-        self.assertNotIn(self.project_three._id, ids)
-        self.assertNotIn(self.private_project_user_one._id, ids)
-        self.assertNotIn(self.private_project_user_two._id, ids)
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.project_one._id not in ids
+        assert self.project_two._id not in ids
+        assert self.project_three._id not in ids
+        assert self.private_project_user_one._id not in ids
+        assert self.private_project_user_two._id not in ids
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_all_registrations_with_no_filter_not_logged_in(self):
         res = self.app.get(self.url)
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.project_one._id, ids)
-        self.assertNotIn(self.project_two._id, ids)
-        self.assertNotIn(self.project_three._id, ids)
-        self.assertNotIn(self.private_project_user_one._id, ids)
-        self.assertNotIn(self.private_project_user_two._id, ids)
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.project_one._id not in ids
+        assert self.project_two._id not in ids
+        assert self.project_three._id not in ids
+        assert self.private_project_user_one._id not in ids
+        assert self.private_project_user_two._id not in ids
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_one_registration_with_exact_filter_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project%20One'
@@ -456,14 +441,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_one_registration_with_exact_filter_not_logged_in(self):
         url = '/{}registrations/?filter[title]=Private%20Project%20User%20One'.format(
@@ -473,14 +458,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertNotIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id not in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_some_registrations_with_substring_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Two'
@@ -489,14 +474,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertNotIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id not in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_some_registrations_with_substring_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=One'
@@ -505,14 +490,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_only_public_or_my_registrations_with_filter_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project'
@@ -521,14 +506,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_get_only_public_registrations_with_filter_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[title]=Project'
@@ -537,14 +522,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_alternate_filtering_field_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[description]=Three'
@@ -553,14 +538,14 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertNotIn(self.project_one_reg._id, ids)
-        self.assertIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id not in ids
+        assert self.project_two_reg._id in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_alternate_filtering_field_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[description]=Two'
@@ -569,25 +554,24 @@ class TestRegistrationFiltering(ApiTestCase):
         reg_json = res.json['data']
 
         ids = [each['id'] for each in reg_json]
-        self.assertIn(self.project_one_reg._id, ids)
-        self.assertNotIn(self.project_two_reg._id, ids)
-        self.assertNotIn(self.project_three_reg._id, ids)
-        self.assertNotIn(self.private_project_user_one_reg._id, ids)
-        self.assertNotIn(self.private_project_user_two_reg._id, ids)
+        assert self.project_one_reg._id in ids
+        assert self.project_two_reg._id not in ids
+        assert self.project_three_reg._id not in ids
+        assert self.private_project_user_one_reg._id not in ids
+        assert self.private_project_user_two_reg._id not in ids
 
-        self.assertNotIn(self.folder._id, ids)
-        self.assertNotIn(self.bookmark_collection._id, ids)
+        assert self.folder._id not in ids
+        assert self.bookmark_collection._id not in ids
 
     def test_incorrect_filtering_field_not_logged_in(self):
         url = f'/{API_BASE}registrations/?filter[notafield]=bogus'
 
         res = self.app.get(url, expect_errors=True)
-        self.assertEqual(res.status_code, 400)
+        assert res.status_code == 400
         errors = res.json['errors']
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(
-            errors[0]['detail'],
-            "'notafield' is not a valid field for this endpoint.")
+        assert len(errors) == 1
+        assert errors[0]['detail'] == \
+            "'notafield' is not a valid field for this endpoint."
 
 
 class TestRegistrationSubjectFiltering(SubjectsFilterMixin):

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -1,5 +1,4 @@
 import abc
-from nose.tools import *  # noqa:
 import re
 import pytest
 
@@ -22,24 +21,19 @@ from addons.zotero.tests.factories import ZoteroAccountFactory
 
 class UserAddonListMixin:
     def set_setting_list_url(self):
-        self.setting_list_url = '/{}users/{}/addons/'.format(
-            API_BASE, self.user._id
-        )
+        self.setting_list_url = "/{}users/{}/addons/".format(API_BASE, self.user._id)
 
     def test_settings_list_GET_returns_user_settings_if_present(self):
         wrong_type = self.should_expect_errors()
-        res = self.app.get(
-            self.setting_list_url,
-            auth=self.user.auth)
+        res = self.app.get(self.setting_list_url, auth=self.user.auth)
 
         if not wrong_type:
-            addon_data = res.json['data'][0]
-            assert_true(addon_data['attributes']['user_has_auth'])
-            assert_in(
-                self.node._id, addon_data['links']['accounts'][self.account_id]['nodes_connected'][0])
+            addon_data = res.json["data"][0]
+            assert addon_data["attributes"]["user_has_auth"] is True
+            assert self.node._id in addon_data["links"]["accounts"][self.account_id]["nodes_connected"][0]
         if wrong_type:
-            assert_equal(res.status_code, 200)
-            assert_equal(res.json['data'], [])
+            assert res.status_code == 200
+            assert res.json["data"] == []
 
     def test_settings_list_GET_returns_none_if_absent(self):
         try:
@@ -49,79 +43,57 @@ class UserAddonListMixin:
         except ValueError:
             # If addon was mandatory -- OSFStorage
             pass
-        res = self.app.get(
-            self.setting_list_url,
-            auth=self.user.auth)
+        res = self.app.get(self.setting_list_url, auth=self.user.auth)
 
-        addon_data = res.json['data']
-        assert_equal(addon_data, [])
+        addon_data = res.json["data"]
+        assert addon_data == []
 
     def test_settings_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
             self.setting_list_url,
-            {
-                'id': self.short_name,
-                'type': 'user-addons'
-            },
+            {"id": self.short_name, "type": "user-addons"},
             auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.setting_list_url,
-            {
-                'id': self.short_name,
-                'type': 'user-addons'
-            },
+            {"id": self.short_name, "type": "user-addons"},
             auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_DELETE(self):
-        res = self.app.delete(
-            self.setting_list_url,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.delete(self.setting_list_url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == 405
 
     def test_settings_list_raises_error_if_nonauthenticated(self):
-        res = self.app.get(
-            self.setting_list_url,
-            expect_errors=True)
-        assert_equal(res.status_code, 401)
+        res = self.app.get(self.setting_list_url, expect_errors=True)
+        assert res.status_code == 401
 
     def test_settings_list_user_cannot_view_other_user(self):
         other_user = AuthUserFactory()
-        res = self.app.get(
-            self.setting_list_url,
-            auth=other_user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.get(self.setting_list_url, auth=other_user.auth, expect_errors=True)
+        assert res.status_code == 403
 
 
 class UserAddonDetailMixin:
     def set_setting_detail_url(self):
-        self.setting_detail_url = '/{}users/{}/addons/{}/'.format(
-            API_BASE, self.user._id, self.short_name
-        )
+        self.setting_detail_url = "/{}users/{}/addons/{}/".format(API_BASE, self.user._id, self.short_name)
 
     def test_settings_detail_GET_returns_user_settings_if_present(self):
         wrong_type = self.should_expect_errors()
-        res = self.app.get(
-            self.setting_detail_url,
-            auth=self.user.auth,
-            expect_errors=wrong_type)
+        res = self.app.get(self.setting_detail_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json['data']
-            assert_true(addon_data['attributes']['user_has_auth'])
-            assert_in(
-                self.node._id,
-                addon_data['links']['accounts'][self.account_id]['nodes_connected'][0]
-            )
+            addon_data = res.json["data"]
+            assert addon_data["attributes"]["user_has_auth"] is True
+            assert self.node._id in addon_data["links"]["accounts"][self.account_id]["nodes_connected"][0]
         if wrong_type:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_settings_detail_GET_raises_error_if_absent(self):
         wrong_type = self.should_expect_errors()
@@ -132,87 +104,63 @@ class UserAddonDetailMixin:
         except ValueError:
             # If addon was mandatory -- OSFStorage
             pass
-        res = self.app.get(
-            self.setting_detail_url,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.get(self.setting_detail_url, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         if not wrong_type:
-            assert_in(
-                'Requested addon not enabled',
-                res.json['errors'][0]['detail'])
+            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
         if wrong_type:
-            assert re.match(
-                r'Requested addon un(available|recognized)',
-                (res.json['errors'][0]['detail']))
+            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
 
     def test_settings_detail_raises_error_if_PUT(self):
-        res = self.app.put_json_api(self.setting_detail_url, {
-            'id': self.short_name,
-            'type': 'user-addon-detail'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.put_json_api(
+            self.setting_detail_url,
+            {"id": self.short_name, "type": "user-addon-detail"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_settings_detail_raises_error_if_PATCH(self):
-        res = self.app.patch_json_api(self.setting_detail_url, {
-            'id': self.short_name,
-            'type': 'user-addon-detail'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.patch_json_api(
+            self.setting_detail_url,
+            {"id": self.short_name, "type": "user-addon-detail"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_settings_detail_raises_error_if_DELETE(self):
-        res = self.app.delete(
-            self.setting_detail_url,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.delete(self.setting_detail_url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == 405
 
     def test_settings_detail_raises_error_if_nonauthenticated(self):
-        res = self.app.get(
-            self.setting_detail_url,
-            expect_errors=True)
+        res = self.app.get(self.setting_detail_url, expect_errors=True)
 
-        assert_equal(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_settings_detail_user_cannot_view_other_user(self):
         other_user = AuthUserFactory()
-        res = self.app.get(
-            self.setting_detail_url,
-            auth=other_user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.get(self.setting_detail_url, auth=other_user.auth, expect_errors=True)
+        assert res.status_code == 403
 
 
 class UserAddonAccountListMixin:
     def set_account_list_url(self):
-        self.account_list_url = '/{}users/{}/addons/{}/accounts/'.format(
-            API_BASE, self.user._id, self.short_name
-        )
+        self.account_list_url = "/{}users/{}/addons/{}/accounts/".format(API_BASE, self.user._id, self.short_name)
 
     def test_account_list_GET_returns_accounts_if_present(self):
         wrong_type = self.should_expect_errors()
-        res = self.app.get(
-            self.account_list_url,
-            auth=self.user.auth,
-            expect_errors=wrong_type)
+        res = self.app.get(self.account_list_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json['data'][0]
-            assert_equal(addon_data['id'], self.account._id)
-            assert_equal(
-                addon_data['attributes']['display_name'],
-                self.account.display_name)
-            assert_equal(
-                addon_data['attributes']['provider'],
-                self.account.provider)
-            assert_equal(
-                addon_data['attributes']['profile_url'],
-                self.account.profile_url)
+            addon_data = res.json["data"][0]
+            assert addon_data["id"] == self.account._id
+            assert addon_data["attributes"]["display_name"] == self.account.display_name
+            assert addon_data["attributes"]["provider"] == self.account.provider
+            assert addon_data["attributes"]["profile_url"] == self.account.profile_url
         if wrong_type:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_account_list_raises_error_if_absent(self):
         wrong_type = self.should_expect_errors()
@@ -223,87 +171,65 @@ class UserAddonAccountListMixin:
         except ValueError:
             # If addon was mandatory -- OSFStorage
             pass
-        res = self.app.get(
-            self.account_list_url,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.get(self.account_list_url, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         if not wrong_type:
-            assert_in(
-                'Requested addon not enabled',
-                res.json['errors'][0]['detail'])
+            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
         if wrong_type:
-            assert re.match(
-                r'Requested addon un(available|recognized)',
-                (res.json['errors'][0]['detail']))
+            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
 
     def test_account_list_raises_error_if_PUT(self):
-        res = self.app.put_json_api(self.account_list_url, {
-            'id': self.short_name,
-            'type': 'user-external_accounts'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.put_json_api(
+            self.account_list_url,
+            {"id": self.short_name, "type": "user-external_accounts"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_account_list_raises_error_if_PATCH(self):
-        res = self.app.patch_json_api(self.account_list_url, {
-            'id': self.short_name,
-            'type': 'user-external_accounts'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.patch_json_api(
+            self.account_list_url,
+            {"id": self.short_name, "type": "user-external_accounts"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_account_list_raises_error_if_DELETE(self):
-        res = self.app.delete(
-            self.account_list_url,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.delete(self.account_list_url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == 405
 
     def test_account_list_raises_error_if_nonauthenticated(self):
-        res = self.app.get(
-            self.account_list_url,
-            expect_errors=True)
+        res = self.app.get(self.account_list_url, expect_errors=True)
 
-        assert_equal(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_account_list_user_cannot_view_other_user(self):
         other_user = AuthUserFactory()
-        res = self.app.get(
-            self.account_list_url,
-            auth=other_user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.get(self.account_list_url, auth=other_user.auth, expect_errors=True)
+        assert res.status_code == 403
 
 
 class UserAddonAccountDetailMixin:
     def set_account_detail_url(self):
-        self.account_detail_url = '/{}users/{}/addons/{}/accounts/{}/'.format(
+        self.account_detail_url = "/{}users/{}/addons/{}/accounts/{}/".format(
             API_BASE, self.user._id, self.short_name, self.account_id
         )
 
     def test_account_detail_GET_returns_account_if_enabled(self):
         wrong_type = self.should_expect_errors()
-        res = self.app.get(
-            self.account_detail_url,
-            auth=self.user.auth,
-            expect_errors=wrong_type)
+        res = self.app.get(self.account_detail_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json['data']
-            assert_equal(addon_data['id'], self.account._id)
-            assert_equal(
-                addon_data['attributes']['display_name'],
-                self.account.display_name)
-            assert_equal(
-                addon_data['attributes']['provider'],
-                self.account.provider)
-            assert_equal(
-                addon_data['attributes']['profile_url'],
-                self.account.profile_url)
+            addon_data = res.json["data"]
+            assert addon_data["id"] == self.account._id
+            assert addon_data["attributes"]["display_name"] == self.account.display_name
+            assert addon_data["attributes"]["provider"] == self.account.provider
+            assert addon_data["attributes"]["profile_url"] == self.account.profile_url
         if wrong_type:
-            assert_equal(res.status_code, 404)
+            assert res.status_code == 404
 
     def test_account_detail_raises_error_if_not_found(self):
         wrong_type = self.should_expect_errors()
@@ -314,77 +240,62 @@ class UserAddonAccountDetailMixin:
         except ValueError:
             # If addon was mandatory -- OSFStorage
             pass
-        res = self.app.get(
-            self.account_detail_url,
-            auth=self.user.auth,
-            expect_errors=True)
+        res = self.app.get(self.account_detail_url, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 404)
+        assert res.status_code == 404
         if not wrong_type:
-            assert_in(
-                'Requested addon not enabled',
-                res.json['errors'][0]['detail'])
+            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
         if wrong_type:
-            assert re.match(
-                r'Requested addon un(available|recognized)',
-                (res.json['errors'][0]['detail']))
+            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
 
     def test_account_detail_raises_error_if_PUT(self):
-        res = self.app.put_json_api(self.account_detail_url, {
-            'id': self.short_name,
-            'type': 'user-external_account-detail'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.put_json_api(
+            self.account_detail_url,
+            {"id": self.short_name, "type": "user-external_account-detail"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_account_detail_raises_error_if_PATCH(self):
-        res = self.app.patch_json_api(self.account_detail_url, {
-            'id': self.short_name,
-            'type': 'user-external_account-detail'
-        }, auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.patch_json_api(
+            self.account_detail_url,
+            {"id": self.short_name, "type": "user-external_account-detail"},
+            auth=self.user.auth,
+            expect_errors=True,
+        )
+        assert res.status_code == 405
 
     def test_account_detail_raises_error_if_DELETE(self):
-        res = self.app.delete(
-            self.account_detail_url,
-            auth=self.user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 405)
+        res = self.app.delete(self.account_detail_url, auth=self.user.auth, expect_errors=True)
+        assert res.status_code == 405
 
     def test_account_detail_raises_error_if_nonauthenticated(self):
-        res = self.app.get(
-            self.account_detail_url,
-            expect_errors=True)
+        res = self.app.get(self.account_detail_url, expect_errors=True)
 
-        assert_equal(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_account_detail_user_cannot_view_other_user(self):
         other_user = AuthUserFactory()
-        res = self.app.get(
-            self.account_detail_url,
-            auth=other_user.auth,
-            expect_errors=True)
-        assert_equal(res.status_code, 403)
+        res = self.app.get(self.account_detail_url, auth=other_user.auth, expect_errors=True)
+        assert res.status_code == 403
 
 
 class UserAddonTestSuiteMixin(
-        UserAddonListMixin,
-        UserAddonDetailMixin,
-        UserAddonAccountListMixin,
-        UserAddonAccountDetailMixin):
+    UserAddonListMixin, UserAddonDetailMixin, UserAddonAccountListMixin, UserAddonAccountDetailMixin
+):
     def set_urls(self):
         self.set_setting_list_url()
         self.set_setting_detail_url()
         self.set_account_list_url()
         self.set_account_detail_url()
 
-    def should_expect_errors(self, success_types=('OAUTH', )):
+    def should_expect_errors(self, success_types=("OAUTH",)):
         return self.addon_type not in success_types
 
 
 class UserOAuthAddonTestSuiteMixin(UserAddonTestSuiteMixin):
-    addon_type = 'OAUTH'
+    addon_type = "OAUTH"
 
     @property
     @abc.abstractmethod
@@ -393,92 +304,87 @@ class UserOAuthAddonTestSuiteMixin(UserAddonTestSuiteMixin):
 
 
 class UserUnmanageableAddonTestSuiteMixin(UserAddonTestSuiteMixin):
-    addon_type = 'UNMANAGEABLE'
+    addon_type = "UNMANAGEABLE"
+
 
 # UNMANAGEABLE
 
 
-class TestUserForwardAddon(
-        UserUnmanageableAddonTestSuiteMixin,
-        ApiAddonTestCase):
-    short_name = 'forward'
+class TestUserForwardAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
+    short_name = "forward"
 
 
-class TestUserOsfStorageAddon(
-        UserUnmanageableAddonTestSuiteMixin,
-        ApiAddonTestCase):
-    short_name = 'osfstorage'
+class TestUserOsfStorageAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
+    short_name = "osfstorage"
 
 
-class TestUserTwoFactorAddon(
-        UserUnmanageableAddonTestSuiteMixin,
-        ApiAddonTestCase):
-    short_name = 'twofactor'
+class TestUserTwoFactorAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
+    short_name = "twofactor"
 
 
 class TestUserWikiAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'wiki'
+    short_name = "wiki"
 
 
 # OAUTH
 
 
 class TestUserBitbucketAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'bitbucket'
+    short_name = "bitbucket"
     AccountFactory = BitbucketAccountFactory
 
 
 class TestUserBoxAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'box'
+    short_name = "box"
     AccountFactory = BoxAccountFactory
 
 
 class TestUserDataverseAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'dataverse'
+    short_name = "dataverse"
     AccountFactory = DataverseAccountFactory
 
 
 class TestUserDropboxAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'dropbox'
+    short_name = "dropbox"
     AccountFactory = DropboxAccountFactory
 
 
 class TestUserGitHubAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'github'
+    short_name = "github"
     AccountFactory = GitHubAccountFactory
 
 
 class TestUserGoogleDriveAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'googledrive'
+    short_name = "googledrive"
     AccountFactory = GoogleDriveAccountFactory
 
 
 class TestUserMendeleyAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'mendeley'
+    short_name = "mendeley"
     AccountFactory = MendeleyAccountFactory
 
 
 class TestUserS3Addon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 's3'
+    short_name = "s3"
     AccountFactory = S3AccountFactory
 
 
 class TestUserZoteroAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'zotero'
+    short_name = "zotero"
     AccountFactory = ZoteroAccountFactory
 
 
 class TestUserOwnCloudAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'owncloud'
+    short_name = "owncloud"
     AccountFactory = OwnCloudAccountFactory
 
 
-@pytest.mark.skip('Unskip when figshare v2 addon is ported')
+@pytest.mark.skip("Unskip when figshare v2 addon is ported")
 class TestUserFigshareAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'figshare'
+    short_name = "figshare"
     # AccountFactory = FigshareAccountFactory
 
 
 class TestUserInvalidAddon(UserAddonTestSuiteMixin, ApiAddonTestCase):
-    addon_type = 'INVALID'
-    short_name = 'fake'
+    addon_type = "INVALID"
+    short_name = "fake"

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -21,19 +21,19 @@ from addons.zotero.tests.factories import ZoteroAccountFactory
 
 class UserAddonListMixin:
     def set_setting_list_url(self):
-        self.setting_list_url = "/{}users/{}/addons/".format(API_BASE, self.user._id)
+        self.setting_list_url = '/{}users/{}/addons/'.format(API_BASE, self.user._id)
 
     def test_settings_list_GET_returns_user_settings_if_present(self):
         wrong_type = self.should_expect_errors()
         res = self.app.get(self.setting_list_url, auth=self.user.auth)
 
         if not wrong_type:
-            addon_data = res.json["data"][0]
-            assert addon_data["attributes"]["user_has_auth"] is True
-            assert self.node._id in addon_data["links"]["accounts"][self.account_id]["nodes_connected"][0]
+            addon_data = res.json['data'][0]
+            assert addon_data['attributes']['user_has_auth'] is True
+            assert self.node._id in addon_data['links']['accounts'][self.account_id]['nodes_connected'][0]
         if wrong_type:
             assert res.status_code == 200
-            assert res.json["data"] == []
+            assert res.json['data'] == []
 
     def test_settings_list_GET_returns_none_if_absent(self):
         try:
@@ -45,13 +45,13 @@ class UserAddonListMixin:
             pass
         res = self.app.get(self.setting_list_url, auth=self.user.auth)
 
-        addon_data = res.json["data"]
+        addon_data = res.json['data']
         assert addon_data == []
 
     def test_settings_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
             self.setting_list_url,
-            {"id": self.short_name, "type": "user-addons"},
+            {'id': self.short_name, 'type': 'user-addons'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -60,7 +60,7 @@ class UserAddonListMixin:
     def test_settings_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.setting_list_url,
-            {"id": self.short_name, "type": "user-addons"},
+            {'id': self.short_name, 'type': 'user-addons'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -82,16 +82,16 @@ class UserAddonListMixin:
 
 class UserAddonDetailMixin:
     def set_setting_detail_url(self):
-        self.setting_detail_url = "/{}users/{}/addons/{}/".format(API_BASE, self.user._id, self.short_name)
+        self.setting_detail_url = '/{}users/{}/addons/{}/'.format(API_BASE, self.user._id, self.short_name)
 
     def test_settings_detail_GET_returns_user_settings_if_present(self):
         wrong_type = self.should_expect_errors()
         res = self.app.get(self.setting_detail_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json["data"]
-            assert addon_data["attributes"]["user_has_auth"] is True
-            assert self.node._id in addon_data["links"]["accounts"][self.account_id]["nodes_connected"][0]
+            addon_data = res.json['data']
+            assert addon_data['attributes']['user_has_auth'] is True
+            assert self.node._id in addon_data['links']['accounts'][self.account_id]['nodes_connected'][0]
         if wrong_type:
             assert res.status_code == 404
 
@@ -108,14 +108,14 @@ class UserAddonDetailMixin:
 
         assert res.status_code == 404
         if not wrong_type:
-            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
+            assert 'Requested addon not enabled' in res.json['errors'][0]['detail']
         if wrong_type:
-            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_settings_detail_raises_error_if_PUT(self):
         res = self.app.put_json_api(
             self.setting_detail_url,
-            {"id": self.short_name, "type": "user-addon-detail"},
+            {'id': self.short_name, 'type': 'user-addon-detail'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -124,7 +124,7 @@ class UserAddonDetailMixin:
     def test_settings_detail_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.setting_detail_url,
-            {"id": self.short_name, "type": "user-addon-detail"},
+            {'id': self.short_name, 'type': 'user-addon-detail'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -147,18 +147,18 @@ class UserAddonDetailMixin:
 
 class UserAddonAccountListMixin:
     def set_account_list_url(self):
-        self.account_list_url = "/{}users/{}/addons/{}/accounts/".format(API_BASE, self.user._id, self.short_name)
+        self.account_list_url = '/{}users/{}/addons/{}/accounts/'.format(API_BASE, self.user._id, self.short_name)
 
     def test_account_list_GET_returns_accounts_if_present(self):
         wrong_type = self.should_expect_errors()
         res = self.app.get(self.account_list_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json["data"][0]
-            assert addon_data["id"] == self.account._id
-            assert addon_data["attributes"]["display_name"] == self.account.display_name
-            assert addon_data["attributes"]["provider"] == self.account.provider
-            assert addon_data["attributes"]["profile_url"] == self.account.profile_url
+            addon_data = res.json['data'][0]
+            assert addon_data['id'] == self.account._id
+            assert addon_data['attributes']['display_name'] == self.account.display_name
+            assert addon_data['attributes']['provider'] == self.account.provider
+            assert addon_data['attributes']['profile_url'] == self.account.profile_url
         if wrong_type:
             assert res.status_code == 404
 
@@ -175,14 +175,14 @@ class UserAddonAccountListMixin:
 
         assert res.status_code == 404
         if not wrong_type:
-            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
+            assert 'Requested addon not enabled' in res.json['errors'][0]['detail']
         if wrong_type:
-            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_account_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(
             self.account_list_url,
-            {"id": self.short_name, "type": "user-external_accounts"},
+            {'id': self.short_name, 'type': 'user-external_accounts'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -191,7 +191,7 @@ class UserAddonAccountListMixin:
     def test_account_list_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.account_list_url,
-            {"id": self.short_name, "type": "user-external_accounts"},
+            {'id': self.short_name, 'type': 'user-external_accounts'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -214,7 +214,7 @@ class UserAddonAccountListMixin:
 
 class UserAddonAccountDetailMixin:
     def set_account_detail_url(self):
-        self.account_detail_url = "/{}users/{}/addons/{}/accounts/{}/".format(
+        self.account_detail_url = '/{}users/{}/addons/{}/accounts/{}/'.format(
             API_BASE, self.user._id, self.short_name, self.account_id
         )
 
@@ -223,11 +223,11 @@ class UserAddonAccountDetailMixin:
         res = self.app.get(self.account_detail_url, auth=self.user.auth, expect_errors=wrong_type)
 
         if not wrong_type:
-            addon_data = res.json["data"]
-            assert addon_data["id"] == self.account._id
-            assert addon_data["attributes"]["display_name"] == self.account.display_name
-            assert addon_data["attributes"]["provider"] == self.account.provider
-            assert addon_data["attributes"]["profile_url"] == self.account.profile_url
+            addon_data = res.json['data']
+            assert addon_data['id'] == self.account._id
+            assert addon_data['attributes']['display_name'] == self.account.display_name
+            assert addon_data['attributes']['provider'] == self.account.provider
+            assert addon_data['attributes']['profile_url'] == self.account.profile_url
         if wrong_type:
             assert res.status_code == 404
 
@@ -244,14 +244,14 @@ class UserAddonAccountDetailMixin:
 
         assert res.status_code == 404
         if not wrong_type:
-            assert "Requested addon not enabled" in res.json["errors"][0]["detail"]
+            assert 'Requested addon not enabled' in res.json['errors'][0]['detail']
         if wrong_type:
-            assert re.match(r"Requested addon un(available|recognized)", (res.json["errors"][0]["detail"]))
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_account_detail_raises_error_if_PUT(self):
         res = self.app.put_json_api(
             self.account_detail_url,
-            {"id": self.short_name, "type": "user-external_account-detail"},
+            {'id': self.short_name, 'type': 'user-external_account-detail'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -260,7 +260,7 @@ class UserAddonAccountDetailMixin:
     def test_account_detail_raises_error_if_PATCH(self):
         res = self.app.patch_json_api(
             self.account_detail_url,
-            {"id": self.short_name, "type": "user-external_account-detail"},
+            {'id': self.short_name, 'type': 'user-external_account-detail'},
             auth=self.user.auth,
             expect_errors=True,
         )
@@ -290,12 +290,12 @@ class UserAddonTestSuiteMixin(
         self.set_account_list_url()
         self.set_account_detail_url()
 
-    def should_expect_errors(self, success_types=("OAUTH",)):
+    def should_expect_errors(self, success_types=('OAUTH',)):
         return self.addon_type not in success_types
 
 
 class UserOAuthAddonTestSuiteMixin(UserAddonTestSuiteMixin):
-    addon_type = "OAUTH"
+    addon_type = 'OAUTH'
 
     @property
     @abc.abstractmethod
@@ -304,87 +304,87 @@ class UserOAuthAddonTestSuiteMixin(UserAddonTestSuiteMixin):
 
 
 class UserUnmanageableAddonTestSuiteMixin(UserAddonTestSuiteMixin):
-    addon_type = "UNMANAGEABLE"
+    addon_type = 'UNMANAGEABLE'
 
 
 # UNMANAGEABLE
 
 
 class TestUserForwardAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "forward"
+    short_name = 'forward'
 
 
 class TestUserOsfStorageAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "osfstorage"
+    short_name = 'osfstorage'
 
 
 class TestUserTwoFactorAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "twofactor"
+    short_name = 'twofactor'
 
 
 class TestUserWikiAddon(UserUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "wiki"
+    short_name = 'wiki'
 
 
 # OAUTH
 
 
 class TestUserBitbucketAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "bitbucket"
+    short_name = 'bitbucket'
     AccountFactory = BitbucketAccountFactory
 
 
 class TestUserBoxAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "box"
+    short_name = 'box'
     AccountFactory = BoxAccountFactory
 
 
 class TestUserDataverseAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "dataverse"
+    short_name = 'dataverse'
     AccountFactory = DataverseAccountFactory
 
 
 class TestUserDropboxAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "dropbox"
+    short_name = 'dropbox'
     AccountFactory = DropboxAccountFactory
 
 
 class TestUserGitHubAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "github"
+    short_name = 'github'
     AccountFactory = GitHubAccountFactory
 
 
 class TestUserGoogleDriveAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "googledrive"
+    short_name = 'googledrive'
     AccountFactory = GoogleDriveAccountFactory
 
 
 class TestUserMendeleyAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "mendeley"
+    short_name = 'mendeley'
     AccountFactory = MendeleyAccountFactory
 
 
 class TestUserS3Addon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "s3"
+    short_name = 's3'
     AccountFactory = S3AccountFactory
 
 
 class TestUserZoteroAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "zotero"
+    short_name = 'zotero'
     AccountFactory = ZoteroAccountFactory
 
 
 class TestUserOwnCloudAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "owncloud"
+    short_name = 'owncloud'
     AccountFactory = OwnCloudAccountFactory
 
 
-@pytest.mark.skip("Unskip when figshare v2 addon is ported")
+@pytest.mark.skip('Unskip when figshare v2 addon is ported')
 class TestUserFigshareAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = "figshare"
+    short_name = 'figshare'
     # AccountFactory = FigshareAccountFactory
 
 
 class TestUserInvalidAddon(UserAddonTestSuiteMixin, ApiAddonTestCase):
-    addon_type = "INVALID"
-    short_name = "fake"
+    addon_type = 'INVALID'
+    short_name = 'fake'

--- a/api_tests/wikis/views/test_wiki_content.py
+++ b/api_tests/wikis/views/test_wiki_content.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa:
-
 from api.base.settings.defaults import API_BASE
 from addons.wiki.models import WikiPage
 from tests.base import ApiWikiTestCase
@@ -34,28 +32,28 @@ class TestWikiContentView(ApiWikiTestCase):
     def test_logged_out_user_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.get_version().content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
 
     def test_logged_in_non_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.get_version().content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
 
     def test_logged_in_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.get_version().content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
 
     def test_logged_out_user_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
     def test_logged_in_non_contributor_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
@@ -63,14 +61,14 @@ class TestWikiContentView(ApiWikiTestCase):
             self.private_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_logged_in_contributor_can_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.private_wiki.get_version().content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.private_wiki.get_version().content)
 
     def test_user_cannot_get_withdrawn_registration_wiki_content(self):
         self._set_up_public_registration_with_wiki_page()
@@ -83,4 +81,4 @@ class TestWikiContentView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)

--- a/api_tests/wikis/views/test_wiki_content.py
+++ b/api_tests/wikis/views/test_wiki_content.py
@@ -32,28 +32,28 @@ class TestWikiContentView(ApiWikiTestCase):
     def test_logged_out_user_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.get_version().content
 
     def test_logged_in_non_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.get_version().content
 
     def test_logged_in_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.get_version().content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.get_version().content
 
     def test_logged_out_user_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_logged_in_non_contributor_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
@@ -61,14 +61,14 @@ class TestWikiContentView(ApiWikiTestCase):
             self.private_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_logged_in_contributor_can_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.private_wiki.get_version().content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.private_wiki.get_version().content
 
     def test_user_cannot_get_withdrawn_registration_wiki_content(self):
         self._set_up_public_registration_with_wiki_page()
@@ -81,4 +81,4 @@ class TestWikiContentView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -201,8 +201,7 @@ class TestWikiDetailView(ApiWikiTestCase):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
         assert res.status_code == 401
-        assert res.json['errors'][0]['detail'] == \
-                     'Authentication credentials were not provided.'
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_private_node_logged_in_non_contributor_cannot_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -211,8 +210,7 @@ class TestWikiDetailView(ApiWikiTestCase):
             auth=self.non_contributor.auth,
             expect_errors=True)
         assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == \
-            'You do not have permission to perform this action.'
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_node_logged_in_contributor_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -282,15 +280,13 @@ class TestWikiDetailView(ApiWikiTestCase):
             auth=self.user.auth,
             expect_errors=True)
         assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == \
-            'You do not have permission to perform this action.'
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_registration_logged_out_user_cannot_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, expect_errors=True)
         assert res.status_code == 401
-        assert res.json['errors'][0]['detail'] == \
-                     'Authentication credentials were not provided.'
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_private_registration_logged_in_non_contributor_cannot_view_wiki(
             self):
@@ -300,8 +296,7 @@ class TestWikiDetailView(ApiWikiTestCase):
             auth=self.non_contributor.auth,
             expect_errors=True)
         assert res.status_code == 403
-        assert res.json['errors'][0]['detail'] == \
-            'You do not have permission to perform this action.'
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_registration_contributor_can_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
@@ -401,10 +396,11 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.public_project._id)
-        assert expected_nodes_relationship_url in \
-            res.json['data']['relationships']['node']['links']['related']['href']
-        assert expected_comments_relationship_url in \
-            res.json['data']['relationships']['comments']['links']['related']['href']
+        assert expected_nodes_relationship_url in res.json['data']['relationships']['node']['links']['related']['href']
+        assert (
+                expected_comments_relationship_url in
+                res.json['data']['relationships']['comments']['links']['related']['href']
+        )
 
     def test_private_node_wiki_relationship_links(self):
         self._set_up_private_project_with_wiki_page()
@@ -413,10 +409,11 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.private_project._id)
-        assert expected_nodes_relationship_url in \
-            res.json['data']['relationships']['node']['links']['related']['href']
-        assert expected_comments_relationship_url in \
+        assert expected_nodes_relationship_url in res.json['data']['relationships']['node']['links']['related']['href']
+        assert (
+            expected_comments_relationship_url in
             res.json['data']['relationships']['comments']['links']['related']['href']
+        )
 
     def test_public_registration_wiki_relationship_links(self):
         self._set_up_public_registration_with_wiki_page()
@@ -425,10 +422,11 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.public_registration._id)
-        assert expected_nodes_relationship_url in \
-            res.json['data']['relationships']['node']['links']['related']['href']
-        assert expected_comments_relationship_url in \
+        assert expected_nodes_relationship_url in res.json['data']['relationships']['node']['links']['related']['href']
+        assert (
+            expected_comments_relationship_url in
             res.json['data']['relationships']['comments']['links']['related']['href']
+        )
 
     def test_private_registration_wiki_relationship_links(self):
         self._set_up_private_registration_with_wiki_page()
@@ -437,10 +435,11 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.private_registration._id)
-        assert expected_nodes_relationship_url in \
-            res.json['data']['relationships']['node']['links']['related']['href']
-        assert expected_comments_relationship_url in \
+        assert expected_nodes_relationship_url in res.json['data']['relationships']['node']['links']['related']['href']
+        assert (
+            expected_comments_relationship_url in
             res.json['data']['relationships']['comments']['links']['related']['href']
+        )
 
     def test_do_not_return_disabled_wiki(self):
         self._set_up_public_project_with_wiki_page()

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -4,7 +4,6 @@ import furl
 import pytz
 import datetime
 from future.moves.urllib.parse import urlparse
-from nose.tools import *  # noqa:
 
 from addons.wiki.models import WikiPage
 from addons.wiki.tests.factories import (
@@ -183,26 +182,26 @@ class TestWikiDetailView(ApiWikiTestCase):
     def test_public_node_logged_out_user_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_wiki_page._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
 
     def test_public_node_logged_in_non_contributor_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_wiki_page._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
 
     def test_public_node_logged_in_contributor_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_wiki_page._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
 
     def test_private_node_logged_out_user_cannot_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'],
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json['errors'][0]['detail'],
                      'Authentication credentials were not provided.')
 
     def test_private_node_logged_in_non_contributor_cannot_view_wiki(self):
@@ -211,16 +210,16 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.private_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'You do not have permission to perform this action.')
 
     def test_private_node_logged_in_contributor_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.private_wiki._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
 
     def test_private_node_user_with_anonymous_link_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -232,8 +231,8 @@ class TestWikiDetailView(ApiWikiTestCase):
             query_params={
                 'view_only': private_link.key}).url
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.private_wiki._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
 
     def test_private_node_user_with_view_only_link_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -245,14 +244,14 @@ class TestWikiDetailView(ApiWikiTestCase):
             query_params={
                 'view_only': private_link.key}).url
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.private_wiki._id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
 
     def test_public_registration_logged_out_user_cannot_view_wiki(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_registration_wiki_id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
 
     def test_public_registration_logged_in_non_contributor_cannot_view_wiki(
             self):
@@ -261,14 +260,14 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_registration_wiki_id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
 
     def test_public_registration_contributor_can_view_wiki(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.public_registration_wiki_id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
 
     def test_user_cannot_view_withdrawn_registration_wikis(self):
         self._set_up_public_registration_with_wiki_page()
@@ -283,16 +282,16 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.user.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'You do not have permission to perform this action.')
 
     def test_private_registration_logged_out_user_cannot_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'],
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json['errors'][0]['detail'],
                      'Authentication credentials were not provided.')
 
     def test_private_registration_logged_in_non_contributor_cannot_view_wiki(
@@ -302,37 +301,37 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.private_registration_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(
             res.json['errors'][0]['detail'],
             'You do not have permission to perform this action.')
 
     def test_private_registration_contributor_can_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.private_registration_wiki_id)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], self.private_registration_wiki_id)
 
     def test_wiki_has_user_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['user']['links']['related']['href']
         expected_url = f'/{API_BASE}users/{self.user._id}/'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(urlparse(url).path, expected_url)
 
     def test_wiki_has_node_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['node']['links']['related']['href']
         expected_url = f'/{API_BASE}nodes/{self.public_project._id}/'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(urlparse(url).path, expected_url)
 
     def test_wiki_has_comments_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         url = res.json['data']['relationships']['comments']['links']['related']['href']
         CommentFactory(
             node=self.public_project,
@@ -340,37 +339,37 @@ class TestWikiDetailView(ApiWikiTestCase):
                 self.public_wiki_page._id),
             user=self.user)
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['type'], 'comments')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data'][0]['type'], 'comments')
 
     def test_only_project_contrib_can_comment_on_closed_project(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'private'})
         res = self.app.get(self.public_url, auth=self.user.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        assert_equal(res.status_code, 200)
-        assert_equal(can_comment, True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(can_comment, True)
 
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        assert_equal(res.status_code, 200)
-        assert_equal(can_comment, False)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(can_comment, False)
 
     def test_any_loggedin_user_can_comment_on_open_project(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'public'})
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        assert_equal(res.status_code, 200)
-        assert_equal(can_comment, True)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(can_comment, True)
 
     def test_non_logged_in_user_cant_comment(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'public'})
         res = self.app.get(self.public_url)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        assert_equal(res.status_code, 200)
-        assert_equal(can_comment, False)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(can_comment, False)
 
     def test_wiki_has_download_link(self):
         self._set_up_public_project_with_wiki_page()
@@ -378,25 +377,25 @@ class TestWikiDetailView(ApiWikiTestCase):
         url = res.json['data']['links']['download']
         expected_url = '/{}wikis/{}/content/'.format(
             API_BASE, self.public_wiki_page._id)
-        assert_equal(res.status_code, 200)
-        assert_in(expected_url, url)
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(expected_url, url)
 
     def test_wiki_invalid_id_not_found(self):
         url = '/{}wikis/{}/'.format(API_BASE, 'abcde')
         res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_deleted_wiki_not_returned(self):
         self._set_up_public_project_with_wiki_page()
         url = '/{}wikis/{}/'.format(
             API_BASE, self.public_wiki_page._id)
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         self.public_wiki_page.deleted = datetime.datetime(2017, 3, 16, 11, 00, tzinfo=pytz.utc)
         self.public_wiki_page.save()
 
         res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 410)
+        self.assertEqual(res.status_code, 410)
 
     def test_public_node_wiki_relationship_links(self):
         self._set_up_public_project_with_wiki_page()
@@ -405,10 +404,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.public_project._id)
-        assert_in(
+        self.assertIn(
             expected_nodes_relationship_url,
             res.json['data']['relationships']['node']['links']['related']['href'])
-        assert_in(
+        self.assertIn(
             expected_comments_relationship_url,
             res.json['data']['relationships']['comments']['links']['related']['href'])
 
@@ -419,10 +418,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.private_project._id)
-        assert_in(
+        self.assertIn(
             expected_nodes_relationship_url,
             res.json['data']['relationships']['node']['links']['related']['href'])
-        assert_in(
+        self.assertIn(
             expected_comments_relationship_url,
             res.json['data']['relationships']['comments']['links']['related']['href'])
 
@@ -433,10 +432,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.public_registration._id)
-        assert_in(
+        self.assertIn(
             expected_nodes_relationship_url,
             res.json['data']['relationships']['node']['links']['related']['href'])
-        assert_in(
+        self.assertIn(
             expected_comments_relationship_url,
             res.json['data']['relationships']['comments']['links']['related']['href'])
 
@@ -447,10 +446,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.private_registration._id)
-        assert_in(
+        self.assertIn(
             expected_nodes_relationship_url,
             res.json['data']['relationships']['node']['links']['related']['href'])
-        assert_in(
+        self.assertIn(
             expected_comments_relationship_url,
             res.json['data']['relationships']['comments']['links']['related']['href'])
 

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -340,12 +340,12 @@ class TestWikiDetailView(ApiWikiTestCase):
         res = self.app.get(self.public_url, auth=self.user.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
         assert res.status_code == 200
-        assert can_comment == True
+        assert can_comment
 
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
         assert res.status_code == 200
-        assert can_comment == False
+        assert not can_comment
 
     def test_any_loggedin_user_can_comment_on_open_project(self):
         self._set_up_public_project_with_wiki_page(
@@ -353,7 +353,7 @@ class TestWikiDetailView(ApiWikiTestCase):
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
         assert res.status_code == 200
-        assert can_comment == True
+        assert can_comment
 
     def test_non_logged_in_user_cant_comment(self):
         self._set_up_public_project_with_wiki_page(
@@ -361,7 +361,7 @@ class TestWikiDetailView(ApiWikiTestCase):
         res = self.app.get(self.public_url)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
         assert res.status_code == 200
-        assert can_comment == False
+        assert not can_comment
 
     def test_wiki_has_download_link(self):
         self._set_up_public_project_with_wiki_page()
@@ -398,8 +398,8 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_project._id)
         assert expected_nodes_relationship_url in res.json['data']['relationships']['node']['links']['related']['href']
         assert (
-                expected_comments_relationship_url in
-                res.json['data']['relationships']['comments']['links']['related']['href']
+            expected_comments_relationship_url in
+            res.json['data']['relationships']['comments']['links']['related']['href']
         )
 
     def test_private_node_wiki_relationship_links(self):

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -182,27 +182,27 @@ class TestWikiDetailView(ApiWikiTestCase):
     def test_public_node_logged_out_user_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_wiki_page._id
 
     def test_public_node_logged_in_non_contributor_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_wiki_page._id
 
     def test_public_node_logged_in_contributor_can_view_wiki(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_wiki_page._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_wiki_page._id
 
     def test_private_node_logged_out_user_cannot_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.json['errors'][0]['detail'],
-                     'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == \
+                     'Authentication credentials were not provided.'
 
     def test_private_node_logged_in_non_contributor_cannot_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -210,16 +210,15 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.private_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == \
+            'You do not have permission to perform this action.'
 
     def test_private_node_logged_in_contributor_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.private_wiki._id
 
     def test_private_node_user_with_anonymous_link_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -231,8 +230,8 @@ class TestWikiDetailView(ApiWikiTestCase):
             query_params={
                 'view_only': private_link.key}).url
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.private_wiki._id
 
     def test_private_node_user_with_view_only_link_can_view_wiki(self):
         self._set_up_private_project_with_wiki_page()
@@ -244,14 +243,14 @@ class TestWikiDetailView(ApiWikiTestCase):
             query_params={
                 'view_only': private_link.key}).url
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.private_wiki._id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.private_wiki._id
 
     def test_public_registration_logged_out_user_cannot_view_wiki(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_registration_wiki_id
 
     def test_public_registration_logged_in_non_contributor_cannot_view_wiki(
             self):
@@ -260,14 +259,14 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_registration_wiki_id
 
     def test_public_registration_contributor_can_view_wiki(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.public_registration_wiki_id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.public_registration_wiki_id
 
     def test_user_cannot_view_withdrawn_registration_wikis(self):
         self._set_up_public_registration_with_wiki_page()
@@ -282,17 +281,16 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.public_registration_url,
             auth=self.user.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == \
+            'You do not have permission to perform this action.'
 
     def test_private_registration_logged_out_user_cannot_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.json['errors'][0]['detail'],
-                     'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == \
+                     'Authentication credentials were not provided.'
 
     def test_private_registration_logged_in_non_contributor_cannot_view_wiki(
             self):
@@ -301,37 +299,36 @@ class TestWikiDetailView(ApiWikiTestCase):
             self.private_registration_url,
             auth=self.non_contributor.auth,
             expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(
-            res.json['errors'][0]['detail'],
-            'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == \
+            'You do not have permission to perform this action.'
 
     def test_private_registration_contributor_can_view_wiki(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], self.private_registration_wiki_id)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == self.private_registration_wiki_id
 
     def test_wiki_has_user_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['user']['links']['related']['href']
         expected_url = f'/{API_BASE}users/{self.user._id}/'
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(urlparse(url).path, expected_url)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
 
     def test_wiki_has_node_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['node']['links']['related']['href']
         expected_url = f'/{API_BASE}nodes/{self.public_project._id}/'
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(urlparse(url).path, expected_url)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
 
     def test_wiki_has_comments_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         url = res.json['data']['relationships']['comments']['links']['related']['href']
         CommentFactory(
             node=self.public_project,
@@ -339,37 +336,37 @@ class TestWikiDetailView(ApiWikiTestCase):
                 self.public_wiki_page._id),
             user=self.user)
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data'][0]['type'], 'comments')
+        assert res.status_code == 200
+        assert res.json['data'][0]['type'] == 'comments'
 
     def test_only_project_contrib_can_comment_on_closed_project(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'private'})
         res = self.app.get(self.public_url, auth=self.user.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(can_comment, True)
+        assert res.status_code == 200
+        assert can_comment == True
 
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(can_comment, False)
+        assert res.status_code == 200
+        assert can_comment == False
 
     def test_any_loggedin_user_can_comment_on_open_project(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'public'})
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(can_comment, True)
+        assert res.status_code == 200
+        assert can_comment == True
 
     def test_non_logged_in_user_cant_comment(self):
         self._set_up_public_project_with_wiki_page(
             project_options={'comment_level': 'public'})
         res = self.app.get(self.public_url)
         can_comment = res.json['data']['attributes']['current_user_can_comment']
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(can_comment, False)
+        assert res.status_code == 200
+        assert can_comment == False
 
     def test_wiki_has_download_link(self):
         self._set_up_public_project_with_wiki_page()
@@ -377,25 +374,25 @@ class TestWikiDetailView(ApiWikiTestCase):
         url = res.json['data']['links']['download']
         expected_url = '/{}wikis/{}/content/'.format(
             API_BASE, self.public_wiki_page._id)
-        self.assertEqual(res.status_code, 200)
-        self.assertIn(expected_url, url)
+        assert res.status_code == 200
+        assert expected_url in url
 
     def test_wiki_invalid_id_not_found(self):
         url = '/{}wikis/{}/'.format(API_BASE, 'abcde')
         res = self.app.get(url, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_deleted_wiki_not_returned(self):
         self._set_up_public_project_with_wiki_page()
         url = '/{}wikis/{}/'.format(
             API_BASE, self.public_wiki_page._id)
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         self.public_wiki_page.deleted = datetime.datetime(2017, 3, 16, 11, 00, tzinfo=pytz.utc)
         self.public_wiki_page.save()
 
         res = self.app.get(url, expect_errors=True)
-        self.assertEqual(res.status_code, 410)
+        assert res.status_code == 410
 
     def test_public_node_wiki_relationship_links(self):
         self._set_up_public_project_with_wiki_page()
@@ -404,12 +401,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.public_project._id)
-        self.assertIn(
-            expected_nodes_relationship_url,
-            res.json['data']['relationships']['node']['links']['related']['href'])
-        self.assertIn(
-            expected_comments_relationship_url,
-            res.json['data']['relationships']['comments']['links']['related']['href'])
+        assert expected_nodes_relationship_url in \
+            res.json['data']['relationships']['node']['links']['related']['href']
+        assert expected_comments_relationship_url in \
+            res.json['data']['relationships']['comments']['links']['related']['href']
 
     def test_private_node_wiki_relationship_links(self):
         self._set_up_private_project_with_wiki_page()
@@ -418,12 +413,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_project._id)
         expected_comments_relationship_url = '{}nodes/{}/comments/'.format(
             API_BASE, self.private_project._id)
-        self.assertIn(
-            expected_nodes_relationship_url,
-            res.json['data']['relationships']['node']['links']['related']['href'])
-        self.assertIn(
-            expected_comments_relationship_url,
-            res.json['data']['relationships']['comments']['links']['related']['href'])
+        assert expected_nodes_relationship_url in \
+            res.json['data']['relationships']['node']['links']['related']['href']
+        assert expected_comments_relationship_url in \
+            res.json['data']['relationships']['comments']['links']['related']['href']
 
     def test_public_registration_wiki_relationship_links(self):
         self._set_up_public_registration_with_wiki_page()
@@ -432,12 +425,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.public_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.public_registration._id)
-        self.assertIn(
-            expected_nodes_relationship_url,
-            res.json['data']['relationships']['node']['links']['related']['href'])
-        self.assertIn(
-            expected_comments_relationship_url,
-            res.json['data']['relationships']['comments']['links']['related']['href'])
+        assert expected_nodes_relationship_url in \
+            res.json['data']['relationships']['node']['links']['related']['href']
+        assert expected_comments_relationship_url in \
+            res.json['data']['relationships']['comments']['links']['related']['href']
 
     def test_private_registration_wiki_relationship_links(self):
         self._set_up_private_registration_with_wiki_page()
@@ -446,12 +437,10 @@ class TestWikiDetailView(ApiWikiTestCase):
             API_BASE, self.private_registration._id)
         expected_comments_relationship_url = '{}registrations/{}/comments/'.format(
             API_BASE, self.private_registration._id)
-        self.assertIn(
-            expected_nodes_relationship_url,
-            res.json['data']['relationships']['node']['links']['related']['href'])
-        self.assertIn(
-            expected_comments_relationship_url,
-            res.json['data']['relationships']['comments']['links']['related']['href'])
+        assert expected_nodes_relationship_url in \
+            res.json['data']['relationships']['node']['links']['related']['href']
+        assert expected_comments_relationship_url in \
+            res.json['data']['relationships']['comments']['links']['related']['href']
 
     def test_do_not_return_disabled_wiki(self):
         self._set_up_public_project_with_wiki_page()

--- a/api_tests/wikis/views/test_wiki_version_content.py
+++ b/api_tests/wikis/views/test_wiki_version_content.py
@@ -27,40 +27,40 @@ class TestWikiVersionContentView(ApiWikiTestCase):
     def test_logged_out_user_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.content
 
     def test_logged_in_non_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.content
 
     def test_logged_in_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.public_wiki.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.public_wiki.content
 
     def test_logged_out_user_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
+        assert res.status_code == 401
 
     def test_logged_in_non_contributor_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403
 
     def test_logged_in_contributor_can_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.private_wiki.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.private_wiki.content
 
     def test_older_versions_content_can_be_accessed(self):
         self._set_up_private_project_with_wiki_page()
@@ -68,15 +68,15 @@ class TestWikiVersionContentView(ApiWikiTestCase):
         wiki_version = self.private_wiki.wiki_page.update(self.user, 'Second draft of wiki')
         wiki_page = wiki_version.wiki_page
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), self.private_wiki.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == self.private_wiki.content
 
         self.private_url_latest = f'/{API_BASE}wikis/{wiki_page._id}/versions/{wiki_version.identifier}/content/'
         res = self.app.get(self.private_url_latest, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.content_type, 'text/markdown')
-        self.assertEqual(res.body.decode(), wiki_version.content)
+        assert res.status_code == 200
+        assert res.content_type == 'text/markdown'
+        assert res.body.decode() == wiki_version.content
 
     def test_user_cannot_get_withdrawn_registration_wiki_content(self):
         self._set_up_public_registration_with_wiki_page()
@@ -85,4 +85,4 @@ class TestWikiVersionContentView(ApiWikiTestCase):
         withdrawal.approve_retraction(self.user, token)
         withdrawal.save()
         res = self.app.get(self.public_registration_url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
+        assert res.status_code == 403

--- a/api_tests/wikis/views/test_wiki_version_content.py
+++ b/api_tests/wikis/views/test_wiki_version_content.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa:
-
 from addons.wiki.models import WikiVersion
 from api.base.settings.defaults import API_BASE
 
@@ -29,40 +27,40 @@ class TestWikiVersionContentView(ApiWikiTestCase):
     def test_logged_out_user_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.content)
 
     def test_logged_in_non_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.content)
 
     def test_logged_in_contributor_can_get_public_wiki_content(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.public_wiki.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.public_wiki.content)
 
     def test_logged_out_user_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        self.assertEqual(res.status_code, 401)
 
     def test_logged_in_non_contributor_cannot_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)
 
     def test_logged_in_contributor_can_get_private_wiki_content(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.private_wiki.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.private_wiki.content)
 
     def test_older_versions_content_can_be_accessed(self):
         self._set_up_private_project_with_wiki_page()
@@ -70,15 +68,15 @@ class TestWikiVersionContentView(ApiWikiTestCase):
         wiki_version = self.private_wiki.wiki_page.update(self.user, 'Second draft of wiki')
         wiki_page = wiki_version.wiki_page
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), self.private_wiki.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), self.private_wiki.content)
 
         self.private_url_latest = f'/{API_BASE}wikis/{wiki_page._id}/versions/{wiki_version.identifier}/content/'
         res = self.app.get(self.private_url_latest, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.content_type, 'text/markdown')
-        assert_equal(res.body.decode(), wiki_version.content)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content_type, 'text/markdown')
+        self.assertEqual(res.body.decode(), wiki_version.content)
 
     def test_user_cannot_get_withdrawn_registration_wiki_content(self):
         self._set_up_public_registration_with_wiki_page()
@@ -87,4 +85,4 @@ class TestWikiVersionContentView(ApiWikiTestCase):
         withdrawal.approve_retraction(self.user, token)
         withdrawal.save()
         res = self.app.get(self.public_registration_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        self.assertEqual(res.status_code, 403)

--- a/api_tests/wikis/views/test_wiki_version_detail.py
+++ b/api_tests/wikis/views/test_wiki_version_detail.py
@@ -47,38 +47,38 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
     def test_public_node_logged_out_user_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_wiki_version.identifier)
 
     def test_public_node_logged_in_non_contributor_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_wiki_version.identifier)
 
     def test_public_node_logged_in_contributor_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_wiki_version.identifier)
 
     def test_private_node_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_private_node_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_node_logged_in_contributor_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.private_wiki_version.identifier)
 
     def test_private_node_user_with_anonymous_link_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
@@ -87,8 +87,8 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
         private_link.save()
         url = furl.furl(self.private_url).add(query_params={'view_only': private_link.key}).url
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.private_wiki_version.identifier)
 
     def test_private_node_user_with_view_only_link_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
@@ -97,26 +97,26 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
         private_link.save()
         url = furl.furl(self.private_url).add(query_params={'view_only': private_link.key}).url
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.private_wiki_version.identifier)
 
     def test_public_registration_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_registration_wiki_version.identifier)
 
     def test_public_registration_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.non_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_registration_wiki_version.identifier)
 
     def test_public_registration_contributor_can_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.public_registration_wiki_version.identifier)
 
     def test_user_cannot_view_withdrawn_registration_wiki_versions(self):
         self._set_up_public_registration_with_wiki_page()
@@ -127,96 +127,96 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
             withdrawal.approve_retraction(self.user, token)
             withdrawal.save()
         res = self.app.get(self.public_registration_url, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_registration_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, expect_errors=True)
-        self.assertEqual(res.status_code, 401)
-        self.assertEqual(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
     def test_private_registration_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.non_contributor.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 403)
-        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
     def test_private_registration_contributor_can_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.json['data']['id'], str(self.private_registration_wiki_version.identifier))
+        assert res.status_code == 200
+        assert res.json['data']['id'] == str(self.private_registration_wiki_version.identifier)
 
     def test_wiki_version_has_user_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['user']['links']['related']['href']
         expected_url = f'/{API_BASE}users/{self.user._id}/'
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(urlparse(url).path, expected_url)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
 
     def test_wiki_version_has_wiki_page_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['wiki_page']['links']['related']['href']
         expected_url = f'/{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/'
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(urlparse(url).path, expected_url)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
 
     def test_wiki_version_has_download_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['links']['download']
         expected_url = f'/{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/versions/{str(self.public_wiki_version.identifier)}/content'
-        self.assertEqual(res.status_code, 200)
-        self.assertIn(expected_url, url)
+        assert res.status_code == 200
+        assert expected_url in url
 
     def test_wiki_version_invalid_identifier_not_found(self):
         self._set_up_public_project_with_wiki_page()
         url = f'/{API_BASE}wikis/{self.public_wiki_page._id}/versions/{500}/'
         res = self.app.get(url, expect_errors=True)
-        self.assertEqual(res.status_code, 404)
+        assert res.status_code == 404
 
     def test_deleted_wiki_version_not_returned(self):
         self._set_up_public_project_with_wiki_page()
         url = f'/{API_BASE}wikis/{self.public_wiki_page._id}/versions/{str(self.public_wiki_version.identifier)}/'
         res = self.app.get(url)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         self.public_wiki_version.wiki_page.deleted = datetime.datetime(2017, 3, 16, 11, 00, tzinfo=pytz.utc)
         self.public_wiki_version.wiki_page.save()
 
         res = self.app.get(url, expect_errors=True)
-        self.assertEqual(res.status_code, 410)
+        assert res.status_code == 410
 
     def test_public_node_wiki_version_relationship_links(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         expected_wiki_page_relationship_url = f'{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/'
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        self.assertIn(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        assert expected_wiki_page_relationship_url in res.json['data']['relationships']['wiki_page']['links']['related']['href']
+        assert expected_user_relationship_url in res.json['data']['relationships']['user']['links']['related']['href']
 
     def test_private_node_wiki_version_relationship_links(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
         expected_wiki_page_relationship_url = f'{API_BASE}wikis/{self.private_wiki_version.wiki_page._id}/'
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        self.assertIn(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        assert expected_wiki_page_relationship_url in res.json['data']['relationships']['wiki_page']['links']['related']['href']
+        assert expected_user_relationship_url in res.json['data']['relationships']['user']['links']['related']['href']
 
     def test_public_registration_wiki_version_relationship_links(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url)
         expected_wiki_page_url = '{}wikis/{}/'.format(API_BASE, WikiPage.objects.get_for_node(self.public_registration, 'home')._id)
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        self.assertIn(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        assert expected_wiki_page_url in res.json['data']['relationships']['wiki_page']['links']['related']['href']
+        assert expected_user_relationship_url in res.json['data']['relationships']['user']['links']['related']['href']
 
     def test_private_registration_wiki_version_relationship_links(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
         expected_wiki_page_url = '{}wikis/{}/'.format(API_BASE, WikiPage.objects.get_for_node(self.private_registration, 'home')._id)
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        self.assertIn(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        assert expected_wiki_page_url in res.json['data']['relationships']['wiki_page']['links']['related']['href']
+        assert expected_user_relationship_url in res.json['data']['relationships']['user']['links']['related']['href']

--- a/api_tests/wikis/views/test_wiki_version_detail.py
+++ b/api_tests/wikis/views/test_wiki_version_detail.py
@@ -3,7 +3,6 @@ import furl
 import datetime
 import pytz
 from future.moves.urllib.parse import urlparse
-from nose.tools import *  # noqa:
 
 from api.base.settings.defaults import API_BASE
 
@@ -48,38 +47,38 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
     def test_public_node_logged_out_user_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
 
     def test_public_node_logged_in_non_contributor_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
 
     def test_public_node_logged_in_contributor_can_view_wiki_version(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_wiki_version.identifier))
 
     def test_private_node_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
 
     def test_private_node_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
 
     def test_private_node_logged_in_contributor_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
 
     def test_private_node_user_with_anonymous_link_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
@@ -88,8 +87,8 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
         private_link.save()
         url = furl.furl(self.private_url).add(query_params={'view_only': private_link.key}).url
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
 
     def test_private_node_user_with_view_only_link_can_view_wiki_version(self):
         self._set_up_private_project_with_wiki_page()
@@ -98,26 +97,26 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
         private_link.save()
         url = furl.furl(self.private_url).add(query_params={'view_only': private_link.key}).url
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.private_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.private_wiki_version.identifier))
 
     def test_public_registration_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
 
     def test_public_registration_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
 
     def test_public_registration_contributor_can_view_wiki_version(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.public_registration_wiki_version.identifier))
 
     def test_user_cannot_view_withdrawn_registration_wiki_versions(self):
         self._set_up_public_registration_with_wiki_page()
@@ -128,96 +127,96 @@ class TestWikiVersionDetailView(ApiWikiTestCase):
             withdrawal.approve_retraction(self.user, token)
             withdrawal.save()
         res = self.app.get(self.public_registration_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
 
     def test_private_registration_logged_out_user_cannot_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        self.assertEqual(res.status_code, 401)
+        self.assertEqual(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
 
     def test_private_registration_logged_in_non_contributor_cannot_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        self.assertEqual(res.status_code, 403)
+        self.assertEqual(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
 
     def test_private_registration_contributor_can_view_wiki_version(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], str(self.private_registration_wiki_version.identifier))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json['data']['id'], str(self.private_registration_wiki_version.identifier))
 
     def test_wiki_version_has_user_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['user']['links']['related']['href']
         expected_url = f'/{API_BASE}users/{self.user._id}/'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(urlparse(url).path, expected_url)
 
     def test_wiki_version_has_wiki_page_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['relationships']['wiki_page']['links']['related']['href']
         expected_url = f'/{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(urlparse(url).path, expected_url)
 
     def test_wiki_version_has_download_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         url = res.json['data']['links']['download']
         expected_url = f'/{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/versions/{str(self.public_wiki_version.identifier)}/content'
-        assert_equal(res.status_code, 200)
-        assert_in(expected_url, url)
+        self.assertEqual(res.status_code, 200)
+        self.assertIn(expected_url, url)
 
     def test_wiki_version_invalid_identifier_not_found(self):
         self._set_up_public_project_with_wiki_page()
         url = f'/{API_BASE}wikis/{self.public_wiki_page._id}/versions/{500}/'
         res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        self.assertEqual(res.status_code, 404)
 
     def test_deleted_wiki_version_not_returned(self):
         self._set_up_public_project_with_wiki_page()
         url = f'/{API_BASE}wikis/{self.public_wiki_page._id}/versions/{str(self.public_wiki_version.identifier)}/'
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         self.public_wiki_version.wiki_page.deleted = datetime.datetime(2017, 3, 16, 11, 00, tzinfo=pytz.utc)
         self.public_wiki_version.wiki_page.save()
 
         res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 410)
+        self.assertEqual(res.status_code, 410)
 
     def test_public_node_wiki_version_relationship_links(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
         expected_wiki_page_relationship_url = f'{API_BASE}wikis/{self.public_wiki_version.wiki_page._id}/'
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        assert_in(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        assert_in(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        self.assertIn(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
+        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
 
     def test_private_node_wiki_version_relationship_links(self):
         self._set_up_private_project_with_wiki_page()
         res = self.app.get(self.private_url, auth=self.user.auth)
         expected_wiki_page_relationship_url = f'{API_BASE}wikis/{self.private_wiki_version.wiki_page._id}/'
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        assert_in(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        assert_in(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        self.assertIn(expected_wiki_page_relationship_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
+        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
 
     def test_public_registration_wiki_version_relationship_links(self):
         self._set_up_public_registration_with_wiki_page()
         res = self.app.get(self.public_registration_url)
         expected_wiki_page_url = '{}wikis/{}/'.format(API_BASE, WikiPage.objects.get_for_node(self.public_registration, 'home')._id)
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        assert_in(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        assert_in(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        self.assertIn(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
+        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
 
     def test_private_registration_wiki_version_relationship_links(self):
         self._set_up_private_registration_with_wiki_page()
         res = self.app.get(self.private_registration_url, auth=self.user.auth)
         expected_wiki_page_url = '{}wikis/{}/'.format(API_BASE, WikiPage.objects.get_for_node(self.private_registration, 'home')._id)
         expected_user_relationship_url = f'{API_BASE}users/{self.user._id}/'
-        assert_in(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
-        assert_in(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])
+        self.assertIn(expected_wiki_page_url, res.json['data']['relationships']['wiki_page']['links']['related']['href'])
+        self.assertIn(expected_user_relationship_url, res.json['data']['relationships']['user']['links']['related']['href'])

--- a/osf_tests/test_analytics.py
+++ b/osf_tests/test_analytics.py
@@ -24,21 +24,21 @@ class TestAnalytics(OsfTestCase):
         user = UserFactory()
         date = timezone.now()
 
-        self.assertEqual(analytics.get_total_activity_count(user._id), 0)
-        self.assertEqual(analytics.get_total_activity_count(user._id), user.get_activity_points())
+        assert analytics.get_total_activity_count(user._id) == 0
+        assert analytics.get_total_activity_count(user._id) == user.get_activity_points()
 
         analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat())
 
-        self.assertEqual(analytics.get_total_activity_count(user._id), 1)
-        self.assertEqual(analytics.get_total_activity_count(user._id), user.get_activity_points())
+        assert analytics.get_total_activity_count(user._id) == 1
+        assert analytics.get_total_activity_count(user._id) == user.get_activity_points()
 
     def test_increment_user_activity_counters(self):
         user = UserFactory()
         date = timezone.now()
 
-        self.assertEqual(user.get_activity_points(), 0)
+        assert user.get_activity_points() == 0
         analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat())
-        self.assertEqual(user.get_activity_points(), 1)
+        assert user.get_activity_points() == 1
 
 
 @pytest.fixture()

--- a/osf_tests/test_analytics.py
+++ b/osf_tests/test_analytics.py
@@ -5,7 +5,6 @@ Unit tests for analytics logic in framework/analytics/__init__.py
 import pytest
 from django.utils import timezone
 from django.conf import settings as django_conf_settings
-from nose.tools import *  # noqa: F403
 
 from datetime import datetime
 from importlib import import_module
@@ -25,21 +24,21 @@ class TestAnalytics(OsfTestCase):
         user = UserFactory()
         date = timezone.now()
 
-        assert_equal(analytics.get_total_activity_count(user._id), 0)
-        assert_equal(analytics.get_total_activity_count(user._id), user.get_activity_points())
+        self.assertEqual(analytics.get_total_activity_count(user._id), 0)
+        self.assertEqual(analytics.get_total_activity_count(user._id), user.get_activity_points())
 
         analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat())
 
-        assert_equal(analytics.get_total_activity_count(user._id), 1)
-        assert_equal(analytics.get_total_activity_count(user._id), user.get_activity_points())
+        self.assertEqual(analytics.get_total_activity_count(user._id), 1)
+        self.assertEqual(analytics.get_total_activity_count(user._id), user.get_activity_points())
 
     def test_increment_user_activity_counters(self):
         user = UserFactory()
         date = timezone.now()
 
-        assert_equal(user.get_activity_points(), 0)
+        self.assertEqual(user.get_activity_points(), 0)
         analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat())
-        assert_equal(user.get_activity_points(), 1)
+        self.assertEqual(user.get_activity_points(), 1)
 
 
 @pytest.fixture()

--- a/osf_tests/test_app.py
+++ b/osf_tests/test_app.py
@@ -3,7 +3,6 @@
 import framework
 
 from flask import Flask
-from nose.tools import *  # noqa (PEP8 asserts)
 from website import settings
 from website.app import attach_handlers
 
@@ -43,6 +42,6 @@ def test_attach_handlers():
     }
 
     # Check that necessary handlers are attached and correctly ordered
-    assert_equal(set(before_funcs), assert_before_funcs)
-    assert_equal(set(after_funcs), assert_after_funcs)
-    assert_equal(set(teardown_funcs), assert_teardown_funcs)
+    assert set(before_funcs) == assert_before_funcs
+    assert set(after_funcs) == assert_after_funcs
+    assert set(teardown_funcs) == assert_teardown_funcs

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1,12 +1,10 @@
-from unittest import mock
 import time
-import unittest
 import logging
 import functools
-
-from nose.tools import *  # noqa: F403
+import unittest
 import pytest
 
+from unittest import mock
 from framework.auth.core import Auth
 
 from website import settings
@@ -109,18 +107,18 @@ class TestCollectionsSearch(OsfTestCase):
 
     def test_only_public_collections_submissions_are_searchable(self):
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         self.collection_public.collect_object(self.node_private, self.user)
         self.reg_collection.collect_object(self.reg_private, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
-        assert_false(self.node_one.collection_submissions.filter(
+        self.assertFalse(self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_false(self.node_public.collection_submissions.filter(
+        self.assertFalse(self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
 
@@ -128,60 +126,60 @@ class TestCollectionsSearch(OsfTestCase):
         self.collection_public.collect_object(self.node_public, self.user)
         self.reg_collection.collect_object(self.reg_public, self.user)
 
-        assert_true(self.node_one.collection_submissions.filter(
+        self.assertTrue(self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.node_public.collection_submissions.filter(
+        self.assertTrue(self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.reg_public.collection_submissions.filter(
+        self.assertTrue(self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 3)
+        self.assertEqual(len(docs), 3)
 
         self.collection_private.collect_object(self.node_two, self.user)
         self.reg_collection_private.collect_object(self.reg_one, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 3)
+        self.assertEqual(len(docs), 3)
 
     def test_index_on_submission_privacy_changes(self):
         # test_submissions_turned_private_are_deleted_from_index
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_one.collect_object(self.node_one, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 2)
+        self.assertEqual(len(docs), 2)
 
         with run_celery_tasks():
             self.node_one.is_public = False
             self.node_one.save()
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         # test_submissions_turned_public_are_added_to_index
         self.collection_public.collect_object(self.node_private, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         with run_celery_tasks():
             self.node_private.is_public = True
             self.node_private.save()
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_index_on_collection_privacy_changes(self):
         # test_submissions_of_collection_turned_private_are_removed_from_index
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_public.collect_object(self.node_two, self.user)
@@ -189,7 +187,7 @@ class TestCollectionsSearch(OsfTestCase):
         self.reg_collection.collect_object(self.reg_public, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 4)
+        self.assertEqual(len(docs), 4)
 
         with run_celery_tasks():
             self.collection_public.is_public = False
@@ -198,7 +196,7 @@ class TestCollectionsSearch(OsfTestCase):
             self.reg_collection.save()
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         # test_submissions_of_collection_turned_public_are_added_to_index
         self.collection_private.collect_object(self.node_one, self.user)
@@ -206,21 +204,21 @@ class TestCollectionsSearch(OsfTestCase):
         self.collection_private.collect_object(self.node_public, self.user)
         self.reg_collection_private.collect_object(self.reg_public, self.user)
 
-        assert_true(self.node_one.collection_submissions.filter(
+        self.assertTrue(self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.node_two.collection_submissions.filter(
+        self.assertTrue(self.node_two.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.node_public.collection_submissions.filter(
+        self.assertTrue(self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.reg_public.collection_submissions.filter(
+        self.assertTrue(self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         with run_celery_tasks():
             self.collection_private.is_public = True
@@ -229,11 +227,11 @@ class TestCollectionsSearch(OsfTestCase):
             self.reg_collection.save()
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 4)
+        self.assertEqual(len(docs), 4)
 
     def test_collection_submissions_are_removed_from_index_on_delete(self):
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_public.collect_object(self.node_two, self.user)
@@ -241,57 +239,57 @@ class TestCollectionsSearch(OsfTestCase):
         self.reg_collection.collect_object(self.reg_public, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 4)
+        self.assertEqual(len(docs), 4)
         self.collection_public.delete()
         self.reg_collection.delete()
 
-        assert_true(self.collection_public.deleted)
-        assert_true(self.reg_collection.deleted)
+        self.assertTrue(self.collection_public.deleted)
+        self.assertTrue(self.reg_collection.deleted)
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_removed_submission_are_removed_from_index(self):
         self.collection_public.collect_object(self.node_one, self.user)
         self.reg_collection.collect_object(self.reg_public, self.user)
-        assert_true(self.node_one.collection_submissions.filter(
+        self.assertTrue(self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_true(self.reg_public.collection_submissions.filter(
+        self.assertTrue(self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 2)
+        self.assertEqual(len(docs), 2)
 
         self.collection_public.remove_object(self.node_one, Auth(self.user))
         self.reg_collection.remove_object(self.reg_public, Auth(self.user))
-        assert_false(self.node_one.collection_submissions.filter(
+        self.assertFalse(self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
-        assert_false(self.reg_public.collection_submissions.filter(
+        self.assertFalse(self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
         ).exists())
 
         docs = query_collections('Salif Keita')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_collection_submission_doc_structure(self):
         self.collection_public.collect_object(self.node_one, self.user)
         docs = query_collections('Keita')['results']
-        assert_equal(docs[0]['_source']['title'], self.node_one.title)
+        self.assertEqual(docs[0]['_source']['title'], self.node_one.title)
         with run_celery_tasks():
             self.node_one.title = 'Keita Royal Family of Mali'
             self.node_one.save()
         docs = query_collections('Keita')['results']
-        assert_equal(docs[0]['_source']['title'], self.node_one.title)
-        assert_equal(docs[0]['_source']['abstract'], self.node_one.description)
-        assert_equal(docs[0]['_source']['contributors'][0]['url'], self.user.url)
-        assert_equal(docs[0]['_source']['contributors'][0]['fullname'], self.user.fullname)
-        assert_equal(docs[0]['_source']['url'], self.node_one.url)
-        assert_equal(docs[0]['_source']['id'], '{}-{}'.format(self.node_one._id,
+        self.assertEqual(docs[0]['_source']['title'], self.node_one.title)
+        self.assertEqual(docs[0]['_source']['abstract'], self.node_one.description)
+        self.assertEqual(docs[0]['_source']['contributors'][0]['url'], self.user.url)
+        self.assertEqual(docs[0]['_source']['contributors'][0]['fullname'], self.user.fullname)
+        self.assertEqual(docs[0]['_source']['url'], self.node_one.url)
+        self.assertEqual(docs[0]['_source']['id'], '{}-{}'.format(self.node_one._id,
             self.node_one.collection_submissions[0].collection._id))
-        assert_equal(docs[0]['_source']['category'], 'collectionSubmission')
+        self.assertEqual(docs[0]['_source']['category'], 'collectionSubmission')
 
     def test_search_updated_after_id_change(self):
         self.provider.primary_collection.collect_object(self.node_one, self.node_one.creator)
@@ -299,11 +297,11 @@ class TestCollectionsSearch(OsfTestCase):
             self.node_one.save()
         term = f'provider:{self.provider._id}'
         docs = search.search(build_query(term), index=elastic_search.INDEX, raw=True)
-        assert_equal(len(docs['results']), 1)
+        self.assertEqual(len(docs['results']), 1)
         self.provider._id = 'new_id'
         self.provider.save()
         docs = query('provider:new_id', raw=True)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
 
 @pytest.mark.enable_search
@@ -319,17 +317,17 @@ class TestUserUpdate(OsfTestCase):
     def test_new_user(self):
         # Verify that user has been added to Elastic Search
         docs = query_user(self.user.fullname)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_new_user_unconfirmed(self):
         user = factories.UnconfirmedUserFactory()
         docs = query_user(user.fullname)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         token = user.get_confirmation_token(user.username)
         user.confirm_email(token)
         user.save()
         docs = query_user(user.fullname)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     @retry_assertion
     def test_change_name(self):
@@ -341,10 +339,10 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs_original = query_user(fullname_original)['results']
-        assert_equal(len(docs_original), 0)
+        self.assertEqual(len(docs_original), 0)
 
         docs_current = query_user(user.fullname)['results']
-        assert_equal(len(docs_current), 1)
+        self.assertEqual(len(docs_current), 1)
 
     def test_disabled_user(self):
         # Test that disabled users are not in search index
@@ -353,27 +351,27 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         # Ensure user is in search index
-        assert_equal(len(query_user(user.fullname)['results']), 1)
+        self.assertEqual(len(query_user(user.fullname)['results']), 1)
 
         # Disable the user
         user.is_disabled = True
         user.save()
 
         # Ensure user is not in search index
-        assert_equal(len(query_user(user.fullname)['results']), 0)
+        self.assertEqual(len(query_user(user.fullname)['results']), 0)
 
     def test_merged_user(self):
         user = factories.UserFactory(fullname='Annie Lennox')
         merged_user = factories.UserFactory(fullname='Lisa Stansfield')
         user.save()
         merged_user.save()
-        assert_equal(len(query_user(user.fullname)['results']), 1)
-        assert_equal(len(query_user(merged_user.fullname)['results']), 1)
+        self.assertEqual(len(query_user(user.fullname)['results']), 1)
+        self.assertEqual(len(query_user(merged_user.fullname)['results']), 1)
 
         user.merge_user(merged_user)
 
-        assert_equal(len(query_user(user.fullname)['results']), 1)
-        assert_equal(len(query_user(merged_user.fullname)['results']), 0)
+        self.assertEqual(len(query_user(user.fullname)['results']), 1)
+        self.assertEqual(len(query_user(merged_user.fullname)['results']), 0)
 
     def test_employment(self):
         user = factories.UserFactory(fullname='Helga Finn')
@@ -381,7 +379,7 @@ class TestUserUpdate(OsfTestCase):
         institution = 'Finn\'s Fine Filers'
 
         docs = query_user(institution)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         user.jobs.append({
             'institution': institution,
             'title': 'The Big Finn',
@@ -389,7 +387,7 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs = query_user(institution)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_education(self):
         user = factories.UserFactory(fullname='Henry Johnson')
@@ -397,7 +395,7 @@ class TestUserUpdate(OsfTestCase):
         institution = 'Henry\'s Amazing School!!!'
 
         docs = query_user(institution)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         user.schools.append({
             'institution': institution,
             'degree': 'failed all classes',
@@ -405,7 +403,7 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs = query_user(institution)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_name_fields(self):
         names = ['Bill Nye', 'William', 'the science guy', 'Sanford', 'the Great']
@@ -416,8 +414,8 @@ class TestUserUpdate(OsfTestCase):
         user.suffix = names[4]
         user.save()
         docs = [query_user(name)['results'] for name in names]
-        assert_equal(sum(map(len, docs)), len(docs))  # 1 result each
-        assert_true(all([user._id == doc[0]['id'] for doc in docs]))
+        self.assertEqual(sum(map(len, docs)), len(docs))  # 1 result each
+        self.assertTrue(all([user._id == doc[0]['id'] for doc in docs]))
 
 
 @pytest.mark.enable_search
@@ -434,7 +432,7 @@ class TestProject(OsfTestCase):
     def test_new_project_private(self):
         # Verify that a private project is not present in Elastic Search.
         docs = query(self.project.title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_make_public(self):
         # Make project public, and verify that it is present in Elastic
@@ -442,7 +440,7 @@ class TestProject(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('public')
         docs = query(self.project.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
 
 @pytest.mark.enable_search
@@ -469,51 +467,51 @@ class TestOSFGroup(OsfTestCase):
         group = OSFGroup(name=title, creator=self.user)
         group.save()
         docs = query(title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_set_group_name(self):
         title = 'Eggs'
         self.group.set_group_name(title)
         self.group.save()
         docs = query(title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         docs = query('Cornbread')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_add_member(self):
         self.group.make_member(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         self.group.make_manager(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         self.group.remove_member(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_connect_to_node(self):
         self.project.add_osf_group(self.group)
         docs = query(f'category:project AND "{self.group.name}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         self.project.remove_osf_group(self.group)
         docs = query(f'category:project AND "{self.group.name}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_remove_group(self):
         group_name = self.group.name
         self.project.add_osf_group(self.group)
         docs = query(f'category:project AND "{group_name}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         self.group.remove_group()
         docs = query(f'category:project AND "{group_name}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         docs = query(group_name)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
 
 @pytest.mark.enable_search
@@ -552,7 +550,7 @@ class TestPreprint(OsfTestCase):
         self.preprint.title = title
         self.preprint.save()
         docs = query(title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_new_preprint_unpublished(self):
         # Verify that an unpublished preprint is not present in Elastic Search.
@@ -560,7 +558,7 @@ class TestPreprint(OsfTestCase):
         self.preprint = factories.PreprintFactory(creator=self.user, is_published=False, title=title)
         assert self.preprint.title == title
         docs = query(title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_unsubmitted_preprint_primary_file(self):
         # Unpublished preprint's primary_file not showing up in Elastic Search
@@ -569,7 +567,7 @@ class TestPreprint(OsfTestCase):
         self.preprint.set_primary_file(self.file, auth=Auth(self.user), save=True)
         assert self.preprint.title == title
         docs = query(title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_publish_preprint(self):
         title = 'Date'
@@ -578,17 +576,17 @@ class TestPreprint(OsfTestCase):
         assert self.preprint.title == title
         docs = query(title)['results']
         # Both preprint and primary_file showing up in Elastic
-        assert_equal(len(docs), 2)
+        self.assertEqual(len(docs), 2)
 
     def test_preprint_title_change(self):
         title_original = self.published_preprint.title
         new_title = 'New preprint title'
         self.published_preprint.set_title(new_title, auth=Auth(self.user), save=True)
         docs = query('category:preprint AND ' + title_original)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         docs = query('category:preprint AND ' + new_title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_preprint_description_change(self):
         description_original = self.published_preprint.description
@@ -596,17 +594,17 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.set_description(new_abstract, auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
         docs = query('category:preprint AND ' + description_original)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         docs = query('category:preprint AND ' + new_abstract)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_set_preprint_private(self):
         # Not currently an option for users, but can be used for spam
         self.published_preprint.set_privacy('private', auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
         # Both preprint and primary_file showing up in Elastic
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_set_primary_file(self):
         # Only primary_file should be in index, if primary_file is changed, other files are removed from index.
@@ -619,8 +617,8 @@ class TestPreprint(OsfTestCase):
         create_file_version(self.file, self.user)
         self.published_preprint.set_primary_file(self.file, auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
-        assert_equal(len(docs), 2)
-        assert_equal(docs[1]['name'], self.file.name)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[1]['name'], self.file.name)
 
     def test_set_license(self):
         license_details = {
@@ -633,9 +631,9 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.set_preprint_license(license_details, Auth(self.user), save=True)
         assert self.published_preprint.title == title
         docs = query(title)['results']
-        assert_equal(len(docs), 2)
-        assert_equal(docs[0]['license']['copyright_holders'][0], 'Iron Man')
-        assert_equal(docs[0]['license']['name'], 'No license')
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(docs[0]['license']['copyright_holders'][0], 'Iron Man')
+        self.assertEqual(docs[0]['license']['name'], 'No license')
 
     def test_add_tags(self):
 
@@ -643,12 +641,12 @@ class TestPreprint(OsfTestCase):
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
             self.published_preprint.add_tag(tag, Auth(self.user), save=True)
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            assert_equal(len(docs), 1)
+            self.assertEqual(len(docs), 1)
 
     def test_remove_tag(self):
 
@@ -658,7 +656,7 @@ class TestPreprint(OsfTestCase):
             self.published_preprint.add_tag(tag, Auth(self.user), save=True)
             self.published_preprint.remove_tag(tag, Auth(self.user), save=True)
             docs = query(f'tags:"{tag}"')['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
 
     def test_add_contributor(self):
         # Add a contributor, then verify that project is found when searching
@@ -666,12 +664,12 @@ class TestPreprint(OsfTestCase):
         user2 = factories.UserFactory(fullname='Adam Lambert')
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         # with run_celery_tasks():
         self.published_preprint.add_contributor(user2, save=True)
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_remove_contributor(self):
         # Add and remove a contributor, then verify that project is not found
@@ -682,28 +680,28 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.remove_contributor(user2, Auth(self.user))
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_hide_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
         self.published_preprint.add_contributor(user2)
         self.published_preprint.set_visible(user2, False, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         self.published_preprint.set_visible(user2, True, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_move_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
         self.published_preprint.add_contributor(user2, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
         docs[0]['contributors'][0]['fullname'] == self.user.fullname
         docs[0]['contributors'][1]['fullname'] == user2.fullname
         self.published_preprint.move_contributor(user2, Auth(self.user), 0)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
         docs[0]['contributors'][0]['fullname'] == user2.fullname
         docs[0]['contributors'][1]['fullname'] == self.user.fullname
 
@@ -739,19 +737,19 @@ class TestNodeSearch(OsfTestCase):
     def test_node_license_added_to_search(self):
         docs = query(self.query)['results']
         node = [d for d in docs if d['title'] == self.node.title][0]
-        assert_in('license', node)
-        assert_equal(node['license']['id'], self.node.node_license.license_id)
+        self.assertIn('license', node)
+        self.assertEqual(node['license']['id'], self.node.node_license.license_id)
 
     @unittest.skip('Elasticsearch latency seems to be causing theses tests to fail randomly.')
     @retry_assertion(retries=10)
     def test_node_license_propogates_to_children(self):
         docs = query(self.query)['results']
         child = [d for d in docs if d['title'] == self.public_child.title][0]
-        assert_in('license', child)
-        assert_equal(child['license'].get('id'), self.node.node_license.license_id)
+        self.assertIn('license', child)
+        self.assertEqual(child['license'].get('id'), self.node.node_license.license_id)
         child = [d for d in docs if d['title'] == self.public_subchild.title][0]
-        assert_in('license', child)
-        assert_equal(child['license'].get('id'), self.node.node_license.license_id)
+        self.assertIn('license', child)
+        self.assertEqual(child['license'].get('id'), self.node.node_license.license_id)
 
     @unittest.skip('Elasticsearch latency seems to be causing theses tests to fail randomly.')
     @retry_assertion(retries=10)
@@ -762,7 +760,7 @@ class TestNodeSearch(OsfTestCase):
         self.node.save()
         docs = query(self.query)['results']
         for doc in docs:
-            assert_equal(doc['license'].get('id'), new_license.license_id)
+            self.assertEqual(doc['license'].get('id'), new_license.license_id)
 
 
 @pytest.mark.enable_search
@@ -790,7 +788,7 @@ class TestRegistrationRetractions(OsfTestCase):
         self.registration.save()
         self.registration.retraction._on_complete(self.user)
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
     def test_pending_retraction_wiki_content_is_searchable(self):
@@ -798,16 +796,16 @@ class TestRegistrationRetractions(OsfTestCase):
         wiki_content = {'home': 'public retraction test'}
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.registration, key, value, self.consolidate_auth)
             # Query and ensure unique string shows up
             docs = query(value)['results']
-            assert_equal(len(docs), 1)
+            self.assertEqual(len(docs), 1)
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         # Retract registration
         self.registration.retract_registration(self.user, '')
@@ -817,11 +815,11 @@ class TestRegistrationRetractions(OsfTestCase):
 
         # Query and ensure unique string in wiki doesn't show up
         docs = query('category:registration AND "{}"'.format(wiki_content['home']))['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
     def test_retraction_wiki_content_is_not_searchable(self):
@@ -829,16 +827,16 @@ class TestRegistrationRetractions(OsfTestCase):
         wiki_content = {'home': 'public retraction test'}
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.registration, key, value, self.consolidate_auth)
             # Query and ensure unique string shows up
             docs = query(value)['results']
-            assert_equal(len(docs), 1)
+            self.assertEqual(len(docs), 1)
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
         # Retract registration
         self.registration.retract_registration(self.user, '')
@@ -850,11 +848,11 @@ class TestRegistrationRetractions(OsfTestCase):
 
         # Query and ensure unique string in wiki doesn't show up
         docs = query('category:registration AND "{}"'.format(wiki_content['home']))['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
 
 @pytest.mark.enable_search
@@ -896,42 +894,42 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('private')
         docs = query('category:project AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         with run_celery_tasks():
             self.component.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_search_node_partial(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Blue')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_search_node_partial_with_sep(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Express')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_search_node_not_name(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Green Flyer-Slow')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
 
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         docs = query('category:component AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
-        assert_equal(docs[0]['parent_title'], 'hello & world')
-        assert_true(docs[0]['parent_url'])
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]['parent_title'], 'hello & world')
+        self.assertTrue(docs[0]['parent_url'])
 
     def test_make_parent_private(self):
         # Make parent of component, public, then private, and verify that the
@@ -939,20 +937,20 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
-        assert_false(docs[0]['parent_title'])
-        assert_false(docs[0]['parent_url'])
+        self.assertEqual(len(docs), 1)
+        self.assertFalse(docs[0]['parent_title'])
+        self.assertFalse(docs[0]['parent_url'])
 
     def test_delete_project(self):
         with run_celery_tasks():
             self.component.remove_node(self.consolidate_auth)
         docs = query('category:component AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         with run_celery_tasks():
             self.project.remove_node(self.consolidate_auth)
         docs = query('category:project AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_change_title(self):
         title_original = self.project.title
@@ -962,10 +960,10 @@ class TestPublicNodes(OsfTestCase):
             )
 
         docs = query('category:project AND ' + title_original)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
         docs = query('category:project AND ' + self.project.title)['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_add_tags(self):
 
@@ -974,12 +972,12 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             for tag in tags:
                 docs = query(f'tags:"{tag}"')['results']
-                assert_equal(len(docs), 0)
+                self.assertEqual(len(docs), 0)
                 self.project.add_tag(tag, self.consolidate_auth, save=True)
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            assert_equal(len(docs), 1)
+            self.assertEqual(len(docs), 1)
 
     def test_remove_tag(self):
 
@@ -989,7 +987,7 @@ class TestPublicNodes(OsfTestCase):
             self.project.add_tag(tag, self.consolidate_auth, save=True)
             self.project.remove_tag(tag, self.consolidate_auth, save=True)
             docs = query(f'tags:"{tag}"')['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
 
     def test_update_wiki(self):
         """Add text to a wiki page, then verify that project is found when
@@ -1002,11 +1000,11 @@ class TestPublicNodes(OsfTestCase):
         }
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            assert_equal(len(docs), 0)
+            self.assertEqual(len(docs), 0)
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.project, key, value, self.consolidate_auth)
             docs = query(value)['results']
-            assert_equal(len(docs), 1)
+            self.assertEqual(len(docs), 1)
 
     def test_clear_wiki(self):
         # Add wiki text to page, then delete, then verify that project is not
@@ -1018,7 +1016,7 @@ class TestPublicNodes(OsfTestCase):
             wp.update(self.user, '')
 
         docs = query(wiki_content)['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_add_contributor(self):
         # Add a contributor, then verify that project is found when searching
@@ -1026,12 +1024,12 @@ class TestPublicNodes(OsfTestCase):
         user2 = factories.UserFactory(fullname='Adam Lambert')
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         with run_celery_tasks():
             self.project.add_contributor(user2, save=True)
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_remove_contributor(self):
         # Add and remove a contributor, then verify that project is not found
@@ -1042,7 +1040,7 @@ class TestPublicNodes(OsfTestCase):
         self.project.remove_contributor(user2, self.consolidate_auth)
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
 
     def test_hide_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
@@ -1050,11 +1048,11 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_visible(user2, False, save=True)
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 0)
+        self.assertEqual(len(docs), 0)
         with run_celery_tasks():
             self.project.set_visible(user2, True, save=True)
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        assert_equal(len(docs), 1)
+        self.assertEqual(len(docs), 1)
 
     def test_wrong_order_search(self):
         title_parts = self.title.split(' ')
@@ -1062,7 +1060,7 @@ class TestPublicNodes(OsfTestCase):
         title_search = ' '.join(title_parts)
 
         docs = query(title_search)['results']
-        assert_equal(len(docs), 3)
+        self.assertEqual(len(docs), 3)
 
     def test_tag_aggregation(self):
         tags = ['stonecoldcrazy', 'just a poor boy', 'from-a-poor-family']
@@ -1096,7 +1094,7 @@ class TestAddContributor(OsfTestCase):
     def test_unreg_users_dont_show_in_search(self):
         unreg = factories.UnregUserFactory()
         contribs = search.search_contributor(unreg.fullname)
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_unreg_users_do_show_on_projects(self):
         with run_celery_tasks():
@@ -1107,59 +1105,59 @@ class TestAddContributor(OsfTestCase):
                 is_public=True,
             )
         results = query(unreg.fullname)['results']
-        assert_equal(len(results), 1)
+        self.assertEqual(len(results), 1)
 
     def test_search_fullname(self):
         # Searching for full name yields exactly one result.
         contribs = search.search_contributor(self.name1)
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name2)
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_firstname(self):
         # Searching for first name yields exactly one result.
         contribs = search.search_contributor(self.name1.split(' ')[0])
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name2.split(' ')[0])
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_partial(self):
         # Searching for part of first name yields exactly one
         # result.
         contribs = search.search_contributor(self.name1.split(' ')[0][:-1])
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name2.split(' ')[0][:-1])
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_fullname_special_character(self):
         # Searching for a fullname with a special character yields
         # exactly one result.
         contribs = search.search_contributor(self.name3)
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name4)
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_firstname_special_charcter(self):
         # Searching for a first name with a special character yields
         # exactly one result.
         contribs = search.search_contributor(self.name3.split(' ')[0])
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name4.split(' ')[0])
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_partial_special_character(self):
         # Searching for a partial name with a special character yields
         # exctly one result.
         contribs = search.search_contributor(self.name3.split(' ')[0][:-1])
-        assert_equal(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users']), 1)
 
         contribs = search.search_contributor(self.name4.split(' ')[0][:-1])
-        assert_equal(len(contribs['users']), 0)
+        self.assertEqual(len(contribs['users']), 0)
 
     def test_search_profile(self):
         orcid = '123456'
@@ -1167,9 +1165,9 @@ class TestAddContributor(OsfTestCase):
         user.social['orcid'] = orcid
         user.save()
         contribs = search.search_contributor(orcid)
-        assert_equal(len(contribs['users']), 1)
-        assert_equal(len(contribs['users'][0]['social']), 1)
-        assert_equal(contribs['users'][0]['social']['orcid'], user.social_links['orcid'])
+        self.assertEqual(len(contribs['users']), 1)
+        self.assertEqual(len(contribs['users'][0]['social']), 1)
+        self.assertEqual(contribs['users'][0]['social']['orcid'], user.social_links['orcid'])
 
 
 @pytest.mark.enable_search
@@ -1213,19 +1211,19 @@ class TestProjectSearchResults(OsfTestCase):
         # possessive and plural versions in results.
         time.sleep(1)
         results = query(self.singular)['results']
-        assert_equal(len(results), 3)
+        self.assertEqual(len(results), 3)
 
     def test_plural_query(self):
         # Verify searching for singular term includes singular,
         # possessive and plural versions in results.
         results = query(self.plural)['results']
-        assert_equal(len(results), 3)
+        self.assertEqual(len(results), 3)
 
     def test_possessive_query(self):
         # Verify searching for possessive term includes singular,
         # possessive and plural versions in results.
         results = query(self.possessive)['results']
-        assert_equal(len(results), 3)
+        self.assertEqual(len(results), 3)
 
 
 def job(**kwargs):
@@ -1299,14 +1297,14 @@ class TestUserSearchResults(OsfTestCase):
         result_names = [r['names']['fullname'] for r in results]
         current_starfleet_names = [u.fullname for u in self.current_starfleet]
         for name in result_names[:2]:
-            assert_in(name, current_starfleet_names)
+            self.assertIn(name, current_starfleet_names)
 
     def test_had_job_in_results(self):
         results = query_user('Star Fleet')['results']
         result_names = [r['names']['fullname'] for r in results]
         were_starfleet_names = [u.fullname for u in self.were_starfleet]
         for name in result_names:
-            assert_in(name, were_starfleet_names)
+            self.assertIn(name, were_starfleet_names)
 
 
 @pytest.mark.enable_search
@@ -1370,28 +1368,28 @@ class TestSearchMigration(OsfTestCase):
     def test_first_migration_no_remove(self):
         migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
-        assert_equal(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+        self.assertEqual(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
 
     def test_multiple_migrations_no_remove(self):
         for n in range(1, 21):
             migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            assert_equal(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
 
     def test_first_migration_with_remove(self):
         migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
-        assert_equal(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+        self.assertEqual(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
 
     def test_multiple_migrations_with_remove(self):
         for n in range(1, 21, 2):
             migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            assert_equal(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
 
             migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            assert_equal(list(var[settings.ELASTIC_INDEX + f'_v{n + 1}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n + 1}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
             assert not var.get(settings.ELASTIC_INDEX + f'_v{n}')
 
     def test_migration_institutions(self):
@@ -1410,7 +1408,7 @@ class TestSearchMigration(OsfTestCase):
             if bucket['key'] == 'institution':
                 institution_bucket_found = True
 
-        assert_equal(institution_bucket_found, True)
+        self.assertEqual(institution_bucket_found, True)
 
     def test_migration_collections(self):
         provider = factories.CollectionProviderFactory()
@@ -1464,22 +1462,22 @@ class TestSearchFiles(OsfTestCase):
         file_ = self.root.append_file('Shake.wav')
         create_file_version(file_, self.user)
         find = query_file('Shake.wav')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_search_file_name_without_separator(self):
         file_ = self.root.append_file('Shake.wav')
         create_file_version(file_, self.user)
         find = query_file('Shake')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_delete_file(self):
         file_ = self.root.append_file('I\'ve Got Dreams To Remember.wav')
         create_file_version(file_, self.user)
         find = query_file('I\'ve Got Dreams To Remember.wav')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
         file_.delete()
         find = query_file('I\'ve Got Dreams To Remember.wav')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
 
     def test_add_tag(self):
         file_ = self.root.append_file('That\'s How Strong My Love Is.mp3')
@@ -1489,7 +1487,7 @@ class TestSearchFiles(OsfTestCase):
         file_.tags.add(tag)
         file_.save()
         find = query_tag_file('Redding')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_remove_tag(self):
         file_ = self.root.append_file('I\'ve Been Loving You Too Long.mp3')
@@ -1499,22 +1497,22 @@ class TestSearchFiles(OsfTestCase):
         file_.tags.add(tag)
         file_.save()
         find = query_tag_file('Blue')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
         file_.tags.remove(tag)
         file_.save()
         find = query_tag_file('Blue')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
 
     def test_make_node_private(self):
         file_ = self.root.append_file('Change_Gonna_Come.wav')
         create_file_version(file_, self.user)
         find = query_file('Change_Gonna_Come.wav')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
         self.node.is_public = False
         with run_celery_tasks():
             self.node.save()
         find = query_file('Change_Gonna_Come.wav')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
 
     def test_make_private_node_public(self):
         self.node.is_public = False
@@ -1522,12 +1520,12 @@ class TestSearchFiles(OsfTestCase):
         file_ = self.root.append_file('Try a Little Tenderness.flac')
         create_file_version(file_, self.user)
         find = query_file('Try a Little Tenderness.flac')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
         self.node.is_public = True
         with run_celery_tasks():
             self.node.save()
         find = query_file('Try a Little Tenderness.flac')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
 
     def test_delete_node(self):
         node = factories.ProjectFactory(is_public=True, title='The Soul Album')
@@ -1536,12 +1534,12 @@ class TestSearchFiles(OsfTestCase):
         file_ = root.append_file('The Dock of the Bay.mp3')
         create_file_version(file_, self.user)
         find = query_file('The Dock of the Bay.mp3')['results']
-        assert_equal(len(find), 1)
+        self.assertEqual(len(find), 1)
         node.is_deleted = True
         with run_celery_tasks():
             node.save()
         find = query_file('The Dock of the Bay.mp3')['results']
-        assert_equal(len(find), 0)
+        self.assertEqual(len(find), 0)
 
     def test_file_download_url_guid(self):
         file_ = self.root.append_file('Timber.mp3')
@@ -1549,7 +1547,7 @@ class TestSearchFiles(OsfTestCase):
         file_guid = file_.get_guid(create=True)
         file_.save()
         find = query_file('Timber.mp3')['results']
-        assert_equal(find[0]['guid_url'], '/' + file_guid._id + '/')
+        self.assertEqual(find[0]['guid_url'], '/' + file_guid._id + '/')
 
     def test_file_download_url_no_guid(self):
         file_ = self.root.append_file('Timber.mp3')
@@ -1557,7 +1555,7 @@ class TestSearchFiles(OsfTestCase):
         path = file_.path
         deep_url = '/' + file_.target._id + '/files/osfstorage' + path + '/'
         find = query_file('Timber.mp3')['results']
-        assert_not_equal(file_.path, '')
-        assert_equal(file_.path, path)
-        assert_equal(find[0]['guid_url'], None)
-        assert_equal(find[0]['deep_url'], deep_url)
+        self.assertNotEqual(file_.path, '')
+        self.assertEqual(file_.path, path)
+        self.assertEqual(find[0]['guid_url'], None)
+        self.assertEqual(find[0]['deep_url'], deep_url)

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -1408,7 +1408,7 @@ class TestSearchMigration(OsfTestCase):
             if bucket['key'] == 'institution':
                 institution_bucket_found = True
 
-        assert institution_bucket_found == True
+        assert institution_bucket_found is True
 
     def test_migration_collections(self):
         provider = factories.CollectionProviderFactory()
@@ -1557,5 +1557,5 @@ class TestSearchFiles(OsfTestCase):
         find = query_file('Timber.mp3')['results']
         assert file_.path != ''
         assert file_.path == path
-        assert find[0]['guid_url'] == None
+        assert find[0]['guid_url'] is None
         assert find[0]['deep_url'] == deep_url

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -107,79 +107,79 @@ class TestCollectionsSearch(OsfTestCase):
 
     def test_only_public_collections_submissions_are_searchable(self):
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         self.collection_public.collect_object(self.node_private, self.user)
         self.reg_collection.collect_object(self.reg_private, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
-        self.assertFalse(self.node_one.collection_submissions.filter(
+        assert not self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertFalse(self.node_public.collection_submissions.filter(
+        ).exists()
+        assert not self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
+        ).exists()
 
         self.collection_one.collect_object(self.node_one, self.user)
         self.collection_public.collect_object(self.node_public, self.user)
         self.reg_collection.collect_object(self.reg_public, self.user)
 
-        self.assertTrue(self.node_one.collection_submissions.filter(
+        assert self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.node_public.collection_submissions.filter(
+        ).exists()
+        assert self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.reg_public.collection_submissions.filter(
+        ).exists()
+        assert self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
+        ).exists()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 3)
+        assert len(docs) == 3
 
         self.collection_private.collect_object(self.node_two, self.user)
         self.reg_collection_private.collect_object(self.reg_one, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 3)
+        assert len(docs) == 3
 
     def test_index_on_submission_privacy_changes(self):
         # test_submissions_turned_private_are_deleted_from_index
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_one.collect_object(self.node_one, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 2)
+        assert len(docs) == 2
 
         with run_celery_tasks():
             self.node_one.is_public = False
             self.node_one.save()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         # test_submissions_turned_public_are_added_to_index
         self.collection_public.collect_object(self.node_private, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         with run_celery_tasks():
             self.node_private.is_public = True
             self.node_private.save()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_index_on_collection_privacy_changes(self):
         # test_submissions_of_collection_turned_private_are_removed_from_index
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_public.collect_object(self.node_two, self.user)
@@ -187,7 +187,7 @@ class TestCollectionsSearch(OsfTestCase):
         self.reg_collection.collect_object(self.reg_public, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 4)
+        assert len(docs) == 4
 
         with run_celery_tasks():
             self.collection_public.is_public = False
@@ -196,7 +196,7 @@ class TestCollectionsSearch(OsfTestCase):
             self.reg_collection.save()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         # test_submissions_of_collection_turned_public_are_added_to_index
         self.collection_private.collect_object(self.node_one, self.user)
@@ -204,21 +204,21 @@ class TestCollectionsSearch(OsfTestCase):
         self.collection_private.collect_object(self.node_public, self.user)
         self.reg_collection_private.collect_object(self.reg_public, self.user)
 
-        self.assertTrue(self.node_one.collection_submissions.filter(
+        assert self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.node_two.collection_submissions.filter(
+        ).exists()
+        assert self.node_two.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.node_public.collection_submissions.filter(
+        ).exists()
+        assert self.node_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.reg_public.collection_submissions.filter(
+        ).exists()
+        assert self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
+        ).exists()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         with run_celery_tasks():
             self.collection_private.is_public = True
@@ -227,11 +227,11 @@ class TestCollectionsSearch(OsfTestCase):
             self.reg_collection.save()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 4)
+        assert len(docs) == 4
 
     def test_collection_submissions_are_removed_from_index_on_delete(self):
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         self.collection_public.collect_object(self.node_one, self.user)
         self.collection_public.collect_object(self.node_two, self.user)
@@ -239,57 +239,57 @@ class TestCollectionsSearch(OsfTestCase):
         self.reg_collection.collect_object(self.reg_public, self.user)
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 4)
+        assert len(docs) == 4
         self.collection_public.delete()
         self.reg_collection.delete()
 
-        self.assertTrue(self.collection_public.deleted)
-        self.assertTrue(self.reg_collection.deleted)
+        assert self.collection_public.deleted
+        assert self.reg_collection.deleted
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_removed_submission_are_removed_from_index(self):
         self.collection_public.collect_object(self.node_one, self.user)
         self.reg_collection.collect_object(self.reg_public, self.user)
-        self.assertTrue(self.node_one.collection_submissions.filter(
+        assert self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertTrue(self.reg_public.collection_submissions.filter(
+        ).exists()
+        assert self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
+        ).exists()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 2)
+        assert len(docs) == 2
 
         self.collection_public.remove_object(self.node_one, Auth(self.user))
         self.reg_collection.remove_object(self.reg_public, Auth(self.user))
-        self.assertFalse(self.node_one.collection_submissions.filter(
+        assert not self.node_one.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
-        self.assertFalse(self.reg_public.collection_submissions.filter(
+        ).exists()
+        assert not self.reg_public.collection_submissions.filter(
             machine_state=CollectionSubmissionStates.ACCEPTED
-        ).exists())
+        ).exists()
 
         docs = query_collections('Salif Keita')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_collection_submission_doc_structure(self):
         self.collection_public.collect_object(self.node_one, self.user)
         docs = query_collections('Keita')['results']
-        self.assertEqual(docs[0]['_source']['title'], self.node_one.title)
+        assert docs[0]['_source']['title'] == self.node_one.title
         with run_celery_tasks():
             self.node_one.title = 'Keita Royal Family of Mali'
             self.node_one.save()
         docs = query_collections('Keita')['results']
-        self.assertEqual(docs[0]['_source']['title'], self.node_one.title)
-        self.assertEqual(docs[0]['_source']['abstract'], self.node_one.description)
-        self.assertEqual(docs[0]['_source']['contributors'][0]['url'], self.user.url)
-        self.assertEqual(docs[0]['_source']['contributors'][0]['fullname'], self.user.fullname)
-        self.assertEqual(docs[0]['_source']['url'], self.node_one.url)
-        self.assertEqual(docs[0]['_source']['id'], '{}-{}'.format(self.node_one._id,
-            self.node_one.collection_submissions[0].collection._id))
-        self.assertEqual(docs[0]['_source']['category'], 'collectionSubmission')
+        assert docs[0]['_source']['title'] == self.node_one.title
+        assert docs[0]['_source']['abstract'] == self.node_one.description
+        assert docs[0]['_source']['contributors'][0]['url'] == self.user.url
+        assert docs[0]['_source']['contributors'][0]['fullname'] == self.user.fullname
+        assert docs[0]['_source']['url'] == self.node_one.url
+        assert docs[0]['_source']['id'] == '{}-{}'.format(self.node_one._id,
+            self.node_one.collection_submissions[0].collection._id)
+        assert docs[0]['_source']['category'] == 'collectionSubmission'
 
     def test_search_updated_after_id_change(self):
         self.provider.primary_collection.collect_object(self.node_one, self.node_one.creator)
@@ -297,11 +297,11 @@ class TestCollectionsSearch(OsfTestCase):
             self.node_one.save()
         term = f'provider:{self.provider._id}'
         docs = search.search(build_query(term), index=elastic_search.INDEX, raw=True)
-        self.assertEqual(len(docs['results']), 1)
+        assert len(docs['results']) == 1
         self.provider._id = 'new_id'
         self.provider.save()
         docs = query('provider:new_id', raw=True)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
 
 @pytest.mark.enable_search
@@ -317,17 +317,17 @@ class TestUserUpdate(OsfTestCase):
     def test_new_user(self):
         # Verify that user has been added to Elastic Search
         docs = query_user(self.user.fullname)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_new_user_unconfirmed(self):
         user = factories.UnconfirmedUserFactory()
         docs = query_user(user.fullname)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         token = user.get_confirmation_token(user.username)
         user.confirm_email(token)
         user.save()
         docs = query_user(user.fullname)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     @retry_assertion
     def test_change_name(self):
@@ -339,10 +339,10 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs_original = query_user(fullname_original)['results']
-        self.assertEqual(len(docs_original), 0)
+        assert len(docs_original) == 0
 
         docs_current = query_user(user.fullname)['results']
-        self.assertEqual(len(docs_current), 1)
+        assert len(docs_current) == 1
 
     def test_disabled_user(self):
         # Test that disabled users are not in search index
@@ -351,27 +351,27 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         # Ensure user is in search index
-        self.assertEqual(len(query_user(user.fullname)['results']), 1)
+        assert len(query_user(user.fullname)['results']) == 1
 
         # Disable the user
         user.is_disabled = True
         user.save()
 
         # Ensure user is not in search index
-        self.assertEqual(len(query_user(user.fullname)['results']), 0)
+        assert len(query_user(user.fullname)['results']) == 0
 
     def test_merged_user(self):
         user = factories.UserFactory(fullname='Annie Lennox')
         merged_user = factories.UserFactory(fullname='Lisa Stansfield')
         user.save()
         merged_user.save()
-        self.assertEqual(len(query_user(user.fullname)['results']), 1)
-        self.assertEqual(len(query_user(merged_user.fullname)['results']), 1)
+        assert len(query_user(user.fullname)['results']) == 1
+        assert len(query_user(merged_user.fullname)['results']) == 1
 
         user.merge_user(merged_user)
 
-        self.assertEqual(len(query_user(user.fullname)['results']), 1)
-        self.assertEqual(len(query_user(merged_user.fullname)['results']), 0)
+        assert len(query_user(user.fullname)['results']) == 1
+        assert len(query_user(merged_user.fullname)['results']) == 0
 
     def test_employment(self):
         user = factories.UserFactory(fullname='Helga Finn')
@@ -379,7 +379,7 @@ class TestUserUpdate(OsfTestCase):
         institution = 'Finn\'s Fine Filers'
 
         docs = query_user(institution)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         user.jobs.append({
             'institution': institution,
             'title': 'The Big Finn',
@@ -387,7 +387,7 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs = query_user(institution)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_education(self):
         user = factories.UserFactory(fullname='Henry Johnson')
@@ -395,7 +395,7 @@ class TestUserUpdate(OsfTestCase):
         institution = 'Henry\'s Amazing School!!!'
 
         docs = query_user(institution)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         user.schools.append({
             'institution': institution,
             'degree': 'failed all classes',
@@ -403,7 +403,7 @@ class TestUserUpdate(OsfTestCase):
         user.save()
 
         docs = query_user(institution)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_name_fields(self):
         names = ['Bill Nye', 'William', 'the science guy', 'Sanford', 'the Great']
@@ -414,8 +414,8 @@ class TestUserUpdate(OsfTestCase):
         user.suffix = names[4]
         user.save()
         docs = [query_user(name)['results'] for name in names]
-        self.assertEqual(sum(map(len, docs)), len(docs))  # 1 result each
-        self.assertTrue(all([user._id == doc[0]['id'] for doc in docs]))
+        assert sum(map(len, docs)) == len(docs)  # 1 result each
+        assert all([user._id == doc[0]['id'] for doc in docs])
 
 
 @pytest.mark.enable_search
@@ -432,7 +432,7 @@ class TestProject(OsfTestCase):
     def test_new_project_private(self):
         # Verify that a private project is not present in Elastic Search.
         docs = query(self.project.title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_make_public(self):
         # Make project public, and verify that it is present in Elastic
@@ -440,7 +440,7 @@ class TestProject(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('public')
         docs = query(self.project.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
 
 @pytest.mark.enable_search
@@ -467,51 +467,51 @@ class TestOSFGroup(OsfTestCase):
         group = OSFGroup(name=title, creator=self.user)
         group.save()
         docs = query(title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_set_group_name(self):
         title = 'Eggs'
         self.group.set_group_name(title)
         self.group.save()
         docs = query(title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         docs = query('Cornbread')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_add_member(self):
         self.group.make_member(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         self.group.make_manager(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         self.group.remove_member(self.user_two)
         docs = query(f'category:group AND "{self.user_two.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_connect_to_node(self):
         self.project.add_osf_group(self.group)
         docs = query(f'category:project AND "{self.group.name}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         self.project.remove_osf_group(self.group)
         docs = query(f'category:project AND "{self.group.name}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_remove_group(self):
         group_name = self.group.name
         self.project.add_osf_group(self.group)
         docs = query(f'category:project AND "{group_name}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         self.group.remove_group()
         docs = query(f'category:project AND "{group_name}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         docs = query(group_name)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
 
 @pytest.mark.enable_search
@@ -550,7 +550,7 @@ class TestPreprint(OsfTestCase):
         self.preprint.title = title
         self.preprint.save()
         docs = query(title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_new_preprint_unpublished(self):
         # Verify that an unpublished preprint is not present in Elastic Search.
@@ -558,7 +558,7 @@ class TestPreprint(OsfTestCase):
         self.preprint = factories.PreprintFactory(creator=self.user, is_published=False, title=title)
         assert self.preprint.title == title
         docs = query(title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_unsubmitted_preprint_primary_file(self):
         # Unpublished preprint's primary_file not showing up in Elastic Search
@@ -567,7 +567,7 @@ class TestPreprint(OsfTestCase):
         self.preprint.set_primary_file(self.file, auth=Auth(self.user), save=True)
         assert self.preprint.title == title
         docs = query(title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_publish_preprint(self):
         title = 'Date'
@@ -576,17 +576,17 @@ class TestPreprint(OsfTestCase):
         assert self.preprint.title == title
         docs = query(title)['results']
         # Both preprint and primary_file showing up in Elastic
-        self.assertEqual(len(docs), 2)
+        assert len(docs) == 2
 
     def test_preprint_title_change(self):
         title_original = self.published_preprint.title
         new_title = 'New preprint title'
         self.published_preprint.set_title(new_title, auth=Auth(self.user), save=True)
         docs = query('category:preprint AND ' + title_original)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         docs = query('category:preprint AND ' + new_title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_preprint_description_change(self):
         description_original = self.published_preprint.description
@@ -594,17 +594,17 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.set_description(new_abstract, auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
         docs = query('category:preprint AND ' + description_original)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         docs = query('category:preprint AND ' + new_abstract)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_set_preprint_private(self):
         # Not currently an option for users, but can be used for spam
         self.published_preprint.set_privacy('private', auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
         # Both preprint and primary_file showing up in Elastic
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_set_primary_file(self):
         # Only primary_file should be in index, if primary_file is changed, other files are removed from index.
@@ -617,8 +617,8 @@ class TestPreprint(OsfTestCase):
         create_file_version(self.file, self.user)
         self.published_preprint.set_primary_file(self.file, auth=Auth(self.user), save=True)
         docs = query(self.published_preprint.title)['results']
-        self.assertEqual(len(docs), 2)
-        self.assertEqual(docs[1]['name'], self.file.name)
+        assert len(docs) == 2
+        assert docs[1]['name'] == self.file.name
 
     def test_set_license(self):
         license_details = {
@@ -631,9 +631,9 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.set_preprint_license(license_details, Auth(self.user), save=True)
         assert self.published_preprint.title == title
         docs = query(title)['results']
-        self.assertEqual(len(docs), 2)
-        self.assertEqual(docs[0]['license']['copyright_holders'][0], 'Iron Man')
-        self.assertEqual(docs[0]['license']['name'], 'No license')
+        assert len(docs) == 2
+        assert docs[0]['license']['copyright_holders'][0] == 'Iron Man'
+        assert docs[0]['license']['name'] == 'No license'
 
     def test_add_tags(self):
 
@@ -641,12 +641,12 @@ class TestPreprint(OsfTestCase):
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
             self.published_preprint.add_tag(tag, Auth(self.user), save=True)
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            self.assertEqual(len(docs), 1)
+            assert len(docs) == 1
 
     def test_remove_tag(self):
 
@@ -656,7 +656,7 @@ class TestPreprint(OsfTestCase):
             self.published_preprint.add_tag(tag, Auth(self.user), save=True)
             self.published_preprint.remove_tag(tag, Auth(self.user), save=True)
             docs = query(f'tags:"{tag}"')['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
 
     def test_add_contributor(self):
         # Add a contributor, then verify that project is found when searching
@@ -664,12 +664,12 @@ class TestPreprint(OsfTestCase):
         user2 = factories.UserFactory(fullname='Adam Lambert')
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         # with run_celery_tasks():
         self.published_preprint.add_contributor(user2, save=True)
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_remove_contributor(self):
         # Add and remove a contributor, then verify that project is not found
@@ -680,28 +680,28 @@ class TestPreprint(OsfTestCase):
         self.published_preprint.remove_contributor(user2, Auth(self.user))
 
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_hide_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
         self.published_preprint.add_contributor(user2)
         self.published_preprint.set_visible(user2, False, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         self.published_preprint.set_visible(user2, True, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_move_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
         self.published_preprint.add_contributor(user2, save=True)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
         docs[0]['contributors'][0]['fullname'] == self.user.fullname
         docs[0]['contributors'][1]['fullname'] == user2.fullname
         self.published_preprint.move_contributor(user2, Auth(self.user), 0)
         docs = query(f'category:preprint AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
         docs[0]['contributors'][0]['fullname'] == user2.fullname
         docs[0]['contributors'][1]['fullname'] == self.user.fullname
 
@@ -737,19 +737,19 @@ class TestNodeSearch(OsfTestCase):
     def test_node_license_added_to_search(self):
         docs = query(self.query)['results']
         node = [d for d in docs if d['title'] == self.node.title][0]
-        self.assertIn('license', node)
-        self.assertEqual(node['license']['id'], self.node.node_license.license_id)
+        assert 'license' in node
+        assert node['license']['id'] == self.node.node_license.license_id
 
     @unittest.skip('Elasticsearch latency seems to be causing theses tests to fail randomly.')
     @retry_assertion(retries=10)
     def test_node_license_propogates_to_children(self):
         docs = query(self.query)['results']
         child = [d for d in docs if d['title'] == self.public_child.title][0]
-        self.assertIn('license', child)
-        self.assertEqual(child['license'].get('id'), self.node.node_license.license_id)
+        assert 'license' in child
+        assert child['license'].get('id') == self.node.node_license.license_id
         child = [d for d in docs if d['title'] == self.public_subchild.title][0]
-        self.assertIn('license', child)
-        self.assertEqual(child['license'].get('id'), self.node.node_license.license_id)
+        assert 'license' in child
+        assert child['license'].get('id') == self.node.node_license.license_id
 
     @unittest.skip('Elasticsearch latency seems to be causing theses tests to fail randomly.')
     @retry_assertion(retries=10)
@@ -760,7 +760,7 @@ class TestNodeSearch(OsfTestCase):
         self.node.save()
         docs = query(self.query)['results']
         for doc in docs:
-            self.assertEqual(doc['license'].get('id'), new_license.license_id)
+            assert doc['license'].get('id') == new_license.license_id
 
 
 @pytest.mark.enable_search
@@ -788,7 +788,7 @@ class TestRegistrationRetractions(OsfTestCase):
         self.registration.save()
         self.registration.retraction._on_complete(self.user)
         docs = query('category:registration AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
     def test_pending_retraction_wiki_content_is_searchable(self):
@@ -796,16 +796,16 @@ class TestRegistrationRetractions(OsfTestCase):
         wiki_content = {'home': 'public retraction test'}
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.registration, key, value, self.consolidate_auth)
             # Query and ensure unique string shows up
             docs = query(value)['results']
-            self.assertEqual(len(docs), 1)
+            assert len(docs) == 1
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         # Retract registration
         self.registration.retract_registration(self.user, '')
@@ -815,11 +815,11 @@ class TestRegistrationRetractions(OsfTestCase):
 
         # Query and ensure unique string in wiki doesn't show up
         docs = query('category:registration AND "{}"'.format(wiki_content['home']))['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     @mock.patch('osf.models.registrations.Registration.archiving', mock.PropertyMock(return_value=False))
     def test_retraction_wiki_content_is_not_searchable(self):
@@ -827,16 +827,16 @@ class TestRegistrationRetractions(OsfTestCase):
         wiki_content = {'home': 'public retraction test'}
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.registration, key, value, self.consolidate_auth)
             # Query and ensure unique string shows up
             docs = query(value)['results']
-            self.assertEqual(len(docs), 1)
+            assert len(docs) == 1
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
         # Retract registration
         self.registration.retract_registration(self.user, '')
@@ -848,11 +848,11 @@ class TestRegistrationRetractions(OsfTestCase):
 
         # Query and ensure unique string in wiki doesn't show up
         docs = query('category:registration AND "{}"'.format(wiki_content['home']))['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         # Query and ensure registration does show up
         docs = query('category:registration AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
 
 @pytest.mark.enable_search
@@ -894,42 +894,42 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('private')
         docs = query('category:project AND ' + self.title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         with run_celery_tasks():
             self.component.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_search_node_partial(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Blue')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_search_node_partial_with_sep(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Express')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_search_node_not_name(self):
         self.project.set_title('Blue Rider-Express', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         find = query('Green Flyer-Slow')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
 
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)
         with run_celery_tasks():
             self.project.save()
         docs = query('category:component AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
-        self.assertEqual(docs[0]['parent_title'], 'hello & world')
-        self.assertTrue(docs[0]['parent_url'])
+        assert len(docs) == 1
+        assert docs[0]['parent_title'] == 'hello & world'
+        assert docs[0]['parent_url']
 
     def test_make_parent_private(self):
         # Make parent of component, public, then private, and verify that the
@@ -937,20 +937,20 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
-        self.assertEqual(len(docs), 1)
-        self.assertFalse(docs[0]['parent_title'])
-        self.assertFalse(docs[0]['parent_url'])
+        assert len(docs) == 1
+        assert not docs[0]['parent_title']
+        assert not docs[0]['parent_url']
 
     def test_delete_project(self):
         with run_celery_tasks():
             self.component.remove_node(self.consolidate_auth)
         docs = query('category:component AND ' + self.title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         with run_celery_tasks():
             self.project.remove_node(self.consolidate_auth)
         docs = query('category:project AND ' + self.title)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_change_title(self):
         title_original = self.project.title
@@ -960,10 +960,10 @@ class TestPublicNodes(OsfTestCase):
             )
 
         docs = query('category:project AND ' + title_original)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
         docs = query('category:project AND ' + self.project.title)['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_add_tags(self):
 
@@ -972,12 +972,12 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             for tag in tags:
                 docs = query(f'tags:"{tag}"')['results']
-                self.assertEqual(len(docs), 0)
+                assert len(docs) == 0
                 self.project.add_tag(tag, self.consolidate_auth, save=True)
 
         for tag in tags:
             docs = query(f'tags:"{tag}"')['results']
-            self.assertEqual(len(docs), 1)
+            assert len(docs) == 1
 
     def test_remove_tag(self):
 
@@ -987,7 +987,7 @@ class TestPublicNodes(OsfTestCase):
             self.project.add_tag(tag, self.consolidate_auth, save=True)
             self.project.remove_tag(tag, self.consolidate_auth, save=True)
             docs = query(f'tags:"{tag}"')['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
 
     def test_update_wiki(self):
         """Add text to a wiki page, then verify that project is found when
@@ -1000,11 +1000,11 @@ class TestPublicNodes(OsfTestCase):
         }
         for key, value in wiki_content.items():
             docs = query(value)['results']
-            self.assertEqual(len(docs), 0)
+            assert len(docs) == 0
             with run_celery_tasks():
                 WikiPage.objects.create_for_node(self.project, key, value, self.consolidate_auth)
             docs = query(value)['results']
-            self.assertEqual(len(docs), 1)
+            assert len(docs) == 1
 
     def test_clear_wiki(self):
         # Add wiki text to page, then delete, then verify that project is not
@@ -1016,7 +1016,7 @@ class TestPublicNodes(OsfTestCase):
             wp.update(self.user, '')
 
         docs = query(wiki_content)['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_add_contributor(self):
         # Add a contributor, then verify that project is found when searching
@@ -1024,12 +1024,12 @@ class TestPublicNodes(OsfTestCase):
         user2 = factories.UserFactory(fullname='Adam Lambert')
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         with run_celery_tasks():
             self.project.add_contributor(user2, save=True)
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_remove_contributor(self):
         # Add and remove a contributor, then verify that project is not found
@@ -1040,7 +1040,7 @@ class TestPublicNodes(OsfTestCase):
         self.project.remove_contributor(user2, self.consolidate_auth)
 
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
 
     def test_hide_contributor(self):
         user2 = factories.UserFactory(fullname='Brian May')
@@ -1048,11 +1048,11 @@ class TestPublicNodes(OsfTestCase):
         with run_celery_tasks():
             self.project.set_visible(user2, False, save=True)
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 0)
+        assert len(docs) == 0
         with run_celery_tasks():
             self.project.set_visible(user2, True, save=True)
         docs = query(f'category:project AND "{user2.fullname}"')['results']
-        self.assertEqual(len(docs), 1)
+        assert len(docs) == 1
 
     def test_wrong_order_search(self):
         title_parts = self.title.split(' ')
@@ -1060,7 +1060,7 @@ class TestPublicNodes(OsfTestCase):
         title_search = ' '.join(title_parts)
 
         docs = query(title_search)['results']
-        self.assertEqual(len(docs), 3)
+        assert len(docs) == 3
 
     def test_tag_aggregation(self):
         tags = ['stonecoldcrazy', 'just a poor boy', 'from-a-poor-family']
@@ -1094,7 +1094,7 @@ class TestAddContributor(OsfTestCase):
     def test_unreg_users_dont_show_in_search(self):
         unreg = factories.UnregUserFactory()
         contribs = search.search_contributor(unreg.fullname)
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_unreg_users_do_show_on_projects(self):
         with run_celery_tasks():
@@ -1105,59 +1105,59 @@ class TestAddContributor(OsfTestCase):
                 is_public=True,
             )
         results = query(unreg.fullname)['results']
-        self.assertEqual(len(results), 1)
+        assert len(results) == 1
 
     def test_search_fullname(self):
         # Searching for full name yields exactly one result.
         contribs = search.search_contributor(self.name1)
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name2)
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_firstname(self):
         # Searching for first name yields exactly one result.
         contribs = search.search_contributor(self.name1.split(' ')[0])
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name2.split(' ')[0])
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_partial(self):
         # Searching for part of first name yields exactly one
         # result.
         contribs = search.search_contributor(self.name1.split(' ')[0][:-1])
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name2.split(' ')[0][:-1])
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_fullname_special_character(self):
         # Searching for a fullname with a special character yields
         # exactly one result.
         contribs = search.search_contributor(self.name3)
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name4)
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_firstname_special_charcter(self):
         # Searching for a first name with a special character yields
         # exactly one result.
         contribs = search.search_contributor(self.name3.split(' ')[0])
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name4.split(' ')[0])
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_partial_special_character(self):
         # Searching for a partial name with a special character yields
         # exctly one result.
         contribs = search.search_contributor(self.name3.split(' ')[0][:-1])
-        self.assertEqual(len(contribs['users']), 1)
+        assert len(contribs['users']) == 1
 
         contribs = search.search_contributor(self.name4.split(' ')[0][:-1])
-        self.assertEqual(len(contribs['users']), 0)
+        assert len(contribs['users']) == 0
 
     def test_search_profile(self):
         orcid = '123456'
@@ -1165,9 +1165,9 @@ class TestAddContributor(OsfTestCase):
         user.social['orcid'] = orcid
         user.save()
         contribs = search.search_contributor(orcid)
-        self.assertEqual(len(contribs['users']), 1)
-        self.assertEqual(len(contribs['users'][0]['social']), 1)
-        self.assertEqual(contribs['users'][0]['social']['orcid'], user.social_links['orcid'])
+        assert len(contribs['users']) == 1
+        assert len(contribs['users'][0]['social']) == 1
+        assert contribs['users'][0]['social']['orcid'] == user.social_links['orcid']
 
 
 @pytest.mark.enable_search
@@ -1211,19 +1211,19 @@ class TestProjectSearchResults(OsfTestCase):
         # possessive and plural versions in results.
         time.sleep(1)
         results = query(self.singular)['results']
-        self.assertEqual(len(results), 3)
+        assert len(results) == 3
 
     def test_plural_query(self):
         # Verify searching for singular term includes singular,
         # possessive and plural versions in results.
         results = query(self.plural)['results']
-        self.assertEqual(len(results), 3)
+        assert len(results) == 3
 
     def test_possessive_query(self):
         # Verify searching for possessive term includes singular,
         # possessive and plural versions in results.
         results = query(self.possessive)['results']
-        self.assertEqual(len(results), 3)
+        assert len(results) == 3
 
 
 def job(**kwargs):
@@ -1297,14 +1297,14 @@ class TestUserSearchResults(OsfTestCase):
         result_names = [r['names']['fullname'] for r in results]
         current_starfleet_names = [u.fullname for u in self.current_starfleet]
         for name in result_names[:2]:
-            self.assertIn(name, current_starfleet_names)
+            assert name in current_starfleet_names
 
     def test_had_job_in_results(self):
         results = query_user('Star Fleet')['results']
         result_names = [r['names']['fullname'] for r in results]
         were_starfleet_names = [u.fullname for u in self.were_starfleet]
         for name in result_names:
-            self.assertIn(name, were_starfleet_names)
+            assert name in were_starfleet_names
 
 
 @pytest.mark.enable_search
@@ -1368,28 +1368,28 @@ class TestSearchMigration(OsfTestCase):
     def test_first_migration_no_remove(self):
         migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
-        self.assertEqual(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+        assert list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0] == settings.ELASTIC_INDEX
 
     def test_multiple_migrations_no_remove(self):
         for n in range(1, 21):
             migrate(delete=False, remove=False, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            assert list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0] == settings.ELASTIC_INDEX
 
     def test_first_migration_with_remove(self):
         migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
         var = self.es.indices.get_aliases()
-        self.assertEqual(list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+        assert list(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys())[0] == settings.ELASTIC_INDEX
 
     def test_multiple_migrations_with_remove(self):
         for n in range(1, 21, 2):
             migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            assert list(var[settings.ELASTIC_INDEX + f'_v{n}']['aliases'].keys())[0] == settings.ELASTIC_INDEX
 
             migrate(delete=False, remove=True, index=settings.ELASTIC_INDEX, app=self.app.app)
             var = self.es.indices.get_aliases()
-            self.assertEqual(list(var[settings.ELASTIC_INDEX + f'_v{n + 1}']['aliases'].keys())[0], settings.ELASTIC_INDEX)
+            assert list(var[settings.ELASTIC_INDEX + f'_v{n + 1}']['aliases'].keys())[0] == settings.ELASTIC_INDEX
             assert not var.get(settings.ELASTIC_INDEX + f'_v{n}')
 
     def test_migration_institutions(self):
@@ -1408,7 +1408,7 @@ class TestSearchMigration(OsfTestCase):
             if bucket['key'] == 'institution':
                 institution_bucket_found = True
 
-        self.assertEqual(institution_bucket_found, True)
+        assert institution_bucket_found == True
 
     def test_migration_collections(self):
         provider = factories.CollectionProviderFactory()
@@ -1462,22 +1462,22 @@ class TestSearchFiles(OsfTestCase):
         file_ = self.root.append_file('Shake.wav')
         create_file_version(file_, self.user)
         find = query_file('Shake.wav')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_search_file_name_without_separator(self):
         file_ = self.root.append_file('Shake.wav')
         create_file_version(file_, self.user)
         find = query_file('Shake')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_delete_file(self):
         file_ = self.root.append_file('I\'ve Got Dreams To Remember.wav')
         create_file_version(file_, self.user)
         find = query_file('I\'ve Got Dreams To Remember.wav')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
         file_.delete()
         find = query_file('I\'ve Got Dreams To Remember.wav')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
 
     def test_add_tag(self):
         file_ = self.root.append_file('That\'s How Strong My Love Is.mp3')
@@ -1487,7 +1487,7 @@ class TestSearchFiles(OsfTestCase):
         file_.tags.add(tag)
         file_.save()
         find = query_tag_file('Redding')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_remove_tag(self):
         file_ = self.root.append_file('I\'ve Been Loving You Too Long.mp3')
@@ -1497,22 +1497,22 @@ class TestSearchFiles(OsfTestCase):
         file_.tags.add(tag)
         file_.save()
         find = query_tag_file('Blue')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
         file_.tags.remove(tag)
         file_.save()
         find = query_tag_file('Blue')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
 
     def test_make_node_private(self):
         file_ = self.root.append_file('Change_Gonna_Come.wav')
         create_file_version(file_, self.user)
         find = query_file('Change_Gonna_Come.wav')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
         self.node.is_public = False
         with run_celery_tasks():
             self.node.save()
         find = query_file('Change_Gonna_Come.wav')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
 
     def test_make_private_node_public(self):
         self.node.is_public = False
@@ -1520,12 +1520,12 @@ class TestSearchFiles(OsfTestCase):
         file_ = self.root.append_file('Try a Little Tenderness.flac')
         create_file_version(file_, self.user)
         find = query_file('Try a Little Tenderness.flac')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
         self.node.is_public = True
         with run_celery_tasks():
             self.node.save()
         find = query_file('Try a Little Tenderness.flac')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
 
     def test_delete_node(self):
         node = factories.ProjectFactory(is_public=True, title='The Soul Album')
@@ -1534,12 +1534,12 @@ class TestSearchFiles(OsfTestCase):
         file_ = root.append_file('The Dock of the Bay.mp3')
         create_file_version(file_, self.user)
         find = query_file('The Dock of the Bay.mp3')['results']
-        self.assertEqual(len(find), 1)
+        assert len(find) == 1
         node.is_deleted = True
         with run_celery_tasks():
             node.save()
         find = query_file('The Dock of the Bay.mp3')['results']
-        self.assertEqual(len(find), 0)
+        assert len(find) == 0
 
     def test_file_download_url_guid(self):
         file_ = self.root.append_file('Timber.mp3')
@@ -1547,7 +1547,7 @@ class TestSearchFiles(OsfTestCase):
         file_guid = file_.get_guid(create=True)
         file_.save()
         find = query_file('Timber.mp3')['results']
-        self.assertEqual(find[0]['guid_url'], '/' + file_guid._id + '/')
+        assert find[0]['guid_url'] == '/' + file_guid._id + '/'
 
     def test_file_download_url_no_guid(self):
         file_ = self.root.append_file('Timber.mp3')
@@ -1555,7 +1555,7 @@ class TestSearchFiles(OsfTestCase):
         path = file_.path
         deep_url = '/' + file_.target._id + '/files/osfstorage' + path + '/'
         find = query_file('Timber.mp3')['results']
-        self.assertNotEqual(file_.path, '')
-        self.assertEqual(file_.path, path)
-        self.assertEqual(find[0]['guid_url'], None)
-        self.assertEqual(find[0]['deep_url'], deep_url)
+        assert file_.path != ''
+        assert file_.path == path
+        assert find[0]['guid_url'] == None
+        assert find[0]['deep_url'] == deep_url

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -1,7 +1,6 @@
 import pytest
 
 from django.contrib.contenttypes.models import ContentType
-from nose.tools import assert_raises
 
 from addons.osfstorage.models import NodeSettings
 from addons.osfstorage import settings as osfstorage_settings
@@ -107,7 +106,7 @@ def test_file_purged(project, create_test_file):
     assert version.purged is None
 
     # False attempt
-    with assert_raises(AttributeError):
+    with pytest.raises(AttributeError):
         freed = test_file._purge(client=mock_client)
 
     version.refresh_from_db()

--- a/osf_tests/test_handlers.py
+++ b/osf_tests/test_handlers.py
@@ -1,5 +1,4 @@
 import pytest
-from nose.tools import assert_raises
 
 from framework.celery_tasks import handlers
 from website.project.tasks import on_node_updated
@@ -35,7 +34,7 @@ class TestCeleryHandlers:
         ]
         queue += tasks
 
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             handlers.get_task_from_queue(
                 'website.project.tasks.on_node_updated',
                 predicate=lambda task: task.kwargs['node_id'] == 'woop'

--- a/osf_tests/test_node_license.py
+++ b/osf_tests/test_node_license.py
@@ -4,7 +4,6 @@ import pytest
 import builtins
 
 from django.db.utils import IntegrityError
-from nose.tools import assert_equal, assert_is_not_none, assert_not_equal, assert_false, assert_raises
 from osf.models.licenses import serialize_node_license_record, serialize_node_license
 from osf.utils.migrations import ensure_licenses
 from osf.exceptions import NodeStateError
@@ -63,30 +62,30 @@ class TestNodeLicenses:
 
     def test_serialize_node_license(self, node_license):
         serialized = serialize_node_license(node_license)
-        assert_equal(serialized['name'], self.LICENSE_NAME)
-        assert_equal(serialized['id'], node_license.license_id)
-        assert_equal(serialized['text'], node_license.text)
+        assert serialized['name'] == self.LICENSE_NAME
+        assert serialized['id'] == node_license.license_id
+        assert serialized['text'] == node_license.text
 
     def test_serialize_node_license_record(self, node, node_license):
         serialized = serialize_node_license_record(node.node_license)
-        assert_equal(serialized['name'], self.LICENSE_NAME)
-        assert_equal(serialized['id'], node_license.license_id)
-        assert_equal(serialized['text'], node_license.text)
-        assert_equal(serialized['year'], self.YEAR)
-        assert_equal(serialized['copyright_holders'], self.COPYRIGHT_HOLDERS)
+        assert serialized['name'] == self.LICENSE_NAME
+        assert serialized['id'] == node_license.license_id
+        assert serialized['text'] == node_license.text
+        assert serialized['year'] == self.YEAR
+        assert serialized['copyright_holders'] == self.COPYRIGHT_HOLDERS
 
     def test_serialize_node_license_record_None(self, node):
         node.node_license = None
         serialized = serialize_node_license_record(node.node_license)
-        assert_equal(serialized, {})
+        assert serialized == {}
 
     def test_copy_node_license_record(self, node):
         record = node.node_license
         copied = record.copy()
-        assert_is_not_none(copied._id)
-        assert_not_equal(record._id, copied._id)
+        assert copied._id is not None
+        assert record._id != copied._id
         for prop in ('license_id', 'name', 'node_license'):
-            assert_equal(getattr(record, prop), getattr(copied, prop))
+            assert getattr(record, prop) == getattr(copied, prop)
 
     def test_license_uniqueness_on_id_is_enforced_in_the_database(self):
         NodeLicense(license_id='foo', name='bar', text='baz').save()
@@ -94,31 +93,31 @@ class TestNodeLicenses:
             NodeLicense(license_id='foo', name='buz', text='boo').save()
 
     def test_ensure_licenses_updates_existing_licenses(self):
-        assert_equal(ensure_licenses(), (0, 18))
+        assert ensure_licenses() == (0, 18)
 
     def test_ensure_licenses_no_licenses(self):
         before_count = NodeLicense.objects.all().count()
         NodeLicense.objects.all().delete()
-        assert_false(NodeLicense.objects.all().count())
+        assert NodeLicense.objects.all().count() is False
 
         ensure_licenses()
-        assert_equal(before_count, NodeLicense.objects.all().count())
+        assert before_count == NodeLicense.objects.all().count()
 
     def test_ensure_licenses_some_missing(self):
         NodeLicense.objects.get(license_id='LGPL3').delete()
-        with assert_raises(NodeLicense.DoesNotExist):
+        with pytest.raises(NodeLicense.DoesNotExist):
             NodeLicense.objects.get(license_id='LGPL3')
         ensure_licenses()
         found = NodeLicense.objects.get(license_id='LGPL3')
-        assert_is_not_none(found)
+        assert found is not None
 
     def test_ensure_licenses_updates_existing(self):
         with mock.patch.object(builtins, 'open', mock.mock_open(read_data=LICENSE_TEXT)):
             ensure_licenses()
         MIT = NodeLicense.objects.get(license_id='MIT')
-        assert_equal(MIT.name, CHANGED_NAME)
-        assert_equal(MIT.text, CHANGED_TEXT)
-        assert_equal(MIT.properties, CHANGED_PROPERTIES)
+        assert MIT.name == CHANGED_NAME
+        assert MIT.text == CHANGED_TEXT
+        assert MIT.properties == CHANGED_PROPERTIES
 
     def test_node_set_node_license(self, node, user):
         GPL3 = NodeLicense.objects.get(license_id='GPL3')
@@ -134,13 +133,13 @@ class TestNodeLicenses:
             save=True
         )
 
-        assert_equal(node.node_license.license_id, GPL3.license_id)
-        assert_equal(node.node_license.name, GPL3.name)
-        assert_equal(node.node_license.copyright_holders, COPYLEFT_HOLDERS)
+        assert node.node_license.license_id == GPL3.license_id
+        assert node.node_license.name == GPL3.name
+        assert node.node_license.copyright_holders == COPYLEFT_HOLDERS
         assert node.logs.latest().action == NodeLog.CHANGED_LICENSE
 
     def test_node_set_node_license_invalid(self, node, user):
-        with assert_raises(NodeStateError):
+        with pytest.raises(NodeStateError):
             node.set_node_license(
                 {
                     'id': 'SOME ID',

--- a/osf_tests/test_project_decorators.py
+++ b/osf_tests/test_project_decorators.py
@@ -9,6 +9,7 @@ from osf_tests.factories import ProjectFactory, NodeFactory, RetractionFactory, 
 
 from framework.exceptions import HTTPError
 from framework.auth import Auth
+import pytest
 
 
 @must_be_valid_project
@@ -30,37 +31,37 @@ class TestValidProject(OsfTestCase):
 
     def test_populates_kwargs_node(self):
         res = valid_project_helper(pid=self.project._id)
-        self.assertEqual(res['node'], self.project)
-        self.assertIsNone(res['parent'])
+        assert res['node'] == self.project
+        assert res['parent'] is None
 
     def test_populates_kwargs_node_and_parent(self):
         res = valid_project_helper(pid=self.project._id, nid=self.node._id)
-        self.assertEqual(res['parent'], self.project)
-        self.assertEqual(res['node'], self.node)
+        assert res['parent'] == self.project
+        assert res['node'] == self.node
 
     def test_project_not_found(self):
-        with self.assertRaises(HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             valid_project_helper(pid='fakepid')
-        self.assertEqual(exc_info.exception.code, 404)
+        assert exc_info.exception.code == 404
 
     def test_project_deleted(self):
         self.project.is_deleted = True
         self.project.save()
-        with self.assertRaises(HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id)
-        self.assertEqual(exc_info.exception.code, 410)
+        assert exc_info.exception.code == 410
 
     def test_node_not_found(self):
-        with self.assertRaises(HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id, nid='fakenid')
-        self.assertEqual(exc_info.exception.code, 404)
+        assert exc_info.exception.code == 404
 
     def test_node_deleted(self):
         self.node.is_deleted = True
         self.node.save()
-        with self.assertRaises(HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id, nid=self.node._id)
-        self.assertEqual(exc_info.exception.code, 410)
+        assert exc_info.exception.code == 410
 
     def test_valid_project_as_factory_allow_retractions_is_retracted(self):
         registration = RegistrationFactory(project=self.project)
@@ -68,11 +69,11 @@ class TestValidProject(OsfTestCase):
         registration.retraction.state = Sanction.UNAPPROVED
         registration.retraction.save()
         res = as_factory_allow_retractions(pid=registration._id)
-        self.assertEqual(res['node'], registration)
+        assert res['node'] == registration
 
     def test_collection_guid_not_found(self):
         collection = CollectionFactory()
         collection.collect_object(self.project, self.auth.user)
-        with self.assertRaises(HTTPError) as exc_info:
+        with pytest.raises(HTTPError) as exc_info:
             valid_project_helper(pid=collection._id, nid=collection._id)
-        self.assertEqual(exc_info.exception.code, 404)
+        assert exc_info.exception.code == 404

--- a/osf_tests/test_project_decorators.py
+++ b/osf_tests/test_project_decorators.py
@@ -1,7 +1,5 @@
 """Tests related to project decorators"""
 
-from nose.tools import *  # noqa: F403
-
 from website.project.decorators import must_be_valid_project
 
 from osf.models import Sanction
@@ -32,37 +30,37 @@ class TestValidProject(OsfTestCase):
 
     def test_populates_kwargs_node(self):
         res = valid_project_helper(pid=self.project._id)
-        assert_equal(res['node'], self.project)
-        assert_is_none(res['parent'])
+        self.assertEqual(res['node'], self.project)
+        self.assertIsNone(res['parent'])
 
     def test_populates_kwargs_node_and_parent(self):
         res = valid_project_helper(pid=self.project._id, nid=self.node._id)
-        assert_equal(res['parent'], self.project)
-        assert_equal(res['node'], self.node)
+        self.assertEqual(res['parent'], self.project)
+        self.assertEqual(res['node'], self.node)
 
     def test_project_not_found(self):
-        with assert_raises(HTTPError) as exc_info:
+        with self.assertRaises(HTTPError) as exc_info:
             valid_project_helper(pid='fakepid')
-        assert_equal(exc_info.exception.code, 404)
+        self.assertEqual(exc_info.exception.code, 404)
 
     def test_project_deleted(self):
         self.project.is_deleted = True
         self.project.save()
-        with assert_raises(HTTPError) as exc_info:
+        with self.assertRaises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id)
-        assert_equal(exc_info.exception.code, 410)
+        self.assertEqual(exc_info.exception.code, 410)
 
     def test_node_not_found(self):
-        with assert_raises(HTTPError) as exc_info:
+        with self.assertRaises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id, nid='fakenid')
-        assert_equal(exc_info.exception.code, 404)
+        self.assertEqual(exc_info.exception.code, 404)
 
     def test_node_deleted(self):
         self.node.is_deleted = True
         self.node.save()
-        with assert_raises(HTTPError) as exc_info:
+        with self.assertRaises(HTTPError) as exc_info:
             valid_project_helper(pid=self.project._id, nid=self.node._id)
-        assert_equal(exc_info.exception.code, 410)
+        self.assertEqual(exc_info.exception.code, 410)
 
     def test_valid_project_as_factory_allow_retractions_is_retracted(self):
         registration = RegistrationFactory(project=self.project)
@@ -70,11 +68,11 @@ class TestValidProject(OsfTestCase):
         registration.retraction.state = Sanction.UNAPPROVED
         registration.retraction.save()
         res = as_factory_allow_retractions(pid=registration._id)
-        assert_equal(res['node'], registration)
+        self.assertEqual(res['node'], registration)
 
     def test_collection_guid_not_found(self):
         collection = CollectionFactory()
         collection.collect_object(self.project, self.auth.user)
-        with assert_raises(HTTPError) as exc_info:
+        with self.assertRaises(HTTPError) as exc_info:
             valid_project_helper(pid=collection._id, nid=collection._id)
-        assert_equal(exc_info.exception.code, 404)
+        self.assertEqual(exc_info.exception.code, 404)

--- a/osf_tests/test_registration_bulk_upload_parser.py
+++ b/osf_tests/test_registration_bulk_upload_parser.py
@@ -3,7 +3,6 @@ import io
 import pytest
 import string
 
-from nose.tools import assert_equal, assert_true
 from rest_framework.exceptions import NotFound
 
 from osf_tests.factories import SubjectFactory
@@ -55,26 +54,26 @@ def make_row(field_values={}):
 def assert_parsed(actual_parsed, expected_parsed):
     parsed = {**actual_parsed['metadata'], **actual_parsed['registration_responses']}
     for key, value in expected_parsed.items():
-        assert_true(key in parsed)
+        assert key in parsed is True
         actual = parsed[key]
         expected = value
         if actual and expected and isinstance(actual, list) and isinstance(expected, list):
             if isinstance(actual[0], str):
-                assert_equal(actual.sort(), expected.sort(), msg=f'"{key}" parsed correctly')
+                assert actual.sort() == expected.sort(), f'"{key}" parsed correctly'
                 continue
-        assert_equal(actual, expected)
+        assert actual == expected
 
 
 def assert_errors(actual_errors, expected_errors):
     for error in actual_errors:
-        assert_true('header' in error)
-        assert_true('column_index' in error)
-        assert_true('row_index' in error)
-        assert_true('external_id' in error)
-        assert_true(error['header'] in expected_errors)
-        assert_equal(error['type'], expected_errors[error['header']])
+        assert 'header' in error is True
+        assert 'column_index' in error is True
+        assert 'row_index' in error is True
+        assert 'external_id' in error is True
+        assert error['header'] in expected_errors is True
+        assert error['type'] == expected_errors[error['header']]
 
-    assert_true(len(actual_errors), len(expected_errors.keys()))
+    assert len(actual_errors), len(expected_errors.keys()) is True
 
 
 @pytest.mark.django_db

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -6,7 +6,6 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from framework.auth.core import Auth
 from framework.exceptions import PermissionsError
-from nose.tools import assert_raises
 from osf.models import Node, Registration, Sanction, RegistrationSchema, NodeLog, GuidMetadataRecord
 from addons.wiki.models import WikiPage
 from osf.utils.permissions import ADMIN
@@ -896,12 +895,12 @@ class TestForcedWithdrawal:
 
     def test_cannot_force_retraction_on_unmoderated_registration(self):
         unmoderated_registration = factories.RegistrationFactory(is_public=True)
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             unmoderated_registration.retract_registration(
                 user=unmoderated_registration.creator, justification='', moderator_initiated=True)
 
     def test_nonmoderator_cannot_force_retraction(self, moderated_registration):
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             moderated_registration.retract_registration(
                 user=moderated_registration.creator, justification='', moderator_initiated=True)
 

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -1,8 +1,6 @@
 from unittest import mock
 import pytest
 
-from nose.tools import assert_raises
-
 from api.providers.workflows import Workflows
 from framework.exceptions import PermissionsError
 from osf.exceptions import PreviousSchemaResponseError, SchemaResponseStateError, SchemaResponseUpdateError
@@ -154,7 +152,7 @@ class TestCreateSchemaResponse():
     def test_create_initial_response_fails_if_no_schema_and_no_parent_schema(self, registration):
         registration.registered_schema.clear()
         registration.save()
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration
@@ -164,7 +162,7 @@ class TestCreateSchemaResponse():
         alt_schema = RegistrationSchema.objects.exclude(
             id=registration.registration_schema.id
         ).first()
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration,
@@ -196,7 +194,7 @@ class TestCreateSchemaResponse():
             parent=registration,
         )
 
-        with assert_raises(PreviousSchemaResponseError):
+        with pytest.raises(PreviousSchemaResponseError):
             schema_response.SchemaResponse.create_initial_response(
                 initiator=registration.creator,
                 parent=registration,
@@ -293,7 +291,7 @@ class TestCreateSchemaResponse():
 
         initial_response.approvals_state_machine.set_state(invalid_response_state)
         initial_response.save()
-        with assert_raises(PreviousSchemaResponseError):
+        with pytest.raises(PreviousSchemaResponseError):
             schema_response.SchemaResponse.create_from_previous_response(
                 initiator=initial_response.initiator,
                 previous_response=intermediate_response
@@ -437,7 +435,7 @@ class TestUpdateSchemaResponses():
         assert revised_response.response_blocks.get(schema_key='q4').id == original_q4_block.id
 
     def test_update_with_unsupported_key_raises(self, revised_response):
-        with assert_raises(SchemaResponseUpdateError) as manager:
+        with pytest.raises(SchemaResponseUpdateError) as manager:
             revised_response.update_responses({'q7': 'sneaky'})
 
         assert manager.exception.unsupported_keys == {'q7'}
@@ -452,7 +450,7 @@ class TestUpdateSchemaResponses():
     )
     def test_update_with_unsupported_key_and_supported_keys_writes_and_raises(
             self, updated_responses, revised_response):
-        with assert_raises(SchemaResponseUpdateError):
+        with pytest.raises(SchemaResponseUpdateError):
             revised_response.update_responses(updated_responses)
 
         revised_response.refresh_from_db()
@@ -460,7 +458,7 @@ class TestUpdateSchemaResponses():
         assert revised_response.all_responses['q2'] == updated_responses['q2']
 
     def test_update_fails_with_invalid_response_types(self, revised_response):
-        with assert_raises(SchemaResponseUpdateError) as manager:
+        with pytest.raises(SchemaResponseUpdateError) as manager:
             revised_response.update_responses(
                 {'q1': 1, 'q2': ['this is a list'], 'q3': 'B', 'q4': 'this is a string'}
             )
@@ -468,7 +466,7 @@ class TestUpdateSchemaResponses():
         assert set(manager.exception.invalid_responses.keys()) == {'q1', 'q2', 'q4'}
 
     def test_update_fails_with_invalid_response_values(self, revised_response):
-        with assert_raises(SchemaResponseUpdateError) as manager:
+        with pytest.raises(SchemaResponseUpdateError) as manager:
             revised_response.update_responses(
                 {'q3': 'Q', 'q4': ['D', 'A']}
             )
@@ -489,7 +487,7 @@ class TestUpdateSchemaResponses():
     )
     def test_update_fails_if_state_is_invalid(self, invalid_response_state, initial_response):
         initial_response.approvals_state_machine.set_state(invalid_response_state)
-        with assert_raises(SchemaResponseStateError):
+        with pytest.raises(SchemaResponseStateError):
             initial_response.update_responses({'q1': 'harrumph'})
 
     def test_update_file_is_noop_if_no_change_in_ids(self, revised_response):
@@ -544,7 +542,7 @@ class TestDeleteSchemaResponse():
     def test_delete_fails_if_state_is_invalid(self, invalid_response_state, initial_response):
         initial_response.approvals_state_machine.set_state(invalid_response_state)
         initial_response.save()
-        with assert_raises(SchemaResponseStateError):
+        with pytest.raises(SchemaResponseStateError):
             initial_response.delete()
 
 
@@ -607,7 +605,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
     def test_submit_response_requires_user(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         initial_response.save()
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.submit(required_approvers=[admin_user])
 
     def test_submit_fails_with_invalid_response_value(self, initial_response, admin_user):
@@ -617,7 +615,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         invalid_block.response = 1
         invalid_block.save()
 
-        with assert_raises(SchemaResponseStateError):
+        with pytest.raises(SchemaResponseStateError):
             initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
     def test_submit_fails_with_missing_required_response(self, initial_response, admin_user):
@@ -627,19 +625,19 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         invalid_block.response = ''
         invalid_block.save()
 
-        with assert_raises(SchemaResponseStateError):
+        with pytest.raises(SchemaResponseStateError):
             initial_response.submit(user=admin_user, required_approvers=[admin_user])
 
     def test_submit_response_requires_required_approvers(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         initial_response.save()
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             initial_response.submit(user=admin_user)
 
     def test_non_parent_admin_cannot_submit_response(self, initial_response, alternate_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         initial_response.save()
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.submit(user=alternate_user)
 
     def test_approve_response_requires_all_approvers(
@@ -713,7 +711,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         initial_response.approvals_state_machine.set_state(ApprovalStates.UNAPPROVED)
         initial_response.save()
         initial_response.pending_approvers.add(admin_user)
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.approve()
 
     def test_non_approver_cannot_approve_response(
@@ -722,7 +720,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         initial_response.save()
         initial_response.pending_approvers.add(admin_user)
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.approve(user=alternate_user)
 
     def test_reject_response_moves_state_to_in_progress(self, initial_response, admin_user, alternate_user):
@@ -786,7 +784,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         initial_response.save()
         initial_response.pending_approvers.add(admin_user)
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.reject()
 
     def test_non_approver_cannnot_reject_response(
@@ -795,7 +793,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         initial_response.save()
         initial_response.pending_approvers.add(admin_user)
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.reject(user=alternate_user)
 
     def test_approver_cannot_call_accept_directly(self, initial_response, admin_user):
@@ -803,7 +801,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         initial_response.save()
         initial_response.pending_approvers.add(admin_user)
 
-        with assert_raises(MachineError):
+        with pytest.raises(MachineError):
             initial_response.accept(user=admin_user)
 
     def test_internal_accept_advances_state(self, initial_response, admin_user, alternate_user):
@@ -997,7 +995,7 @@ class TestModeratedSchemaResponseApprovalFlows():
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.submit(user=moderator, required_approvers=[moderator])
 
     def test_moderator_cannot_approve_in_unapproved_state(
@@ -1005,7 +1003,7 @@ class TestModeratedSchemaResponseApprovalFlows():
         initial_response.approvals_state_machine.set_state(ApprovalStates.UNAPPROVED)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.approve(user=moderator)
 
     def test_moderator_cannot_reject_in_unapproved_state(
@@ -1013,26 +1011,26 @@ class TestModeratedSchemaResponseApprovalFlows():
         initial_response.approvals_state_machine.set_state(ApprovalStates.UNAPPROVED)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.reject(user=moderator)
 
     def test_admin_cannot_accept_in_pending_moderation(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.PENDING_MODERATION)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.accept(user=admin_user)
 
     def test_admin_cannot_reject_in_pending_moderation(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.PENDING_MODERATION)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.reject(user=admin_user)
 
     def test_user_required_to_accept_in_pending_moderation(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.PENDING_MODERATION)
         initial_response.save()
 
-        with assert_raises(PermissionsError):
+        with pytest.raises(PermissionsError):
             initial_response.accept()

--- a/osf_tests/test_search_views.py
+++ b/osf_tests/test_search_views.py
@@ -1,5 +1,4 @@
 import pytest
-from nose.tools import *  # noqa: F403
 
 from osf_tests import factories
 from tests.base import OsfTestCase
@@ -38,65 +37,65 @@ class TestSearchViews(OsfTestCase):
         #Test search contributor
         url = api_url_for('search_contributor')
         res = self.app.get(url, {'query': self.contrib.fullname})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
-        assert_equal(len(result), 1)
+        self.assertEqual(len(result), 1)
         brian = result[0]
-        assert_equal(brian['fullname'], self.contrib.fullname)
-        assert_in('profile_image_url', brian)
-        assert_equal(brian['registered'], self.contrib.is_registered)
-        assert_equal(brian['active'], self.contrib.is_active)
+        self.assertEqual(brian['fullname'], self.contrib.fullname)
+        self.assertIn('profile_image_url', brian)
+        self.assertEqual(brian['registered'], self.contrib.is_registered)
+        self.assertEqual(brian['active'], self.contrib.is_active)
 
         #Test search pagination
         res = self.app.get(url, {'query': 'fr'})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        assert_equal(len(result), 5)
-        assert_equal(pages, 3)
-        assert_equal(page, 0)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(pages, 3)
+        self.assertEqual(page, 0)
 
         #Test default page 1
         res = self.app.get(url, {'query': 'fr', 'page': 1})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
         page = res.json['page']
-        assert_equal(len(result), 5)
-        assert_equal(page, 1)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(page, 1)
 
         #Test default page 2
         res = self.app.get(url, {'query': 'fr', 'page': 2})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
         page = res.json['page']
-        assert_equal(len(result), 4)
-        assert_equal(page, 2)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(page, 2)
 
         #Test smaller pages
         res = self.app.get(url, {'query': 'fr', 'size': 5})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        assert_equal(len(result), 5)
-        assert_equal(page, 0)
-        assert_equal(pages, 3)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(page, 0)
+        self.assertEqual(pages, 3)
 
         #Test smaller pages page 2
         res = self.app.get(url, {'query': 'fr', 'page': 2, 'size': 5, })
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        assert_equal(len(result), 4)
-        assert_equal(page, 2)
-        assert_equal(pages, 3)
+        self.assertEqual(len(result), 4)
+        self.assertEqual(page, 2)
+        self.assertEqual(pages, 3)
 
         #Test search projects
         url = '/search/'
         res = self.app.get(url, {'q': self.project.title})
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
         #Test search node
         res = self.app.post_json(
@@ -104,7 +103,7 @@ class TestSearchViews(OsfTestCase):
             {'query': self.project.title},
             auth=factories.AuthUserFactory().auth
         )
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
         #Test search node includePublic true
         res = self.app.post_json(
@@ -113,10 +112,10 @@ class TestSearchViews(OsfTestCase):
             auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
-        assert_in(self.project_private_user_one._id, node_ids)
-        assert_in(self.project_public_user_one._id, node_ids)
-        assert_in(self.project_public_user_two._id, node_ids)
-        assert_not_in(self.project_private_user_two._id, node_ids)
+        self.assertIn(self.project_private_user_one._id, node_ids)
+        self.assertIn(self.project_public_user_one._id, node_ids)
+        self.assertIn(self.project_public_user_two._id, node_ids)
+        self.assertNotIn(self.project_private_user_two._id, node_ids)
 
         #Test search node includePublic false
         res = self.app.post_json(
@@ -125,25 +124,25 @@ class TestSearchViews(OsfTestCase):
             auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
-        assert_in(self.project_private_user_one._id, node_ids)
-        assert_in(self.project_public_user_one._id, node_ids)
-        assert_not_in(self.project_public_user_two._id, node_ids)
-        assert_not_in(self.project_private_user_two._id, node_ids)
+        self.assertIn(self.project_private_user_one._id, node_ids)
+        self.assertIn(self.project_public_user_one._id, node_ids)
+        self.assertNotIn(self.project_public_user_two._id, node_ids)
+        self.assertNotIn(self.project_private_user_two._id, node_ids)
 
         #Test search user
         url = '/api/v1/search/user/'
         res = self.app.get(url, {'q': 'Umwali'})
-        assert_equal(res.status_code, 200)
-        assert_false(res.json['results'])
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.json['results'])
 
         user_one = factories.AuthUserFactory(fullname='Joe Umwali')
         user_two = factories.AuthUserFactory(fullname='Joan Uwase')
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['results']), 1)
-        assert_false(res.json['results'][0]['social'])
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['results']), 1)
+        self.assertFalse(res.json['results'][0]['social'])
 
         user_one.social = {
             'github': user_one.given_name,
@@ -154,14 +153,14 @@ class TestSearchViews(OsfTestCase):
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['results']), 1)
-        assert_not_in('Joan', res.body.decode())
-        assert_true(res.json['results'][0]['social'])
-        assert_equal(res.json['results'][0]['names']['fullname'], user_one.fullname)
-        assert_equal(res.json['results'][0]['social']['github'], f'http://github.com/{user_one.given_name}')
-        assert_equal(res.json['results'][0]['social']['twitter'], f'http://twitter.com/{user_one.given_name}')
-        assert_equal(res.json['results'][0]['social']['ssrn'], f'http://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id={user_one.given_name}')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['results']), 1)
+        self.assertNotIn('Joan', res.body.decode())
+        self.assertTrue(res.json['results'][0]['social'])
+        self.assertEqual(res.json['results'][0]['names']['fullname'], user_one.fullname)
+        self.assertEqual(res.json['results'][0]['social']['github'], f'http://github.com/{user_one.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['twitter'], f'http://twitter.com/{user_one.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['ssrn'], f'http://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id={user_one.given_name}')
 
         user_two.social = {
             'profileWebsites': [f'http://me.com/{user_two.given_name}'],
@@ -182,25 +181,25 @@ class TestSearchViews(OsfTestCase):
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['results']), 2)
-        assert_true(res.json['results'][0]['social'])
-        assert_true(res.json['results'][1]['social'])
-        assert_not_equal(res.json['results'][0]['social']['ssrn'], res.json['results'][1]['social']['ssrn'])
-        assert_not_equal(res.json['results'][0]['social']['github'], res.json['results'][1]['social']['github'])
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['results']), 2)
+        self.assertTrue(res.json['results'][0]['social'])
+        self.assertTrue(res.json['results'][1]['social'])
+        self.assertNotEqual(res.json['results'][0]['social']['ssrn'], res.json['results'][1]['social']['ssrn'])
+        self.assertNotEqual(res.json['results'][0]['social']['github'], res.json['results'][1]['social']['github'])
 
         res = self.app.get(url, {'q': 'Uwase'})
 
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json['results']), 1)
-        assert_true(res.json['results'][0]['social'])
-        assert_not_in('ssrn', res.json['results'][0]['social'])
-        assert_equal(res.json['results'][0]['social']['profileWebsites'][0], f'http://me.com/{user_two.given_name}')
-        assert_equal(res.json['results'][0]['social']['impactStory'], f'https://impactstory.org/u/{user_two.given_name}')
-        assert_equal(res.json['results'][0]['social']['orcid'], f'http://orcid.org/{user_two.given_name}')
-        assert_equal(res.json['results'][0]['social']['baiduScholar'], f'http://xueshu.baidu.com/scholarID/{user_two.given_name}')
-        assert_equal(res.json['results'][0]['social']['linkedIn'], f'https://www.linkedin.com/{user_two.given_name}')
-        assert_equal(res.json['results'][0]['social']['scholar'], f'http://scholar.google.com/citations?user={user_two.given_name}')
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json['results']), 1)
+        self.assertTrue(res.json['results'][0]['social'])
+        self.assertNotIn('ssrn', res.json['results'][0]['social'])
+        self.assertEqual(res.json['results'][0]['social']['profileWebsites'][0], f'http://me.com/{user_two.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['impactStory'], f'https://impactstory.org/u/{user_two.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['orcid'], f'http://orcid.org/{user_two.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['baiduScholar'], f'http://xueshu.baidu.com/scholarID/{user_two.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['linkedIn'], f'https://www.linkedin.com/{user_two.given_name}')
+        self.assertEqual(res.json['results'][0]['social']['scholar'], f'http://scholar.google.com/citations?user={user_two.given_name}')
 
 
 @pytest.mark.enable_bookmark_creation
@@ -232,24 +231,24 @@ class TestODMTitleSearch(OsfTestCase):
 
     def test_search_projects_by_title(self):
         res = self.app.get(self.url, {'term': self.project.title}, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.public_project.title,
                                'includePublic': 'yes',
                                'includeContributed': 'no'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
                                'includePublic': 'no',
                                'includeContributed': 'yes'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
@@ -257,8 +256,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'no'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
@@ -266,8 +265,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.public_project.title,
@@ -275,8 +274,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.registration_project.title,
@@ -284,8 +283,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 2)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 2)
         res = self.app.get(self.url,
                            {
                                'term': self.registration_project.title,
@@ -293,8 +292,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'no'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 1)
         res = self.app.get(self.url,
                            {
                                'term': self.folder.title,
@@ -302,7 +301,7 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
         assert len(res.json) == 0
         res = self.app.get(self.url,
                            {
@@ -311,8 +310,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'no'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 0)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 0)
         res = self.app.get(self.url,
                            {
                                'term': self.dashboard.title,
@@ -320,8 +319,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'no'
                            }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 0)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 0)
         res = self.app.get(self.url,
                            {
                                'term': self.dashboard.title,
@@ -329,5 +328,5 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 0)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(len(res.json), 0)

--- a/osf_tests/test_search_views.py
+++ b/osf_tests/test_search_views.py
@@ -37,65 +37,65 @@ class TestSearchViews(OsfTestCase):
         #Test search contributor
         url = api_url_for('search_contributor')
         res = self.app.get(url, {'query': self.contrib.fullname})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
         brian = result[0]
-        self.assertEqual(brian['fullname'], self.contrib.fullname)
-        self.assertIn('profile_image_url', brian)
-        self.assertEqual(brian['registered'], self.contrib.is_registered)
-        self.assertEqual(brian['active'], self.contrib.is_active)
+        assert brian['fullname'] == self.contrib.fullname
+        assert 'profile_image_url' in brian
+        assert brian['registered'] == self.contrib.is_registered
+        assert brian['active'] == self.contrib.is_active
 
         #Test search pagination
         res = self.app.get(url, {'query': 'fr'})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        self.assertEqual(len(result), 5)
-        self.assertEqual(pages, 3)
-        self.assertEqual(page, 0)
+        assert len(result) == 5
+        assert pages == 3
+        assert page == 0
 
         #Test default page 1
         res = self.app.get(url, {'query': 'fr', 'page': 1})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
         page = res.json['page']
-        self.assertEqual(len(result), 5)
-        self.assertEqual(page, 1)
+        assert len(result) == 5
+        assert page == 1
 
         #Test default page 2
         res = self.app.get(url, {'query': 'fr', 'page': 2})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
         page = res.json['page']
-        self.assertEqual(len(result), 4)
-        self.assertEqual(page, 2)
+        assert len(result) == 4
+        assert page == 2
 
         #Test smaller pages
         res = self.app.get(url, {'query': 'fr', 'size': 5})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        self.assertEqual(len(result), 5)
-        self.assertEqual(page, 0)
-        self.assertEqual(pages, 3)
+        assert len(result) == 5
+        assert page == 0
+        assert pages == 3
 
         #Test smaller pages page 2
         res = self.app.get(url, {'query': 'fr', 'page': 2, 'size': 5, })
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         result = res.json['users']
         pages = res.json['pages']
         page = res.json['page']
-        self.assertEqual(len(result), 4)
-        self.assertEqual(page, 2)
-        self.assertEqual(pages, 3)
+        assert len(result) == 4
+        assert page == 2
+        assert pages == 3
 
         #Test search projects
         url = '/search/'
         res = self.app.get(url, {'q': self.project.title})
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
         #Test search node
         res = self.app.post_json(
@@ -103,7 +103,7 @@ class TestSearchViews(OsfTestCase):
             {'query': self.project.title},
             auth=factories.AuthUserFactory().auth
         )
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
 
         #Test search node includePublic true
         res = self.app.post_json(
@@ -112,10 +112,10 @@ class TestSearchViews(OsfTestCase):
             auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
-        self.assertIn(self.project_private_user_one._id, node_ids)
-        self.assertIn(self.project_public_user_one._id, node_ids)
-        self.assertIn(self.project_public_user_two._id, node_ids)
-        self.assertNotIn(self.project_private_user_two._id, node_ids)
+        assert self.project_private_user_one._id in node_ids
+        assert self.project_public_user_one._id in node_ids
+        assert self.project_public_user_two._id in node_ids
+        assert self.project_private_user_two._id not in node_ids
 
         #Test search node includePublic false
         res = self.app.post_json(
@@ -124,25 +124,25 @@ class TestSearchViews(OsfTestCase):
             auth=self.user_one.auth
         )
         node_ids = [node['id'] for node in res.json['nodes']]
-        self.assertIn(self.project_private_user_one._id, node_ids)
-        self.assertIn(self.project_public_user_one._id, node_ids)
-        self.assertNotIn(self.project_public_user_two._id, node_ids)
-        self.assertNotIn(self.project_private_user_two._id, node_ids)
+        assert self.project_private_user_one._id in node_ids
+        assert self.project_public_user_one._id in node_ids
+        assert self.project_public_user_two._id not in node_ids
+        assert self.project_private_user_two._id not in node_ids
 
         #Test search user
         url = '/api/v1/search/user/'
         res = self.app.get(url, {'q': 'Umwali'})
-        self.assertEqual(res.status_code, 200)
-        self.assertFalse(res.json['results'])
+        assert res.status_code == 200
+        assert not res.json['results']
 
         user_one = factories.AuthUserFactory(fullname='Joe Umwali')
         user_two = factories.AuthUserFactory(fullname='Joan Uwase')
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['results']), 1)
-        self.assertFalse(res.json['results'][0]['social'])
+        assert res.status_code == 200
+        assert len(res.json['results']) == 1
+        assert not res.json['results'][0]['social']
 
         user_one.social = {
             'github': user_one.given_name,
@@ -153,14 +153,14 @@ class TestSearchViews(OsfTestCase):
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['results']), 1)
-        self.assertNotIn('Joan', res.body.decode())
-        self.assertTrue(res.json['results'][0]['social'])
-        self.assertEqual(res.json['results'][0]['names']['fullname'], user_one.fullname)
-        self.assertEqual(res.json['results'][0]['social']['github'], f'http://github.com/{user_one.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['twitter'], f'http://twitter.com/{user_one.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['ssrn'], f'http://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id={user_one.given_name}')
+        assert res.status_code == 200
+        assert len(res.json['results']) == 1
+        assert 'Joan' not in res.body.decode()
+        assert res.json['results'][0]['social']
+        assert res.json['results'][0]['names']['fullname'] == user_one.fullname
+        assert res.json['results'][0]['social']['github'] == f'http://github.com/{user_one.given_name}'
+        assert res.json['results'][0]['social']['twitter'] == f'http://twitter.com/{user_one.given_name}'
+        assert res.json['results'][0]['social']['ssrn'] == f'http://papers.ssrn.com/sol3/cf_dev/AbsByAuth.cfm?per_id={user_one.given_name}'
 
         user_two.social = {
             'profileWebsites': [f'http://me.com/{user_two.given_name}'],
@@ -181,25 +181,25 @@ class TestSearchViews(OsfTestCase):
 
         res = self.app.get(url, {'q': 'Umwali'})
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['results']), 2)
-        self.assertTrue(res.json['results'][0]['social'])
-        self.assertTrue(res.json['results'][1]['social'])
-        self.assertNotEqual(res.json['results'][0]['social']['ssrn'], res.json['results'][1]['social']['ssrn'])
-        self.assertNotEqual(res.json['results'][0]['social']['github'], res.json['results'][1]['social']['github'])
+        assert res.status_code == 200
+        assert len(res.json['results']) == 2
+        assert res.json['results'][0]['social']
+        assert res.json['results'][1]['social']
+        assert res.json['results'][0]['social']['ssrn'] != res.json['results'][1]['social']['ssrn']
+        assert res.json['results'][0]['social']['github'] != res.json['results'][1]['social']['github']
 
         res = self.app.get(url, {'q': 'Uwase'})
 
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json['results']), 1)
-        self.assertTrue(res.json['results'][0]['social'])
-        self.assertNotIn('ssrn', res.json['results'][0]['social'])
-        self.assertEqual(res.json['results'][0]['social']['profileWebsites'][0], f'http://me.com/{user_two.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['impactStory'], f'https://impactstory.org/u/{user_two.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['orcid'], f'http://orcid.org/{user_two.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['baiduScholar'], f'http://xueshu.baidu.com/scholarID/{user_two.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['linkedIn'], f'https://www.linkedin.com/{user_two.given_name}')
-        self.assertEqual(res.json['results'][0]['social']['scholar'], f'http://scholar.google.com/citations?user={user_two.given_name}')
+        assert res.status_code == 200
+        assert len(res.json['results']) == 1
+        assert res.json['results'][0]['social']
+        assert 'ssrn' not in res.json['results'][0]['social']
+        assert res.json['results'][0]['social']['profileWebsites'][0] == f'http://me.com/{user_two.given_name}'
+        assert res.json['results'][0]['social']['impactStory'] == f'https://impactstory.org/u/{user_two.given_name}'
+        assert res.json['results'][0]['social']['orcid'] == f'http://orcid.org/{user_two.given_name}'
+        assert res.json['results'][0]['social']['baiduScholar'] == f'http://xueshu.baidu.com/scholarID/{user_two.given_name}'
+        assert res.json['results'][0]['social']['linkedIn'] == f'https://www.linkedin.com/{user_two.given_name}'
+        assert res.json['results'][0]['social']['scholar'] == f'http://scholar.google.com/citations?user={user_two.given_name}'
 
 
 @pytest.mark.enable_bookmark_creation
@@ -231,24 +231,24 @@ class TestODMTitleSearch(OsfTestCase):
 
     def test_search_projects_by_title(self):
         res = self.app.get(self.url, {'term': self.project.title}, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.public_project.title,
                                'includePublic': 'yes',
                                'includeContributed': 'no'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
                                'includePublic': 'no',
                                'includeContributed': 'yes'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
@@ -256,8 +256,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'no'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.project.title,
@@ -265,8 +265,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.public_project.title,
@@ -274,8 +274,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.registration_project.title,
@@ -283,8 +283,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'either'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 2)
+        assert res.status_code == 200
+        assert len(res.json) == 2
         res = self.app.get(self.url,
                            {
                                'term': self.registration_project.title,
@@ -292,8 +292,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isRegistration': 'no'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 1)
+        assert res.status_code == 200
+        assert len(res.json) == 1
         res = self.app.get(self.url,
                            {
                                'term': self.folder.title,
@@ -301,7 +301,7 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
+        assert res.status_code == 200
         assert len(res.json) == 0
         res = self.app.get(self.url,
                            {
@@ -310,8 +310,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'no'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 0)
+        assert res.status_code == 200
+        assert len(res.json) == 0
         res = self.app.get(self.url,
                            {
                                'term': self.dashboard.title,
@@ -319,8 +319,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'no'
                            }, auth=self.user.auth)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 0)
+        assert res.status_code == 200
+        assert len(res.json) == 0
         res = self.app.get(self.url,
                            {
                                'term': self.dashboard.title,
@@ -328,5 +328,5 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        self.assertEqual(res.status_code, 200)
-        self.assertEqual(len(res.json), 0)
+        assert res.status_code == 200
+        assert len(res.json) == 0

--- a/scripts/tests/test_add_preprint_providers.py
+++ b/scripts/tests/test_add_preprint_providers.py
@@ -1,5 +1,4 @@
 import logging
-from nose.tools import *  # noqa
 
 
 from tests.base import OsfTestCase
@@ -7,6 +6,7 @@ from website.models import PreprintProvider
 from scripts.update_taxonomies import main as taxonomy_main
 from scripts.populate_preprint_providers import main as populate_main
 from scripts.populate_preprint_providers import STAGING_PREPRINT_PROVIDERS, PROD_PREPRINT_PROVIDERS
+
 
 class TestAddPreprintProviders(OsfTestCase):
     def setUp(self):
@@ -20,27 +20,27 @@ class TestAddPreprintProviders(OsfTestCase):
     def test_add_prod_providers(self):
         populate_main('prod')
         providers = PreprintProvider.objects.all()
-        assert_equal(providers.count(), len(PROD_PREPRINT_PROVIDERS))
+        self.assertEqual(providers.count(), len(PROD_PREPRINT_PROVIDERS))
         ids = [provider._id for provider in providers]
         for id in PROD_PREPRINT_PROVIDERS:
-            assert_in(id, ids)
+            self.assertIn(id, ids)
         for id in set(STAGING_PREPRINT_PROVIDERS) - set(PROD_PREPRINT_PROVIDERS):
-            assert_not_in(id, ids)
+            self.assertNotIn(id, ids)
 
     def test_add_default_providers(self):
         populate_main(None)
         providers = PreprintProvider.objects.all()
-        assert_equal(providers.count(), len(PROD_PREPRINT_PROVIDERS))
+        self.assertEqual(providers.count(), len(PROD_PREPRINT_PROVIDERS))
         ids = [provider._id for provider in providers]
         for id in PROD_PREPRINT_PROVIDERS:
-            assert_in(id, ids)
+            self.assertIn(id, ids)
         for id in set(STAGING_PREPRINT_PROVIDERS) - set(PROD_PREPRINT_PROVIDERS):
-            assert_not_in(id, ids)
+            self.assertNotIn(id, ids)
 
     def test_add_staging_providers(self):
         populate_main('stage')
         providers = PreprintProvider.objects.all()
-        assert_equal(PreprintProvider.objects.all().count(), len(STAGING_PREPRINT_PROVIDERS))
+        self.assertEqual(PreprintProvider.objects.all().count(), len(STAGING_PREPRINT_PROVIDERS))
         ids = [provider._id for provider in providers]
         for id in STAGING_PREPRINT_PROVIDERS:
-            assert_in(id, ids)
+            self.assertIn(id, ids)

--- a/scripts/tests/test_add_preprint_providers.py
+++ b/scripts/tests/test_add_preprint_providers.py
@@ -20,27 +20,27 @@ class TestAddPreprintProviders(OsfTestCase):
     def test_add_prod_providers(self):
         populate_main('prod')
         providers = PreprintProvider.objects.all()
-        self.assertEqual(providers.count(), len(PROD_PREPRINT_PROVIDERS))
+        assert providers.count() == len(PROD_PREPRINT_PROVIDERS)
         ids = [provider._id for provider in providers]
         for id in PROD_PREPRINT_PROVIDERS:
-            self.assertIn(id, ids)
+            assert id in ids
         for id in set(STAGING_PREPRINT_PROVIDERS) - set(PROD_PREPRINT_PROVIDERS):
-            self.assertNotIn(id, ids)
+            assert id not in ids
 
     def test_add_default_providers(self):
         populate_main(None)
         providers = PreprintProvider.objects.all()
-        self.assertEqual(providers.count(), len(PROD_PREPRINT_PROVIDERS))
+        assert providers.count() == len(PROD_PREPRINT_PROVIDERS)
         ids = [provider._id for provider in providers]
         for id in PROD_PREPRINT_PROVIDERS:
-            self.assertIn(id, ids)
+            assert id in ids
         for id in set(STAGING_PREPRINT_PROVIDERS) - set(PROD_PREPRINT_PROVIDERS):
-            self.assertNotIn(id, ids)
+            assert id not in ids
 
     def test_add_staging_providers(self):
         populate_main('stage')
         providers = PreprintProvider.objects.all()
-        self.assertEqual(PreprintProvider.objects.all().count(), len(STAGING_PREPRINT_PROVIDERS))
+        assert PreprintProvider.objects.all().count() == len(STAGING_PREPRINT_PROVIDERS)
         ids = [provider._id for provider in providers]
         for id in STAGING_PREPRINT_PROVIDERS:
-            self.assertIn(id, ids)
+            assert id in ids

--- a/scripts/tests/test_approve_embargo_terminations.py
+++ b/scripts/tests/test_approve_embargo_terminations.py
@@ -2,13 +2,13 @@ from unittest import mock
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
 from osf_tests.factories import AuthUserFactory, NodeFactory, EmbargoTerminationApprovalFactory, RegistrationFactory, EmbargoFactory
 from osf.models import Sanction, Registration
 
 from scripts.approve_embargo_terminations import main, get_pending_embargo_termination_requests
+
 
 class TestApproveEmbargoTerminations(OsfTestCase):
 
@@ -53,19 +53,19 @@ class TestApproveEmbargoTerminations(OsfTestCase):
 
     def test_get_pending_embargo_termination_requests_returns_only_unapproved(self):
         targets = get_pending_embargo_termination_requests()
-        assert_equal(targets.count(), 1)
-        assert_equal(targets.first()._id, self.registration2.embargo_termination_approval._id)
+        self.assertEqual(targets.count(), 1)
+        self.assertEqual(targets.first()._id, self.registration2.embargo_termination_approval._id)
 
     def test_main_auto_approves_embargo_termination_request(self):
         for node in self.registration2.node_and_primary_descendants():
-            assert_false(node.is_public)
-            assert_true(node.is_embargoed)
+            self.assertFalse(node.is_public)
+            self.assertTrue(node.is_embargoed)
         main()
         for node in self.registration2.node_and_primary_descendants():
             node.reload()
-            assert_true(node.is_public)
-            assert_equal(node.embargo_termination_approval.state, Sanction.APPROVED)
-            assert_false(node.is_embargoed)
+            self.assertTrue(node.is_public)
+            self.assertEqual(node.embargo_termination_approval.state, Sanction.APPROVED)
+            self.assertFalse(node.is_embargoed)
 
     def test_main_removes_embargo_termination_approvals_for_completed_embargos(self):
         self.registration2.embargo.mark_as_completed()

--- a/scripts/tests/test_approve_embargo_terminations.py
+++ b/scripts/tests/test_approve_embargo_terminations.py
@@ -53,19 +53,19 @@ class TestApproveEmbargoTerminations(OsfTestCase):
 
     def test_get_pending_embargo_termination_requests_returns_only_unapproved(self):
         targets = get_pending_embargo_termination_requests()
-        self.assertEqual(targets.count(), 1)
-        self.assertEqual(targets.first()._id, self.registration2.embargo_termination_approval._id)
+        assert targets.count() == 1
+        assert targets.first()._id == self.registration2.embargo_termination_approval._id
 
     def test_main_auto_approves_embargo_termination_request(self):
         for node in self.registration2.node_and_primary_descendants():
-            self.assertFalse(node.is_public)
-            self.assertTrue(node.is_embargoed)
+            assert not node.is_public
+            assert node.is_embargoed
         main()
         for node in self.registration2.node_and_primary_descendants():
             node.reload()
-            self.assertTrue(node.is_public)
-            self.assertEqual(node.embargo_termination_approval.state, Sanction.APPROVED)
-            self.assertFalse(node.is_embargoed)
+            assert node.is_public
+            assert node.embargo_termination_approval.state == Sanction.APPROVED
+            assert not node.is_embargoed
 
     def test_main_removes_embargo_termination_approvals_for_completed_embargos(self):
         self.registration2.embargo.mark_as_completed()

--- a/scripts/tests/test_approve_registrations.py
+++ b/scripts/tests/test_approve_registrations.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
 from osf.models import NodeLog
@@ -20,64 +19,64 @@ class TestApproveRegistrations(OsfTestCase):
         self.registration.require_approval(self.user)
 
     def test_new_registration_should_not_be_approved(self):
-        assert_true(self.registration.is_pending_registration)
+        self.assertTrue(self.registration.is_pending_registration)
 
         main(dry_run=False)
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
     def test_should_not_approve_pending_registration_less_than_48_hours_old(self):
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(hours=47)
         self.registration.registration_approval.save()
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
         main(dry_run=False)
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
     def test_should_approve_pending_registration_that_is_48_hours_old(self):
-        assert_true(self.registration.registration_approval.state)  # sanity check
+        self.assertTrue(self.registration.registration_approval.state)  # sanity check
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(hours=48)
         self.registration.registration_approval.save()
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
         main(dry_run=False)
         self.registration.registration_approval.reload()
-        assert_true(self.registration.is_registration_approved)
+        self.assertTrue(self.registration.is_registration_approved)
 
     def test_should_approve_pending_registration_more_than_48_hours_old(self):
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(days=365)
         self.registration.registration_approval.save()
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
         main(dry_run=False)
         self.registration.registration_approval.reload()
-        assert_true(self.registration.is_registration_approved)
+        self.assertTrue(self.registration.is_registration_approved)
 
     def test_registration_adds_to_parent_projects_log(self):
-        assert_false(
+        self.assertFalse(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.REGISTRATION_APPROVAL_APPROVED
             ).exists()
         )
-        assert_false(
+        self.assertFalse(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.PROJECT_REGISTERED
             ).exists()
         )
-        assert_false(self.registration.is_registration_approved)
+        self.assertFalse(self.registration.is_registration_approved)
 
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(days=365)
         self.registration.registration_approval.save()
         main(dry_run=False)
         self.registration.registration_approval.reload()
 
-        assert_true(self.registration.is_registration_approved)
-        assert_true(self.registration.is_public)
-        assert_true(
+        self.assertTrue(self.registration.is_registration_approved)
+        self.assertTrue(self.registration.is_public)
+        self.assertTrue(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.REGISTRATION_APPROVAL_APPROVED
             ).exists()
         )
-        assert_true(
+        self.assertTrue(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.PROJECT_REGISTERED
             ).exists()

--- a/scripts/tests/test_approve_registrations.py
+++ b/scripts/tests/test_approve_registrations.py
@@ -19,65 +19,57 @@ class TestApproveRegistrations(OsfTestCase):
         self.registration.require_approval(self.user)
 
     def test_new_registration_should_not_be_approved(self):
-        self.assertTrue(self.registration.is_pending_registration)
+        assert self.registration.is_pending_registration
 
         main(dry_run=False)
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
     def test_should_not_approve_pending_registration_less_than_48_hours_old(self):
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(hours=47)
         self.registration.registration_approval.save()
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
         main(dry_run=False)
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
     def test_should_approve_pending_registration_that_is_48_hours_old(self):
-        self.assertTrue(self.registration.registration_approval.state)  # sanity check
+        assert self.registration.registration_approval.state  # sanity check
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(hours=48)
         self.registration.registration_approval.save()
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
         main(dry_run=False)
         self.registration.registration_approval.reload()
-        self.assertTrue(self.registration.is_registration_approved)
+        assert self.registration.is_registration_approved
 
     def test_should_approve_pending_registration_more_than_48_hours_old(self):
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(days=365)
         self.registration.registration_approval.save()
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
         main(dry_run=False)
         self.registration.registration_approval.reload()
-        self.assertTrue(self.registration.is_registration_approved)
+        assert self.registration.is_registration_approved
 
     def test_registration_adds_to_parent_projects_log(self):
-        self.assertFalse(
-            self.registration.registered_from.logs.filter(
+        assert not self.registration.registered_from.logs.filter(
                 action=NodeLog.REGISTRATION_APPROVAL_APPROVED
             ).exists()
-        )
-        self.assertFalse(
-            self.registration.registered_from.logs.filter(
+        assert not self.registration.registered_from.logs.filter(
                 action=NodeLog.PROJECT_REGISTERED
             ).exists()
-        )
-        self.assertFalse(self.registration.is_registration_approved)
+        assert not self.registration.is_registration_approved
 
         self.registration.registration_approval.initiation_date = timezone.now() - timedelta(days=365)
         self.registration.registration_approval.save()
         main(dry_run=False)
         self.registration.registration_approval.reload()
 
-        self.assertTrue(self.registration.is_registration_approved)
-        self.assertTrue(self.registration.is_public)
-        self.assertTrue(
-            self.registration.registered_from.logs.filter(
+        assert self.registration.is_registration_approved
+        assert self.registration.is_public
+        assert self.registration.registered_from.logs.filter(
                 action=NodeLog.REGISTRATION_APPROVAL_APPROVED
             ).exists()
-        )
-        self.assertTrue(
-            self.registration.registered_from.logs.filter(
+        assert self.registration.registered_from.logs.filter(
                 action=NodeLog.PROJECT_REGISTERED
             ).exists()
-        )

--- a/scripts/tests/test_deactivate_requested_accounts.py
+++ b/scripts/tests/test_deactivate_requested_accounts.py
@@ -1,13 +1,12 @@
 import pytest
 from unittest import mock
 
-from nose.tools import *  # noqa
-
 from osf_tests.factories import ProjectFactory, AuthUserFactory
 
 from osf.management.commands.deactivate_requested_accounts import deactivate_requested_accounts
 
 from website import mails, settings
+
 
 @pytest.mark.django_db
 class TestDeactivateRequestedAccount:

--- a/scripts/tests/test_embargo_registrations.py
+++ b/scripts/tests/test_embargo_registrations.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
 from osf.models import NodeLog
@@ -23,83 +22,83 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.save()
 
     def test_new_embargo_should_be_unapproved(self):
-        assert_true(self.registration.is_pending_embargo)
-        assert_false(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.embargo_end_date)
 
         main(dry_run=False)
-        assert_true(self.registration.is_pending_embargo)
-        assert_false(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.embargo_end_date)
 
     def test_should_not_activate_pending_embargo_less_than_48_hours_old(self):
         self.registration.embargo.initiation_date = timezone.now() - timedelta(hours=47)
         self.registration.embargo.save()
-        assert_false(self.registration.embargo_end_date)
+        self.assertFalse(self.registration.embargo_end_date)
 
         main(dry_run=False)
         self.registration.embargo.refresh_from_db()
         self.registration.refresh_from_db()
-        assert_true(self.registration.is_pending_embargo)
-        assert_false(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.embargo_end_date)
 
     def test_should_activate_pending_embargo_that_is_48_hours_old(self):
         self.registration.embargo.initiation_date = timezone.now() - timedelta(hours=48)
         self.registration.embargo.save()
-        assert_true(self.registration.is_pending_embargo)
-        assert_false(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.embargo_end_date)
 
         main(dry_run=False)
         self.registration.embargo.refresh_from_db()
         self.registration.refresh_from_db()
-        assert_true(self.registration.is_embargoed)
-        assert_true(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_embargoed)
+        self.assertTrue(self.registration.embargo_end_date)
 
     def test_should_activate_pending_embargo_more_than_48_hours_old(self):
         self.registration.embargo.initiation_date = timezone.now() - timedelta(days=365)
         self.registration.embargo.save()
-        assert_true(self.registration.is_pending_embargo)
-        assert_false(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.embargo_end_date)
 
         main(dry_run=False)
         self.registration.embargo.refresh_from_db()
         self.registration.refresh_from_db()
-        assert_true(self.registration.is_embargoed)
-        assert_false(self.registration.is_pending_embargo)
-        assert_true(self.registration.embargo_end_date)
+        self.assertTrue(self.registration.is_embargoed)
+        self.assertFalse(self.registration.is_pending_embargo)
+        self.assertTrue(self.registration.embargo_end_date)
 
     def test_embargo_past_end_date_should_be_completed(self):
         self.registration.embargo.accept()
-        assert_true(self.registration.embargo_end_date)
-        assert_false(self.registration.is_pending_embargo)
+        self.assertTrue(self.registration.embargo_end_date)
+        self.assertFalse(self.registration.is_pending_embargo)
 
         self.registration.embargo.end_date = timezone.now() - timedelta(days=1)
         self.registration.embargo.save()
 
-        assert_false(self.registration.is_public)
+        self.assertFalse(self.registration.is_public)
         main(dry_run=False)
         self.registration.embargo.refresh_from_db()
         self.registration.refresh_from_db()
-        assert_true(self.registration.is_public)
-        assert_false(self.registration.embargo_end_date)
-        assert_false(self.registration.is_pending_embargo)
-        assert_equal(self.registration.embargo.state, 'completed')
+        self.assertTrue(self.registration.is_public)
+        self.assertFalse(self.registration.embargo_end_date)
+        self.assertFalse(self.registration.is_pending_embargo)
+        self.assertEqual(self.registration.embargo.state, 'completed')
 
     def test_embargo_before_end_date_should_not_be_completed(self):
         self.registration.embargo.accept()
-        assert_true(self.registration.embargo_end_date)
-        assert_false(self.registration.is_pending_embargo)
+        self.assertTrue(self.registration.embargo_end_date)
+        self.assertFalse(self.registration.is_pending_embargo)
 
         self.registration.embargo.end_date = timezone.now() + timedelta(days=1)
         self.registration.embargo.save()
 
-        assert_false(self.registration.is_public)
+        self.assertFalse(self.registration.is_public)
         main(dry_run=False)
         self.registration.embargo.refresh_from_db()
-        assert_false(self.registration.is_public)
-        assert_true(self.registration.embargo_end_date)
-        assert_false(self.registration.is_pending_embargo)
+        self.assertFalse(self.registration.is_public)
+        self.assertTrue(self.registration.embargo_end_date)
+        self.assertFalse(self.registration.is_pending_embargo)
 
     def test_embargo_approval_adds_to_parent_projects_log(self):
-        assert_false(
+        self.assertFalse(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.EMBARGO_APPROVED
             ).exists()
@@ -109,14 +108,14 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.embargo.save()
         main(dry_run=False)
 
-        assert_true(
+        self.assertTrue(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.EMBARGO_APPROVED
             ).exists()
         )
 
     def test_embargo_completion_adds_to_parent_projects_log(self):
-        assert_false(
+        self.assertFalse(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.EMBARGO_COMPLETED
             ).exists()
@@ -127,7 +126,7 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.embargo.save()
 
         main(dry_run=False)
-        assert_true(
+        self.assertTrue(
             self.registration.registered_from.logs.filter(
                 action=NodeLog.EMBARGO_COMPLETED
             ).exists()

--- a/scripts/tests/test_populate_new_and_noteworthy.py
+++ b/scripts/tests/test_populate_new_and_noteworthy.py
@@ -30,15 +30,15 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
 
     def test_get_new_and_noteworthy_nodes(self):
         new_noteworthy = script.get_new_and_noteworthy_nodes(self.new_and_noteworthy_links_node)
-        self.assertEqual(set(new_noteworthy), self.all_ids)
+        assert set(new_noteworthy) == self.all_ids
 
     def test_populate_new_and_noteworthy(self):
-        self.assertEqual(self.new_and_noteworthy_links_node._nodes.count(), 0)
+        assert self.new_and_noteworthy_links_node._nodes.count() == 0
 
         script.main(dry_run=False)
         self.new_and_noteworthy_links_node.reload()
 
-        self.assertEqual(self.new_and_noteworthy_links_node._nodes.count(), 5)
+        assert self.new_and_noteworthy_links_node._nodes.count() == 5
 
         script.main(dry_run=False)
 
@@ -47,4 +47,4 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
         # new_and_noteworthy_node_links = {pointer.node._id for pointer in self.new_and_noteworthy_links_node.nodes}
         new_and_noteworthy_node_links = self.new_and_noteworthy_links_node._nodes.all().values_list('guids___id', flat=True)
 
-        self.assertEqual(set(new_and_noteworthy_node_links), self.all_ids)
+        assert set(new_and_noteworthy_node_links) == self.all_ids

--- a/scripts/tests/test_populate_new_and_noteworthy.py
+++ b/scripts/tests/test_populate_new_and_noteworthy.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa
-
 from tests.base import OsfTestCase
 from osf_tests.factories import ProjectFactory
 
@@ -32,15 +30,15 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
 
     def test_get_new_and_noteworthy_nodes(self):
         new_noteworthy = script.get_new_and_noteworthy_nodes(self.new_and_noteworthy_links_node)
-        assert_equal(set(new_noteworthy), self.all_ids)
+        self.assertEqual(set(new_noteworthy), self.all_ids)
 
     def test_populate_new_and_noteworthy(self):
-        assert_equal(self.new_and_noteworthy_links_node._nodes.count(), 0)
+        self.assertEqual(self.new_and_noteworthy_links_node._nodes.count(), 0)
 
         script.main(dry_run=False)
         self.new_and_noteworthy_links_node.reload()
 
-        assert_equal(self.new_and_noteworthy_links_node._nodes.count(), 5)
+        self.assertEqual(self.new_and_noteworthy_links_node._nodes.count(), 5)
 
         script.main(dry_run=False)
 
@@ -49,4 +47,4 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
         # new_and_noteworthy_node_links = {pointer.node._id for pointer in self.new_and_noteworthy_links_node.nodes}
         new_and_noteworthy_node_links = self.new_and_noteworthy_links_node._nodes.all().values_list('guids___id', flat=True)
 
-        assert_equal(set(new_and_noteworthy_node_links), self.all_ids)
+        self.assertEqual(set(new_and_noteworthy_node_links), self.all_ids)

--- a/scripts/tests/test_populate_popular_projects_and_registrations.py
+++ b/scripts/tests/test_populate_popular_projects_and_registrations.py
@@ -80,16 +80,16 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
 
         mock_client.return_value = {'node_pageviews': node_pageviews, 'node_visits': node_visits}
 
-        self.assertEqual(len(self.popular_links_node.nodes), 0)
-        self.assertEqual(len(self.popular_links_registrations.nodes), 0)
+        assert len(self.popular_links_node.nodes) == 0
+        assert len(self.popular_links_registrations.nodes) == 0
 
         script.main(dry_run=False)
 
         self.popular_links_node.reload()
         self.popular_links_registrations.reload()
 
-        self.assertEqual(len(self.popular_links_node.nodes), 2)
-        self.assertEqual(len(self.popular_links_registrations.nodes), 2)
+        assert len(self.popular_links_node.nodes) == 2
+        assert len(self.popular_links_registrations.nodes) == 2
 
-        self.assertEqual(popular_nodes, self.popular_links_node.nodes)
-        self.assertEqual(popular_registrations, self.popular_links_registrations.nodes)
+        assert popular_nodes == self.popular_links_node.nodes
+        assert popular_registrations == self.popular_links_registrations.nodes

--- a/scripts/tests/test_populate_popular_projects_and_registrations.py
+++ b/scripts/tests/test_populate_popular_projects_and_registrations.py
@@ -1,5 +1,3 @@
-from nose.tools import *  # noqa
-
 from unittest import mock
 
 from tests.base import OsfTestCase
@@ -82,16 +80,16 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
 
         mock_client.return_value = {'node_pageviews': node_pageviews, 'node_visits': node_visits}
 
-        assert_equal(len(self.popular_links_node.nodes), 0)
-        assert_equal(len(self.popular_links_registrations.nodes), 0)
+        self.assertEqual(len(self.popular_links_node.nodes), 0)
+        self.assertEqual(len(self.popular_links_registrations.nodes), 0)
 
         script.main(dry_run=False)
 
         self.popular_links_node.reload()
         self.popular_links_registrations.reload()
 
-        assert_equal(len(self.popular_links_node.nodes), 2)
-        assert_equal(len(self.popular_links_registrations.nodes), 2)
+        self.assertEqual(len(self.popular_links_node.nodes), 2)
+        self.assertEqual(len(self.popular_links_registrations.nodes), 2)
 
-        assert_equals(popular_nodes, self.popular_links_node.nodes)
-        assert_equals(popular_registrations, self.popular_links_registrations.nodes)
+        self.assertEqual(popular_nodes, self.popular_links_node.nodes)
+        self.assertEqual(popular_registrations, self.popular_links_registrations.nodes)

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -1,6 +1,5 @@
 from unittest import mock
 from django.utils import timezone
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
 
@@ -32,9 +31,9 @@ class TestRefreshTokens(OsfTestCase):
     def test_look_up_provider(self):
         for Provider in PROVIDER_CLASSES:
             result = look_up_provider(Provider.short_name)
-            assert_equal(result, Provider)
+            self.assertEqual(result, Provider)
         fake_result = look_up_provider('fake_addon_name')
-        assert_equal(fake_result, None)
+        self.assertEqual(fake_result, None)
 
     def test_get_targets(self):
         now = timezone.now()
@@ -49,12 +48,12 @@ class TestRefreshTokens(OsfTestCase):
         box_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='box'))
         drive_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='googledrive'))
         mendeley_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='mendeley'))
-        assert_equal(records[0]._id, box_targets[0]._id)
-        assert_not_in(records[1], box_targets)
-        assert_equal(records[2]._id, drive_targets[0]._id)
-        assert_not_in(records[3], drive_targets)
-        assert_equal(records[4]._id, mendeley_targets[0]._id)
-        assert_not_in(records[5], mendeley_targets)
+        self.assertEqual(records[0]._id, box_targets[0]._id)
+        self.assertNotIn(records[1], box_targets)
+        self.assertEqual(records[2]._id, drive_targets[0]._id)
+        self.assertNotIn(records[3], drive_targets)
+        self.assertEqual(records[4]._id, mendeley_targets[0]._id)
+        self.assertNotIn(records[5], mendeley_targets)
 
     @mock.patch('scripts.refresh_addon_tokens.Mendeley.refresh_oauth_key')
     @mock.patch('scripts.refresh_addon_tokens.GoogleDriveProvider.refresh_oauth_key')
@@ -69,6 +68,6 @@ class TestRefreshTokens(OsfTestCase):
         for addon in self.addons:
             Provider = look_up_provider(addon)
             main(delta=relativedelta(days=3), Provider=Provider, rate_limit=(5, 1), dry_run=False)
-        assert_equal(1, mock_box_refresh.call_count)
-        assert_equal(1, mock_drive_refresh.call_count)
-        assert_equal(1, mock_mendeley_refresh.call_count)
+        self.assertEqual(1, mock_box_refresh.call_count)
+        self.assertEqual(1, mock_drive_refresh.call_count)
+        self.assertEqual(1, mock_mendeley_refresh.call_count)

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -33,7 +33,7 @@ class TestRefreshTokens(OsfTestCase):
             result = look_up_provider(Provider.short_name)
             assert result == Provider
         fake_result = look_up_provider('fake_addon_name')
-        assert fake_result == None
+        assert fake_result is None
 
     def test_get_targets(self):
         now = timezone.now()

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -31,9 +31,9 @@ class TestRefreshTokens(OsfTestCase):
     def test_look_up_provider(self):
         for Provider in PROVIDER_CLASSES:
             result = look_up_provider(Provider.short_name)
-            self.assertEqual(result, Provider)
+            assert result == Provider
         fake_result = look_up_provider('fake_addon_name')
-        self.assertEqual(fake_result, None)
+        assert fake_result == None
 
     def test_get_targets(self):
         now = timezone.now()
@@ -48,12 +48,12 @@ class TestRefreshTokens(OsfTestCase):
         box_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='box'))
         drive_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='googledrive'))
         mendeley_targets = list(get_targets(delta=relativedelta(days=3), addon_short_name='mendeley'))
-        self.assertEqual(records[0]._id, box_targets[0]._id)
-        self.assertNotIn(records[1], box_targets)
-        self.assertEqual(records[2]._id, drive_targets[0]._id)
-        self.assertNotIn(records[3], drive_targets)
-        self.assertEqual(records[4]._id, mendeley_targets[0]._id)
-        self.assertNotIn(records[5], mendeley_targets)
+        assert records[0]._id == box_targets[0]._id
+        assert records[1] not in box_targets
+        assert records[2]._id == drive_targets[0]._id
+        assert records[3] not in drive_targets
+        assert records[4]._id == mendeley_targets[0]._id
+        assert records[5] not in mendeley_targets
 
     @mock.patch('scripts.refresh_addon_tokens.Mendeley.refresh_oauth_key')
     @mock.patch('scripts.refresh_addon_tokens.GoogleDriveProvider.refresh_oauth_key')
@@ -68,6 +68,6 @@ class TestRefreshTokens(OsfTestCase):
         for addon in self.addons:
             Provider = look_up_provider(addon)
             main(delta=relativedelta(days=3), Provider=Provider, rate_limit=(5, 1), dry_run=False)
-        self.assertEqual(1, mock_box_refresh.call_count)
-        self.assertEqual(1, mock_drive_refresh.call_count)
-        self.assertEqual(1, mock_mendeley_refresh.call_count)
+        assert 1 == mock_box_refresh.call_count
+        assert 1 == mock_drive_refresh.call_count
+        assert 1 == mock_mendeley_refresh.call_count

--- a/scripts/tests/test_retract_registrations.py
+++ b/scripts/tests/test_retract_registrations.py
@@ -1,10 +1,8 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
-from osf.models import NodeLog
 from osf_tests.factories import RegistrationFactory, UserFactory
 
 from scripts.retract_registrations import main
@@ -21,49 +19,49 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.save()
 
     def test_new_retraction_should_not_be_retracted(self):
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
         main(dry_run=False)
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
     def test_should_not_retract_pending_retraction_less_than_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(hours=47))
         self.registration.retraction.save()
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
         main(dry_run=False)
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
     def test_should_retract_pending_retraction_that_is_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(hours=48))
         self.registration.retraction.save()
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        assert_true(self.registration.is_retracted)
+        self.assertTrue(self.registration.is_retracted)
 
     def test_should_retract_pending_retraction_more_than_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(days=365))
         self.registration.retraction.save()
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        assert_true(self.registration.is_retracted)
+        self.assertTrue(self.registration.is_retracted)
 
     def test_retraction_adds_to_parent_projects_log(self):
         initial_project_logs = len(self.registration.registered_from.logs.all())
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date =(timezone.now() - timedelta(days=365))
         self.registration.retraction.save()
-        assert_false(self.registration.is_retracted)
+        self.assertFalse(self.registration.is_retracted)
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        assert_true(self.registration.is_retracted)
+        self.assertTrue(self.registration.is_retracted)
         # Logs: Created, made public, retraction initiated, retracted approved
-        assert_equal(len(self.registration.registered_from.logs.all()), initial_project_logs + 1)
+        self.assertEqual(len(self.registration.registered_from.logs.all()), initial_project_logs + 1)

--- a/scripts/tests/test_retract_registrations.py
+++ b/scripts/tests/test_retract_registrations.py
@@ -19,49 +19,49 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.save()
 
     def test_new_retraction_should_not_be_retracted(self):
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
         main(dry_run=False)
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
     def test_should_not_retract_pending_retraction_less_than_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(hours=47))
         self.registration.retraction.save()
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
         main(dry_run=False)
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
     def test_should_retract_pending_retraction_that_is_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(hours=48))
         self.registration.retraction.save()
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        self.assertTrue(self.registration.is_retracted)
+        assert self.registration.is_retracted
 
     def test_should_retract_pending_retraction_more_than_48_hours_old(self):
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date = (timezone.now() - timedelta(days=365))
         self.registration.retraction.save()
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        self.assertTrue(self.registration.is_retracted)
+        assert self.registration.is_retracted
 
     def test_retraction_adds_to_parent_projects_log(self):
         initial_project_logs = len(self.registration.registered_from.logs.all())
         # Retraction#iniation_date is read only
         self.registration.retraction.initiation_date =(timezone.now() - timedelta(days=365))
         self.registration.retraction.save()
-        self.assertFalse(self.registration.is_retracted)
+        assert not self.registration.is_retracted
 
         main(dry_run=False)
         self.registration.retraction.refresh_from_db()
-        self.assertTrue(self.registration.is_retracted)
+        assert self.registration.is_retracted
         # Logs: Created, made public, retraction initiated, retracted approved
-        self.assertEqual(len(self.registration.registered_from.logs.all()), initial_project_logs + 1)
+        assert len(self.registration.registered_from.logs.all()) == initial_project_logs + 1

--- a/scripts/tests/test_send_queued_mails.py
+++ b/scripts/tests/test_send_queued_mails.py
@@ -2,7 +2,6 @@ from unittest import mock
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import *
 
 from tests.base import OsfTestCase
 from osf_tests.factories import UserFactory
@@ -10,6 +9,7 @@ from osf.models.queued_mail import QueuedMail, queue_mail, NO_ADDON, NO_LOGIN_TY
 
 from scripts.send_queued_mails import main, pop_and_verify_mails_for_each_user, find_queued_mails_ready_to_be_sent
 from website import settings
+
 
 class TestSendQueuedMails(OsfTestCase):
 
@@ -33,7 +33,7 @@ class TestSendQueuedMails(OsfTestCase):
     def test_queue_addon_mail(self, mock_send):
         self.queue_mail()
         main(dry_run=False)
-        assert_true(mock_send.called)
+        self.assertTrue(mock_send.called)
 
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_no_two_emails_to_same_person(self, mock_send):
@@ -43,7 +43,7 @@ class TestSendQueuedMails(OsfTestCase):
         self.queue_mail(user=user)
         self.queue_mail(user=user)
         main(dry_run=False)
-        assert_equal(mock_send.call_count, 1)
+        self.assertEqual(mock_send.call_count, 1)
 
     def test_pop_and_verify_mails_for_each_user(self):
         user_with_email_sent = UserFactory()
@@ -67,15 +67,15 @@ class TestSendQueuedMails(OsfTestCase):
             user_with_no_emails_sent._id: [mail4]
         }
         mails_ = list(pop_and_verify_mails_for_each_user(user_queue))
-        assert_equal(len(mails_), 2)
+        self.assertEqual(len(mails_), 2)
         user_mails = [mail.user for mail in mails_]
-        assert_false(user_with_email_sent in user_mails)
-        assert_true(user_with_multiple_emails in user_mails)
-        assert_true(user_with_no_emails_sent in user_mails)
+        self.assertFalse(user_with_email_sent in user_mails)
+        self.assertTrue(user_with_multiple_emails in user_mails)
+        self.assertTrue(user_with_no_emails_sent in user_mails)
 
     def test_find_queued_mails_ready_to_be_sent(self):
         mail1 = self.queue_mail()
         mail2 = self.queue_mail(send_at=timezone.now()+timedelta(days=1))
         mail3 = self.queue_mail(send_at=timezone.now())
         mails = find_queued_mails_ready_to_be_sent()
-        assert_equal(mails.count(), 2)
+        self.assertEqual(mails.count(), 2)

--- a/scripts/tests/test_send_queued_mails.py
+++ b/scripts/tests/test_send_queued_mails.py
@@ -33,7 +33,7 @@ class TestSendQueuedMails(OsfTestCase):
     def test_queue_addon_mail(self, mock_send):
         self.queue_mail()
         main(dry_run=False)
-        self.assertTrue(mock_send.called)
+        assert mock_send.called
 
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_no_two_emails_to_same_person(self, mock_send):
@@ -43,7 +43,7 @@ class TestSendQueuedMails(OsfTestCase):
         self.queue_mail(user=user)
         self.queue_mail(user=user)
         main(dry_run=False)
-        self.assertEqual(mock_send.call_count, 1)
+        assert mock_send.call_count == 1
 
     def test_pop_and_verify_mails_for_each_user(self):
         user_with_email_sent = UserFactory()
@@ -67,15 +67,15 @@ class TestSendQueuedMails(OsfTestCase):
             user_with_no_emails_sent._id: [mail4]
         }
         mails_ = list(pop_and_verify_mails_for_each_user(user_queue))
-        self.assertEqual(len(mails_), 2)
+        assert len(mails_) == 2
         user_mails = [mail.user for mail in mails_]
-        self.assertFalse(user_with_email_sent in user_mails)
-        self.assertTrue(user_with_multiple_emails in user_mails)
-        self.assertTrue(user_with_no_emails_sent in user_mails)
+        assert not (user_with_email_sent in user_mails)
+        assert user_with_multiple_emails in user_mails
+        assert user_with_no_emails_sent in user_mails
 
     def test_find_queued_mails_ready_to_be_sent(self):
         mail1 = self.queue_mail()
         mail2 = self.queue_mail(send_at=timezone.now()+timedelta(days=1))
         mail3 = self.queue_mail(send_at=timezone.now())
         mails = find_queued_mails_ready_to_be_sent()
-        self.assertEqual(mails.count(), 2)
+        assert mails.count() == 2

--- a/scripts/tests/test_triggered_mails.py
+++ b/scripts/tests/test_triggered_mails.py
@@ -2,13 +2,13 @@ from unittest import mock
 from datetime import timedelta
 
 from django.utils import timezone
-from nose.tools import * # noqa
 
 from tests.base import OsfTestCase
 from osf_tests.factories import UserFactory
 
 from scripts.triggered_mails import main, find_inactive_users_with_no_inactivity_email_sent_or_queued
 from website import mails
+
 
 class TestTriggeredMails(OsfTestCase):
 
@@ -23,7 +23,7 @@ class TestTriggeredMails(OsfTestCase):
         self.user.date_last_login = timezone.now() - timedelta(seconds=6)
         self.user.save()
         main(dry_run=False)
-        assert_false(mock_queue.called)
+        self.assertFalse(mock_queue.called)
 
     @mock.patch('website.mails.queue_mail')
     def test_trigger_no_login_mail(self, mock_queue):
@@ -54,4 +54,4 @@ class TestTriggeredMails(OsfTestCase):
                          user=user_already_received_mail,
                          mail=mails.NO_LOGIN)
         users = find_inactive_users_with_no_inactivity_email_sent_or_queued()
-        assert_equal(len(users), 1)
+        self.assertEqual(len(users), 1)

--- a/scripts/tests/test_triggered_mails.py
+++ b/scripts/tests/test_triggered_mails.py
@@ -23,7 +23,7 @@ class TestTriggeredMails(OsfTestCase):
         self.user.date_last_login = timezone.now() - timedelta(seconds=6)
         self.user.save()
         main(dry_run=False)
-        self.assertFalse(mock_queue.called)
+        assert not mock_queue.called
 
     @mock.patch('website.mails.queue_mail')
     def test_trigger_no_login_mail(self, mock_queue):
@@ -54,4 +54,4 @@ class TestTriggeredMails(OsfTestCase):
                          user=user_already_received_mail,
                          mail=mails.NO_LOGIN)
         users = find_inactive_users_with_no_inactivity_email_sent_or_queued()
-        self.assertEqual(len(users), 1)
+        assert len(users) == 1


### PR DESCRIPTION
## Purpose

Get rid of nose library as it is deprecated

## Changes
Removed nose assertions in favor of pytest ones (native python asssert statements)

## QA Notes

## Documentation

## Side Effects

## Ticket

[ENG-5325](https://openscience.atlassian.net/browse/ENG-5325)


[ENG-5325]: https://openscience.atlassian.net/browse/ENG-5325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ