### PR TITLE
[fix] usable waffle admin

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -373,3 +373,5 @@ TRAVIS_ENV = False
 
 CITATION_STYLES_REPO_URL = 'https://github.com/CenterForOpenScience/styles/archive/88e6ed31a91e9f5a480b486029cda97b535935d4.zip'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+WAFFLE_ENABLE_ADMIN_PAGES = False  # instead, customized waffle admins in osf/admin.py

--- a/osf/admin.py
+++ b/osf/admin.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import Group
 from django.db.models import Q, Count
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+import waffle
 
 from osf.external.spam.tasks import reclassify_domain_references
 from osf.models import OSFUser, Node, NotableDomain, NodeLicense
@@ -140,7 +141,20 @@ class NotableDomainAdmin(admin.ModelAdmin):
         qs = super().get_queryset(request).annotate(number_of_references=Count('domainreference'))
         return qs
 
+
+class _ManygroupWaffleFlagAdmin(waffle.admin.FlagAdmin):
+    '''customized `waffle.admin.FlagAdmin` to support many groups
+
+    (reverse incorrect assumption in https://github.com/jazzband/django-waffle/commit/bf36c19ee03baf1c5850ffe0b284900a5c416f53 )
+    '''
+    raw_id_fields = (*waffle.admin.FlagAdmin.raw_id_fields, 'groups')
+
+
 admin.site.register(OSFUser, OSFUserAdmin)
 admin.site.register(Node, NodeAdmin)
 admin.site.register(NotableDomain, NotableDomainAdmin)
 admin.site.register(NodeLicense, LicenseAdmin)
+
+admin.site.register(waffle.models.Flag, _ManygroupWaffleFlagAdmin)
+admin.site.register(waffle.models.Sample, waffle.admin.SampleAdmin)
+admin.site.register(waffle.models.Switch, waffle.admin.SwitchAdmin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ google-api-python-client==1.6.4
 Babel==2.9.1
 citeproc-py==0.4.0
 boto3==1.4.7
-django-waffle==2.4.1
+django-waffle==2.5.0  # TODO: 4.1.0 when python 3.8+
 pymongo==3.7.1
 PyYAML==6.0.1
 tqdm==4.28.1


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
make it possible to edit waffle flags thru the osf admin (`/admin/waffle/flag/`)
<!-- Describe the purpose of your changes -->

## Changes
- upgrade waffle (by only one version) to allow disabling default model admins
- disable default waffle admins, instead register in `osf/admin.py`
- customize `Flag` admin: add `'groups'` to `raw_id_fields`
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify can view flags in the osf admin at `/admin/waffle/flag/`, can click on a flag to view details, and can save changes to flag config

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
