### PR TITLE
[ENG-4527] Fix citation to use registered date

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -700,7 +700,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             csl['DOI'] = doi
 
         if self.logs.exists():
-            csl['issued'] = datetime_to_csl(self.logs.latest().date)
+            csl['issued'] = datetime_to_csl(self.registered_date)
 
         return csl
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -699,8 +699,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         if doi:
             csl['DOI'] = doi
 
-        if self.logs.exists():
+        if self.registered_date:
             csl['issued'] = datetime_to_csl(self.registered_date)
+        else:
+            if self.logs.exists():
+                csl['issued'] = datetime_to_csl(self.logs.latest().date)
 
         return csl
 


### PR DESCRIPTION
## Purpose

Fix the citation generation to use the registered_date instead of the last log date.

## Changes

Updated the csl property to set the issued value to registered_date in the citation format.

## Ticket

<(https://openscience.atlassian.net/browse/ENG-4527)>
