### PR TITLE
[ENG-4903] Fixes issue with email confirmation links failing due to database congestion

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -34,13 +34,6 @@ from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from api.base.schemas.utils import validate_user_json, from_json
 from framework.auth.views import send_confirm_email
 from api.base.versioning import get_kebab_snake_case_field
-from framework.postcommit_tasks.handlers import enqueue_postcommit_task
-
-
-def send_confirmation_email_task(user_id, email):
-    from framework.auth import get_user
-    user = get_user(user_id)
-    send_confirm_email(user, email=email)
 
 
 class SocialField(ser.DictField):
@@ -603,7 +596,7 @@ class UserEmailsSerializer(JSONAPISerializer):
             token = user.add_unconfirmed_email(address)
             user.save()
             if CONFIRM_REGISTRATIONS_BY_EMAIL:
-                enqueue_postcommit_task(send_confirmation_email_task, user.id, address)
+                send_confirm_email(user, email=address)
                 user.email_last_sent = timezone.now()
                 user.save()
         except ValidationError as e:

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -34,6 +34,13 @@ from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from api.base.schemas.utils import validate_user_json, from_json
 from framework.auth.views import send_confirm_email
 from api.base.versioning import get_kebab_snake_case_field
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
+
+
+def send_confirmation_email_task(user_id, email):
+    from framework.auth import get_user
+    user = get_user(user_id)
+    send_confirm_email(user, email=email)
 
 
 class SocialField(ser.DictField):
@@ -596,7 +603,7 @@ class UserEmailsSerializer(JSONAPISerializer):
             token = user.add_unconfirmed_email(address)
             user.save()
             if CONFIRM_REGISTRATIONS_BY_EMAIL:
-                send_confirm_email(user, email=address)
+                enqueue_postcommit_task(send_confirmation_email_task, user.id, address)
                 user.email_last_sent = timezone.now()
                 user.save()
         except ValidationError as e:

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -32,7 +32,7 @@ from osf.models.provider import AbstractProviderGroupObjectPermission
 from website.profile.views import update_osf_help_mails_subscription, update_mailchimp_subscription
 from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from api.base.schemas.utils import validate_user_json, from_json
-from framework.auth.views import send_confirm_email
+from framework.auth.views import send_confirm_email_async
 from api.base.versioning import get_kebab_snake_case_field
 
 
@@ -596,7 +596,7 @@ class UserEmailsSerializer(JSONAPISerializer):
             token = user.add_unconfirmed_email(address)
             user.save()
             if CONFIRM_REGISTRATIONS_BY_EMAIL:
-                send_confirm_email(user, email=address)
+                send_confirm_email_async(user, email=address)
                 user.email_last_sent = timezone.now()
                 user.save()
         except ValidationError as e:

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -60,7 +60,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
 from django.utils import timezone
 from framework.auth.core import get_user
-from framework.auth.views import send_confirm_email
+from framework.auth.views import send_confirm_email_async
 from framework.auth.oauth_scopes import CoreScopes, normalize_scopes
 from framework.auth.exceptions import ChangePasswordError
 from framework.utils import throttle_period_expired
@@ -900,7 +900,7 @@ class UserEmailsDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, U
         if self.request.method == 'GET' and is_truthy(self.request.query_params.get('resend_confirmation')):
             if not confirmed and settings.CONFIRM_REGISTRATIONS_BY_EMAIL:
                 if throttle_period_expired(user.email_last_sent, settings.SEND_EMAIL_THROTTLE):
-                    send_confirm_email(user, email=address, renew=True)
+                    send_confirm_email_async(user, email=address, renew=True)
                     user.email_last_sent = timezone.now()
                     user.save()
 

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -12,7 +12,7 @@ from api.institutions.authentication import INSTITUTION_SHARED_SSO_MAP
 
 from framework.auth import signals, Auth
 from framework.auth.core import get_user
