### PR TITLE
[CR][ENG-6022] Hotfix: fix postcommit celery bug for spam checks

### DIFF
--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -200,7 +200,6 @@ class SpamMixin(models.Model):
             'user_agent': request_headers.get('User-Agent'),
             'referer': request_headers.get('Referer'),
         }
-        request_kwargs.update(request_headers)
 
         check_resource_for_domains_postcommit(
             self.guids.first()._id,


### PR DESCRIPTION
## Purpose

Something in python-upgrade started adding complex objects to the request headers. These headers were being passed into the celery task call for spam-checking. Because the complex objects can't be serialized, the task was failing. Knock that off.

## Changes

Stop adding request headers to spam check kwargs. We already set the necessary kwargs.

## QA Notes

Will be dev-tested.

## Documentation

None.

## Side Effects

None expected.

## Ticket

https://openscience.atlassian.net/browse/ENG-6022
