### PR TITLE
[dev experience] unclobbering metrics tests

### DIFF
--- a/api_tests/institutions/views/test_institution_department_list.py
+++ b/api_tests/institutions/views/test_institution_department_list.py
@@ -10,7 +10,7 @@ from osf_tests.factories import (
 from osf.metrics import UserInstitutionProjectCounts
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionDepartmentList:
 

--- a/api_tests/institutions/views/test_institution_summary_metrics.py
+++ b/api_tests/institutions/views/test_institution_summary_metrics.py
@@ -9,7 +9,7 @@ from osf_tests.factories import (
 from osf.metrics import InstitutionProjectCounts
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionSummaryMetrics:
 

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -14,7 +14,7 @@ from osf_tests.factories import (
 from osf.metrics import UserInstitutionProjectCounts
 from api.base import settings
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionUserMetricList:
 

--- a/api_tests/metrics/test_composite_query.py
+++ b/api_tests/metrics/test_composite_query.py
@@ -29,7 +29,7 @@ def base_url():
     return f'/{API_BASE}metrics/preprints/'
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestElasticSearch:
 

--- a/api_tests/metrics/test_preprint_metrics.py
+++ b/api_tests/metrics/test_preprint_metrics.py
@@ -116,7 +116,7 @@ class TestPreprintMetrics:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Malformed elasticsearch query.'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_agg_query(self, app, user, base_url):
 
         post_url = f'{base_url}downloads/'

--- a/api_tests/metrics/test_raw_metrics.py
+++ b/api_tests/metrics/test_raw_metrics.py
@@ -14,7 +14,7 @@ from api.base.settings import API_PRIVATE_BASE as API_BASE
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 class TestRawMetrics:
 
     @pytest.fixture(autouse=True)

--- a/api_tests/metrics/test_registries_moderation_metrics.py
+++ b/api_tests/metrics/test_registries_moderation_metrics.py
@@ -22,7 +22,7 @@ class TestRegistrationModerationMetrics:
         with override_switch(features.ELASTICSEARCH_METRICS, active=True):
             yield
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_record_transitions(self, registration):
         registration._write_registration_action(
             RegistrationModerationStates.INITIAL,
@@ -70,7 +70,7 @@ class TestRegistrationModerationMetricsView:
     def base_url(self):
         return '/_/metrics/registries_moderation/transitions/'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     def test_registries_moderation_view(self, app, user, base_url, registration):
         registration._write_registration_action(
             RegistrationModerationStates.INITIAL,

--- a/osf_tests/management_commands/test_reindex_es6.py
+++ b/osf_tests/management_commands/test_reindex_es6.py
@@ -45,7 +45,7 @@ class TestReindexingMetrics:
     def url(self):
         return f'{settings.API_DOMAIN}_/metrics/preprints/downloads/'
 
-    @pytest.mark.es
+    @pytest.mark.es_metrics
     @pytest.mark.skipif(django_settings.TRAVIS_ENV, reason='Non-deterministic fails on travis')
     def test_reindexing(self, app, url, preprint, user, admin, es6_client):
         preprint_download = PreprintDownload.record_for_preprint(

--- a/osf_tests/test_management_commands.py
+++ b/osf_tests/test_management_commands.py
@@ -265,7 +265,7 @@ class TestDataStorageUsage(DbTestCase):
                 assert (key, expected_summary_data[key]) == (key, actual_summary_data[key])
 
 
-@pytest.mark.es
+@pytest.mark.es_metrics
 @pytest.mark.django_db
 class TestInstitutionMetricsUpdate:
 


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
when running tests that use elasticsearch-metrics, the test setup/teardown clobbers all existing indexes and index templates in the local environment, which is surprising and annoying when those indexes have been set up and populated with data
<!-- Describe the purpose of your changes -->

## Changes
- rename the custom `es` pytest marker to `es_metrics` (for clarity)
- update the effect of that marker:
  - patch a prefix to each metric class's index and template names
  - instead of deleting ALL indexes and index templates, delete only those with the patched prefix

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
