### PR TITLE
[ENG-5908] Add Test Confirming Preprint Affiliated Iinstitution Data is Sent to SHARE

### DIFF
--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -538,6 +538,7 @@ class TestOsfGathering(TestCase):
         institution_iri = URIRef(institution.ror_uri)
         self.user__admin.add_or_update_affiliated_institution(institution)
         self.project.add_affiliated_institution(institution, self.user__admin)
+        self.preprint.add_affiliated_institution(institution, self.user__admin)
         assert_triples(osf_gathering.gather_affiliated_institutions(self.projectfocus), {
             (self.projectfocus.iri, OSF.affiliation, institution_iri),
             (institution_iri, RDF.type, DCTERMS.Agent),
@@ -559,6 +560,15 @@ class TestOsfGathering(TestCase):
         assert_triples(osf_gathering.gather_affiliated_institutions(self.registrationfocus), set())
         # focus: file
         assert_triples(osf_gathering.gather_affiliated_institutions(self.filefocus), set())
+        # focus: preprint
+        assert_triples(osf_gathering.gather_affiliated_institutions(self.preprintfocus), {
+            (self.preprintfocus.iri, OSF.affiliation, institution_iri),
+            (institution_iri, RDF.type, DCTERMS.Agent),
+            (institution_iri, RDF.type, FOAF.Organization),
+            (institution_iri, FOAF.name, Literal(institution.name)),
+            (institution_iri, DCTERMS.identifier, Literal(institution.identifier_domain)),
+            (institution_iri, DCTERMS.identifier, Literal(institution.ror_uri)),
+        })
 
     def test_gather_funding(self):
         # focus: project


### PR DESCRIPTION
## Purpose

Confirm preprint affiliation data is sent to SHARE.

## Changes

- modifies test of affiliation gathering.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-5908