### PR TITLE
[ENG-6119] api changes for institution-users updates

### DIFF
--- a/api/base/elasticsearch_dsl_views.py
+++ b/api/base/elasticsearch_dsl_views.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+import abc
+import typing
+
+import elasticsearch_dsl as edsl
+from rest_framework import generics
+from rest_framework import exceptions as drf_exceptions
+from rest_framework.settings import api_settings as drf_settings
+if typing.TYPE_CHECKING:
+    from rest_framework import serializers
+
+from api.base.filters import FilterMixin
+from api.base.views import JSONAPIBaseView
+
+
+class ElasticsearchListView(FilterMixin, JSONAPIBaseView, generics.ListAPIView, abc.ABC):
+    '''abstract view class using `elasticsearch_dsl.Search` as a queryset-analogue
+
+    builds a `Search` based on `self.get_default_search()` and the request's
+    query parameters for filtering, sorting, and pagination -- fetches only
+    the data required for the response, just like with a queryset!
+    '''
+    serializer_class: type[serializers.BaseSerializer]  # required on subclasses
+
+    default_ordering: str | None = None  # name of a serializer field, prepended with "-" for descending sort
+    ordering_fields: frozenset[str] = frozenset()  # serializer field names
+
+    @abc.abstractmethod
+    def get_default_search(self) -> edsl.Search | None:
+        '''the base `elasticsearch_dsl.Search` for this list, based on url path
+
+        (common jsonapi query parameters will be considered automatically)
+        '''
+        ...
+
+    ###
+    # beware! inheritance shenanigans below
+
+    # override FilterMixin to disable all operators besides 'eq' and 'ne'
+    MATCHABLE_FIELDS = ()
+    COMPARABLE_FIELDS = ()
+    DEFAULT_OPERATOR_OVERRIDES = {}
+    # (if you want to add fulltext-search or range-filter support, remove the override
+    #  and update `__add_search_filter` to handle those operators -- tho note that the
+    #  underlying elasticsearch field mapping will need to be compatible with the query)
+
+    # override DEFAULT_FILTER_BACKENDS rest_framework setting
+    # (filtering handled in-view to reuse logic from FilterMixin)
+    filter_backends = ()
+
+    # note: because elasticsearch_dsl.Search supports slicing and gives results when iterated on,
+    #       it works fine with default pagination
+
+    # override rest_framework.generics.GenericAPIView
+    def get_queryset(self):
+        _search = self.get_default_search()
+        if _search is None:
+            return []
+        # using parsing logic from FilterMixin (oddly nested dict and all)
+        for _parsed_param in self.parse_query_params(self.request.query_params).values():
+            for _parsed_filter in _parsed_param.values():
+                _search = self.__add_search_filter(
+                    _search,
+                    elastic_field_name=_parsed_filter['source_field_name'],
+                    operator=_parsed_filter['op'],
+                    value=_parsed_filter['value'],
+                )
+        return self.__add_sort(_search)
+
+    ###
+    # private methods
+
+    def __add_sort(self, search: edsl.Search) -> edsl.Search:
+        _elastic_sort = self.__get_elastic_sort()
+        return (search if _elastic_sort is None else search.sort(_elastic_sort))
+
+    def __get_elastic_sort(self) -> str | None:
+        _sort_param = self.request.query_params.get(drf_settings.ORDERING_PARAM, self.default_ordering)
+        if not _sort_param:
+            return None
+        _sort_field, _ascending = (
+            (_sort_param[1:], False)
+            if _sort_param.startswith('-')
+            else (_sort_param, True)
+        )
+        if _sort_field not in self.ordering_fields:
+            raise drf_exceptions.ValidationError(
+                f'invalid value for {drf_settings.ORDERING_PARAM} query param (valid values: {", ".join(self.ordering_fields)})',
+            )
+        _serializer_field = self.get_serializer().fields[_sort_field]
+        _elastic_sort_field = _serializer_field.source
+        return (_elastic_sort_field if _ascending else f'-{_elastic_sort_field}')
+
+    def __add_search_filter(
+        self,
+        search: edsl.Search,
+        elastic_field_name: str,
+        operator: str,
+        value: str,
+    ) -> edsl.Search:
+        match operator:  # operators from FilterMixin
+            case 'eq':
+                if value == '':
+                    return search.exclude('exists', field=elastic_field_name)
+                return search.filter('term', **{elastic_field_name: value})
+            case 'ne':
+                if value == '':
+                    return search.filter('exists', field=elastic_field_name)
+                return search.exclude('term', **{elastic_field_name: value})
+            case _:
+                raise NotImplementedError(f'unsupported filter operator "{operator}"')

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -17,6 +17,7 @@ from rest_framework.reverse import reverse as drf_reverse
 
 from api.base import utils
 from api.base.exceptions import EnumFieldMemberError
