### PR TITLE
[ENG-5588] - Fix test_old_password_invalid_attempts_reset_if_password_successfully_reset

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1720,7 +1720,7 @@ class TestUserAccount(OsfTestCase):
             'new_password': 'thisisanewpassword',
             'confirm_password': 'thisisanewpassword',
         }
-        res = self.app.post(url, json=post_data, auth=self.user.auth)
+        res = self.app.post(url, data=post_data, auth=self.user.auth, follow_redirects=True)
         assert len(mock_push_status_message.mock_calls) == 1
         assert 'Old password is invalid' == mock_push_status_message.mock_calls[0][1][0]
         self.user.reload()
@@ -1729,7 +1729,7 @@ class TestUserAccount(OsfTestCase):
         assert res.status_code == 200
 
         # Make a second request that successfully changes password
-        res = self.app.post(url, json=correct_post_data, auth=self.user.auth)
+        res = self.app.post(url, data=correct_post_data, auth=self.user.auth)
         self.user.reload()
         assert self.user.change_password_last_attempt is not None
         assert self.user.old_password_invalid_attempts == 0


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

**Fix** test_old_password_invalid_attempts_reset_if_password_successfully_reset;

## Changes

- **replace** json with data;
- **add** follow_redirects=True as it helped return status code `200` instead of `301`;

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5588