-from framework.auth.views import send_confirm_email
+from framework.auth.views import send_confirm_email_async
 
 from osf.models import OSFUser, InstitutionAffiliation, InstitutionStorageRegion
 from osf.models.institution import SsoFilterCriteriaAction
@@ -454,7 +454,7 @@ class TestInstitutionAuth:
         assert user.external_identity
 
         # Send confirm email in order to add new email verifications
-        send_confirm_email(
+        send_confirm_email_async(
             user,
             user.username,
             external_id_provider=external_id_provider,

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -216,7 +216,7 @@ class TestUserEmailsList:
         assert res.status_code == 200
         assert unconfirmed_address in [result['attributes']['email_address'] for result in res.json['data']]
 
-    @mock.patch('api.users.serializers.send_confirm_email')
+    @mock.patch('api.users.serializers.send_confirm_email_async')
     def test_create_new_email_current_user(self, mock_send_confirm_mail, user_one, user_two, app, url, payload):
         new_email = 'hhh@wwe.test'
         payload['data']['attributes']['email_address'] = new_email
@@ -229,7 +229,7 @@ class TestUserEmailsList:
         assert new_email in user_one.unconfirmed_emails
         assert mock_send_confirm_mail.called
 
-    @mock.patch('api.users.serializers.send_confirm_email')
+    @mock.patch('api.users.serializers.send_confirm_email_async')
     def test_create_new_email_not_current_user(self, mock_send_confirm_mail, app, url, payload, user_one, user_two):
         new_email = 'HHH@wwe.test'
         payload['data']['attributes']['email_address'] = new_email
@@ -239,7 +239,7 @@ class TestUserEmailsList:
         assert new_email not in user_one.unconfirmed_emails
         assert not mock_send_confirm_mail.called
 
-    @mock.patch('api.users.serializers.send_confirm_email')
+    @mock.patch('api.users.serializers.send_confirm_email_async')
     def test_create_email_already_exists(self, mock_send_confirm_mail, app, url, payload, user_one):
         new_email = 'hello@email.test'
         Email.objects.create(address=new_email, user=user_one)
@@ -578,28 +578,28 @@ class TestUserEmailDetail:
         assert res.json['data']['attributes']['confirmed'] is True
         assert res.json['data']['attributes']['is_merge'] is False
 
-    @mock.patch('api.users.views.send_confirm_email')
-    def test_resend_confirmation_email(self, mock_send_confirm_email, app, user_one, unconfirmed_url, confirmed_url):
+    @mock.patch('api.users.views.send_confirm_email_async')
+    def test_resend_confirmation_email(self, mock_send_confirm_email_async, app, user_one, unconfirmed_url, confirmed_url):
         url = '{}?resend_confirmation=True'.format(unconfirmed_url)
         res = app.get(url, auth=user_one.auth)
         assert res.status_code == 202
-        assert mock_send_confirm_email.called
-        call_count = mock_send_confirm_email.call_count
+        assert mock_send_confirm_email_async.called
+        call_count = mock_send_confirm_email_async.call_count
 
         # make sure setting false does not send confirm email
         url = '{}?resend_confirmation=False'.format(unconfirmed_url)
         res = app.get(url, auth=user_one.auth)
         # should return 200 instead of 202 because nothing has been done
         assert res.status_code == 200
-        assert mock_send_confirm_email.call_count
+        assert mock_send_confirm_email_async.call_count
 
         # make sure normal GET request does not re-send confirmation email
         res = app.get(unconfirmed_url, auth=user_one.auth)
-        assert mock_send_confirm_email.call_count == call_count
+        assert mock_send_confirm_email_async.call_count == call_count
         assert res.status_code == 200
 
         # resend confirmation with confirmed email address does not send confirmation email
         url = '{}?resend_confirmation=True'.format(confirmed_url)
         res = app.get(url, auth=user_one.auth)
-        assert mock_send_confirm_email.call_count == call_count
+        assert mock_send_confirm_email_async.call_count == call_count
         assert res.status_code == 200

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -873,7 +873,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         logo=logo if logo else settings.OSF_LOGO
     )
 
-    enqueue_postcommit_task(send_confirmation_email_task, (user.id, email), {})
+    enqueue_postcommit_task(send_confirmation_email_task, args=(user.id, email), kwargs={})
 
 def send_confirmation_email_task(user_id, email):
     from framework.auth import get_user

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -801,6 +801,11 @@ def unconfirmed_email_add(auth=None):
         'removed_email': json_body['address']
     }, 200
 