+from osf.metrics.utils import YearMonth
 from osf.utils import permissions as osf_permissions
 from osf.utils import sanitize
 from osf.utils import functional
@@ -2024,3 +2025,18 @@ class EnumField(ser.ChoiceField):
             return self._enum_class[data.upper()].value
         except KeyError:
             raise EnumFieldMemberError(self._enum_class, data)
+
+
+class YearmonthField(ser.Field):
+    def to_representation(self, value: YearMonth | None) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    def to_internal_value(self, data: str | None) -> YearMonth | None:
+        if data is None:
+            return None
+        try:
+            return YearMonth.from_str(data)
+        except ValueError as e:
+            raise ser.ValidationError(str(e))

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -15,6 +15,7 @@ from api.base.serializers import (
     ShowIfObjectPermission,
 )
 
+from api.base.serializers import YearmonthField
 from api.nodes.serializers import CompoundIDField
 from api.base.exceptions import RelationshipPostMakesNoChanges
 from api.base.utils import absolute_reverse
@@ -323,4 +324,28 @@ class NewInstitutionUserMetricsSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'institution-users'
 
-    ...  # TODO: serializer fields
+    id = IDField(source='meta.id', read_only=True)
+    user_name = ser.CharField(read_only=True)
+    department = ser.CharField(read_only=True, source='department_name')
+    orcid_id = ser.CharField(read_only=True)
+    month_last_login = YearmonthField(read_only=True)
+    account_creation_date = YearmonthField(read_only=True)
+
+    public_projects = ser.IntegerField(read_only=True, source='public_project_count')
+    private_projects = ser.IntegerField(read_only=True, source='private_project_count')
+    public_registration_count = ser.IntegerField(read_only=True)
+    embargoed_registration_count = ser.IntegerField(read_only=True)
+    published_preprint_count = ser.IntegerField(read_only=True)
+    public_file_count = ser.IntegerField(read_only=True)
+    storage_byte_count = ser.IntegerField(read_only=True)
+
+    user = RelationshipField(
+        related_view='users:user-detail',
+        related_view_kwargs={'user_id': '<user_id>'},
+    )
+    institution = RelationshipField(
+        related_view='institutions:institution-detail',
+        related_view_kwargs={'institution_id': '<institution_id>'},
+    )
+
+    links = LinksField({})

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -270,7 +270,12 @@ class InstitutionDepartmentMetricsSerializer(JSONAPISerializer):
         )
 
 
-class InstitutionUserMetricsSerializer(JSONAPISerializer):
+class OldInstitutionUserMetricsSerializer(JSONAPISerializer):
+    '''serializer for institution-users metrics
+
+    used only when the INSTITUTIONAL_DASHBOARD_2024 feature flag is NOT active
+    (and should be removed when that flag is permanently active)
+    '''
 
     class Meta:
         type_ = 'institution-users'
@@ -306,3 +311,16 @@ class InstitutionUserMetricsSerializer(JSONAPISerializer):
                 'version': 'v2',
             },
         )
+
+
+class NewInstitutionUserMetricsSerializer(JSONAPISerializer):
+    '''serializer for institution-users metrics
+
+    used only when the INSTITUTIONAL_DASHBOARD_2024 feature flag is active
+    (and should be renamed without "New" when that flag is permanently active)
+    '''
+
+    class Meta:
+        type_ = 'institution-users'
+
+    ...  # TODO: serializer fields

