### PR TITLE
[ENG-5178] Allow unauthenticated users to see public files

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -342,9 +342,6 @@ def authenticate_user_if_needed(auth, waterbutler_data, resource):
     if authorization and authorization.startswith('Bearer '):
         auth.user = authenticate_via_oauth_bearer_token(resource, waterbutler_data['action'])
 
-    if not auth.user:
-        raise HTTPError(http_status.HTTP_401_UNAUTHORIZED, 'User authentication failed.')
-
 
 @collect_auth
 def get_auth(auth, **kwargs):

--- a/tests/base.py
+++ b/tests/base.py
@@ -152,12 +152,12 @@ class ApiAppTestCase(unittest.TestCase):
 class SearchTestCase(unittest.TestCase):
 
     def setUp(self):
-        settings.ELASTIC_INDEX = uuid.uuid1().hex
-        settings.ELASTIC_TIMEOUT = 60
+#        settings.ELASTIC_INDEX = uuid.uuid1().hex
+#        settings.ELASTIC_TIMEOUT = 60
 
-        from website.search import elastic_search
-        elastic_search.INDEX = settings.ELASTIC_INDEX
-        elastic_search.create_index(settings.ELASTIC_INDEX)
+#       from website.search import elastic_search
+#        elastic_search.INDEX = settings.ELASTIC_INDEX
+#        elastic_search.create_index(settings.ELASTIC_INDEX)
 
         # NOTE: Super is called last to ensure the ES connection can be established before
         #       the responses module patches the socket.
@@ -166,8 +166,8 @@ class SearchTestCase(unittest.TestCase):
     def tearDown(self):
         super(SearchTestCase, self).tearDown()
 
-        from website.search import elastic_search
-        elastic_search.delete_index(settings.ELASTIC_INDEX)
+#        from website.search import elastic_search
+#        elastic_search.delete_index(settings.ELASTIC_INDEX)
 
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -152,12 +152,12 @@ class ApiAppTestCase(unittest.TestCase):
 class SearchTestCase(unittest.TestCase):
 
     def setUp(self):
-#        settings.ELASTIC_INDEX = uuid.uuid1().hex
-#        settings.ELASTIC_TIMEOUT = 60
+        settings.ELASTIC_INDEX = uuid.uuid1().hex
+        settings.ELASTIC_TIMEOUT = 60
 
-#       from website.search import elastic_search
-#        elastic_search.INDEX = settings.ELASTIC_INDEX
-#        elastic_search.create_index(settings.ELASTIC_INDEX)
+        from website.search import elastic_search
+        elastic_search.INDEX = settings.ELASTIC_INDEX
+        elastic_search.create_index(settings.ELASTIC_INDEX)
 
         # NOTE: Super is called last to ensure the ES connection can be established before
         #       the responses module patches the socket.
@@ -166,8 +166,8 @@ class SearchTestCase(unittest.TestCase):
     def tearDown(self):
         super(SearchTestCase, self).tearDown()
 
-#        from website.search import elastic_search
-#        elastic_search.delete_index(settings.ELASTIC_INDEX)
+        from website.search import elastic_search
+        elastic_search.delete_index(settings.ELASTIC_INDEX)
 
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Restore expected functionality that unauthenticated users should be able to render/download public files.

NOTE:
This PR does not address the code smells of having additional auth checks that duplicate the work done by `@collect_auth`.  https://github.com/CenterForOpenScience/osf.io/pull/10642 proposes an alternative which keeps us from needing to re-confirm token scopes with CAS, but the team lacks time to address all of the test breakages it causes. This PR, meanwhile restores the status quo.

## Changes
Remove explicit error case when auth.user does not exist.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
