### PR TITLE
[ENG-3685] Add permissions for withdrawn registration files

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -305,6 +305,9 @@ def get_authenticated_resource(resource_id):
     if resource.deleted:
         raise HTTPError(http_status.HTTP_410_GONE, message='Resource has been deleted.')
 
+    if getattr(resource, 'is_retracted', False):
+        raise HTTPError(http_status.HTTP_410_GONE, message='Resource has been retracted.')
+
     return resource
 
 

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -41,7 +41,7 @@ class IsPreprintFile(PreprintPublishedOrAdmin):
     
 
 class WithdrawnRegistrationPermission(permissions.BasePermission):
-    acceptable_models = (Registration, )
+    acceptable_models = (Registration,)
     REQUIRED_PERMISSIONS = {}
 
     def has_permission(self, request, view):

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -40,9 +40,9 @@ class IsPreprintFile(PreprintPublishedOrAdmin):
         return True
 
 
-class WithdrawnRegistrationPermission(permissions.BasePermission):
+class RegistrationFileDetailPermission(permissions.BasePermission):
     acceptable_models = (Registration,)
-    REQUIRED_PERMISSIONS = {}
+    REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write', 'PUT': 'write'}
 
     def has_permission(self, request, view):
         if request.method not in self.REQUIRED_PERMISSIONS.keys() and request.method not in permissions.SAFE_METHODS:
@@ -73,6 +73,3 @@ class WithdrawnRegistrationPermission(permissions.BasePermission):
         if required_permission:
             return target.has_permission(auth.user, required_permission)
         return True
-
-class FileDetailPermission(WithdrawnRegistrationPermission, permissions.BasePermission):
-    REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write', 'PUT': 'write'}

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -1,12 +1,10 @@
-from rest_framework import exceptions
 from rest_framework import permissions
 
-from api.base.utils import get_user_auth, assert_resource_type
-from osf.models import BaseFileNode, Registration
+from api.base.utils import get_user_auth
+from osf.models import BaseFileNode
 from api.preprints.permissions import PreprintPublishedOrAdmin
 from osf.utils.permissions import ADMIN
 from osf.utils.workflows import DefaultStates
-from api.base.exceptions import Gone
 
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -1,10 +1,12 @@
+from rest_framework import exceptions
 from rest_framework import permissions
 
-from api.base.utils import get_user_auth
-from osf.models import BaseFileNode
+from api.base.utils import get_user_auth, assert_resource_type
+from osf.models import BaseFileNode, Registration
 from api.preprints.permissions import PreprintPublishedOrAdmin
 from osf.utils.permissions import ADMIN
 from osf.utils.workflows import DefaultStates
+from api.base.exceptions import Gone
 
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
@@ -36,3 +38,41 @@ class IsPreprintFile(PreprintPublishedOrAdmin):
             return super(IsPreprintFile, self).has_object_permission(request, view, obj.target)
 
         return True
+    
+
+class WithdrawnRegistrationPermission(permissions.BasePermission):
+    acceptable_models = (Registration, )
+    REQUIRED_PERMISSIONS = {}
+
+    def has_permission(self, request, view):
+        if request.method not in self.REQUIRED_PERMISSIONS.keys() and request.method not in permissions.SAFE_METHODS:
+            raise exceptions.MethodNotAllowed(request.method)
+
+        obj = view.get_object()
+        return self.has_object_permission(request, view, obj)
+
+    def has_object_permission(self, request, view, obj):
+        if request.method not in ['GET', *self.REQUIRED_PERMISSIONS.keys()]:
+            raise exceptions.MethodNotAllowed(request.method)
+        assert isinstance(obj, BaseFileNode), 'obj must be a BaseFileNode, got {}'.format(obj)
+        if not isinstance(obj.target, self.acceptable_models):
+            return True
+        assert_resource_type(obj.target, self.acceptable_models)
+
+        target = obj.target
+        if target.is_deleted:
+            raise Gone
+        if getattr(target, 'is_withdrawn', False):
+            return False
+
+        auth = get_user_auth(request)
+        if request.method in permissions.SAFE_METHODS:
+            return target.is_public or target.can_view(auth)
+
+        required_permission = self.REQUIRED_PERMISSIONS.get(request.method)
+        if required_permission:
+            return target.has_permission(auth.user, required_permission)
+        return True
+
+class FileDetailPermission(WithdrawnRegistrationPermission, permissions.BasePermission):
+    REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write'}

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -62,7 +62,7 @@ class WithdrawnRegistrationPermission(permissions.BasePermission):
         target = obj.target
         if target.is_deleted:
             raise Gone
