### PR TITLE
Don't create an "everyone" entry for GRAVY_WAFFLE

### DIFF
--- a/osf/features.yaml
+++ b/osf/features.yaml
@@ -17,7 +17,7 @@ flags:
     note: This is used to enable GravyValet, the system responible for addons, this will remove the files widget on the
           project overview page. Will be used with EMBER_USER_SETTINGS_ADDONS and EMBER_NODE_SETTINGS_ADDONS to flip all
           UI elements to the new addons system.
-    everyone: false
+    everyone: null
 
   - flag_name: EMBER_FILE_PROJECT_DETAIL
     name: ember_file_project_detail_page


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the `features.yaml` to keep it from blocking access to GravyValet integrations on every server restart.

Context: In `waffle`, setting a value for `everyone` overrides any other values. As such, having a default `everyone: false` for `GRAVY_WAFFLE` was preventing superusers from accessing GV features for integration. 

## Changes
Change the `everyone` value for `GRAVY_WAFFLE` from `false` to `null`

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
