### PR TITLE
[ENG-4658] Add default "No description included" text in node description

### DIFF
--- a/osf/metadata/serializers/google_dataset_json_ld.py
+++ b/osf/metadata/serializers/google_dataset_json_ld.py
@@ -13,6 +13,9 @@ from website import settings
 class GoogleDatasetJsonLdSerializer(_base.MetadataSerializer):
     mediatype = 'application/ld+json'
 
+    # Descriptions must innclude the 50 minimum characters for Google Dataset Discovery to accept the item as valid
+    default_description_text = 'No description was included in this Dataset collected from the OSF'
+
     def filename_for_itemid(self, itemid: str):
         return f'{itemid}-metadata-schemadotorg.json'
 
@@ -30,7 +33,7 @@ class GoogleDatasetJsonLdSerializer(_base.MetadataSerializer):
             'dateCreated': next(self.basket[DCTERMS.created]),
             'dateModified': next(self.basket[DCTERMS.modified]),
             'name': next(self.basket[DCTERMS.title | OSF.fileName]),
-            'description': next(self.basket[DCTERMS.description], None),
+            'description': next(self.basket[DCTERMS.description], self.default_description_text),
             'url': next(url for url in self.basket[DCTERMS.identifier] if url.startswith(OSFIO)),
             'keywords': [keyword for keyword in self.basket[OSF.keyword]],
             'publisher': {

--- a/osf/metadata/serializers/google_dataset_json_ld.py
+++ b/osf/metadata/serializers/google_dataset_json_ld.py
@@ -14,7 +14,7 @@ class GoogleDatasetJsonLdSerializer(_base.MetadataSerializer):
     mediatype = 'application/ld+json'
 
     # Descriptions must innclude the 50 minimum characters for Google Dataset Discovery to accept the item as valid
-    default_description_text = 'No description was included in this Dataset collected from the OSF'
+    DEFAULT_DESCRIPTION = 'No description was included in this Dataset collected from the OSF'
 
     def filename_for_itemid(self, itemid: str):
         return f'{itemid}-metadata-schemadotorg.json'
@@ -27,13 +27,17 @@ class GoogleDatasetJsonLdSerializer(_base.MetadataSerializer):
         )
 
     def metadata_as_dict(self) -> dict:
+        description = next(self.basket[DCTERMS.description], None)
+        if not description or len(description) < 50:
+            description = self.DEFAULT_DESCRIPTION
+
         metadata = {
             '@context': 'https://schema.org',
             '@type': 'Dataset',
             'dateCreated': next(self.basket[DCTERMS.created]),
             'dateModified': next(self.basket[DCTERMS.modified]),
             'name': next(self.basket[DCTERMS.title | OSF.fileName]),
-            'description': next(self.basket[DCTERMS.description], self.default_description_text),
+            'description': description,
             'url': next(url for url in self.basket[DCTERMS.identifier] if url.startswith(OSFIO)),
             'keywords': [keyword for keyword in self.basket[OSF.keyword]],
             'publisher': {

--- a/osf_tests/metadata/test_google_datasets.py
+++ b/osf_tests/metadata/test_google_datasets.py
@@ -1,0 +1,25 @@
+from tests.base import OsfTestCase
+from osf_tests import factories
+from osf.metadata.tools import pls_gather_metadata_as_dict
+from osf.metadata.serializers import GoogleDatasetJsonLdSerializer
+
+
+class TestGoogleDatasetJsonLdSerializer(OsfTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.project_description_short = factories.ProjectFactory(description='Under 50')
+        self.project_description_null = factories.ProjectFactory(description='')
+        self.project_description_50_chars = factories.ProjectFactory(description='N' * 50)
+
+    def test_description_short(self):
+        result_metadata = pls_gather_metadata_as_dict(self.project_description_short, 'google-dataset-json-ld')
+        assert result_metadata['description'] == GoogleDatasetJsonLdSerializer.DEFAULT_DESCRIPTION
+
+    def test_description_null(self):
+        result_metadata = pls_gather_metadata_as_dict(self.project_description_null, 'google-dataset-json-ld')
+        assert result_metadata['description'] == GoogleDatasetJsonLdSerializer.DEFAULT_DESCRIPTION
+
+    def test_description_50(self):
+        result_metadata = pls_gather_metadata_as_dict(self.project_description_50_chars, 'google-dataset-json-ld')
+        assert result_metadata['description'] == self.project_description_50_chars.description


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Add default "No description included" text in description to avoid not reaching number of characters necesarry for Dataset validation

## Changes

- add default text with comments
- [wip] add tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-4658