### PR TITLE
Docs for what I had to do to run the updated Dockfile locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache --virtual .run-deps \
     libxslt \
     libpq-dev \
     libffi \
+    libffi-dev \
     libev \
     libevent \
     && yarn global add bower \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
     ports:
       - 5432:5432
     environment:
+      POSTGRES_DB: osf
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_SQL: |
         SELECT 'CREATE DATABASE gravyvalet' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'gravyvalet')\gexec
     volumes:


### PR DESCRIPTION
## Purpose

This should help you run the OSF locally if you have the following versions:


Works with: 
Mac OS 14.5 M2 with Docker version 27.1.1
Mac OS 14.1.1. and  Docker version 25.0.3


4.33.0 (160616)

Help people set up the new Dockerfile image for py3 locally and adjust the docker config for good locally use.
## Changes

- adds libcffi-dev to Dockerfile preventing [this error](https://gist.github.com/Johnetordoff/33b39ad275ccf7d5f3025ecfbc825d92)
- adds some env vars to pass auth info to postgress

## QA Notes

What I did:

0. Stop and remove all containers and purge images and volumes
1. Build the image  ` docker build -t osf-py3 .`  (if I don't include `libffi-dev` it crashes)
2. overwrite `docker-compose.override.yml` to use that image:
```
## Reference README-docker-compose.md for instructions.

#
services:

  #######
  # OSF #
  #######

  requirements:
    image: osf-py3
    platform: linux/arm64

  assets:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true

  admin_assets:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true

  worker:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true

  admin:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true

  api:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true

  web:
    image: osf-py3
    platform: linux/arm64
    # Need to allocate tty to be able to call invoke for requirements task
    tty: true
```

4. run `docker compose up -d --force-recreate requirements`  (this seems to require restarting sometimes check that it exits with: 
```
requirements-1  |   - Installing pytest-socket (0.7.0)
requirements-1  |   - Installing pytest-testmon (2.1.0)
requirements-1  |   - Installing pytest-xdist (3.5.0)
requirements-1  |   - Installing python-coveralls (2.9.3)
requirements-1  |   - Installing responses (0.25.0)
requirements-1  |   - Installing schema (0.7.4)
requirements-1  |   - Installing webtest-plus (1.0.0)
requirements-1 exited with code 0
```

5.) run `docker compose up -d --force-recreate api web` this should show a postgres connection to an unmigrated DB:
```
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 102, in execute
api-1  |     return super().execute(sql, params)
api-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 67, in execute
api-1  |     return self._execute_with_wrappers(
api-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
api-1  |     return executor(sql, params, many, context)
api-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 84, in _execute
api-1  |     with self.db.wrap_database_errors:
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
api-1  |     raise dj_exc_value.with_traceback(traceback) from exc_value
api-1  |   File "/usr/local/lib/python3.12/site-packages/django/db/backends/utils.py", line 89, in _execute
api-1  |     return self.cursor.execute(sql, params)
api-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1  | django.db.utils.ProgrammingError: relation "osf_institution" does not exist
api-1  | LINE 1: SELECT "osf_institution"."domains" FROM "osf_institution" WH...
api-1  |                                                 ^
api-1  |
```

6.) run `docker compose exec web /bin/bash` to access the docker container and ` python manage.py migrate` to migrate the DB to current. 

7) `python -V` to check you are 100% on the right version 3.12!





What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
