### PR TITLE
Fix get auth number two

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -393,7 +393,7 @@ def get_auth(auth, **kwargs):
     # Get the file version from Waterbutler data, which is used for file-specific actions
     file_node = None
     fileversion = None
-    if waterbutler_data[provider] == 'osfstorage':
+    if waterbutler_data['provider'] == 'osfstorage':
         file_node = _get_osfstorage_file_node(waterbutler_data.get('path'))
         fileversion = _get_osfstorage_file_version(file_node, waterbutler_data.get('version'))
 

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -302,11 +302,11 @@ def get_authenticated_resource(resource_id):
     return resource
 
 
-def get_osfstorage_file_version(file_node: OsfStorageFileNode, version=None) -> FileVersion:
+def _get_osfstorage_file_version(file_node: OsfStorageFileNode, version_string: str = None) -> FileVersion:
     if not (file_node and file_node.is_file):
         return None
 
-    version = int(version or file_node.versions.count())
+    version = int(version_string) if version_string else file_node.versions.count()
     try:
         return FileVersion.objects.select_related('region').get(
             basefilenode=file_node,
@@ -316,7 +316,7 @@ def get_osfstorage_file_version(file_node: OsfStorageFileNode, version=None) -> 
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST, 'Requested File Version unavailable')
 
 
-def get_osfstorage_file_node(file_path: str) -> FileVersion:
+def _get_osfstorage_file_node(file_path: str) -> OsfStorageFileNode:
     if not file_path:
         return None
 
@@ -398,8 +398,8 @@ def get_auth(auth, **kwargs):
     file_node = None
     fileversion = None
     if waterbutler_data[provider] == 'osfstorage':
-        file_node = get_osfstorage_file_node(waterbutler_data.get('path'))
-        fileversion = get_osfstorage_file_version(file_node, waterbutler_data.get('version'))
+        file_node = _get_osfstorage_file_node(waterbutler_data.get('path'))
+        fileversion = _get_osfstorage_file_version(file_node, waterbutler_data.get('version'))
 
     # Fetch Waterbutler credentials and settings for the resource
     credentials, waterbutler_settings = get_waterbutler_data(

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -320,8 +320,7 @@ def _get_osfstorage_file_node(file_path: str) -> OsfStorageFileNode:
         return None
 
     file_id = file_path.strip('/')
-    try:
-        return OsfStorageFileNode.load(file_id)
+    return OsfStorageFileNode.load(file_id)
 
 
 def authenticate_user_if_needed(auth, waterbutler_data, resource):

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -399,7 +399,7 @@ def get_auth(auth, **kwargs):
     fileversion = None
     if waterbutler_data[provider] == 'osfstorage':
         file_node = get_osfstorage_file_node(waterbutler_data.get('path'))
-        fileversion = get_osfstorage_file_version(file_node, waterbutler_data['version'])
+        fileversion = get_osfstorage_file_version(file_node, waterbutler_data.get('version'))
 
     # Fetch Waterbutler credentials and settings for the resource
     credentials, waterbutler_settings = get_waterbutler_data(

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -306,11 +306,10 @@ def _get_osfstorage_file_version(file_node: OsfStorageFileNode, version_string: 
     if not (file_node and file_node.is_file):
         return None
 
-    version = int(version_string) if version_string else file_node.versions.count()
     try:
         return FileVersion.objects.select_related('region').get(
             basefilenode=file_node,
-            identifier=version
+            identifier=version_string or str(file_node.versions.count())
         )
     except FileVersion.DoesNotExist:
         raise HTTPError(http_status.HTTP_400_BAD_REQUEST, 'Requested File Version unavailable')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
`get_auth` was checking for `FileVersions` on all `osfstorage` entities -- including folders. This was breaking access to `osfstorage` on projects. Fix that.

## Changes
* Rename `get_file_node_from_wb` and `get_file_version_from_wb` to `_get_osfstorage_file_node` and `_get_osfstorage_file_version` and only provide them the information they need from `waterbutler_data`.
* Grab the `OsfStorageFileNode` before grabbing the version
  * Calls `load` using the file_id to [match behavior from original get_auth](https://github.com/CenterForOpenScience/osf.io/blob/b2916f756c792bb9eb8f3252e0b6fc56c5b0618c/addons/base/views.py#L315).
* Pass the OsfStorageFileNode to `get_osfstorage_file_version'. Short circuit when trying to retrieve a FileVersion for a non-"file" OsfStorageFileNode

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
