### PR TITLE
Use `make_auth` to avoid assumptions about `auth.user`

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -466,7 +466,7 @@ def construct_payload(auth, resource, credentials, waterbutler_settings):
     jwt_data = {
         'exp': timezone.now() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
         'data': {
-            'auth': make_auth(auth),
+            'auth': make_auth(auth.user),
             'credentials': credentials,
             'settings': waterbutler_settings,
             'callback_url': callback_url

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -466,11 +466,7 @@ def construct_payload(auth, resource, credentials, waterbutler_settings):
     jwt_data = {
         'exp': timezone.now() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
         'data': {
-            'auth': {
-                'id': auth.user._id,
-                'email': f'{auth.user._id}@osf.io',
-                'name': auth.user.fullname,
-            },
+            'auth': make_auth(auth),
             'credentials': credentials,
             'settings': waterbutler_settings,
             'callback_url': callback_url


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Previous refactor stopped using the `make_auth` function, instead directly constructing the auth dictionary. This was adding another failure point for unauthenticated users.

## Changes
Restore use of `make_auth` to gracefully handle the unauthenticated user case.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
