### PR TITLE
[ENG-5727][ENG-5728] Get Addon information from GravyValet

### DIFF
--- a/osf/external/gravy_valet/auth_helpers.py
+++ b/osf/external/gravy_valet/auth_helpers.py
@@ -7,7 +7,6 @@ import urllib
 
 from django.utils import timezone
 
-from osf.models import OSFUser, AbstractNode
 from osf.utils import permissions as osf_permissions
 from website import settings
 
@@ -56,8 +55,8 @@ def _get_signed_components(
 
 
 def make_permissions_headers(
-    requesting_user: typing.Optional[OSFUser] = None,
-    requested_resource: typing.Optional[AbstractNode] = None
+    requesting_user=None,  # OSFUser | None
+    requested_resource=None,  # AbstractNode | None
 ) -> dict:
     osf_permissions_headers = {}
     if requesting_user:

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -3,7 +3,6 @@ import enum
 import dataclasses
 
 from addons.box.apps import BoxAddonAppConfig
-from osf.models import Node, OSFUser
 from . import request_helpers as gv_requests
 
 
@@ -66,8 +65,8 @@ class EphemeralNodeSettings:
     gv_id: str
 
     # These are needed in order to make further requests for credentials
-    configured_resource: Node
-    active_user: OSFUser
+    configured_resource: type  # Node
+    active_user: type  # OSFUser
 
     # retrieved from WB on-demand and cached
     _credentials: dict = None
@@ -111,7 +110,7 @@ class EphemeralUserSettings:
     config: EphemeralAddonConfig
     gv_id: str
     # This is needed to support making further requests
-    active_user: OSFUser
+    active_user: type  # : OSFUser
 
     @property
     def short_name(self):

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -115,3 +115,6 @@ class EphemeralUserSettings:
     @property
     def short_name(self):
         return self.config.short_name
+
+    def can_be_merged(self):
+        return True

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -99,6 +99,11 @@ class EphemeralNodeSettings:
         )
         self._credentials = result.get_attribute('credentials')
 
+    def create_waterbutler_log(self, *args, **kwargs):
+        pass
+
+    def save():
+        pass
 
 @dataclasses.dataclass
 class EphemeralUserSettings:

