### PR TITLE
[ENG-5352][ENG-5267] Messaging for Account Status Changes (OSF-side)

### DIFF
--- a/framework/auth/signals.py
+++ b/framework/auth/signals.py
@@ -7,5 +7,8 @@ user_registered = signals.signal('user-registered')
 user_confirmed = signals.signal('user-confirmed')
 user_email_removed = signals.signal('user-email-removed')
 user_merged = signals.signal('user-merged')
+user_account_deactivated = signals.signal('user-account-deactivated')
+user_account_reactivated = signals.signal('user-account-reactivated')
+update_mailchimp_subscription = signals.signal('user-update-mailchimp')
 
 unconfirmed_user_created = signals.signal('unconfirmed-user-created')

--- a/framework/auth/signals.py
+++ b/framework/auth/signals.py
@@ -9,6 +9,6 @@ user_email_removed = signals.signal('user-email-removed')
 user_merged = signals.signal('user-merged')
 user_account_deactivated = signals.signal('user-account-deactivated')
 user_account_reactivated = signals.signal('user-account-reactivated')
-update_mailchimp_subscription = signals.signal('user-update-mailchimp')
+user_update_mailchimp = signals.signal('user-update-mailchimp')
 
 unconfirmed_user_created = signals.signal('unconfirmed-user-created')

--- a/framework/celery_tasks/routers.py
+++ b/framework/celery_tasks/routers.py
@@ -14,6 +14,8 @@ def match_by_module(task_path):
             return CeleryConfig.task_high_queue
         if task_subpath in CeleryConfig.remote_computing_modules:
             return CeleryConfig.task_remote_computing_queue
+        if task_subpath in CeleryConfig.account_status_changes:
+            return CeleryConfig.account_status_changes
     return CeleryConfig.task_default_queue
 
 

--- a/osf/external/messages/celery_publishers.py
+++ b/osf/external/messages/celery_publishers.py
@@ -1,0 +1,40 @@
+from framework.celery_tasks import app as celery_app
+from osf.models import OSFUser
+from kombu import Exchange
+
+
+def publish_deactivated_user(user: OSFUser):
+    _publish_user_status_change(
+        body={
+            'action': 'deactivate',
+            'user_uri': user.url,
+        },
+    )
+
+
+def publish_reactivate_user(user: OSFUser):
+    _publish_user_status_change(
+        body={
+            'action': 'reactivate',
+            'user_uri': user.url,
+        },
+    )
+
+
+def publish_merged_user(user: OSFUser):
+    _publish_user_status_change(
+        body={
+            'action': 'merge',
+            'user_uri': user.url,
+            'merged_user_uri': user.merged_by.url,
+        },
+    )
+
+
+def _publish_user_status_change(body: dict):
+    with celery_app.producer_pool.acquire(block=True) as producer:
+        producer.publish(
+            body=body,
+            exchange=Exchange(celery_app.conf.account_status_changes),
+            serializer='json'
+        )

--- a/osf/management/commands/test_publish.py
+++ b/osf/management/commands/test_publish.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+from osf.models import OSFUser
+from osf.external.messages.celery_publishers import (
+    publish_deactivated_user,
+    publish_reactivate_user,
+    publish_merged_user,
+)
+
+
+class Command(BaseCommand):
+    help = 'Sends a message to manage a user state, for test purposes only.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('user_guid', type=str, help='URI of the user to post.')
+        # Adding a new argument to specify the action to perform
+        parser.add_argument(
+            'action',
+            type=str,
+            help='The action to perform on the user (deactivate, reactivate, merge).',
+            choices=['deactivate', 'reactivate', 'merge']
+        )
+
+    def handle(self, *args, **options):
+        user_guid = options['user_guid']
+        user = OSFUser.objects.get(guids___id=user_guid)
+        action = options['action']
+
+        # Using a mapping of action to function to simplify the control flow
+        actions_to_functions = {
+            'deactivate': publish_deactivated_user,
+            'reactivate': publish_reactivate_user,
+            'merge': publish_merged_user,
+        }
+
+        if action in actions_to_functions:
+            actions_to_functions[action](user)  # Call the appropriate function
+            self.stdout.write(self.style.SUCCESS(f'Successfully {action} message for user: {user._id}'))
+        else:
+            self.stdout.write(self.style.ERROR('Invalid action specified.'))

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -750,10 +750,10 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             for key, value in user.mailchimp_mailing_lists.items():
                 # subscribe to each list if either user was subscribed
                 subscription = value or self.mailchimp_mailing_lists.get(key)
-                signals.update_mailchimp_subscription.send(self, list_name=key, subscription=subscription)
+                signals.user_update_mailchimp.send(self, list_name=key, subscription=subscription)
 
                 # clear subscriptions for merged user
-                signals.update_mailchimp_subscription(user, list_name=key, subscription=False, send_goodbye=False)
+                signals.user_update_mailchimp.send(user, list_name=key, subscription=False, send_goodbye=False)
 
         for target_id, timestamp in user.comments_viewed_timestamp.items():
             if not self.comments_viewed_timestamp.get(target_id):

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -411,6 +411,7 @@ class CeleryConfig:
     task_med_queue = 'med'
     task_high_queue = 'high'
     task_remote_computing_queue = 'remote'
+    account_status_changes = 'account_status_changes'
 
     remote_computing_modules = {
         'addons.boa.tasks.submit_to_boa',
@@ -488,6 +489,9 @@ class CeleryConfig:
                   routing_key=task_med_queue, consumer_arguments={'x-priority': 1}),
             Queue(task_high_queue, Exchange(task_high_queue),
                   routing_key=task_high_queue, consumer_arguments={'x-priority': 10}),
+            Queue(account_status_changes, Exchange(account_status_changes),
+                  routing_key=account_status_changes, consumer_arguments={'x-priority': 0}
+            )
         )
 
         task_default_exchange_type = 'direct'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -489,9 +489,6 @@ class CeleryConfig:
                   routing_key=task_med_queue, consumer_arguments={'x-priority': 1}),
             Queue(task_high_queue, Exchange(task_high_queue),
                   routing_key=task_high_queue, consumer_arguments={'x-priority': 10}),
-            Queue(account_status_changes, Exchange(account_status_changes),
-                  routing_key=account_status_changes, consumer_arguments={'x-priority': 0}
-            )
         )
 
         task_default_exchange_type = 'direct'


### PR DESCRIPTION
## Purpose

Create a messaging system using RabbitMq to pass account status chages to GravyValet and other services.

## Changes

- adds function and management command to post a message for a user that is disabled or merged
- Adds deactivated_user signal
- Adds reactivated_user signal
- modifies merged_user signal
- adds new queue for account status changes messaging

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5352
https://openscience.atlassian.net/browse/ENG-5267

## GV side PR
https://github.com/CenterForOpenScience/gravyvalet/pull/17
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
