### PR TITLE
Revert "[ENG-3685] Add permissions for withdrawn registration files"

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -318,9 +318,6 @@ def get_authenticated_resource(resource_id):
     if resource.deleted:
         raise HTTPError(http_status.HTTP_410_GONE, message='Resource has been deleted.')
 
-    if getattr(resource, 'is_retracted', False):
-        raise HTTPError(http_status.HTTP_410_GONE, message='Resource has been retracted.')
-
     return resource
 
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -441,6 +441,7 @@ class FileDetailSerializer(FileSerializer):
         guid = Guid.load(view.kwargs['file_id'])
         if guid:
             data['data']['id'] = guid._id
+
         return data
 
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -57,9 +57,6 @@ class FileMixin(object):
             if obj.target.creator.is_disabled:
                 raise Gone(detail='This user has been deactivated and their quickfiles are no longer available.')
 
-        if getattr(obj.target, 'is_retracted', False):
-            raise Gone(detail='The requested file is no longer available.')
-
         if check_permissions:
             # May raise a permission denied
             self.check_object_permissions(self.request, obj)

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -31,9 +31,6 @@ from website import settings as website_settings
 
 SessionStore = import_module(django_conf_settings.SESSION_ENGINE).SessionStore
 
-from addons.base.views import get_authenticated_resource
-from framework.exceptions import HTTPError
-
 # stolen from^W^Winspired by DRF
 # rest_framework.fields.DateTimeField.to_representation
 def _dt_to_iso8601(value):
@@ -642,10 +639,6 @@ class TestFileVersionView:
         }).save()
         return file
 
-    @pytest.fixture()
-    def file_url(self, file):
-        return '/{}files/{}/'.format(API_BASE, file._id)
-
     def test_listing(self, app, user, file):
         file.create_version(user, {
             'object': '0683m38e',
@@ -711,67 +704,6 @@ class TestFileVersionView:
             '/{}files/{}/versions/1/'.format(API_BASE, file._id),
             expect_errors=True, auth=user.auth,
         ).status_code == 405
-
-    def test_retracted_registration_file(self, app, user, file_url, file):
-        resource = RegistrationFactory(is_public=True)
-        retraction = resource.retract_registration(
-            user=resource.creator,
-            justification='Justification for retraction',
-            save=True,
-            moderator_initiated=False
-        )
-
-        retraction.accept()
-        resource.save()
-        resource.refresh_from_db()
-
-        file.target = resource
-        file.save()
-
-        res = app.get(file_url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 410
-
-    def test_retracted_file_returns_410(self, app, user, file_url, file):
-        resource = RegistrationFactory(is_public=True)
-        retraction = resource.retract_registration(
-            user=resource.creator,
-            justification='Justification for retraction',
-            save=True,
-            moderator_initiated=False
-        )
-
-        retraction.accept()
-        resource.save()
-        resource.refresh_from_db()
-
-        file.target = resource
-        file.save()
-
-        res = app.get(file_url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 410
-
-    def test_get_authenticated_resource_retracted(self):
-        resource = RegistrationFactory(is_public=True)
-
-        assert resource.is_retracted is False
-
-        retraction = resource.retract_registration(
-            user=resource.creator,
-            justification='Justification for retraction',
-            save=True,
-            moderator_initiated=False
-        )
-
-        retraction.accept()
-        resource.save()
-        resource.refresh_from_db()
-
-        assert resource.is_retracted is True
-
-        with pytest.raises(HTTPError) as excinfo:
-            get_authenticated_resource(resource._id)
-
-        assert excinfo.value.code == 410
 
 
 @pytest.mark.django_db
@@ -984,20 +916,20 @@ class TestPreprintFileView:
 
         # Unauthenticated
         res = app.get(file_url, expect_errors=True)
-        assert res.status_code == 410
+        assert res.status_code == 401
 
         # Noncontrib
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
-        assert res.status_code == 410
+        assert res.status_code == 403
 
         # Write contributor
         preprint.add_contributor(other_user, WRITE, save=True)
         res = app.get(file_url, auth=other_user.auth, expect_errors=True)
-        assert res.status_code == 410
+        assert res.status_code == 403
 
         # Admin contrib
         res = app.get(file_url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 410
+        assert res.status_code == 403
 
 @pytest.mark.django_db
 class TestShowAsUnviewed:


### PR DESCRIPTION
Reverts CenterForOpenScience/osf.io#10650

Revert this for the time being to avoid having it go out with the upcoming python-upgrade release.