--- a/osf/models/draft_node.py
+++ b/osf/models/draft_node.py
@@ -37,6 +37,12 @@ class DraftNode(AbstractNode):
         """
         return
 
+    def can_view(self, auth):
+        return self.registered_draft.first().can_view(auth)
+
+    def can_edit(self, auth=None, user=None):
+        return self.registered_draft.first().can_edit(auth, user)
+
     def convert_draft_node_to_node(self, auth):
         self.recast('osf.node')
         self.save()

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -492,8 +492,9 @@ class AddonModelMixin(models.Model):
     def get_addons(self):
         request, user_id = get_request_and_user_id()
         if waffle.flag_is_active(request, features.ENABLE_GV):
-            osf_addons = (
-                self.get_addon(addon) for addon in self.OSF_HOSTED_ADDONS
+            osf_addons = filter(
+                lambda x: x is not None,
+                (self.get_addon(addon) for addon in self.OSF_HOSTED_ADDONS)
             )
             return itertools.chain(osf_addons, self._get_addons_from_gv(requesting_user_id=user_id))
 

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -524,9 +524,11 @@ class AddonModelMixin(models.Model):
         return self.add_addon(name, *args, **kwargs)
 
     def get_addon(self, name, is_deleted=False):
-        request, user_id = get_request_and_user_id()
-        if waffle.flag_is_active(request, features.ENABLE_GV) and name not in self.OSF_HOSTED_ADDONS:
-            return self._get_addon_from_gv(gv_pk=name, requesting_user_id=user_id)
+        # Avoid test-breakages by avoiding early access to the request context
+        if name not in self.OSF_HOSTED_ADDONS:
+            request, user_id = get_request_and_user_id()
+            if waffle.flag_is_active(request, features.ENABLE_GV):
+                return self._get_addon_from_gv(gv_pk=name, requesting_user_id=user_id)
 
         try:
             settings_model = self._settings_model(name)

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1,6 +1,9 @@
+import itertools
 import pytz
 import markupsafe
 import logging
+
+import waffle
 
 from django.apps import apps
 from django.contrib.auth.models import Group, AnonymousUser
@@ -32,6 +35,7 @@ from .validators import validate_title
 from .tag import Tag
 from osf.utils import sanitize
 from .validators import validate_subject_hierarchy, validate_email, expand_subject_hierarchy
+from osf import features
 from osf.utils.fields import NonNaiveDateTimeField
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.machines import (
@@ -471,6 +475,8 @@ class AddonModelMixin(models.Model):
     settings_type = None
     ADDONS_AVAILABLE = sorted([config for config in apps.get_app_configs() if config.name.startswith('addons.') and
         config.label != 'base'], key=lambda config: config.name)
+    # These addon configurations will continue to live in the OSF for the foreseeable future
+    OSF_HOSTED_ADDONS = ['forward', 'osfstorage', 'twofactor', 'wiki']
 
     class Meta:
         abstract = True
@@ -484,6 +490,13 @@ class AddonModelMixin(models.Model):
         return self.get_addons()
 
     def get_addons(self):
+        request, user_id = get_request_and_user_id()
+        if waffle.flag_is_active(request, features.ENABLE_GV):
+            osf_addons = (
+                self.get_addon(addon) for addon in self.OSF_HOSTED_ADDONS
+            )
+            return itertools.chain(osf_addons, self._get_addons_from_gv(requesting_user_id=user_id))
+
         return [_f for _f in [
             self.get_addon(config.short_name)
             for config in self.ADDONS_AVAILABLE
@@ -511,6 +524,10 @@ class AddonModelMixin(models.Model):
         return self.add_addon(name, *args, **kwargs)
 
     def get_addon(self, name, is_deleted=False):
+        request, user_id = get_request_and_user_id()
+        if waffle.flag_is_active(request, features.ENABLE_GV) and name not in self.OSF_HOSTED_ADDONS:
+            return self._get_addon_from_gv(gv_pk=name, requesting_user_id=user_id)
+
         try:
             settings_model = self._settings_model(name)
         except LookupError:

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -928,6 +928,8 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         Since preprints don't have addons, this method has been pulled over from the
         OSFStorage addon
         """