+def send_confirmation_email_task(args):
+    user_id, email = args
+    from framework.auth import get_user
+    user = get_user(user_id)
+    send_confirm_email(user, email=email)
 
 def send_confirm_email(user, email, renew=False, external_id_provider=None, external_id=None, destination=None):
     """
@@ -874,11 +879,6 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
     )
 
     enqueue_postcommit_task(send_confirmation_email_task, args=(user.id, email), kwargs={})
-
-def send_confirmation_email_task(user_id, email):
-    from framework.auth import get_user
-    user = get_user(user_id)
-    send_confirm_email(user, email=email)
 
 
 def register_user(**kwargs):

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -37,6 +37,7 @@ from osf.utils.requests import check_select_for_update
 from website.util.metrics import CampaignClaimedTags, CampaignSourceTags
 from website.ember_osf_web.decorators import ember_flag_is_active
 from osf import features
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 # from osf.models import PreprintProvider
 
 
@@ -871,6 +872,13 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         can_change_preferences=False,
         logo=logo if logo else settings.OSF_LOGO
     )
+
+    enqueue_postcommit_task(send_confirmation_email_task, (user.id, email), {})
+
+def send_confirmation_email_task(user_id, email):
+    from framework.auth import get_user
+    user = get_user(user_id)
+    send_confirm_email(user, email=email)
 
 
 def register_user(**kwargs):

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -801,12 +801,6 @@ def unconfirmed_email_add(auth=None):
         'removed_email': json_body['address']
     }, 200
 
-def send_confirmation_email_task(args):
-    user_id, email = args
-    from framework.auth import get_user
-    user = get_user(user_id)
-    send_confirm_email(user, email=email)
-
 def send_confirm_email(user, email, renew=False, external_id_provider=None, external_id=None, destination=None):
     """
     Sends `user` a confirmation to the given `email`.