-        if getattr(target, 'is_withdrawn', False):
+        if getattr(target, 'is_retracted', False):
             return False
 
         auth = get_user_auth(request)
@@ -73,6 +73,6 @@ class WithdrawnRegistrationPermission(permissions.BasePermission):
         if required_permission:
             return target.has_permission(auth.user, required_permission)
         return True
-
+    
 class FileDetailPermission(WithdrawnRegistrationPermission, permissions.BasePermission):
-    REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write'}
+    REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write', 'PUT': 'write'}

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -38,7 +38,7 @@ class IsPreprintFile(PreprintPublishedOrAdmin):
             return super(IsPreprintFile, self).has_object_permission(request, view, obj.target)
 
         return True
-    
+
 
 class WithdrawnRegistrationPermission(permissions.BasePermission):
     acceptable_models = (Registration,)
@@ -73,6 +73,6 @@ class WithdrawnRegistrationPermission(permissions.BasePermission):
         if required_permission:
             return target.has_permission(auth.user, required_permission)
         return True
-    
+
 class FileDetailPermission(WithdrawnRegistrationPermission, permissions.BasePermission):
     REQUIRED_PERMISSIONS = {'PATCH': 'write', 'DELETE': 'write', 'PUT': 'write'}

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -442,6 +442,16 @@ class FileDetailSerializer(FileSerializer):
         if guid:
             data['data']['id'] = guid._id
 
+        if isinstance(value.target, Registration) and value.target.is_retracted:
+            restricted_fields = [
+                'checkout', 'size', 'provider', 'materialized_path', 'last_touched',
+                'date_modified', 'date_created', 'extra', 'tags', 'current_user_can_comment',
+                'current_version', 'show_as_unviewed', 'links'
+            ]
+            for field in restricted_fields:
+                data['data']['attributes'].pop(field, None)
+            data['data']['links'] = {}
+
         return data
 
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -441,17 +441,6 @@ class FileDetailSerializer(FileSerializer):
         guid = Guid.load(view.kwargs['file_id'])
         if guid:
             data['data']['id'] = guid._id
-
-        if isinstance(value.target, Registration) and value.target.is_retracted:
-            restricted_fields = [
-                'checkout', 'size', 'provider', 'materialized_path', 'last_touched',
-                'date_modified', 'date_created', 'extra', 'tags', 'current_user_can_comment',
-                'current_version', 'show_as_unviewed', 'links',
-            ]
-            for field in restricted_fields:
-                data['data']['attributes'].pop(field, None)
-            data['data']['links'] = {}
-
         return data
 
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -446,7 +446,7 @@ class FileDetailSerializer(FileSerializer):
             restricted_fields = [
                 'checkout', 'size', 'provider', 'materialized_path', 'last_touched',
                 'date_modified', 'date_created', 'extra', 'tags', 'current_user_can_comment',
-                'current_version', 'show_as_unviewed', 'links'
+                'current_version', 'show_as_unviewed', 'links',
             ]
             for field in restricted_fields:
                 data['data']['attributes'].pop(field, None)

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -30,6 +30,7 @@ from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer
 from api.files.serializers import FileVersionSerializer
 from osf.utils.permissions import ADMIN
+from api.files.permissions import FileDetailPermission
 
 
 class FileMixin(object):
@@ -72,6 +73,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
         CheckedOutOrAdmin,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'target'),
+        FileDetailPermission,
     )
 
     required_read_scopes = [CoreScopes.NODE_FILE_READ]

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -30,7 +30,6 @@ from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer
 from api.files.serializers import FileVersionSerializer
 from osf.utils.permissions import ADMIN
-from api.files.permissions import RegistrationFileDetailPermission
 
 
 class FileMixin(object):
@@ -76,7 +75,6 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
         CheckedOutOrAdmin,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'target'),
-        RegistrationFileDetailPermission,
     )
 
     required_read_scopes = [CoreScopes.NODE_FILE_READ]

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -30,7 +30,7 @@ from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer
 from api.files.serializers import FileVersionSerializer
 from osf.utils.permissions import ADMIN
-from api.files.permissions import FileDetailPermission
+from api.files.permissions import RegistrationFileDetailPermission
 
 
 class FileMixin(object):
@@ -58,6 +58,9 @@ class FileMixin(object):
             if obj.target.creator.is_disabled:
                 raise Gone(detail='This user has been deactivated and their quickfiles are no longer available.')
 
+        if getattr(obj.target, 'is_retracted', False):
+            raise Gone(detail='The requested file is no longer available.')
+
         if check_permissions:
             # May raise a permission denied
             self.check_object_permissions(self.request, obj)
@@ -73,7 +76,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
         CheckedOutOrAdmin,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'target'),
