### PR TITLE
[ENG-5514] Fix bleach sanitization issues

### DIFF
--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -188,7 +188,7 @@ class TestPreprintProviderChangeForm(AdminTestCase):
             'subjects_acceptable': '[]',
             'advisory_board': '<div><ul><li>Bill<i class="fa fa-twitter"></i> Nye</li></ul></div>',
             'description': '<span>Open Preprints <code>Open</code> Science<script></script></span>',
-            'footer_links': '<p>Xiv: <script>Support</script> | <pre>Contact<pre> | <a href=""><span class="fa fa-facebook"></span></a></p>',
+            'footer_links': '<p>Xiv: <script>Support</script> | Contact | <a href=""><span class="fa fa-facebook"></span></a></p>',
             'preprint_word': 'preprint'
         }
 


### PR DESCRIPTION
## Purpose

> Definition of problem: `<pre>` tag is being replaced to `\n` instead of being wiped. Location:
> `admin_tests/preprint_providers/test_views.py::TestPreprintProviderChangeForm::test_html_fields_are_stripped`

After discussion with @opaduchak, we discovered that "`<pre>` tag is being replaced to `\n`" is an expected behavior since `<pre>` is a block tag. See https://github.com/mozilla/bleach/issues/663.

Our next attempt is to not sanitize `<pre>`, however, this results in unexpected output too. This is caused by `<pre>` inside `<p>` being illegal. See https://github.com/mozilla/bleach/issues/588.

Thus, our solution is to provide a valid HTML for testing the sanitization, rather than tweak `bleach` or our code.

We also verified that the user for this form is our admin (product team or devops) who creates preprints providers in the admin app. We expect them to provide valid HTML code for the foot-link. They are also able to verify quickly if things are wrong and then fix it.

## Changes

* Remove `<pre>` tag from the string to test.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5514