### PR TITLE
fix: usable waffle-flag admin

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -364,3 +364,5 @@ TRAVIS_ENV = False
 
 CITATION_STYLES_REPO_URL = 'https://github.com/CenterForOpenScience/styles/archive/88e6ed31a91e9f5a480b486029cda97b535935d4.zip'
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+WAFFLE_ENABLE_ADMIN_PAGES = False  # instead, customized waffle admins in osf/admin.py


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
allow editing a waffle flag in the admin interface (`admin.osf.example/admin/waffle/flag/<id>/change/`) -- currently, it tries to display a list of all django `Group`s, and (especially on production) there are tooo many
<!-- Describe the purpose of your changes -->

## Changes
- set `WAFFLE_ENABLE_ADMIN_PAGES=False`
- register waffle admins explicitly
  - customized `FlagAdmin` to work with many groups
  - `SwitchAdmin` and `SampleAdmin` left as-is
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
