### PR TITLE
[ENG-5848] Add button to admin to move preprint from initial to pending

### DIFF
--- a/admin/preprints/forms.py
+++ b/admin/preprints/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 
 from osf.models import Preprint
-
+from osf.utils.workflows import ReviewStates
 
 class ChangeProviderForm(forms.ModelForm):
     class Meta:
@@ -13,3 +13,21 @@ class MachineStateForm(forms.ModelForm):
     class Meta:
         model = Preprint
         fields = ('machine_state',)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if not self.instance.is_public:
+            self.fields['machine_state'].widget.attrs['disabled'] = 'disabled'
+        else:
+            if self.instance.machine_state == ReviewStates.INITIAL.db_name:
+                self.fields['machine_state'].choices = [
+                    (ReviewStates.INITIAL.value, ReviewStates.INITIAL.value),
+                    (ReviewStates.PENDING.value, ReviewStates.PENDING.value),
+                ]
+            else:
+                # Disabled Option you are on
+                self.fields['machine_state'].widget.attrs['disabled'] = 'disabled'
+                self.fields['machine_state'].choices = [
+                    (self.instance.machine_state.title(), self.instance.machine_state)
+                ]

--- a/admin/preprints/forms.py
+++ b/admin/preprints/forms.py
@@ -7,3 +7,9 @@ class ChangeProviderForm(forms.ModelForm):
     class Meta:
         model = Preprint
         fields = ('provider',)
+
+
+class MachineStateForm(forms.ModelForm):
+    class Meta:
+        model = Preprint
+        fields = ('machine_state',)

