### PR TITLE
[ENG-5995] Make resubmission emails more like submissions emails

### DIFF
--- a/osf/utils/notifications.py
+++ b/osf/utils/notifications.py
@@ -43,13 +43,18 @@ def notify_submit(resource, user, *args, **kwargs):
     )
 
 
-def notify_resubmit(resource, user, action, *args, **kwargs):
+def notify_resubmit(resource, user, *args, **kwargs):
     context = get_email_template_context(resource)
-    reviews_signals.reviews_email.send(
-        creator=user,
+    context['referrer'] = user
+    recipients = list(resource.contributors)
+    reviews_signals.reviews_email_submit.send(
+        recipients=recipients,
         context=context,
-        template='reviews_resubmission_confirmation',
-        action=action
+        template=mails.REVIEWS_RESUBMISSION_CONFIRMATION,
+    )
+    reviews_signals.reviews_email_submit_moderators_notifications.send(
+        timestamp=timezone.now(),
+        context=context
     )
 
 

--- a/osf_tests/test_reviewable.py
+++ b/osf_tests/test_reviewable.py
@@ -4,6 +4,8 @@ import pytest
 from osf.models import Preprint
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import PreprintFactory, AuthUserFactory
+from website import mails
+
 
 @pytest.mark.django_db
 class TestReviewable:
@@ -31,3 +33,29 @@ class TestReviewable:
         assert preprint.machine_state == DefaultStates.ACCEPTED.value
         from_db.refresh_from_db()
         assert from_db.machine_state == DefaultStates.ACCEPTED.value
+
+    @mock.patch('website.reviews.listeners.mails.send_mail')
+    def test_reject_resubmission_sends_emails(self, send_mail):
+        user = AuthUserFactory()
+        preprint = PreprintFactory(
+            reviews_workflow='pre-moderation',
+            is_published=False
+        )
+        assert preprint.machine_state == DefaultStates.INITIAL.value
+        assert not send_mail.call_count
+
+        preprint.run_submit(user)
+        assert send_mail.call_count == 1
+        assert preprint.machine_state == DefaultStates.PENDING.value
+        mail_template = send_mail.call_args[0][1]
+        assert mail_template == mails.REVIEWS_SUBMISSION_CONFIRMATION
+
+        assert not user.notification_subscriptions.exists()
+        preprint.run_reject(user, 'comment')
+        assert preprint.machine_state == DefaultStates.REJECTED.value
+
+        preprint.run_submit(user)  # Resubmission alerts users and moderators
+        assert preprint.machine_state == DefaultStates.PENDING.value
+        mail_template = send_mail.call_args[0][1]
+        assert send_mail.call_count == 2
+        assert mail_template == mails.REVIEWS_RESUBMISSION_CONFIRMATION

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -459,6 +459,11 @@ REVIEWS_SUBMISSION_CONFIRMATION = Mail(
     subject='Confirmation of your submission to ${provider_name}'
 )
 
+REVIEWS_RESUBMISSION_CONFIRMATION = Mail(
+    'reviews_resubmission_confirmation',
+    subject='Confirmation of your submission to ${provider_name}'
+)
+
 ACCESS_REQUEST_SUBMITTED = Mail(
     'access_request_submitted',
     subject='An OSF user has requested access to your ${node.project_or_component}'

--- a/website/reviews/listeners.py
+++ b/website/reviews/listeners.py
@@ -6,9 +6,12 @@ from website.reviews import signals as reviews_signals
 from website.settings import OSF_PREPRINTS_LOGO, OSF_REGISTRIES_LOGO, DOMAIN
 
 
-# Handle email notifications including: update comment, accept, and reject of submission.
 @reviews_signals.reviews_email.connect
 def reviews_notification(self, creator, template, context, action):
+    """
+    Handle email notifications including: update comment, accept, and reject of submission, but not initial submission
+    or resubmission.
+    """
     # Avoid AppRegistryNotReady error
     from website.notifications.emails import notify_global_event
     recipients = list(action.target.contributors)
@@ -25,9 +28,14 @@ def reviews_notification(self, creator, template, context, action):
     )
 
 
-# Handle email notifications for a new submission.
 @reviews_signals.reviews_email_submit.connect
-def reviews_submit_notification(self, recipients, context):
+def reviews_submit_notification(self, recipients, context, template=None):
+    """
+    Handle email notifications for a new submission or a resubmission
+    """
+    if not template:
+        template = mails.REVIEWS_SUBMISSION_CONFIRMATION
+
     # Avoid AppRegistryNotReady error
     from website.notifications.emails import get_user_subscriptions
 
@@ -51,15 +59,17 @@ def reviews_submit_notification(self, recipients, context):
         context['provider_name'] = context['reviewable'].provider.name
         mails.send_mail(
             recipient.username,
-            mails.REVIEWS_SUBMISSION_CONFIRMATION,
+            template,
             user=recipient,
             **context
         )
 
 
-# Handle email notifications to notify moderators of new submissions.
 @reviews_signals.reviews_email_submit_moderators_notifications.connect
 def reviews_submit_notification_moderators(self, timestamp, context):
+    """
+    Handle email notifications to notify moderators of new submissions or resubmission.
+    """
     # imports moved here to avoid AppRegistryNotReady error
     from osf.models import NotificationSubscription
     from website.profile.utils import get_profile_image_url

--- a/website/templates/emails/reviews_resubmission_confirmation.html.mako
+++ b/website/templates/emails/reviews_resubmission_confirmation.html.mako
@@ -1,6 +1,6 @@
 ## -*- coding: utf-8 -*-
 <div style="margin: 40px;">
-    <p>Hello ${recipient.fullname},</p>
+    <p>Hello ${referrer.fullname},</p>
         <p>
             The ${document_type}
             <a href="${reviewable.absolute_url}">${reviewable.title}</a>


### PR DESCRIPTION
## Purpose

Ensure emails are sent to users and moderators when preprints are resubmitted. 

## Changes

- resubmission sents message to `reviews_email` to `reviews_email_submit` 
- add test to check for email template

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5995