### PR TITLE
[ENG-6094] Poetry won't install deps properly in when venv is inside project root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -358,7 +358,7 @@ services:
       - /bin/bash
       - -c
       - python -m venv /tmp/venv
-        && /tmp/venv/bin/pip install poetry==1.8.0 &&
+        && /tmp/venv/bin/pip install poetry==1.8.3 &&
         /tmp/venv/bin/poetry install --no-root --without release --compile --sync &&
         rm -rf /python3.12/* &&
         cp -Rf -p /usr/local/lib/python3.12 /
@@ -366,7 +366,8 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
     volumes:
-      - ./:/code:cached
+      - ./pyproject.toml:/code/pyproject.toml
+      - ./poetry.lock:/code/poetry.lock
       - osf_requirements_3_12_vol:/python3.12
 
   assets:


### PR DESCRIPTION
## Purpose

Fix devenv setup for people who use virtualenv inside project root in conjuction with docker-compose

## Changes

Changed mount for `docker-compose` `requirements` service 

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-6094](https://openscience.atlassian.net/browse/ENG-6094)



[ENG-6094]: https://openscience.atlassian.net/browse/ENG-6094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