### PR TITLE
[Don't Merge] Reference PR: Fix broken postgres init in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
     ports:
       - 5432:5432
     environment:
+      POSTGRES_DB: osf
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_SQL: |
         SELECT 'CREATE DATABASE gravyvalet' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'gravyvalet')\gexec
     volumes:


### PR DESCRIPTION
## Purpose

* Note: don't merge since this breaks GV
* Note: only need this two envs to init the OSF DB

`postgres` container fails to start

```
(osf-3.12) ➜  osf git:(develop) ✗ docker compose up postgres
[+] Running 2/2
 ✔ Network osf_default       Created
 ✔ Container osf-postgres-1  Created
Attaching to postgres-1
postgres-1  | Error: Database is uninitialized and superuser password is not specified.
postgres-1  |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgres-1  |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgres-1  |
postgres-1  |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgres-1  |        connections without a password. This is *not* recommended.
postgres-1  |
postgres-1  |        See PostgreSQL documentation about "trust":
postgres-1  |        https://www.postgresql.org/docs/current/auth-trust.html
postgres-1 exited with code 1
```

## Changes

Add back the following configuration

```
POSTGRES_DB: osf
POSTGRES_HOST_AUTH_METHOD: trust
```

## QA Notes

N/A

## Documentation

N/A

## Side Effects

Breaks GravyValet

## Ticket

Discovered during [ENG-6297](https://openscience.atlassian.net/browse/ENG-6297)


[ENG-6297]: https://openscience.atlassian.net/browse/ENG-6297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