### PR TITLE
[ENG-5352][ENG-5267] Messaging for Account Status Changes (OSF-side)

### DIFF
--- a/framework/auth/signals.py
+++ b/framework/auth/signals.py
@@ -7,5 +7,7 @@ user_registered = signals.signal('user-registered')
 user_confirmed = signals.signal('user-confirmed')
 user_email_removed = signals.signal('user-email-removed')
 user_merged = signals.signal('user-merged')
+user_account_deactivated = signals.signal('user-account-deactivated')
+user_account_reactivated = signals.signal('user-account-reactivated')
 
 unconfirmed_user_created = signals.signal('unconfirmed-user-created')

--- a/framework/celery_tasks/routers.py
+++ b/framework/celery_tasks/routers.py
@@ -14,6 +14,8 @@ def match_by_module(task_path):
             return CeleryConfig.task_high_queue
         if task_subpath in CeleryConfig.remote_computing_modules:
             return CeleryConfig.task_remote_computing_queue
+        if task_subpath in CeleryConfig.account_status_changes:
+            return CeleryConfig.account_status_changes
     return CeleryConfig.task_default_queue
 
 

--- a/osf/external/messages/celery_publishers.py
+++ b/osf/external/messages/celery_publishers.py
@@ -5,28 +5,28 @@ from kombu import Exchange
 def publish_deactivated_user(user):
     _publish_user_status_change(
         body={
+            'action': 'deactivate',
             'user_uri': user.url,
         },
-        routing_key=celery_app.conf.DEACTIVATED_ROUTING_KEY
     )
 
 
 def publish_reactivate_user(user):
     _publish_user_status_change(
         body={
+            'action': 'reactivate',
             'user_uri': user.url,
         },
-        routing_key=celery_app.conf.REACTIVATED_ROUTING_KEY
     )
 
 
 def publish_merged_user(user):
     _publish_user_status_change(
         body={
+            'action': 'merge',
             'user_uri': user.url,
             'merged_user_uri': user.merged_by.url,
         },
-        routing_key=celery_app.conf.MERGED_ROUTING_KEY
     )
 
 
@@ -35,6 +35,5 @@ def _publish_user_status_change(body, routing_key):
         producer.publish(
             body=body,
             exchange=Exchange(celery_app.conf.account_status_changes),
-            routing_key=routing_key,
             serializer='json'
         )

--- a/osf/external/messages/celery_publishers.py
+++ b/osf/external/messages/celery_publishers.py
@@ -1,0 +1,40 @@
+from framework.celery_tasks import app as celery_app
+from kombu import Exchange
+
+
+def publish_deactivated_user(user):
+    _publish_user_status_change(
+        body={
+            'user_uri': user.url,
+        },
+        routing_key=celery_app.conf.DEACTIVATED_ROUTING_KEY
+    )
+
+
+def publish_reactivate_user(user):
+    _publish_user_status_change(
+        body={
+            'user_uri': user.url,
+        },
+        routing_key=celery_app.conf.REACTIVATED_ROUTING_KEY
+    )
+
+
+def publish_merged_user(user):
+    _publish_user_status_change(
+        body={
+            'user_uri': user.url,
+            'merged_user_uri': user.merged_by.url,
+        },
+        routing_key=celery_app.conf.MERGED_ROUTING_KEY
+    )
+
+
+def _publish_user_status_change(body, routing_key):
+    with celery_app.producer_pool.acquire(block=True) as producer:
+        producer.publish(
+            body=body,
+            exchange=Exchange(celery_app.conf.account_status_changes),
+            routing_key=routing_key,
+            serializer='json'
+        )

--- a/osf/management/commands/test_publish.py
+++ b/osf/management/commands/test_publish.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+from osf.models import OSFUser
+from osf.external.messages.celery_publishers import (
+    publish_deactivated_user,
+    publish_reactivate_user,
+    publish_merged_user,
+)
+
+
+class Command(BaseCommand):
+    help = 'Sends a message to manage a user state, for test purposes only.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('user_guid', type=str, help='URI of the user to post.')
+        # Adding a new argument to specify the action to perform
+        parser.add_argument(
+            'action',
+            type=str,
+            help='The action to perform on the user (deactivate, reactivate, merge).',
+            choices=['deactivate', 'reactivate', 'merge']  # Limiting the choices to specific actions
+        )
+
+    def handle(self, *args, **options):
+        user_guid = options['user_guid']
+        user = OSFUser.objects.get(guids___id=user_guid)
+        action = options['action']
+
+        # Using a mapping of action to function to simplify the control flow
+        actions_to_functions = {
+            'deactivate': publish_deactivated_user,
+            'reactivate': publish_reactivate_user,
+            'merge': publish_merged_user,
+        }
+
+        if action in actions_to_functions:
+            actions_to_functions[action](user)  # Call the appropriate function
+            self.stdout.write(self.style.SUCCESS(f'Successfully {action} message for user: {user._id}'))
+        else:
+            self.stdout.write(self.style.ERROR('Invalid action specified.'))

--- a/osf/management/commands/test_publish.py
+++ b/osf/management/commands/test_publish.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             'action',
             type=str,
             help='The action to perform on the user (deactivate, reactivate, merge).',
