### PR TITLE
Added support for additional resource identification

### DIFF
--- a/osf/metadata/schemas/datacite.json
+++ b/osf/metadata/schemas/datacite.json
@@ -10,6 +10,11 @@
       "type": "string",
       "pattern": "10\\..+/.+"
     },
+    "contentURL": {
+      "description": "Content url that allows for identification outside of DOI.",
+      "type": "string",
+      "pattern": "https://osf.io+"
+    },
     "year": {
       "type": "string"
     },
@@ -47,15 +52,21 @@
   "type": "object",
   "properties": {
     "identifier": {
-      "description": "A persistent identifier that identifies a resource. Currently, only DOI is allowed.",
+      "description": "A persistent identifier that identifies a resource. Can use DOI or URL.",
       "type": "object",
       "properties": {
         "identifier": {
-          "$ref": "#/definitions/doi"
+          "DOI": {
+            "$ref": "#/definitions/doi"
+          },
+          "URL": {
+            "$ref": "#/definitions/contentURL"
+          }
         },
         "identifierType": {
           "enum": [
-            "DOI"
+            "DOI",
+            "URL"
           ]
         }
       },


### PR DESCRIPTION
## Purpose
Add support to datacite.json (in osf/metadata/schemas) to be able to support additional identifiers for resources (i.e. url in addition to the current sole identifier doi)

## Changes
Add contentURL property to json

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://github.com/CenterForOpenScience/osf.io/issues/10369
