### PR TITLE
[ENG-6321] Add after_set_privacy noop

### DIFF
--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -144,6 +144,9 @@ class EphemeralNodeSettings:
     def save(self):
         pass
 
+    def after_set_privacy(self, *args, **kwargs):
+        pass
+
 
 @dataclasses.dataclass
 class EphemeralUserSettings:


### PR DESCRIPTION
## Purpose

After recent changes to addons, making node private/public no longer works because on `EphemeralNodeSetting` there is not a `after_set_privacy` hook to call. Upon closer inspection, it seems that the `after_set_privacy` hooks for addons were all noops. Hence, this PR adds an `after_set_privacy` noop to `EphermeralNodeSetting`.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
