### PR TITLE
[ENG-5587] Phase 3: Fix OTP test failures

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,6 +35,8 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
+      contents: read
+      actions: read
     services:
       postgres:
         image: postgres
@@ -62,6 +64,8 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
+      contents: read
+      actions: read
     services:
       postgres:
         image: postgres
@@ -90,6 +94,8 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
+      contents: read
+      actions: read
     services:
       postgres:
         image: postgres
@@ -121,6 +127,8 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
+      contents: read
+      actions: read
     services:
       postgres:
         image: postgres
@@ -147,6 +155,8 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       checks: write
+      contents: read
+      actions: read
     needs: build-cache
     services:
       postgres:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,8 +35,6 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
-      contents: read
-      actions: read
     services:
       postgres:
         image: postgres
@@ -56,7 +54,7 @@ jobs:
     - name: Run tests
       run: python3 -m invoke test-travis-addons -n 1 --junit
     - name: Upload report
-      if: success() || failure()    # run this step even if previous step failed
+      if: (github.event_name != 'pull_request') && (success() || failure())    # run this step even if previous step failed
       uses: ./.github/actions/gen-report
 
   website:
@@ -64,8 +62,6 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
-      contents: read
-      actions: read
     services:
       postgres:
         image: postgres
@@ -86,7 +82,7 @@ jobs:
     - name: Run tests
       run: python3 -m invoke test-travis-website -n 1 --junit
     - name: Upload report
-      if: success() || failure()    # run this step even if previous step failed
+      if: (github.event_name != 'pull_request') && (success() || failure())    # run this step even if previous step failed
       uses: ./.github/actions/gen-report
 
   api1_and_js:
@@ -94,8 +90,6 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
-      contents: read
-      actions: read
     services:
       postgres:
         image: postgres
@@ -119,7 +113,7 @@ jobs:
       - name: Run test
         run: python3 -m invoke test-travis-api1-and-js -n 1 --junit
       - name: Upload report
-        if: success() || failure()    # run this step even if previous step failed
+        if: (github.event_name != 'pull_request') && (success() || failure())    # run this step even if previous step failed
         uses: ./.github/actions/gen-report
 
   api2:
@@ -127,8 +121,6 @@ jobs:
     needs: build-cache
     permissions:
       checks: write
-      contents: read
-      actions: read
     services:
       postgres:
         image: postgres
@@ -148,15 +140,13 @@ jobs:
     - name: Run tests
       run: python3 -m invoke test-travis-api2 -n 1 --junit
     - name: Upload report
-      if: success() || failure()    # run this step even if previous step failed
+      if: (github.event_name != 'pull_request') && (success() || failure())    # run this step even if previous step failed
       uses: ./.github/actions/gen-report
 
   api3_and_osf:
     runs-on: ubuntu-20.04
     permissions:
       checks: write
-      contents: read
-      actions: read
     needs: build-cache
     services:
       postgres:
@@ -178,5 +168,5 @@ jobs:
     - name: Run tests
       run: python3 -m invoke test-travis-api3-and-osf -n 1 --junit
     - name: Upload report
-      if: success() || failure()    # run this step even if previous step failed
+      if: (github.event_name != 'pull_request') && (success() || failure())    # run this step even if previous step failed
       uses: ./.github/actions/gen-report

--- a/addons/twofactor/models.py
+++ b/addons/twofactor/models.py
@@ -1,5 +1,6 @@
 import secrets
 from base64 import b32encode
+from datetime import datetime, timedelta
 from typing import Final
 
 from addons.base.models import BaseUserSettings
@@ -42,7 +43,8 @@ class UserSettings(BaseUserSettings):
         client = TOTP(self.totp_secret_b32)
         accepted = client.verify(
             otp=str(code),
-            valid_window=self.totp_drift * DRIFT_PERIOD,
+            for_time=datetime.now() + timedelta(seconds=self.totp_drift * DRIFT_PERIOD),
+            valid_window=1
         )
         if accepted:
             self.totp_drift += 1

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -55,6 +55,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         res = self.app.get(
             self.unreachable_url,
             auth=(self.user1.username, 'invalid password'),
+            expect_errors=True
         )
         assert res.status_code == 401
         assert res.json.get('errors')[0]['detail'] == 'Invalid username/password.'
@@ -68,6 +69,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         res = self.app.get(
             self.unreachable_url,
             auth=self.user1.auth,
+            expect_errors=True
         )
         assert res.status_code == 403, res.json
 
@@ -81,6 +83,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         res = self.app.get(
             self.reachable_url,
             auth=self.user1.auth,
+            expect_errors=True
         )
         assert res.status_code == 401
         assert res.headers['X-OSF-OTP'] == 'required; app'
@@ -97,6 +100,7 @@ class TestBasicAuthenticationValidation(ApiTestCase):
             self.reachable_url,
             auth=self.user1.auth,
             headers={'X-OSF-OTP': 'invalid otp'},
+            expect_errors=True
         )
         assert res.status_code == 401
         assert 'X-OSF-OTP' not in res.headers


### PR DESCRIPTION
## Purpose

Fix OTP test failures which popped up after python and libs upgrade and after migration from oath to pyotp

## Changes

Fixed http requests raising unwanted excaptions in 
- `test_valid_credential_authenticates_but_user_lacks_object_permissions`
- `test_invalid_credential_fails`
- `test_valid_credential_but_twofactor_required`
- `test_valid_credential_twofactor_invalid_otp`

Fixed OTP drift in in otp validation logic, and added 1 second buffer after OTP expires

In addition, disable CI failure report for pull requests

## QA Notes

There will be need to thoroughly test OTP logic, as library was changed to filter out any bugs and security concerns.

Yes, QA has the CAS server on staging servers to test OTP.

## Documentation

## Side Effects

<!-- Any possible side effects? -->

## Ticket

[ENG-5587](https://openscience.atlassian.net/browse/ENG-5587)


[ENG-5587]: https://openscience.atlassian.net/browse/ENG-5587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