### PR TITLE
[ENG-5716] Get root_folder for preprints

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -153,6 +153,7 @@ from osf.models import (
     File,
     Folder,
     CedarMetadataRecord,
+    Preprint,
 )
 from addons.osfstorage.models import Region
 from osf.utils.permissions import ADMIN, WRITE_NODE
@@ -1481,11 +1482,17 @@ class NodeStorageProvider(object):
         self.node_id = node._id
         self.pk = node._id
         self.id = node.id
-        self.root_folder = storage_addon.root_node if storage_addon else None
+        self.root_folder = self._get_root_folder(storage_addon)
 
     @property
     def target(self):
         return self.node
+
+    def _get_root_folder(self, storage_addon):
+        if isinstance(self.target, Preprint):
+            return self.target.root_folder
+        else:
+            return storage_addon.root_node if storage_addon else None
 
 class NodeStorageProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_providers_list).


### PR DESCRIPTION
## Purpose

Make it so preprints api serialization has a root_folder

## Changes

1. Modify the view to get the root_folder in the case of preprints

## Side Effects

Should only affect preprints

## Ticket

https://openscience.atlassian.net/browse/ENG-5716
