### PR TITLE
fix: in tests, use es6 url from settings

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -317,7 +317,7 @@ HASHIDS_SALT = 'pinkhimalayan'
 # django-elasticsearch-metrics
 ELASTICSEARCH_DSL = {
     'default': {
-        'hosts': os.environ.get('ELASTIC6_URI', '127.0.0.1:9201'),
+        'hosts': osf_settings.ELASTIC6_URI,
         'retry_on_timeout': True,
     },
 }

--- a/conftest.py
+++ b/conftest.py
@@ -124,7 +124,7 @@ def _test_speedups_disable(request, settings, _test_speedups):
 
 @pytest.fixture(scope='session')
 def setup_connections():
-    connections.create_connection(hosts=['http://localhost:9201'])
+    connections.create_connection(hosts=[website_settings.ELASTIC6_URI])
 
 
 @pytest.fixture(scope='function')

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -114,6 +114,7 @@ ELASTIC_KWARGS = {
     # 'client_cert': None,
     # 'client_key': None
 }
+ELASTIC6_URI = os.environ.get('ELASTIC6_URI', '127.0.0.1:9201')
 
 # Sessions
 COOKIE_NAME = 'osf'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
allow running tests that use es6 locally (...without the effort of addressing various deeper problems here)
<!-- Describe the purpose of your changes -->

## Changes
- put `ELASTIC6_URL` environment variable into its own website-setting
- in `conftest.py`, use that setting instead of hardcoded localhost url
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
