### PR TITLE
ENG-5533 Deactivate "Welcome to OSF" mailgun email

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -655,14 +655,6 @@ def external_login_confirm_email_get(auth, uid, token):
     service_url = request.url
 
     if external_status == 'CREATE':
-        mails.send_mail(
-            to_addr=user.username,
-            mail=mails.WELCOME,
-            user=user,
-            domain=settings.DOMAIN,
-            osf_support_email=settings.OSF_SUPPORT_EMAIL,
-            storage_flag_is_active=storage_i18n_flag_active(),
-        )
         service_url += '&{}'.format(urlencode({'new': 'true'}))
     elif external_status == 'LINK':
         mails.send_mail(

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -29,7 +29,6 @@ from framework.utils import throttle_period_expired
 from osf.models import OSFUser
 from osf.utils.sanitize import strip_html
 from website import settings, mails, language
-from api.waffle.utils import storage_i18n_flag_active
 from website.util import web_url_for
 from osf.exceptions import ValidationValueError, BlockedEmailError
 from osf.models.provider import PreprintProvider

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -732,16 +732,6 @@ def confirm_email_get(token, auth=None, **kwargs):
         user.update_date_last_login()
         user.save()
 
-        # send out our welcome message
-        mails.send_mail(
-            to_addr=user.username,
-            mail=mails.WELCOME,
-            user=user,
-            domain=settings.DOMAIN,
-            osf_support_email=settings.OSF_SUPPORT_EMAIL,
-            storage_flag_is_active=storage_i18n_flag_active(),
-        )
-
     # new random verification key, allows CAS to authenticate the user w/o password one-time only.
     user.verification_key = generate_verification_key()
     user.save()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,12 +89,7 @@ class TestAuthUtils(OsfTestCase):
 
         user.reload()
 
-        mock_mail.assert_called_with(osf_support_email=settings.OSF_SUPPORT_EMAIL,
-                                     storage_flag_is_active=False,
-                                     to_addr=user.username,
-                                     domain=settings.DOMAIN,
-                                     user=user,
-                                     mail=mails.WELCOME)
+        mock_mail.assert_not_called_with()
 
 
         self.app.set_cookie(settings.COOKIE_NAME, user.get_or_create_cookie().decode())
@@ -104,7 +99,7 @@ class TestAuthUtils(OsfTestCase):
 
         assert_equal(res.status_code, 302)
         assert_equal('/', urlparse(res.location).path)
-        assert_equal(len(mock_mail.call_args_list), 1)
+        assert_equal(len(mock_mail.call_args_list), 0)
         assert_equal(len(get_session()['status']), 1)
 
     def test_get_user_by_id(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,7 +89,7 @@ class TestAuthUtils(OsfTestCase):
 
         user.reload()
 
-        mock_mail.assert_not_called_with()
+        mock_mail.assert_not_called()
 
 
         self.app.set_cookie(settings.COOKIE_NAME, user.get_or_create_cookie().decode())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4101,7 +4101,7 @@ class TestExternalAuthViews(OsfTestCase):
         assert_in('/login?service=', res.location)
         assert_in('new=true', res.location)
 
-        assert_equal(mock_welcome.call_count, 1)
+        assert_equal(mock_welcome.call_count, 0)
 
         self.user.reload()
         assert_equal(self.user.external_identity['orcid'][self.provider_id], 'VERIFIED')
@@ -4135,7 +4135,7 @@ class TestExternalAuthViews(OsfTestCase):
         assert_equal(res.status_code, 302, 'redirects to cas login')
         assert_in('/login?service=', res.location)
 
-        assert_equal(mock_confirm.call_count, 1)
+        assert_equal(mock_confirm.call_count, 0)
 
         self.user.reload()
         dupe_user.reload()


### PR DESCRIPTION
## Purpose

To deactivate the "Welcome to OSF" email functionality as part of the transition to a new user onboarding process using Mailchimp.

## Changes

Removed the email sending code in views.py to stop the "Welcome to OSF" emails from being dispatched to new users.

## QA Notes


## Documentation

## Side Effects


## Ticket

https://openscience.atlassian.net/browse/ENG-5533
