### PR TITLE
ENG-5535 Adjust the serialization of embargo end dates in the registration API

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -445,8 +445,8 @@ class RegistrationSerializer(NodeSerializer):
         return None
 
     def get_embargo_end_date(self, obj):
-        if obj.embargo_end_date:
-            return obj.embargo_end_date
+        if obj.root.embargo:
+            return obj.root.embargo.end_date if obj.root.embargo.end_date else None
         return None
 
     def get_registration_supplement(self, obj):


### PR DESCRIPTION
## Purpose

Adjust the serialization of embargo end dates in the registration API

## Changes

Updated the get_embargo_end_date method to accurately retrieve embargo end dates from the root registration object.

## QA Notes

## Ticket
https://openscience.atlassian.net/browse/ENG-5535