--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -324,6 +324,11 @@ class NewInstitutionUserMetricsSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'institution-users'
 
+    filterable_fields = frozenset({
+        'department',
+        'orcid_id',
+    })
+
     id = IDField(source='meta.id', read_only=True)
     user_name = ser.CharField(read_only=True)
     department = ser.CharField(read_only=True, source='department_name')
@@ -349,3 +354,6 @@ class NewInstitutionUserMetricsSerializer(JSONAPISerializer):
     )
 
     links = LinksField({})
+
+    def get_absolute_url(self):
+        return None  # there is no detail view for institution-users

--- a/api/institutions/urls.py
+++ b/api/institutions/urls.py
@@ -15,5 +15,5 @@ urlpatterns = [
     re_path(r'^(?P<institution_id>\w+)/users/$', views.InstitutionUserList.as_view(), name=views.InstitutionUserList.view_name),
     re_path(r'^(?P<institution_id>\w+)/metrics/summary/$', views.InstitutionSummaryMetrics.as_view(), name=views.InstitutionSummaryMetrics.view_name),
     re_path(r'^(?P<institution_id>\w+)/metrics/departments/$', views.InstitutionDepartmentList.as_view(), name=views.InstitutionDepartmentList.view_name),
-    re_path(r'^(?P<institution_id>\w+)/metrics/users/$', views.InstitutionUserMetricsList.as_view(), name=views.InstitutionUserMetricsList.view_name),
+    re_path(r'^(?P<institution_id>\w+)/metrics/users/$', views.institution_user_metrics_list_view, name=views.institution_user_metrics_list_view.view_name),
 ]

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -43,9 +43,9 @@ for mod in URLS_MODULES:
         if hasattr(patt, 'url_patterns'):
             # Namespaced list of patterns
             for subpatt in patt.url_patterns:
-                VIEW_CLASSES.append(subpatt.callback.cls)
+                VIEW_CLASSES.append(subpatt.callback.view_class)
         else:
-            VIEW_CLASSES.append(patt.callback.cls)
+            VIEW_CLASSES.append(patt.callback.view_class)
 
 
 class TestApiBaseViews(ApiTestCase):