--- a/admin/preprints/urls.py
+++ b/admin/preprints/urls.py
@@ -10,6 +10,8 @@ urlpatterns = [
     re_path(r'^known_ham$', views.PreprintKnownHamList.as_view(), name='known-ham'),
     re_path(r'^withdrawal_requests$', views.PreprintWithdrawalRequestList.as_view(), name='withdrawal-requests'),
     re_path(r'^(?P<guid>[a-z0-9]+)/$', views.PreprintView.as_view(), name='preprint'),
+    re_path(r'^(?P<guid>[a-z0-9]+)/change_provider/$', views.PreprintProviderChangeView.as_view(), name='preprint-provider'),
+    re_path(r'^(?P<guid>[a-z0-9]+)/machine_state/$', views.PreprintMachineStateView.as_view(), name='preprint-machine-state'),
     re_path(r'^(?P<guid>[a-z0-9]+)/reindex_share_preprint/$', views.PreprintReindexShare.as_view(),
         name='reindex-share-preprint'),
     re_path(r'^(?P<guid>[a-z0-9]+)/remove_user/(?P<user_id>[a-z0-9]+)/$', views.PreprintRemoveContributorView.as_view(),

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -103,8 +103,8 @@ class PreprintMachineStateView(PreprintMixin, GuidView):
 
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
-        new_machine_state = request.POST['machine_state']
-        if preprint.machine_state != new_machine_state:
+        new_machine_state = request.POST.get('machine_state')
+        if new_machine_state and preprint.machine_state != new_machine_state:
             preprint.machine_state = new_machine_state
             preprint.save()
             preprint.refresh_from_db()

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -15,7 +15,7 @@ from django.urls import reverse_lazy
 from admin.base.views import GuidView
 from admin.base.forms import GuidForm
 from admin.nodes.views import NodeRemoveContributorView
-from admin.preprints.forms import ChangeProviderForm
+from admin.preprints.forms import ChangeProviderForm, MachineStateForm
 
 from api.share.utils import update_share
 
@@ -62,6 +62,21 @@ class PreprintView(PreprintMixin, GuidView):
     """
     template_name = 'preprints/preprint.html'
     permission_required = ('osf.view_preprint', 'osf.change_preprint',)
+
+    def get_context_data(self, **kwargs):
+        preprint = self.get_object()
+        return super().get_context_data(**{
+            'preprint': preprint,
+            'SPAM_STATUS': SpamStatus,
+            'change_provider_form': ChangeProviderForm(instance=preprint),
+            'change_machine_state_form': MachineStateForm(instance=preprint),
+        }, **kwargs)
+
+
+class PreprintProviderChangeView(PreprintMixin, GuidView):
+    """ Allows authorized users to view preprint info and change a preprint's provider.
+    """
+    permission_required = ('osf.view_preprint', 'osf.change_preprint',)
     form_class = ChangeProviderForm
 
     def post(self, request, *args, **kwargs):
@@ -79,13 +94,22 @@ class PreprintView(PreprintMixin, GuidView):
 
         return redirect(self.get_success_url())
 
-    def get_context_data(self, **kwargs):
+
+class PreprintMachineStateView(PreprintMixin, GuidView):
+    """ Allows authorized users to view preprint info and change a preprint's machine_state.
+    """
+    permission_required = ('osf.view_preprint', 'osf.change_preprint',)
+    form_class = MachineStateForm
+
+    def post(self, request, *args, **kwargs):
         preprint = self.get_object()
-        return super().get_context_data(**{
-            'preprint': preprint,
-            'SPAM_STATUS': SpamStatus,
-            'form': ChangeProviderForm(instance=preprint),
-        }, **kwargs)
+        new_machine_state = request.POST['machine_state']
+        if preprint.machine_state != new_machine_state:
+            preprint.machine_state = new_machine_state
+            preprint.save()
+            preprint.refresh_from_db()
+
+        return redirect(self.get_success_url())
 
 
 class PreprintSearchView(PermissionRequiredMixin, FormView):

--- a/admin/templates/preprints/machine_state.html
+++ b/admin/templates/preprints/machine_state.html
@@ -1,0 +1,22 @@
+{% load node_extras %}
+<tr>
+    <td>Machine State</td>
+    <td>
+        <h4 >{{ preprint.machine_state }}</h4>
+        <h4 >{{ preprint.state }}</h4>
+        {% if perms.osf.change_preprint %}
+            <a class="btn btn-link" role="button" data-toggle="collapse" href="#collapseChangeMachineState">
+                Change preprint machine_state
+            </a>
+            <div class="collapse" id="collapseChangeMachineState">
+                <div class="well">
+                    <form action="{% url 'preprints:preprint-machine-state' guid=preprint.guid %}" method="post">
+                        {% csrf_token %}
+                        {{ change_machine_state_form.as_p }}
+                        <input class="btn-btn-primary" type="submit" value="Submit" />
+                    </form>
+                </div>
+            </div>
+        {% endif %}
+    </td>
+</tr>

--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -74,10 +74,6 @@
                         <td>Published</td>
                         <td>{{ preprint.is_published }}</td>
                     </tr>
-                    <tr>
-                        <td>Machine State</td>
-                        <td>{{ preprint.machine_state }}</td>
-                    </tr>
                     {%  if preprint.is_published %}
                         <tr>
                             <td>Date Published</td>
@@ -104,6 +100,7 @@
                         </tr>
                     {% endif %}
                     {% include "preprints/provider.html" with preprint=preprint %}
+                    {% include "preprints/machine_state.html" with preprint=preprint %}
                     <tr>
                         <td>Subjects</td>
                         <td>

--- a/admin/templates/preprints/provider.html
+++ b/admin/templates/preprints/provider.html
@@ -9,9 +9,9 @@
             </a>
             <div class="collapse" id="collapseChangeProvider">
                 <div class="well">
-                    <form action="{% url 'preprints:preprint' guid=preprint.guid %}" method="post">
+                    <form action="{% url 'preprints:preprint-provider' guid=preprint.guid %}" method="post">
                         {% csrf_token %}
-                        {{ form.as_p }}
+                        {{ change_provider_form.as_p }}
                         <input class="btn-btn-primary" type="submit" value="Submit" />
                     </form>
                 </div>


### PR DESCRIPTION
## Purpose

Allows admins to adjust preprint machine state

## Changes

- Splits `PreprintView` into a GET only view and makes Form view `PreprintProviderChangeView`
- add `PreprintMachineStateView`
- adds tests
- remove ald machine_state label

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5848