-        FileDetailPermission,
+        RegistrationFileDetailPermission,
     )
 
     required_read_scopes = [CoreScopes.NODE_FILE_READ]

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -732,7 +732,7 @@ class TestFileVersionView:
                     moderator_initiated=False
                 )
             except APIException as e:
-                print(f"Retraction failed: {e}")
+                print(f'Retraction failed: {e}')
 
             resource.save()
 

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -28,7 +28,6 @@ from osf_tests.factories import (
     PreprintFactory,
 )
 from website import settings as website_settings
-from rest_framework.exceptions import APIException
 
 SessionStore = import_module(django_conf_settings.SESSION_ENGINE).SessionStore
 

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -723,7 +723,7 @@ class TestFileVersionView:
 
     def test_get_authenticated_resource_retracted(self):
         resource = RegistrationFactory()
-        resource.retract_registration(user=resource.creator, justification="Justification for retraction")
+        resource.retract_registration(user=resource.creator, justification='Justification for retraction')
         resource.retraction.state = ApprovalStates.APPROVED
         resource.retraction.save()
         resource.save()

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -727,7 +727,7 @@ class TestFileVersionView:
             try:
                 resource.retract_registration(
                     user=resource.creator,
-                    justification="Justification for retraction",
+                    justification='Justification for retraction',
                     save=True,
                     moderator_initiated=False
                 )

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -722,7 +722,7 @@ class TestFileVersionView:
 
     def test_get_authenticated_resource_retracted(self):
         resource = ProjectFactory()
-        resource.is_retracted = True
+        resource.retract_registration()
         resource.save()
 
         with pytest.raises(HTTPError) as excinfo:
@@ -941,20 +941,20 @@ class TestPreprintFileView:
 
         # Unauthenticated
         res = app.get(file_url, expect_errors=True)
-        assert res.status_code == 401
+        assert res.status_code == 410
 
         # Noncontrib
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 410
 
         # Write contributor
         preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 410
 
         # Admin contrib
         res = app.get(file_url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 410
 
 @pytest.mark.django_db
 class TestShowAsUnviewed:

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -721,10 +721,8 @@ class TestFileVersionView:
             moderator_initiated=False
         )
 
-        approval_token = retraction.approval_state[resource.creator._id]['approval_token']
-        retraction.approve(user=resource.creator, token=approval_token)
+        retraction.accept()
         resource.save()
-
         resource.refresh_from_db()
 
         file.target = resource
@@ -742,10 +740,8 @@ class TestFileVersionView:
             moderator_initiated=False
         )
 
-        approval_token = retraction.approval_state[resource.creator._id]['approval_token']
-        retraction.approve(user=resource.creator, token=approval_token)
+        retraction.accept()
         resource.save()
-
         resource.refresh_from_db()
 
         file.target = resource
@@ -766,10 +762,8 @@ class TestFileVersionView:
             moderator_initiated=False
         )
 
-        approval_token = retraction.approval_state[resource.creator._id]['approval_token']
-        retraction.approve(user=resource.creator, token=approval_token)
+        retraction.accept()
         resource.save()
-
         resource.refresh_from_db()
 
         assert resource.is_retracted is True

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -28,6 +28,7 @@ from osf_tests.factories import (
     PreprintFactory,
 )
 from website import settings as website_settings
+from osf.utils.workflows import ApprovalStates
 
 SessionStore = import_module(django_conf_settings.SESSION_ENGINE).SessionStore
 
@@ -721,8 +722,10 @@ class TestFileVersionView:
         assert res.status_code == 410
 
     def test_get_authenticated_resource_retracted(self):
-        resource = ProjectFactory()
-        resource.retract_registration()
+        resource = RegistrationFactory()
+        resource.retract_registration(user=resource.creator, justification="Justification for retraction")
+        resource.retraction.state = ApprovalStates.APPROVED
+        resource.retraction.save()
         resource.save()
 
         with pytest.raises(HTTPError) as excinfo:

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -722,7 +722,7 @@ class TestFileVersionView:
         assert res.status_code == 410
 
     def test_get_authenticated_resource_retracted(self):
-        resource = RegistrationFactory()
+        resource = RegistrationFactory(is_public=True)
         resource.retract_registration(user=resource.creator, justification='Justification for retraction')
         resource.retraction.state = ApprovalStates.APPROVED
         resource.retraction.save()


### PR DESCRIPTION
## Purpose

Implement custom permissions to handle file access for withdrawn registrations.

## Changes

- Added WithdrawnRegistrationPermission and updated FileDetailPermission to enforce access control for withdrawn registrations.
- Restrict API response

## Ticket

<(https://openscience.atlassian.net/browse/ENG-3685)>
