### PR TITLE
[ENG-5356] Unlimit the number of highlighted subjects are displayed

### DIFF
--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -181,9 +181,9 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
     @property
     def highlighted_subjects(self):
         if self.has_highlighted_subjects:
-            return self.subjects.filter(highlighted=True).order_by('text')[:10]
+            return self.subjects.filter(highlighted=True).order_by('text')
         else:
-            return sorted(self.top_level_subjects, key=lambda s: s.text)[:10]
+            return sorted(self.top_level_subjects, key=lambda s: s.text)
 
     @property
     def top_level_subjects(self):
@@ -413,9 +413,9 @@ class PreprintProvider(AbstractProvider):
     @property
     def highlighted_subjects(self):
         if self.has_highlighted_subjects:
-            return self.subjects.filter(highlighted=True).order_by('text')[:10]
+            return self.subjects.filter(highlighted=True).order_by('text')
         else:
-            return sorted(self.top_level_subjects, key=lambda s: s.text)[:10]
+            return sorted(self.top_level_subjects, key=lambda s: s.text)
 
     @property
     def top_level_subjects(self):

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -407,17 +407,6 @@ class PreprintProvider(AbstractProvider):
             return rules_to_subjects(self.subjects_acceptable)
 
     @property
-    def has_highlighted_subjects(self):
-        return self.subjects.filter(highlighted=True).exists()
-
-    @property
-    def highlighted_subjects(self):
-        if self.has_highlighted_subjects:
-            return self.subjects.filter(highlighted=True).order_by('text')
-        else:
-            return sorted(self.top_level_subjects, key=lambda s: s.text)
-
-    @property
     def top_level_subjects(self):
         if self.subjects.exists():
             return optimize_subject_query(self.subjects.filter(parent__isnull=True))

--- a/osf/models/subject.py
+++ b/osf/models/subject.py
@@ -8,7 +8,7 @@ from django.utils.functional import cached_property
 from website.util import api_v2_url
 
 from .base import BaseModel, ObjectIDMixin
-from .validators import validate_subject_hierarchy_length, validate_subject_highlighted_count
+from .validators import validate_subject_hierarchy_length
 
 class SubjectQuerySet(QuerySet):
     def include_children(self):
@@ -86,7 +86,6 @@ class Subject(ObjectIDMixin, BaseModel, DirtyFieldsMixin):
 
     def save(self, *args, **kwargs):
         saved_fields = self.get_dirty_fields() or []
-        validate_subject_highlighted_count(self.provider, bool('highlighted' in saved_fields and self.highlighted))
         if 'text' in saved_fields and self.pk and (self.preprints.exists() or self.abstractnodes.exists()):
             raise ValidationError('Cannot edit a used Subject')
         return super(Subject, self).save()

--- a/osf/models/validators.py
+++ b/osf/models/validators.py
@@ -112,10 +112,6 @@ def validate_email(value):
         raise BlockedEmailError('Invalid Email')
 
 
-def validate_subject_highlighted_count(provider, is_highlighted_addition):
-    if is_highlighted_addition and provider.subjects.filter(highlighted=True).count() >= 10:
-        raise DjangoValidationError('Too many highlighted subjects for PreprintProvider {}'.format(provider._id))
-
 def validate_subject_hierarchy_length(parent):
     from osf.models import Subject
     parent = Subject.objects.get(id=parent)

--- a/tests/test_subjects.py
+++ b/tests/test_subjects.py
@@ -148,11 +148,6 @@ class TestSubjectEditValidation(OsfTestCase):
         with assert_raises(ValidationError):
             self.subject.delete()
 
-    def test_max_highlighted_count(self):
-        highlights = [SubjectFactory(provider=self.subject.provider, highlighted=True) for _ in range(10)]
-        with assert_raises(ValidationError):
-            self.subject.highlighted=True
-            self.subject.save()
 
 class TestSubjectProperties(OsfTestCase):
     def setUp(self):


### PR DESCRIPTION
## Purpose

Remove the limit of 10 highlighted subjects.

## Changes

- remove limits of ten elements from the views `highlighted_subjects`.
- remove validators that prevent addional highlighted subjects from being added.
- remove tests that ensure the limit is maintained.
- remove redundant methods that were enforcing the limit.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5356