### PR TITLE
[ENG-5639] Phase 4: Fix CSRF Middleware

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -140,7 +140,8 @@ class OSFSessionAuthentication(authentication.BaseAuthentication):
         Same implementation as django-rest-framework's SessionAuthentication.
         Enforce CSRF validation for session based authentication.
         """
-        reason = CSRFCheck().process_view(request, None, (), {})
+        # crutch let CSRFCheck process this view, but generally middleware shouldn't be used this way
+        reason = CSRFCheck(lambda _: _).process_view(request, None, (), {})
         if reason:
             # CSRF failed, bail with explicit error message
             raise exceptions.PermissionDenied('CSRF Failed: %s' % reason)

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -491,7 +491,7 @@ class TestCSRFValidation:
                 expect_errors=True
             )
         assert res.status_code == 403
-        assert csrf.REASON_BAD_TOKEN in res.json['errors'][0]['detail']
+        assert csrf.REASON_CSRF_TOKEN_MISSING in res.json['errors'][0]['detail']
 
     def test_send_csrf_cookie_and_headers(self, app, csrf_token, url, payload):
         app.set_cookie(CSRF_COOKIE_NAME, csrf_token)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix CSRF Middleware usage inside authentication

## Changes

Added a crutch of `get_response` function to make CSRF checks not fail. This function isn't even being called during this check, so this is literally a crutch 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerfc2256ations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5639