-            choices=['deactivate', 'reactivate', 'merge']  # Limiting the choices to specific actions
+            choices=['deactivate', 'reactivate', 'merge']
         )
 
     def handle(self, *args, **options):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -16,7 +16,7 @@ from framework.auth.decorators import must_be_logged_in
 from framework.auth.decorators import must_be_confirmed
 from framework.auth.exceptions import ChangePasswordError
 from framework.auth.views import send_confirm_email
-from framework.auth.signals import user_merged
+from framework.auth.signals import user_merged, user_account_deactivated, user_account_reactivated
 from framework.exceptions import HTTPError, PermissionsError
 from framework.flask import redirect  # VOL-aware redirect
 from framework.status import push_status_message
@@ -36,6 +36,12 @@ from website.profile import utils as profile_utils
 from website.util import api_v2_url, web_url_for, paths
 from website.util.sanitize import escape_html
 from addons.base import utils as addon_utils
+from osf.external.messages.celery_publishers import (
+    publish_reactivate_user,
+    publish_deactivated_user,
+    publish_merged_user
+)
+
 
 from api.waffle.utils import storage_i18n_flag_active
 
@@ -506,7 +512,6 @@ def user_choose_mailing_lists(auth, **kwargs):
     return {'message': 'Successfully updated mailing lists', 'result': all_mailing_lists}, 200
 
 
-@user_merged.connect
 def update_mailchimp_subscription(user, list_name, subscription, send_goodbye=True):
     """ Update mailing list subscription in mailchimp.
 
@@ -525,6 +530,24 @@ def update_mailchimp_subscription(user, list_name, subscription, send_goodbye=Tr
         except (MailChimpError, OSFError):
             # User has already unsubscribed, so nothing to do
             pass
+
+
+@user_merged.connect
+def send_account_merged_message(user):
+    """ Sends a signal using Celery messaging to alert other services that an osf.io user has been merged."""
+    publish_merged_user(user)
+
+
+@user_account_deactivated.connect
+def send_account_deactivation_message(user):
+    """ Sends a signal using Celery messaging to alert other services that an osf.io user has been deactivated."""
+    publish_deactivated_user(user)
+
+
+@user_account_reactivated.connect
+def send_account_reactivation_message(user):
+    """ Sends a signal using Celery messaging to alert other services that an osf.io user has been reactivated."""
+    publish_reactivate_user(user)
 
 
 def mailchimp_get_endpoint(**kwargs):

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -411,6 +411,7 @@ class CeleryConfig:
     task_med_queue = 'med'
     task_high_queue = 'high'
     task_remote_computing_queue = 'remote'
+    account_status_changes = 'account_status_changes'
 
     remote_computing_modules = {
         'addons.boa.tasks.submit_to_boa',
@@ -471,6 +472,9 @@ class CeleryConfig:
         'osf.management.commands.fix_quickfiles_waterbutler_logs',
         'api.share.utils',
     }
+    DEACTIVATED_ROUTING_KEY = 'user.deactivated'
+    REACTIVATED_ROUTING_KEY = 'user.reactivated'
+    MERGED_ROUTING_KEY = 'user.merged'
 
     try:
         from kombu import Queue, Exchange
@@ -488,6 +492,24 @@ class CeleryConfig:
                   routing_key=task_med_queue, consumer_arguments={'x-priority': 1}),
             Queue(task_high_queue, Exchange(task_high_queue),
                   routing_key=task_high_queue, consumer_arguments={'x-priority': 10}),
+            Queue(
+                account_status_changes,
+                Exchange(account_status_changes),
+                routing_key=DEACTIVATED_ROUTING_KEY,
+                consumer_arguments={'x-priority': 0}
+            ),
+            Queue(
+                account_status_changes,
+                Exchange(account_status_changes),
+                routing_key=REACTIVATED_ROUTING_KEY,
+                consumer_arguments={'x-priority': 0}
+            ),
+            Queue(
+                account_status_changes,
+                Exchange(account_status_changes),
+                routing_key=MERGED_ROUTING_KEY,
+                consumer_arguments={'x-priority': 0}
+            ),
         )
 
         task_default_exchange_type = 'direct'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -492,22 +492,7 @@ class CeleryConfig:
                   routing_key=task_med_queue, consumer_arguments={'x-priority': 1}),
             Queue(task_high_queue, Exchange(task_high_queue),
                   routing_key=task_high_queue, consumer_arguments={'x-priority': 10}),
-            Queue(
-                account_status_changes,
-                Exchange(account_status_changes),
-                routing_key=DEACTIVATED_ROUTING_KEY,
-                consumer_arguments={'x-priority': 0}
-            ),
-            Queue(
-                account_status_changes,
-                Exchange(account_status_changes),
-                routing_key=REACTIVATED_ROUTING_KEY,
-                consumer_arguments={'x-priority': 0}
-            ),
-            Queue(
-                account_status_changes,
-                Exchange(account_status_changes),
-                routing_key=MERGED_ROUTING_KEY,
+            Queue(account_status_changes, Exchange(account_status_changes), routing_key=account_status_changes,
                 consumer_arguments={'x-priority': 0}
             ),
         )


### PR DESCRIPTION
## Purpose

Create a messaging system using RabbitMq to pass account status chages to GravyValet and other services.

## Changes

- adds function and management command to post a message for a user that is disabled or merged
- Adds deactivated_user signal
- Adds reactivated_user signal
- modifies merged_user signal
- adds new queue for account status changes messaging

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5352
https://openscience.atlassian.net/browse/ENG-5267

## GV side PR
https://github.com/CenterForOpenScience/gravyvalet/pull/17
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
