### PR TITLE
Set Default Resource Type for Registrations to "Study Registration"

### DIFF
--- a/osf/metadata/osf_gathering.py
+++ b/osf/metadata/osf_gathering.py
@@ -256,6 +256,7 @@ DATACITE_RESOURCE_TYPES_GENERAL = {
 }
 DATACITE_RESOURCE_TYPE_BY_OSF_TYPE = {
     OSF.Preprint: 'Preprint',
+    OSF.Registration: 'StudyRegistration',
 }
 
 ##### END osfmap #####

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -168,6 +168,14 @@ class TestOsfGathering(TestCase):
             (self.registrationfocus.iri, DCTERMS.type, _datacite_studyregistration_ref),
             (_datacite_studyregistration_ref, rdflib.RDFS.label, Literal('StudyRegistration', lang='en')),
         })
+        # focus: file
+        assert_triples(osf_gathering.gather_flexible_types(self.filefocus), set())
+        self.filefocus.guid_metadata_record.resource_type_general = 'Dataset'
+        _datacite_dataset_ref = URIRef('https://schema.datacite.org/meta/kernel-4/#Dataset')
+        assert_triples(osf_gathering.gather_flexible_types(self.filefocus), {
+            (self.filefocus.iri, DCTERMS.type, _datacite_dataset_ref),
+            (_datacite_dataset_ref, rdflib.RDFS.label, Literal('Dataset', lang='en')),
+        })
 
     def test_gather_created(self):
         # focus: project

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -158,21 +158,15 @@ class TestOsfGathering(TestCase):
             (_datacite_book_ref, rdflib.RDFS.label, Literal('Book', lang='en')),
         })
         # focus: registration
-        assert_triples(osf_gathering.gather_flexible_types(self.registrationfocus), {
-        })
-        self.registrationfocus.guid_metadata_record.resource_type_general = 'StudyRegistration'
         _datacite_studyregistration_ref = URIRef('https://schema.datacite.org/meta/kernel-4/#StudyRegistration')
         assert_triples(osf_gathering.gather_flexible_types(self.registrationfocus), {
             (self.registrationfocus.iri, DCTERMS.type, _datacite_studyregistration_ref),
             (_datacite_studyregistration_ref, rdflib.RDFS.label, Literal('StudyRegistration', lang='en')),
         })
-        # focus: file
-        assert_triples(osf_gathering.gather_flexible_types(self.filefocus), set())
-        self.filefocus.guid_metadata_record.resource_type_general = 'Dataset'
-        _datacite_dataset_ref = URIRef('https://schema.datacite.org/meta/kernel-4/#Dataset')
-        assert_triples(osf_gathering.gather_flexible_types(self.filefocus), {
-            (self.filefocus.iri, DCTERMS.type, _datacite_dataset_ref),
-            (_datacite_dataset_ref, rdflib.RDFS.label, Literal('Dataset', lang='en')),
+        self.registrationfocus.guid_metadata_record.resource_type_general = 'StudyRegistration'
+        assert_triples(osf_gathering.gather_flexible_types(self.registrationfocus), {
+            (self.registrationfocus.iri, DCTERMS.type, _datacite_studyregistration_ref),
+            (_datacite_studyregistration_ref, rdflib.RDFS.label, Literal('StudyRegistration', lang='en')),
         })
 
     def test_gather_created(self):

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -98,7 +98,7 @@ class TestDataCiteClient:
 
         resource_type = root.find('{%s}resourceType' % schema40.ns[None])
         assert resource_type.text == 'Pre-registration'
-        assert resource_type.attrib['resourceTypeGeneral'] == 'Text'
+        assert resource_type.attrib['resourceTypeGeneral'] == 'StudyRegistration'
 
     def test_datcite_format_contributors(self, datacite_client):
         visible_contrib = AuthUserFactory()


### PR DESCRIPTION
## Purpose

Ensure that all registrations have a default resource type of "Study Registration"

## Changes

Updated DATACITE_RESOURCE_TYPE_BY_OSF_TYPE to set the default resource type for registrations to "StudyRegistration".

## Ticket

(https://openscience.atlassian.net/browse/ENG-5135)