@@ -821,64 +815,64 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
     :return:
     :raises: KeyError if user does not have a confirmation token for the given email.
     """
+    def send_email_task():
+        confirmation_url = user.get_confirmation_url(
+            email,
+            external=True,
+            force=True,
+            renew=renew,
+            external_id_provider=external_id_provider,
+            destination=destination
+        )
 
-    confirmation_url = user.get_confirmation_url(
-        email,
-        external=True,
-        force=True,
-        renew=renew,
-        external_id_provider=external_id_provider,
-        destination=destination
-    )
+        try:
+            merge_target = OSFUser.objects.get(emails__address=email)
+        except OSFUser.DoesNotExist:
+            merge_target = None
 
-    try:
-        merge_target = OSFUser.objects.get(emails__address=email)
-    except OSFUser.DoesNotExist:
-        merge_target = None
+        campaign = campaigns.campaign_for_user(user)
+        branded_preprints_provider = None
+        logo = None
+        # Choose the appropriate email template to use and add existing_user flag if a merge or adding an email.
+        if external_id_provider and external_id:
+            # First time login through external identity provider, link or create an OSF account confirmation
+            if user.external_identity[external_id_provider][external_id] == 'CREATE':
+                mail_template = mails.EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE
+            elif user.external_identity[external_id_provider][external_id] == 'LINK':
+                mail_template = mails.EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK
+        elif merge_target:
+            # Merge account confirmation
+            mail_template = mails.CONFIRM_MERGE
+            confirmation_url = '{}?logout=1'.format(confirmation_url)
+        elif user.is_active:
+            # Add email confirmation
+            mail_template = mails.CONFIRM_EMAIL
+            confirmation_url = '{}?logout=1'.format(confirmation_url)
+        elif campaign:
+            # Account creation confirmation: from campaign
+            mail_template = campaigns.email_template_for_campaign(campaign)
+            if campaigns.is_proxy_login(campaign) and campaigns.get_service_provider(campaign) != 'OSF':
+                branded_preprints_provider = campaigns.get_service_provider(campaign)
+            logo = campaigns.get_campaign_logo(campaign)
+        else:
+            # Account creation confirmation: from OSF
+            mail_template = mails.INITIAL_CONFIRM_EMAIL
 
-    campaign = campaigns.campaign_for_user(user)
-    branded_preprints_provider = None
-    logo = None
-    # Choose the appropriate email template to use and add existing_user flag if a merge or adding an email.
-    if external_id_provider and external_id:
-        # First time login through external identity provider, link or create an OSF account confirmation
-        if user.external_identity[external_id_provider][external_id] == 'CREATE':
-            mail_template = mails.EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE
-        elif user.external_identity[external_id_provider][external_id] == 'LINK':
-            mail_template = mails.EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK
-    elif merge_target:
-        # Merge account confirmation
-        mail_template = mails.CONFIRM_MERGE
-        confirmation_url = '{}?logout=1'.format(confirmation_url)
-    elif user.is_active:
-        # Add email confirmation
-        mail_template = mails.CONFIRM_EMAIL
-        confirmation_url = '{}?logout=1'.format(confirmation_url)
-    elif campaign:
-        # Account creation confirmation: from campaign
-        mail_template = campaigns.email_template_for_campaign(campaign)
-        if campaigns.is_proxy_login(campaign) and campaigns.get_service_provider(campaign) != 'OSF':
-            branded_preprints_provider = campaigns.get_service_provider(campaign)
-        logo = campaigns.get_campaign_logo(campaign)
-    else:
-        # Account creation confirmation: from OSF
-        mail_template = mails.INITIAL_CONFIRM_EMAIL
+        mails.send_mail(
+            email,
+            mail_template,
+            user=user,
+            confirmation_url=confirmation_url,
+            email=email,
+            merge_target=merge_target,
+            external_id_provider=external_id_provider,
+            branded_preprints_provider=branded_preprints_provider,
+            osf_support_email=settings.OSF_SUPPORT_EMAIL,
+            can_change_preferences=False,
+            logo=logo if logo else settings.OSF_LOGO
+        )
 
-    mails.send_mail(
-        email,
-        mail_template,
-        user=user,
-        confirmation_url=confirmation_url,
-        email=email,
-        merge_target=merge_target,
-        external_id_provider=external_id_provider,
-        branded_preprints_provider=branded_preprints_provider,
-        osf_support_email=settings.OSF_SUPPORT_EMAIL,
-        can_change_preferences=False,
-        logo=logo if logo else settings.OSF_LOGO
-    )
-
-    enqueue_postcommit_task(send_confirmation_email_task, args=(user.id, email), kwargs={})
+    enqueue_postcommit_task(send_email_task, [], {})
 
 
 def register_user(**kwargs):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3325,7 +3325,7 @@ class TestAuthViews(OsfTestCase):
         user = OSFUser.objects.get(username=email)
         assert_equal(user.accepted_terms_of_service, None)
 
-    @mock.patch('framework.auth.views.send_confirm_email')
+    @mock.patch('framework.auth.views._async')
     def test_register_scrubs_username(self, _):
         url = api_url_for('register_user')
         name = "<i>Eunice</i> O' \"Cornwallis\"<script type='text/javascript' src='http://www.cornify.com/js/cornify.js'></script><script type='text/javascript'>cornify_add()</script>"
@@ -3509,8 +3509,8 @@ class TestAuthViews(OsfTestCase):
         assert_true(new_user.check_password(password))
         assert_equal(new_user.fullname, real_name)
 
-    @mock.patch('framework.auth.views.send_confirm_email')
-    def test_register_sends_user_registered_signal(self, mock_send_confirm_email):
+    @mock.patch('framework.auth.views.send_confirm_email_async')
+    def test_register_sends_user_registered_signal(self, mock_send_confirm_email_async):
         url = api_url_for('register_user')
         name, email, password = fake.name(), fake_email(), 'underpressure'
         with capture_signals() as mock_signals:
@@ -3525,7 +3525,7 @@ class TestAuthViews(OsfTestCase):
             )
         assert_equal(mock_signals.signals_sent(), set([auth.signals.user_registered,
                                                        auth.signals.unconfirmed_user_created]))
-        assert_true(mock_send_confirm_email.called)
+        assert_true(mock_send_confirm_email_async.called)
 
     @mock.patch('framework.auth.views.mails.send_mail')
     def test_resend_confirmation(self, send_mail):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3325,7 +3325,7 @@ class TestAuthViews(OsfTestCase):
         user = OSFUser.objects.get(username=email)
         assert_equal(user.accepted_terms_of_service, None)
 
-    @mock.patch('framework.auth.views._async')
+    @mock.patch('framework.auth.views.send_confirm_email_async')
     def test_register_scrubs_username(self, _):
         url = api_url_for('register_user')
         name = "<i>Eunice</i> O' \"Cornwallis\"<script type='text/javascript' src='http://www.cornify.com/js/cornify.js'></script><script type='text/javascript'>cornify_add()</script>"

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -15,7 +15,7 @@ from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
 from framework.auth.decorators import must_be_confirmed
 from framework.auth.exceptions import ChangePasswordError
-from framework.auth.views import send_confirm_email
+from framework.auth.views import send_confirm_email_async
 from framework.auth.signals import (
     user_account_merged,
     user_account_deactivated,
@@ -84,7 +84,7 @@ def resend_confirmation(auth):
 
     # TODO: This setting is now named incorrectly.
     if settings.CONFIRM_REGISTRATIONS_BY_EMAIL:
-        send_confirm_email(user, email=address)
+        send_confirm_email_async(user, email=address)
         user.email_last_sent = timezone.now()
 
     user.save()
@@ -167,7 +167,7 @@ def update_user(auth):
                 if not throttle_period_expired(user.email_last_sent, settings.SEND_EMAIL_THROTTLE):
                     raise HTTPError(http_status.HTTP_400_BAD_REQUEST,
                                     data={'message_long': 'Too many requests. Please wait a while before adding an email to your account.'})
-                send_confirm_email(user, email=address)
+                send_confirm_email_async(user, email=address)
 
         ############
         # Username #


### PR DESCRIPTION
## Purpose

Move email confirmation to a post-commit task.

## Changes

- Moved send_confirm_email call to a post-commit task in UserEmailsSerializer.
- Defined send_confirm_email_async to handle email sending after database transactions are committed.

## QA Notes

The send_confirm_email function has been refactored to send_confirm_email_async across various parts of the codebase. 
- API User Email Creation (api/users/serializers.py):
Scenario: Adding a new email address to a user profile.

- API User Email Resend Confirmation (api/users/views.py):
Scenario: Resending confirmation email.

- User Registration (framework/auth/views.py):
Scenario: New user registration.

- Resend Confirmation Email (framework/auth/views.py):
Scenario: Resending a confirmation email.

- External Login Email Handling (framework/auth/views.py):
Scenario: Handling email submission for first-time OAuth login user.

- Resend Confirmation Email from Profile (website/profile/views.py):
Scenario: Resending a confirmation email from user profile.

- Update User Profile Emails (website/profile/views.py):
Scenario: Adding a new email to the user profile.

- General Email Throttling:
Scenario: Ensuring email throttling is respected.

## Ticket

https://openscience.atlassian.net/browse/ENG-4903
