### PR TITLE
[CR][ENG-6019][ENG-6021][ENG-6023] hotfixes for recent python-upgrade release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.17 as base
+FROM python:3.12-alpine3.17 AS base
 
 # Creation of www-data group was removed as it is created by default in alpine 3.14 and higher
 # Alpine does not create a www-data user, so we still need to create that. 82 is the standard
@@ -30,7 +30,7 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_OPTIONS_ALWAYS_COPY=1 \
     POETRY_VIRTUALENVS_CREATE=0
 
-FROM base as build
+FROM base AS build
 
 ENV POETRY_VIRTUALENVS_IN_PROJECT=1 \
     YARN_CACHE_FOLDER=/tmp/yarn-cache \
@@ -128,7 +128,7 @@ RUN \
 COPY ./ ./
 
 ARG GIT_COMMIT=
-ENV GIT_COMMIT ${GIT_COMMIT}
+ENV GIT_COMMIT=${GIT_COMMIT}
 
 # TODO: Admin/API should fully specify their bower static deps, and not
 #       include ./website/static in their defaults.py.
@@ -149,7 +149,7 @@ RUN for module in \
    ; done \
    && rm ./website/settings/local.py ./api/base/settings/local.py
 
-FROM base as runtime
+FROM base AS runtime
 
 WORKDIR /code
 COPY --from=build /usr/local/lib/python3.12 /usr/local/lib/python3.12

--- a/addons/dataverse/requirements.txt
+++ b/addons/dataverse/requirements.txt
@@ -1,3 +1,3 @@
 # Allow for optional timeout parameter.
 # https://github.com/IQSS/dataverse-client-python/pull/27
-git+https://github.com/CenterForOpenScience/dataverse-client-python.git@feature/dv-client-updates
+git+https://github.com/CenterForOpenScience/dataverse-client-python.git@2b3827578048e6df3818f82381c7ea9a2395e526 # branch is feature/dv-client-updates

--- a/addons/mendeley/requirements.txt
+++ b/addons/mendeley/requirements.txt
@@ -1,2 +1,2 @@
 # up-to-date with mendeley's master + add folder support and future dep updates
-git+https://github.com/CenterForOpenScience/mendeley-python-sdk.git@feature/osf-dep-updates
+git+https://github.com/CenterForOpenScience/mendeley-python-sdk.git@be8a811fa6c3b105d9f5c656cabb6b1ba855ed5b # branch is feature/osf-dep-updates

--- a/api/ia/views.py
+++ b/api/ia/views.py
@@ -30,7 +30,7 @@ class IACallbackView(APIView):
 
     def post(self, request, *args, **kwargs):
         registration = self.get_object()
-        ia_url = json.loads(request._request._body.decode())['ia_url']
+        ia_url = json.loads(request.body)['ia_url']
         registration.ia_url = ia_url
         registration.save()
         return JsonResponse({'status': 'complete'})

--- a/docker-compose-dist-arm64.override.yml
+++ b/docker-compose-dist-arm64.override.yml
@@ -1,7 +1,5 @@
 ## Reference README-docker-compose.md for instructions.
 
-version: '3.4'
-
 services:
 
   #######

--- a/docker-compose-dist.override.yml
+++ b/docker-compose-dist.override.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # Additional configuration for development on services linked with osf.io
 # services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 # Reference README-docker-compose.md for instructions.
 
-version: '3.5'
-
 volumes:
   redis_data_vol:
     external: false

--- a/osf/metrics/reports.py
+++ b/osf/metrics/reports.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.dispatch import receiver
-from elasticsearch_dsl import InnerDoc
+from elasticsearch6_dsl import InnerDoc
 from elasticsearch_metrics import metrics
 from elasticsearch_metrics.signals import pre_save as metrics_pre_save
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -368,13 +368,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.146"
+version = "1.34.147"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.146-py3-none-any.whl", hash = "sha256:3fd4782362bd29c192704ebf859c5c8c5189ad05719e391eefe23088434427ae"},
-    {file = "botocore-1.34.146.tar.gz", hash = "sha256:849cb8e54e042443aeabcd7822b5f2b76cb5cfe33fe3a71f91c7c069748a869c"},
+    {file = "botocore-1.34.147-py3-none-any.whl", hash = "sha256:be94a2f4874b1d1705cae2bd512c475047497379651678593acb6c61c50d91de"},
+    {file = "botocore-1.34.147.tar.gz", hash = "sha256:2e8f000b77e4ca345146cb2edab6403769a517b564f627bb084ab335417f3dbe"},
 ]
 
 [package.dependencies]
@@ -1128,8 +1128,8 @@ tests = ["factory-boy (==2.11.1)", "mock", "pytest", "pytest-django (==3.10.0)"]
 
 [package.source]
 type = "git"
-url = "https://github.com/CenterForOpenScience/django-elasticsearch-metrics"
-reference = "feature/pin-esdsl"
+url = "https://github.com/CenterForOpenScience/django-elasticsearch-metrics.git"
+reference = "f5b9312914154e213aa01731e934c593e3434269"
 resolved_reference = "f5b9312914154e213aa01731e934c593e3434269"
 
 [[package]]
@@ -1284,7 +1284,7 @@ develop = false
 
 [package.source]
 type = "git"
-url = "https://github.com/felliott/django-webpack-loader.git"
+url = "https://github.com/CenterForOpenScience/django-webpack-loader.git"
 reference = "af8438c2da909ec9f2188a6c07c9d2caad0f7e93"
 resolved_reference = "af8438c2da909ec9f2188a6c07c9d2caad0f7e93"
 
@@ -2813,7 +2813,7 @@ requests-oauthlib = ">=0.4.2"
 [package.source]
 type = "git"
 url = "https://github.com/CenterForOpenScience/mendeley-python-sdk.git"
-reference = "feature/osf-dep-updates"
+reference = "be8a811fa6c3b105d9f5c656cabb6b1ba855ed5b"
 resolved_reference = "be8a811fa6c3b105d9f5c656cabb6b1ba855ed5b"
 
 [[package]]
@@ -5013,4 +5013,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "be88170e95e44e88a6112fae04f2bc11ba75603bedc424c01127d67b4d6c450e"
+content-hash = "78f529cdfdc2cbc64c62d3acb53e096f6a7090ade7e3ee70a232b059061ec13d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osf-io"
-version = "24.05.0"
+version = "24.05.2"
 description = "The code for [https://osf.io](https://osf.io)."
 authors = ["Your Name <you@example.com>"]
 license = "Apache License 2.0"
@@ -73,7 +73,7 @@ cryptography = "42.0.5"
 jsonschema = "4.21.1"
 django-guardian = "2.4.0"
 # Admin requirements
-django-webpack-loader = {git = "https://github.com/felliott/django-webpack-loader.git", rev = "af8438c2da909ec9f2188a6c07c9d2caad0f7e93"}
+django-webpack-loader = {git = "https://github.com/CenterForOpenScience/django-webpack-loader.git", rev = "af8438c2da909ec9f2188a6c07c9d2caad0f7e93"} # branch is feature/v1-webpack-stats
 django-sendgrid-v5 = "1.2.3" # metadata says python 3.10 not supported, but tests pass
 
 # Analytics requirements
@@ -94,7 +94,7 @@ datacite = "1.1.3"
 rdflib = "7.0.0"
 colorlog = "6.8.2"
 # Metrics
-django-elasticsearch-metrics = {git ="https://github.com/CenterForOpenScience/django-elasticsearch-metrics", branch = "feature/pin-esdsl"}
+django-elasticsearch-metrics = {git ="https://github.com/CenterForOpenScience/django-elasticsearch-metrics.git", rev = "f5b9312914154e213aa01731e934c593e3434269"} # branch is feature/pin-esdsl
 # Impact Metrics CSV Export
 djangorestframework-csv = "3.0.2"
 gevent = "24.2.1"
@@ -144,7 +144,7 @@ asgiref = "3.7.2"
 boxsdk = "3.9.2"
 # Allow for optional timeout parameter.
 # https://github.com/IQSS/dataverse-client-python/pull/27
-dataverse = {git = "https://github.com/CenterForOpenScience/dataverse-client-python.git", rev="2b3827578048e6df3818f82381c7ea9a2395e526"}
+dataverse = {git = "https://github.com/CenterForOpenScience/dataverse-client-python.git", rev="2b3827578048e6df3818f82381c7ea9a2395e526"} # branch is feature/dv-client-updates
 dropbox = "11.36.2"
 
 cachecontrol = "0.14.0"
@@ -152,7 +152,7 @@ cachecontrol = "0.14.0"
 uritemplate = "4.1.1"
 python-gitlab = "4.4.0"
 # up-to-date with mendeley's master + add folder support and future dep updates
-mendeley = {git = "https://github.com/CenterForOpenScience/mendeley-python-sdk.git", rev="feature/osf-dep-updates"}
+mendeley = {git = "https://github.com/CenterForOpenScience/mendeley-python-sdk.git", rev="be8a811fa6c3b105d9f5c656cabb6b1ba855ed5b"} # branch is feature/osf-dep-updates
 # Requirements for the owncloud add-on
 pyocclient = "0.6.0"
 boto3 = "1.34.60"

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ django-guardian==2.4.0
 
 # Admin requirements
 # django-webpack-loader==3.1.0
-git+https://github.com/felliott/django-webpack-loader@feature/old-style-peanut-butter
+git+https://github.com/CenterForOpenScience/django-webpack-loader.git@af8438c2da909ec9f2188a6c07c9d2caad0f7e93 # branch is feature/v1-webpack-stats
 django-sendgrid-v5==1.2.3 # metadata says python 3.10 not supported, but tests pass
 
 # Analytics requirements
@@ -100,7 +100,7 @@ packaging==24.0
 
 colorlog==6.8.2
 # Metrics
-git+https://github.com/CenterForOpenScience/django-elasticsearch-metrics@feature/pin-esdsl
+git+https://github.com/CenterForOpenScience/django-elasticsearch-metrics.git@f5b9312914154e213aa01731e934c593e3434269 # branch is feature/pin-esdsl
 
 # Impact Metrics CSV Export
 djangorestframework-csv==3.0.2


### PR DESCRIPTION
## Purpose

Fix brokes and nits in:

 * admin metrics reports
 * IA archiving failures
 * Dockerfile cleanups
 * docker-compose cleanups
 * pinning pyproject.toml github deps to commit shas rather than branches
 * others to come?

## Changes

* use the correct `elasticsearch_dsl` module in our metric reports
* stop using protected method for IA archiving
* update pyproject.toml deps to point to commit shas (add comment with name of branch for reference)
* fix a few nitpicks from recent Docker
* remove deprecated `version` stanza from Dockerfiles

## QA Notes

* verify on admin app that metrics are correct
* verify that new registrations are being archived

## Documentation

nope, nope, nope

## Side Effects

None expected.

## Tickets

* ✅ ENG-6019: https://openscience.atlassian.net/browse/ENG-6019
* ✅ ENG-6021: https://openscience.atlassian.net/browse/ENG-6021
* ~~🔲  ENG-6022: https://openscience.atlassian.net/browse/ENG-6022~~ - deferred
* ✅ ENG-6023: https://openscience.atlassian.net/browse/ENG-6023
* ~~🔲  ENG-6024: https://openscience.atlassian.net/browse/ENG-6024~~ - deferred indefinitely
* ~~🔲  ENG-6025: https://openscience.atlassian.net/browse/ENG-6025~~ - deferred