--- a/api_tests/institutions/views/test_institution_department_list.py
+++ b/api_tests/institutions/views/test_institution_department_list.py
@@ -10,7 +10,7 @@ from osf_tests.factories import (
 from osf.metrics import UserInstitutionProjectCounts
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionDepartmentList:
 

--- a/api_tests/institutions/views/test_institution_summary_metrics.py
+++ b/api_tests/institutions/views/test_institution_summary_metrics.py
@@ -9,7 +9,7 @@ from osf_tests.factories import (
 from osf.metrics import InstitutionProjectCounts
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionSummaryMetrics:
 

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -17,7 +17,7 @@ from osf_tests.factories import (
 from osf.metrics import UserInstitutionProjectCounts
 from osf.metrics.reports import InstitutionalUserReport
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestOldInstitutionUserMetricList:
 
@@ -266,6 +266,7 @@ class TestOldInstitutionUserMetricList:
         assert data[2]['attributes']['department'] == 'Psychology dept'
 
 
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestNewInstitutionUserMetricList:
     @pytest.fixture(autouse=True)
@@ -336,13 +337,11 @@ class TestNewInstitutionUserMetricList:
         _resp = app.get(url, auth=rando.auth, expect_errors=True)
         assert _resp.status_code == 403
 
-    @pytest.mark.es
     def test_get_empty(self, app, url, institutional_admin):
         _resp = app.get(url, auth=institutional_admin.auth)
         assert _resp.status_code == 200
         assert _resp.json['data'] == []
 
-    @pytest.mark.es
     def test_get_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
         _resp = app.get(url, auth=institutional_admin.auth)
         assert _resp.status_code == 200
@@ -350,7 +349,6 @@ class TestNewInstitutionUserMetricList:
         _expected_user_ids = {_report.user_id for _report in reports}
         assert set(_user_ids(_resp)) == _expected_user_ids
 
-    @pytest.mark.es
     def test_filter_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
         for _query, _expected_user_ids in (
             ({'filter[department]': 'nunavum'}, set()),
@@ -386,7 +384,6 @@ class TestNewInstitutionUserMetricList:
             assert _resp.status_code == 200
             assert set(_user_ids(_resp)) == _expected_user_ids
 
-    @pytest.mark.es
     def test_sort_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
         for _query, _expected_user_id_list in (
             ({'sort': 'storage_byte_count'}, ['u_sparse', 'u_orc', 'u_blargl', 'u_orcomma']),
@@ -396,7 +393,6 @@ class TestNewInstitutionUserMetricList:
             assert _resp.status_code == 200
             assert list(_user_ids(_resp)) == _expected_user_id_list
 
-    @pytest.mark.es
     def test_paginate_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
         for _query, _expected_user_id_list in (
             ({'sort': 'storage_byte_count', 'page[size]': 2}, ['u_sparse', 'u_orc']),

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -2,6 +2,7 @@ import datetime
 import csv
 from io import StringIO
 from random import random
+from urllib.parse import urlencode
 
 import pytest
 from waffle.testutils import override_flag
@@ -14,10 +15,11 @@ from osf_tests.factories import (
 )
 
 from osf.metrics import UserInstitutionProjectCounts
+from osf.metrics.reports import InstitutionalUserReport
 
 @pytest.mark.es
 @pytest.mark.django_db
-class TestInstitutionUserMetricList:
+class TestOldInstitutionUserMetricList:
 
     @pytest.fixture(autouse=True)
     def _waffled(self):
@@ -262,3 +264,159 @@ class TestInstitutionUserMetricList:
         assert data[0]['attributes']['department'] == 'Biology dept'
         assert data[1]['attributes']['department'] == 'N/A'
         assert data[2]['attributes']['department'] == 'Psychology dept'
+
+
+@pytest.mark.django_db
+class TestNewInstitutionUserMetricList:
+    @pytest.fixture(autouse=True)
+    def _waffled(self):
+        with override_flag(osf.features.INSTITUTIONAL_DASHBOARD_2024, active=True):
+            yield  # these tests apply only after institution dashboard improvements
+
+    @pytest.fixture()
+    def institution(self):
+        return InstitutionFactory()
+
+    @pytest.fixture()
+    def rando(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def institutional_admin(self, institution):
+        _admin_user = AuthUserFactory()
+        institution.get_group('institutional_admins').user_set.add(_admin_user)
+        return _admin_user
+
+    @pytest.fixture()
+    def unshown_reports(self, institution):
+        # unshown because another institution
+        _another_institution = InstitutionFactory()
+        _report_factory('2024-08', _another_institution, user_id='nother_inst')
+        # unshown because old
+        _report_factory('2024-07', institution, user_id='old')
+
+    @pytest.fixture()
+    def reports(self, institution):
+        return [
+            _report_factory(
+                '2024-08', institution,
+                user_id='u_sparse',
+                storage_byte_count=53,
+            ),
+            _report_factory(
+                '2024-08', institution,
+                user_id='u_orc',
+                orcid_id='5555-4444-3333-2222',
+                storage_byte_count=8277,
+            ),
+            _report_factory(
+                '2024-08', institution,
+                user_id='u_blargl',
+                department_name='blargl',
+                storage_byte_count=34834834,
+            ),
+            _report_factory(
+                '2024-08', institution,
+                user_id='u_orcomma',
+                orcid_id='4444-3333-2222-1111',
+                department_name='a department, or so, that happens, incidentally, to have commas',
+                storage_byte_count=736662999298,
+            ),
+        ]
+
+    @pytest.fixture()
+    def url(self, institution):
+        return f'/{API_BASE}institutions/{institution._id}/metrics/users/'
+
+    def test_anon(self, app, url):
+        _resp = app.get(url, expect_errors=True)
+        assert _resp.status_code == 401
+
+    def test_rando(self, app, url, rando):
+        _resp = app.get(url, auth=rando.auth, expect_errors=True)
+        assert _resp.status_code == 403
+
+    @pytest.mark.es
+    def test_get_empty(self, app, url, institutional_admin):
+        _resp = app.get(url, auth=institutional_admin.auth)
+        assert _resp.status_code == 200
+        assert _resp.json['data'] == []
+
+    @pytest.mark.es
+    def test_get_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
+        _resp = app.get(url, auth=institutional_admin.auth)
+        assert _resp.status_code == 200
+        assert len(_resp.json['data']) == len(reports)
+        _expected_user_ids = {_report.user_id for _report in reports}
+        assert set(_user_ids(_resp)) == _expected_user_ids
+
+    @pytest.mark.es
+    def test_filter_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
+        for _query, _expected_user_ids in (
+            ({'filter[department]': 'nunavum'}, set()),
+            ({'filter[department]': 'incidentally'}, set()),
+            ({'filter[department]': 'blargl'}, {'u_blargl'}),
+            ({'filter[department]': 'a department, or so, that happens, incidentally, to have commas'}, {'u_orcomma'}),
+            ({'filter[department][eq]': 'nunavum'}, set()),
+            ({'filter[department][eq]': 'blargl'}, {'u_blargl'}),
+            ({'filter[department][eq]': 'a department, or so, that happens, incidentally, to have commas'}, {'u_orcomma'}),
+            ({'filter[department][ne]': 'nunavum'}, {'u_sparse', 'u_blargl', 'u_orc', 'u_orcomma'}),
+
+            ({'filter[orcid_id][eq]': '5555-4444-3333-2222'}, {'u_orc'}),
+            ({'filter[orcid_id][ne]': ''}, {'u_orc', 'u_orcomma'}),
+            ({'filter[orcid_id][eq]': ''}, {'u_sparse', 'u_blargl'}),
+            ({
+                'filter[orcid_id]': '',
+                'filter[department]': 'blargl',
+            }, {'u_blargl'}),
+            ({
+                'filter[orcid_id]': '',
+                'filter[department][ne]': 'blargl',
+            }, {'u_sparse'}),
+            ({
+                'filter[orcid_id]': '5555-4444-3333-2222',
+                'filter[department][ne]': 'blargl',
+            }, {'u_orc'}),
+            ({
+                'filter[orcid_id]': '5555-4444-3333-2222',
+                'filter[department][ne]': '',
+            }, set()),
+        ):
+            _resp = app.get(f'{url}?{urlencode(_query)}', auth=institutional_admin.auth)
+            assert _resp.status_code == 200
+            assert set(_user_ids(_resp)) == _expected_user_ids
+
+    @pytest.mark.es
+    def test_sort_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
+        for _query, _expected_user_id_list in (
+            ({'sort': 'storage_byte_count'}, ['u_sparse', 'u_orc', 'u_blargl', 'u_orcomma']),
+            ({'sort': '-storage_byte_count'}, ['u_orcomma', 'u_blargl', 'u_orc', 'u_sparse']),
+        ):
+            _resp = app.get(f'{url}?{urlencode(_query)}', auth=institutional_admin.auth)
+            assert _resp.status_code == 200
+            assert list(_user_ids(_resp)) == _expected_user_id_list
+
+    @pytest.mark.es
+    def test_paginate_reports(self, app, url, institutional_admin, institution, reports, unshown_reports):
+        for _query, _expected_user_id_list in (
+            ({'sort': 'storage_byte_count', 'page[size]': 2}, ['u_sparse', 'u_orc']),
+            ({'sort': 'storage_byte_count', 'page[size]': 2, 'page': 2}, ['u_blargl', 'u_orcomma']),
+            ({'sort': '-storage_byte_count', 'page[size]': 3}, ['u_orcomma', 'u_blargl', 'u_orc']),
+            ({'sort': '-storage_byte_count', 'page[size]': 3, 'page': 2}, ['u_sparse']),
+        ):
+            _resp = app.get(f'{url}?{urlencode(_query)}', auth=institutional_admin.auth)
+            assert _resp.status_code == 200
+            assert list(_user_ids(_resp)) == _expected_user_id_list
+
+def _user_ids(api_response):
+    for _datum in api_response.json['data']:
+        yield _datum['relationships']['user']['data']['id']
+
+def _report_factory(yearmonth, institution, **kwargs):
+    _report = InstitutionalUserReport(
+        report_yearmonth=yearmonth,
+        institution_id=institution._id,
+        **kwargs,
+    )
+    _report.save(refresh=True)
+    return _report

--- a/api_tests/metrics/test_composite_query.py
+++ b/api_tests/metrics/test_composite_query.py
@@ -29,7 +29,7 @@ def base_url():
     return f'/{API_BASE}metrics/preprints/'
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestElasticSearch:
 

--- a/api_tests/metrics/test_preprint_metrics.py
+++ b/api_tests/metrics/test_preprint_metrics.py
@@ -116,7 +116,7 @@ class TestPreprintMetrics:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Malformed elasticsearch query.'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_agg_query(self, app, user, base_url):
 
         post_url = f'{base_url}downloads/'

--- a/api_tests/metrics/test_registries_moderation_metrics.py
+++ b/api_tests/metrics/test_registries_moderation_metrics.py
@@ -22,7 +22,7 @@ class TestRegistrationModerationMetrics:
         with override_switch(features.ELASTICSEARCH_METRICS, active=True):
             yield
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_record_transitions(self, registration):
         registration._write_registration_action(
             RegistrationModerationStates.INITIAL,
@@ -70,7 +70,7 @@ class TestRegistrationModerationMetricsView:
     def base_url(self):
         return '/_/metrics/registries_moderation/transitions/'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_registries_moderation_view(self, app, user, base_url, registration):
         registration._write_registration_action(
             RegistrationModerationStates.INITIAL,

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 from unittest import mock
 import logging
 import os
@@ -5,7 +6,9 @@ import re
 
 from django.core.management import call_command
 from django.db import transaction
+from elasticsearch import exceptions as es_exceptions
 from elasticsearch_dsl.connections import connections
+from elasticsearch_metrics.registry import registry as es_metrics_registry
 from faker import Factory
 import pytest
 import responses
@@ -133,22 +136,44 @@ def es6_client(setup_connections):
 
 
 @pytest.fixture(scope='function', autouse=True)
-def _es_marker(request):
+def _es_metrics_marker(request):
     """Clear out all indices and index templates before and after
-    tests marked with ``es``.
+    tests marked with `es_metrics`.
     """
-    marker = request.node.get_closest_marker('es')
+    marker = request.node.get_closest_marker('es_metrics')
     if marker:
         es6_client = request.getfixturevalue('es6_client')
+        _temp_prefix = 'temp_metrics_'
+        _temp_wildcard = f'{_temp_prefix}*'
 
-        def teardown_es():
-            es6_client.indices.delete(index='*')
-            es6_client.indices.delete_template('*')
+        def _teardown_es_temps():
+            es6_client.indices.delete(index=_temp_wildcard)
+            try:
+                es6_client.indices.delete_template(_temp_wildcard)
+            except es_exceptions.NotFoundError:
+                pass
 
-        teardown_es()
-        call_command('sync_metrics')
-        yield
-        teardown_es()
+        @contextlib.contextmanager
+        def _mock_metric_names():
+            with contextlib.ExitStack() as _exit:
+                for _metric_class in es_metrics_registry.get_metrics():
+                    _exit.enter_context(mock.patch.object(
+                        _metric_class,
+                        '_template_name',  # also used to construct index names
+                        f'{_temp_prefix}{_metric_class._template_name}',
+                    ))
+                    _exit.enter_context(mock.patch.object(
+                        _metric_class,
+                        '_template',  # a wildcard string for indexes and templates
+                        f'{_temp_prefix}{_metric_class._template}',
+                    ))
+                yield
+
+        _teardown_es_temps()
+        with _mock_metric_names():
+            call_command('sync_metrics')
+            yield
+        _teardown_es_temps()
     else:
         yield
 

--- a/osf/features.yaml
+++ b/osf/features.yaml
@@ -189,6 +189,10 @@ flags:
     note: This is not used
     everyone: true
 
+  - flag_name: INSTITUTIONAL_DASHBOARD_2024
+    name: institutional_dashboard_2024
+    note: whether to surface older or updated (in 2024) institutional metrics
+
 switches:
   - flag_name: DISABLE_ENGAGEMENT_EMAILS
     name: disable_engagement_emails

--- a/osf/metrics/utils.py
+++ b/osf/metrics/utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import dataclasses
 import re
 import datetime
@@ -27,12 +28,12 @@ class YearMonth:
     YEARMONTH_RE: ClassVar[re.Pattern] = re.compile(r'(?P<year>\d{4})-(?P<month>\d{2})')
 
     @classmethod
-    def from_date(cls, date):
+    def from_date(cls, date: datetime.date) -> YearMonth:
         assert isinstance(date, (datetime.datetime, datetime.date))
         return cls(date.year, date.month)
 
     @classmethod
-    def from_str(cls, input_str):
+    def from_str(cls, input_str: str) -> YearMonth:
         match = cls.YEARMONTH_RE.fullmatch(input_str)
         if match:
             return cls(

--- a/osf_tests/management_commands/test_reindex_es6.py
+++ b/osf_tests/management_commands/test_reindex_es6.py
@@ -45,7 +45,7 @@ class TestReindexingMetrics:
     def url(self):
         return f'{settings.API_DOMAIN}_/metrics/preprints/downloads/'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     @pytest.mark.skipif(django_settings.TRAVIS_ENV, reason='Non-deterministic fails on travis')
     def test_reindexing(self, app, url, preprint, user, admin, es6_client):
         preprint_download = PreprintDownload.record_for_preprint(

--- a/osf_tests/test_management_commands.py
+++ b/osf_tests/test_management_commands.py
@@ -265,7 +265,7 @@ class TestDataStorageUsage(DbTestCase):
                 assert (key, expected_summary_data[key]) == (key, actual_summary_data[key])
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionMetricsUpdate:
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
update api to serve institutional-user metrics based on the monthly report added in #10722 
<!-- Describe the purpose of your changes -->

## Changes
reusable things added:
- `toggle_view_by_flag` util to ease feature-flagged views
    - also allow non-class views to exist (minor updates to api tests and bases)
- base view `ElasticsearchListView`
    - use `elasticsearch_dsl.Search` as queryset-analogue, for code reuse
    - allows filtering (with 'eq' and 'ne' operators) following `filterable_fields` on the serializer (using `api.base.filters.FilterMixin`)
    - allows sorting, following `default_ordering` and `ordering_fields` on the view
    - allows pagination (with `page` and `page[size]` params), using default paginator
- `api.base.serializers.YearmonthField`
- `MonthlyReport.most_recent_yearmonth` classmethod

specific to this project:
- add feature flag `INSTITUTIONAL_DASHBOARD_2024`
- rename prior institution-user view and serializer with `Old` prefix
- use `toggle_view_by_flag` to toggle new/old views (with new/old serializers)
- add "new" institution-user metrics view (using `ElasticsearchListView`)
- add "new" institution-user metrics serializer

incidental:
- fix: old institution-user metrics tests
    - set INSTITUTIONAL_DASHBOARD_2024 flag inactive for existing institution-user metrics tests
    - remove `time.sleep` calls; use index refreshes instead (saves ~70 sec)
    - unskip tests -- "non-deterministic fails" may be fixed by refreshes?
- avoid clobbering all indexes by running tests
    - rename the `es` pytest marker to `es_metrics` (for clarity)
    - update the effect of that marker:
        - patch a prefix to each metric class's index and template names
        - instead of deleting ALL indexes and index templates, delete only
          those with the patched prefix
    - update `api_tests.metrics.test_raw_metrics` to clean up after itself
      and stop depending on the clobbering

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-6119]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-6119]: https://openscience.atlassian.net/browse/ENG-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