### PR TITLE
[ENG-6105] Prevent recording of Preprint metrics from contributors

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -696,6 +696,10 @@ def osfstoragefile_mark_viewed(self, auth, fileversion, file_node):
 @file_signals.file_viewed.connect
 def osfstoragefile_update_view_analytics(self, auth, fileversion, file_node):
     resource = file_node.target
+    user = getattr(auth, 'user', None)
+    if hasattr(resource, 'is_contributor_or_group_member') and resource.is_contributor_or_group_member(user):
+        # Don't record views by contributors
+        return
     enqueue_update_analytics(
         resource,
         file_node,
@@ -707,6 +711,10 @@ def osfstoragefile_update_view_analytics(self, auth, fileversion, file_node):
 @file_signals.file_viewed.connect
 def osfstoragefile_viewed_update_metrics(self, auth, fileversion, file_node):
     resource = file_node.target
+    user = getattr(auth, 'user', None)
+    if hasattr(resource, 'is_contributor_or_group_member') and resource.is_contributor_or_group_member(user):
+        # Don't record views by contributors
+        return
     if waffle.switch_is_active(features.ELASTICSEARCH_METRICS) and isinstance(resource, Preprint):
         try:
             PreprintView.record_for_preprint(
@@ -730,6 +738,10 @@ def osfstoragefile_downloaded_update_analytics(self, auth, fileversion, file_nod
 @file_signals.file_downloaded.connect
 def osfstoragefile_downloaded_update_metrics(self, auth, fileversion, file_node):
     resource = file_node.target
+    user = getattr(auth, 'user', None)
+    if hasattr(resource, 'is_contributor_or_group_member') and resource.is_contributor_or_group_member(user):
+        # Don't record downloads by contributors
+        return
     if waffle.switch_is_active(features.ELASTICSEARCH_METRICS) and isinstance(resource, Preprint):
         try:
             PreprintDownload.record_for_preprint(


### PR DESCRIPTION
## Purpose
Fix regression from #10584 

## Changes
- Don't record preprint metrics generated by contributors

## QA Notes
- Preprints that you're a contributor on should not record view or download metrics by you
- Preprints that you're not a contributor on should record view or download metrics by you

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/ENG-6105
