### PR TITLE
[ENG - 5008] Support Unicode and special characters in file names during archiving

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -1,6 +1,5 @@
 import pytz
 import json
-from unicodedata import normalize
 from website.archiver.utils import normalize_unicode_filename
 
 from distutils.version import StrictVersion

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -1,6 +1,6 @@
 import pytz
 import json
-from website.archiver.utils import normalize_unicode_filename
+from website.archiver.utils import normalize_unicode_filenames
 
 from distutils.version import StrictVersion
 from django.core.exceptions import ValidationError
@@ -773,7 +773,7 @@ class RegistrationCreateSerializer(RegistrationSerializer):
             return False
 
         # Confirm that the file has the expected name
-        normalized_file_name = normalize_unicode_filename(file_metadata['file_name'])
+        normalized_file_name = normalize_unicode_filenames(file_metadata['file_name'])
         if attached_file.name not in normalized_file_name:
             return False
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -1,6 +1,7 @@
 import pytz
 import json
 from unicodedata import normalize
+from website.archiver.utils import normalize_unicode_filename
 
 from distutils.version import StrictVersion
 from django.core.exceptions import ValidationError
@@ -773,11 +774,8 @@ class RegistrationCreateSerializer(RegistrationSerializer):
             return False
 
         # Confirm that the file has the expected name
-        normalized_file_names = [
-            normalize('NFD', file_metadata['file_name']),
-            normalize('NFC', file_metadata['file_name']),
-        ]
-        if attached_file.name not in normalized_file_names:
+        normalized_file_name = normalize_unicode_filename(file_metadata['file_name'])
+        if attached_file.name not in normalized_file_name:
             return False
 
         # Confirm that the file belongs to a node being registered

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -31,7 +31,6 @@ from osf.models import Guid, RegistrationSchema, Registration
 from osf.models.archive import ArchiveTarget, ArchiveJob
 from osf.models.base import generate_object_id
 from osf.utils.migrations import map_schema_to_schemablocks
-from osf.utils.sanitize import strip_html
 from addons.base.models import BaseStorageAddon
 from api.base.utils import waterbutler_api_url_for
 

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -586,7 +586,7 @@ class TestArchiverTasks(ArchiverTestCase):
     def test_archive_success_escaped_file_names(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
-        fake_file_name = normalize_unicode_filenames(fake_file['name'])['0']
+        fake_file_name = normalize_unicode_filenames(fake_file['name'])[0]
         file_tree['children'] = [fake_file]
 
         node = factories.NodeFactory(creator=self.user)

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -587,7 +587,7 @@ class TestArchiverTasks(ArchiverTestCase):
     def test_archive_success_escaped_file_names(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
-        fake_file_name = strip_html(fake_file['name']).replace('&amp;', '&')
+        fake_file_name = normalize_unicode_filenames(fake_file['name'])['0']
         file_tree['children'] = [fake_file]
 
         node = factories.NodeFactory(creator=self.user)

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -33,7 +33,6 @@ from osf.models import (
     AbstractNode,
     DraftRegistration,
 )
-import unicodedata
 
 
 def create_app_context():
@@ -205,7 +204,7 @@ def archive_addon(addon_short_name, job_pk):
         addon_short_name = 'dataverse'
     src_provider = src.get_addon(addon_short_name)
     folder_name_nfd, folder_name_nfc = normalize_unicode_filename(src_provider.archive_folder_name)
-    rename = '{}{}'.format(folder_name, rename_suffix)
+    rename = '{}{}'.format(folder_name_nfd, rename_suffix)
     url = waterbutler_api_url_for(src._id, addon_short_name, _internal=True, base_url=src.osfstorage_region.waterbutler_url, **params)
     data = make_waterbutler_payload(dst._id, rename)
     make_copy_request.delay(job_pk=job_pk, url=url, data=data)

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -22,6 +22,7 @@ from website.archiver import (
     AggregateStatResult,
 )
 from website.archiver import utils
+from website.archiver.utils import normalize_unicode_filename
 from website.archiver import signals as archiver_signals
 
 from website.project import signals as project_signals
@@ -32,7 +33,6 @@ from osf.models import (
     AbstractNode,
     DraftRegistration,
 )
-import bleach
 import unicodedata
 
 
@@ -44,14 +44,6 @@ def create_app_context():
 
 
 logger = get_task_logger(__name__)
-
-
-def normalize_unicode_filename(filename):
-    return [
-        bleach.clean(unicodedata.normalize(form, filename)).replace('&amp;', '&')
-        for form in ['NFD', 'NFC']
-    ]
-
 
 class ArchiverSizeExceeded(Exception):
     def __init__(self, result, *args, **kwargs):

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -22,7 +22,7 @@ from website.archiver import (
     AggregateStatResult,
 )
 from website.archiver import utils
-from website.archiver.utils import normalize_unicode_filename
+from website.archiver.utils import normalize_unicode_filenames
 from website.archiver import signals as archiver_signals
 
 from website.project import signals as project_signals
@@ -203,7 +203,7 @@ def archive_addon(addon_short_name, job_pk):
         rename_suffix = ' (draft)' if addon_short_name.split('-')[-1] == 'draft' else ' (published)'
         addon_short_name = 'dataverse'
     src_provider = src.get_addon(addon_short_name)
-    folder_name_nfd, folder_name_nfc = normalize_unicode_filename(src_provider.archive_folder_name)
+    folder_name_nfd, folder_name_nfc = normalize_unicode_filenames(src_provider.archive_folder_name)
     rename = '{}{}'.format(folder_name_nfd, rename_suffix)
     url = waterbutler_api_url_for(src._id, addon_short_name, _internal=True, base_url=src.osfstorage_region.waterbutler_url, **params)
     data = make_waterbutler_payload(dst._id, rename)

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -24,7 +24,7 @@ FILE_DOWNLOAD_LINK_TEMPLATE = settings.DOMAIN + 'download/{file_id}'
 
 def normalize_unicode_filename(filename):
     return [
-        bleach.clean(unicodedata.normalize(form, filename)).replace('&amp;', '&')
+        bleach.clean(unicodedata.normalize(form, filename)).replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>')
         for form in ['NFD', 'NFC']
     ]
 
@@ -329,7 +329,7 @@ def _make_file_response(file_info, parent_guid):
     archived_file_id = file_info['path'].lstrip('/')
     return {
         'file_id': archived_file_id,
-        'file_name': normalize_unicode_filename(bleach.clean(file_info['name']).replace('&amp;', '&'))[0],
+        'file_name': normalize_unicode_filename(file_info['name'])[0],
         'file_urls': {
             'html':
                 FILE_HTML_LINK_TEMPLATE.format(

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -18,11 +18,10 @@ from website.archiver import (
     ARCHIVER_FORCED_FAILURE,
 )
 
-
 FILE_HTML_LINK_TEMPLATE = settings.DOMAIN + 'project/{registration_guid}/files/osfstorage/{file_id}'
 FILE_DOWNLOAD_LINK_TEMPLATE = settings.DOMAIN + 'download/{file_id}'
 
-def normalize_unicode_filename(filename):
+def normalize_unicode_filenames(filename):
     return [
         bleach.clean(unicodedata.normalize(form, filename)).replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>')
         for form in ['NFD', 'NFC']
@@ -167,7 +166,7 @@ def aggregate_file_tree_metadata(addon_short_name, fileobj_metadata, user):
     disk_usage = fileobj_metadata.get('size')
     if fileobj_metadata['kind'] == 'file':
         result = StatResult(
-            target_name=normalize_unicode_filename(fileobj_metadata['name'])[0],
+            target_name=normalize_unicode_filenames(fileobj_metadata['name'])[0],
             target_id=fileobj_metadata['path'].lstrip('/'),
             disk_usage=disk_usage or 0,
         )
@@ -175,7 +174,7 @@ def aggregate_file_tree_metadata(addon_short_name, fileobj_metadata, user):
     else:
         return AggregateStatResult(
             target_id=fileobj_metadata['path'].lstrip('/'),
-            target_name=normalize_unicode_filename(fileobj_metadata['name'])[0],
+            target_name=normalize_unicode_filenames(fileobj_metadata['name'])[0],
             targets=[aggregate_file_tree_metadata(addon_short_name, child, user) for child in fileobj_metadata.get('children', [])],
         )
 
@@ -308,9 +307,10 @@ def _get_updated_file_references(registration, file_response_keys_by_hash):
             for qid in file_response_keys_by_hash[file_sha]:
                 # Handle the case where the same file exists in multiple components
                 original_response = _get_response_entry_for_hash(original_responses, qid, file_sha)
+                normalized_original_file_name = normalize_unicode_filenames(original_response['file_name'])[0]
                 if (
                     source_project_id in original_response['file_urls']['html']
-                    and response_value['file_name'] == original_response['file_name']
+                    and response_value['file_name'] == normalized_original_file_name
                 ):
                     updated_file_responses[qid].append(response_value)
 
@@ -329,7 +329,7 @@ def _make_file_response(file_info, parent_guid):
     archived_file_id = file_info['path'].lstrip('/')
     return {
         'file_id': archived_file_id,
-        'file_name': normalize_unicode_filename(file_info['name'])[0],
+        'file_name': normalize_unicode_filenames(file_info['name'])[0],
         'file_urls': {
             'html':
                 FILE_HTML_LINK_TEMPLATE.format(


### PR DESCRIPTION
## Purpose

Support Unicode in OSF Storage to prevent archiving failures due to special characters in filenames.

## Changes

- Enhanced filename normalization to handle Unicode characters.
- Updated archiving workflow to ensure proper handling of special characters.

## Ticket

<https://openscience.atlassian.net/browse/ENG-5008>
