### PR TITLE
[ENG-5752] Phase 4: Fix archiver test not detecting call to `celery.group`

### DIFF
--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -530,22 +530,14 @@ class TestArchiverTasks(ArchiverTestCase):
         assert self.archive_job.get_target('osfstorage').status == ARCHIVER_INITIATED
         cookie = self.user.get_or_create_cookie()
         mock_make_copy_request.assert_called_with(
-            self.archive_job._id,
-            settings.WATERBUTLER_URL + '/ops/copy',
+            job_pk=self.archive_job._id,
+            url=f'{settings.WATERBUTLER_URL}/v1/resources/{self.src._id}/providers/osfstorage/?cookie={cookie.decode()}',
             data={
+                'action': 'copy',
+                'path': '/',
                 'rename': 'Archive of OSF Storage',
-                'source': {
-                    'cookie': cookie,
-                    'nid': self.src._id,
-                    'provider': 'osfstorage',
-                    'path': '/',
-                },
-                'destination': {
-                    'cookie': cookie,
-                    'nid': self.dst._id,
-                    'provider': settings.ARCHIVE_PROVIDER,
-                    'path': '/',
-                },
+                'resource': self.archive_job.info()[1]._id,
+                'provider': 'osfstorage',
             }
         )
 
@@ -1135,7 +1127,7 @@ class TestArchiverScripts(ArchiverTestCase):
         failed.sort()
         assert failed == failures
         for pk in legacy:
-            assert not (pk in failed)
+            assert pk not in failed
 
 
 class TestArchiverDecorators(ArchiverTestCase):


### PR DESCRIPTION
## Purpose

Fix archiver test not detecting call to `celery.group`

## Changes

Instead of checking `celery.group` now checking `archive_addon.delay` in affected tests.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

[ENG-5752](https://openscience.atlassian.net/browse/ENG-5752)


[ENG-5752]: https://openscience.atlassian.net/browse/ENG-5752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