+        if provider_name != 'osfstorage':
+            raise ValueError('Preprints only have access to osfstorage')
         return dict(Region.objects.get(id=self.region_id).waterbutler_settings, **{
             'nid': self._id,
             'rootId': self.root_folder._id,
@@ -944,6 +946,8 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         Since preprints don't have addons, this method has been pulled over from the
         OSFStorage addon
         """
+        if provider_name != 'osfstorage':
+            raise ValueError('Preprints only have access to osfstorage')
         return Region.objects.get(id=self.region_id).waterbutler_credentials
 
     def create_waterbutler_log(self, auth, action, payload):

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -928,7 +928,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         Since preprints don't have addons, this method has been pulled over from the
         OSFStorage addon
         """
-        if provider_name != 'osfstorage':
+        if provider_name and provider_name != 'osfstorage':
             raise ValueError('Preprints only have access to osfstorage')
         return dict(Region.objects.get(id=self.region_id).waterbutler_settings, **{
             'nid': self._id,
@@ -946,7 +946,7 @@ class Preprint(DirtyFieldsMixin, GuidMixin, IdentifierMixin, ReviewableMixin, Ba
         Since preprints don't have addons, this method has been pulled over from the
         OSFStorage addon
         """
-        if provider_name != 'osfstorage':
+        if provider_name and provider_name != 'osfstorage':
             raise ValueError('Preprints only have access to osfstorage')
         return Region.objects.get(id=self.region_id).waterbutler_credentials
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1912,7 +1912,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     def _get_addon_from_gv(self, gv_pk, requesting_user_id):
         requesting_user = OSFUser.load(requesting_user_id)
-        if requesting_user != self:
+        if requesting_user and requesting_user != self:
             raise ValueError('Cannot get user addons for a user other than self')
 
         gv_account_data = gv_requests.get_account(
@@ -1921,21 +1921,21 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         )
         return gv_translations.make_ephemeral_node_settings(
             gv_account_data=gv_account_data,
-            requesting_user=requesting_user
+            requesting_user=self,
         )
 
     def _get_addons_from_gv(self, requesting_user_id):
         requesting_user = OSFUser.load(requesting_user_id)
-        if requesting_user != self:
+        if requesting_user and requesting_user != self:
             raise ValueError('Cannot get user addons for a user other than self')
 
         all_user_account_data = gv_requests.iterate_accounts_for_user(
-            requesting_user=requesting_user
+            requesting_user=self,
         )
         for account_data in all_user_account_data:
             yield gv_translations.make_ephemeral_user_settings(
                 gv_account_data=account_data,
-                requesting_user=requesting_user
+                requesting_user=self,
             )
 
     def _validate_admin_status_for_gdpr_delete(self, resource):

--- a/tests/base.py
+++ b/tests/base.py
@@ -152,12 +152,12 @@ class ApiAppTestCase(unittest.TestCase):
 class SearchTestCase(unittest.TestCase):
 
     def setUp(self):
-#        settings.ELASTIC_INDEX = uuid.uuid1().hex
-#        settings.ELASTIC_TIMEOUT = 60
+        settings.ELASTIC_INDEX = uuid.uuid1().hex
+        settings.ELASTIC_TIMEOUT = 60
 
-#        from website.search import elastic_search
-#        elastic_search.INDEX = settings.ELASTIC_INDEX
-#        elastic_search.create_index(settings.ELASTIC_INDEX)
+        from website.search import elastic_search
+        elastic_search.INDEX = settings.ELASTIC_INDEX
+        elastic_search.create_index(settings.ELASTIC_INDEX)
 
         # NOTE: Super is called last to ensure the ES connection can be established before
         #       the responses module patches the socket.
@@ -166,8 +166,8 @@ class SearchTestCase(unittest.TestCase):
     def tearDown(self):
         super(SearchTestCase, self).tearDown()
 
-#        from website.search import elastic_search
-#        elastic_search.delete_index(settings.ELASTIC_INDEX)
+        from website.search import elastic_search
+        elastic_search.delete_index(settings.ELASTIC_INDEX)
 
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -152,12 +152,12 @@ class ApiAppTestCase(unittest.TestCase):
 class SearchTestCase(unittest.TestCase):
 
     def setUp(self):
-        settings.ELASTIC_INDEX = uuid.uuid1().hex
-        settings.ELASTIC_TIMEOUT = 60
+#        settings.ELASTIC_INDEX = uuid.uuid1().hex
+#        settings.ELASTIC_TIMEOUT = 60
 
-        from website.search import elastic_search
-        elastic_search.INDEX = settings.ELASTIC_INDEX
-        elastic_search.create_index(settings.ELASTIC_INDEX)
+#        from website.search import elastic_search
+#        elastic_search.INDEX = settings.ELASTIC_INDEX
+#        elastic_search.create_index(settings.ELASTIC_INDEX)
 
         # NOTE: Super is called last to ensure the ES connection can be established before
         #       the responses module patches the socket.
@@ -166,8 +166,8 @@ class SearchTestCase(unittest.TestCase):
     def tearDown(self):
         super(SearchTestCase, self).tearDown()
 
-        from website.search import elastic_search
-        elastic_search.delete_index(settings.ELASTIC_INDEX)
+#        from website.search import elastic_search
+#        elastic_search.delete_index(settings.ELASTIC_INDEX)
 
 
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2069,7 +2069,7 @@ class TestPreprintOsfStorage(OsfTestCase):
         return self.preprint.api_url_for('get_auth', **options)
 
     def test_auth_download(self):
-        url = self.build_url(cookie=self.cookie)
+        url = self.build_url()
         res = self.app.get(url, auth=Auth(user=self.user))
         data = jwt.decode(jwe.decrypt(res.json['payload'].encode('utf-8'), self.JWE_KEY), settings.WATERBUTLER_JWT_SECRET, algorithm=settings.WATERBUTLER_JWT_ALGORITHM)['data']
         assert_equal(data['credentials'], self.preprint.serialize_waterbutler_credentials())
@@ -2088,41 +2088,59 @@ class TestCheckPreprintAuth(OsfTestCase):
         self.preprint = PreprintFactory(creator=self.user)
 
     def test_has_permission(self):
-        res = views.check_resource_permissions(self.preprint, Auth(user=self.user), 'upload')
+        res = views._check_resource_permissions(self.preprint, Auth(user=self.user), 'upload')
         assert_true(res)
 
     def test_not_has_permission_read_published(self):
-        res = views.check_resource_permissions(self.preprint, Auth(), 'download')
+        res = views._check_resource_permissions(self.preprint, Auth(), 'download')
         assert_true(res)
 
     def test_not_has_permission_logged_in(self):
         user2 = AuthUserFactory()
         self.preprint.is_published = False
         self.preprint.save()
-        assert_false(views.check_resource_permissions(self.preprint, Auth(user=user2), 'download'))
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(user=user2), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
     def test_not_has_permission_not_logged_in(self):
         self.preprint.is_published = False
         self.preprint.save()
-        assert_false(views.check_resource_permissions(self.preprint, Auth(), 'download'))
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
-    def test_check_access_withdrawn_preprint_file(self):
+    def test_check_access_withdrawn_preprint_file__unauthenticated(self):
         self.preprint.date_withdrawn = timezone.now()
         self.preprint.save()
         # Unauthenticated
-        assert_false(views.check_resource_permissions(self.preprint, Auth(), 'download'))
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
-        # Noncontributor
-        user2 = AuthUserFactory()
-        assert_false(views.check_resource_permissions(self.preprint, Auth(user2), 'download'))
+    def test_check_access_withdrawn_preprint_file__noncontributor(self):
+        self.preprint.date_withdrawn = timezone.now()
+        self.preprint.save()
+        noncontrib = AuthUserFactory()
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(user=noncontrib), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
-        # Read contributor
-        self.preprint.add_contributor(user2, READ, save=True)
-        assert_false(views.check_resource_permissions(self.preprint, Auth(user2), 'download'))
+    def test_check_access_withdrawn_preprint_file__read_user(self):
+        self.preprint.date_withdrawn = timezone.now()
+        self.preprint.save()
+        read_user = AuthUserFactory()
+        self.preprint.add_contributor(read_user, READ, save=True)
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(user=read_user), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
-        # Admin contributor
-        assert_false(views.check_resource_permissions(self.preprint, Auth(self.user), 'download'))
-
+    def test_check_access_withdrawn_preprint_file__admin_user(self):
+        self.preprint.date_withdrawn = timezone.now()
+        self.preprint.save()
+        with assert_raises(HTTPError) as exc_info:
+            views._check_resource_permissions(self.preprint, Auth(user=self.user), 'download')
+        self.assertEqual(exc_info.exception.code, 403)
 
 
 class TestPreprintOsfStorageLogs(OsfTestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ from framework.auth.utils import generate_csl_given_name
 from framework.routing import Rule, json_renderer
 from framework.utils import secure_filename, throttle_period_expired
 from api.base.utils import waterbutler_api_url_for
+from osf_tests.external.gravy_valet.gv_fakes import FakeGravyValet
 from osf.utils.functional import rapply
 from waffle.testutils import override_flag
 from website.routes import process_rules, OsfWebRenderer
@@ -569,7 +570,10 @@ class TestUserSignals:
     ):
         with mock.patch.object(settings, 'USE_CELERY', True):
             with override_flag(features.ENABLE_GV, active=True):
-                user.merge_user(old_user)
+                fake_gv = FakeGravyValet()
+                fake_gv._get_or_create_user_entry(old_user)
+                with fake_gv.run_fake():
+                    user.merge_user(old_user)
 
         mock_publish_user_status_change().__enter__().publish.assert_called_once_with(
             body={


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Update `get_addon` and `get_addons` to return EphemeralSettings objects populated from GravyValet data when the GV waffle is active. Also, remove special casing for GravyValet from `get_auth` now that `get_addon` handles this transparently.

Also, further refactor `get_auth` to remove unnecessary checks, revert some deltas from the pre-refactored version, and improve consistency

## Changes
**Changes to `get_addon(s)` and GV-facing libraries**
* update `AddonModelMixin.get_addon(s)` to conditionally check with GravyValet as the source of truth for configurations
  * Maintain `osfstorage` `twofactor` `wiki` and `forward` as `OSF_HOSTED_ADDONS` that will follow legacy routes
* Add `_get_addon(s)_from_gv` to `AbstractNode` and `OSFUser` to handle retrieving the appropriate data and `EphemeralSettings`
* Remove imports that were only used for type annotations and which were causing import cycles 
  * After Python Upgrade is complete, these imports can be restored with an `if typing.TYPE_CHECKING` guard

**Changes to `get_auth`**
* Remove extra authentication bits from `get_auth`, since all auth information should be gathered by `@collect_auth`
  * Needed to retain extra CAS check for token scopes because those aren't available elsewhere
    * Test fixes here may enable a follow-up PR similar to pack token scopes into the `Auth` object similar to https://github.com/CenterForOpenScience/osf.io/pull/10642
* Co-locate checks for token scope with other permissions checks
* Consolidate permissions checks for various resource types around the `can_view_files`
* Make `DraftNodes` forward `can_view` and `can_edit` checks to their DraftRegistration to avoid special casing
* Fix permission checking logic that only had us checking hierarchical permissions for `WRITE` operations
   * `copyfrom` actions were historically included in hierarchical permissions checks, but `copyfrom` is a READ action
     * This was confused by the use of `can_edit` to check for all hierarchical permissions, but I have no clue if that's a load-bearing bug
* Make `_check_resource_permissions` raise a 403 on its own, following the pattern of other helpers
* Combine `get_osfstorage_file_node` and `get_osfstorage_file_version` into `get_osfstorage_file_version_and_node`
* Simplify collection of waterbutler settings/credentials
   *  Always get settings from `resource.serialize_waterbutler_settings`, then update with the region settings for the actual fileversion if appropriate
     * This is identical to using `fileversion.serialize_waterbutler_settings` without requiring knowledge of the NodeSettings
* Restructure the file so `get_auth` defintion comes before all helper functions
* Make all helper functions "protected"

**Changes to tests**
* Resolve deprecation warnings in `tests/test_addons.py` by universally replacing old `nose` functions `assert_(equal|true|false)` with `self.assert(Equal|True|False)`
* Set the auth cookie on the test request instead of passing it in the payload
  * Confirmed that waterbutler does this (though technically it puts it both places)
* Expect errors from `_check_resource_permissions` instead of a `False` result
* Actually add `asserts` for tests that were missing them
* Replace tests for `authenticate_via_oauth_bearer_token` with tests for `_confirm_token_scope`, including replacing the old mocks with new ones to A) provide an `Authorization` header and B) set the returned scopes instead of mocking a CAS response
  * If/When scopes live on the `Auth` object, we will be able to remove this mocking and just...set the scopes on the `Auth` object 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-5727 
https://openscience.atlassian.net/browse/ENG-5728