### PR TITLE
[ENG-5994] Ensure Resubmitted Preprints Enter Moderation Queue and Trigger Notifications

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -297,10 +297,13 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         save_preprint = False
         recently_published = False
 
+        status_changed = False
+
         primary_file = validated_data.pop('primary_file', None)
         if primary_file:
             self.set_field(preprint.set_primary_file, primary_file, auth)
             save_preprint = True
+            status_changed = True
 
         old_tags = set(preprint.tags.values_list('name', flat=True))
         if 'tags' in validated_data:
@@ -424,6 +427,10 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             preprint.set_privacy('public', log=False, save=True)
 
         if save_preprint:
+            preprint.save()
+
+        if status_changed:
+            preprint.status = 'waiting_for_moderation'
             preprint.save()
 
         if recently_published:

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -47,7 +47,7 @@ from osf.models import (
     NodeLicense,
 )
 from osf.utils import permissions as osf_permissions
-from osf.utils.workflows import ApprovalStates
+from osf.utils.workflows import DefaultStates
 
 from osf.exceptions import PreprintStateError
 
@@ -431,7 +431,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             preprint.save()
 
         if status_changed:
-            preprint.state = ApprovalStates.PENDING_MODERATION
+            preprint.state = DefaultStates.PENDING
             preprint.save()
 
         if recently_published:

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -47,6 +47,7 @@ from osf.models import (
     NodeLicense,
 )
 from osf.utils import permissions as osf_permissions
+from osf.utils.workflows import ApprovalStates
 
 from osf.exceptions import PreprintStateError
 
@@ -430,7 +431,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             preprint.save()
 
         if status_changed:
-            preprint.status = 'waiting_for_moderation'
+            preprint.state = ApprovalStates.PENDING_MODERATION
             preprint.save()
 
         if recently_published:

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -8,7 +8,7 @@ from rest_framework import permissions as drf_permissions
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import ReviewAction, Preprint, PreprintContributor, PreprintLog
 from osf.utils.requests import check_select_for_update
-from osf.utils.workflows import ApprovalStates
+from osf.utils.workflows import DefaultStates
 
 from api.actions.permissions import ReviewActionPermission
 from api.actions.serializers import ReviewActionSerializer
@@ -213,8 +213,8 @@ class PreprintDetail(PreprintMetricsViewMixin, JSONAPIBaseView, generics.Retriev
                 },
                 auth=auth,
             )
-            if instance.machine_state != ApprovalStates.PENDING_MODERATION.value:
-                instance.machine_state = ApprovalStates.PENDING_MODERATION.value
+            if instance.machine_state != DefaultStates.PENDING.value:
+                instance.machine_state = DefaultStates.PENDING.value
 
         if 'is_published' in request.data:
             published = request.data['is_published']

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -208,7 +208,7 @@ class PreprintDetail(PreprintMetricsViewMixin, JSONAPIBaseView, generics.Retriev
                 action=PreprintLog.FILE_UPDATED,
                 params={
                     'preprint': instance._id,
-                    'file': instance.primary_file._id
+                    'file': instance.primary_file._id,
                 },
                 auth=auth,
             )

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -8,6 +8,7 @@ from rest_framework import permissions as drf_permissions
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import ReviewAction, Preprint, PreprintContributor, PreprintLog
 from osf.utils.requests import check_select_for_update
+from osf.utils.workflows import ApprovalStates
 
 from api.actions.permissions import ReviewActionPermission
 from api.actions.serializers import ReviewActionSerializer
@@ -212,6 +213,8 @@ class PreprintDetail(PreprintMetricsViewMixin, JSONAPIBaseView, generics.Retriev
                 },
                 auth=auth,
             )
+            if instance.machine_state != ApprovalStates.PENDING_MODERATION.value:
+                instance.machine_state = ApprovalStates.PENDING_MODERATION.value
 
         if 'is_published' in request.data:
             published = request.data['is_published']

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -222,7 +222,6 @@ class PreprintDetail(PreprintMetricsViewMixin, JSONAPIBaseView, generics.Retriev
                     params={'preprint': instance._id},
                     auth=auth,
                 )
-                instance.notify_user_submitted(auth.user)
 
         instance.save()
 

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -11,7 +11,6 @@ from waffle.testutils import (
 
 from osf import features
 from osf.utils.permissions import READ
-from osf.utils.workflows import ApprovalStates
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from api_tests.subjects.mixins import UpdateSubjectsMixin

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -510,7 +510,6 @@ class TestPreprintUpdate:
 
         assert preprint.machine_state == ApprovalStates.PENDING_MODERATION.value
 
-
     def test_update_preprints_with_none_type(self, app, user, preprint, url):
         payload = {
             'data': {

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -502,13 +502,13 @@ class TestPreprintUpdate:
 
         preprint.reload()
         assert preprint.primary_file == new_file
-        assert int(preprint.machine_state) == ApprovalStates.PENDING_MODERATION.value
+        assert int(preprint.machine_state) == DefaultStates.PENDING.value
 
         log = preprint.logs.latest()
         assert log.action == PreprintLog.FILE_UPDATED
         assert log.params.get('preprint') == preprint._id
 
-        assert int(preprint.machine_state) == ApprovalStates.PENDING_MODERATION.value
+        assert int(preprint.machine_state) == DefaultStates.PENDING.value
 
     def test_update_preprints_with_none_type(self, app, user, preprint, url):
         payload = {

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -501,13 +501,13 @@ class TestPreprintUpdate:
 
         preprint.reload()
         assert preprint.primary_file == new_file
-        assert int(preprint.machine_state) == DefaultStates.PENDING.value
+        assert preprint.machine_state == DefaultStates.PENDING.value
 
         log = preprint.logs.latest()
         assert log.action == PreprintLog.FILE_UPDATED
         assert log.params.get('preprint') == preprint._id
 
-        assert int(preprint.machine_state) == DefaultStates.PENDING.value
+        assert preprint.machine_state == DefaultStates.PENDING.value
 
     def test_update_preprints_with_none_type(self, app, user, preprint, url):
         payload = {

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -502,13 +502,13 @@ class TestPreprintUpdate:
 
         preprint.reload()
         assert preprint.primary_file == new_file
-        assert preprint.machine_state == ApprovalStates.PENDING_MODERATION.value
+        assert int(preprint.machine_state) == ApprovalStates.PENDING_MODERATION.value
 
         log = preprint.logs.latest()
         assert log.action == PreprintLog.FILE_UPDATED
         assert log.params.get('preprint') == preprint._id
 
-        assert preprint.machine_state == ApprovalStates.PENDING_MODERATION.value
+        assert int(preprint.machine_state) == ApprovalStates.PENDING_MODERATION.value
 
     def test_update_preprints_with_none_type(self, app, user, preprint, url):
         payload = {

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -497,21 +497,17 @@ class TestPreprintUpdate:
         update_file_payload = build_preprint_update_payload(
             preprint._id, relationships=relationships)
 
-        # Send the update request
         res = app.patch_json_api(url, update_file_payload, auth=user.auth)
         assert res.status_code == 200
 
-        # Reload the preprint and verify changes
         preprint.reload()
         assert preprint.primary_file == new_file
         assert preprint.machine_state == ApprovalStates.PENDING_MODERATION.value
 
-        # Verify the creation of a log entry
         log = preprint.logs.latest()
         assert log.action == PreprintLog.FILE_UPDATED
         assert log.params.get('preprint') == preprint._id
 
-        # Check that the state has been updated
         assert preprint.machine_state == ApprovalStates.PENDING_MODERATION.value
 
 


### PR DESCRIPTION
## Purpose

Ensure Resubmitted Preprints Enter Moderation Queue and Trigger Notifications

## Changes

- Added perform_update method that handles the update of the primary file and logs the action
- Sets the status_changed flag when updates to the primary file are made

## Ticket

(https://openscience.atlassian.net/browse/ENG-5994)
