### PR TITLE
[ENG-4438] Add OOPSpam and Akismet metrics to spam report

### DIFF
--- a/osf/external/askismet/client.py
+++ b/osf/external/askismet/client.py
@@ -133,3 +133,27 @@ class AkismetClient:
         )
         if res.status_code != requests.codes.ok:
             raise AkismetClientError(reason=res.text)
+
+    def get_flagged_count(self, start_date, end_date):
+        from osf.models import NodeLog
+
+        flagged_count = NodeLog.objects.filter(
+            action=NodeLog.FLAG_SPAM,
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='akismet'
+        ).count()
+
+        return flagged_count
+
+    def get_hammed_count(self, start_date, end_date):
+        from osf.models import NodeLog
+
+        hammed_count = NodeLog.objects.filter(
+            action=NodeLog.CONFIRM_HAM,
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='akismet'
+        ).count()
+
+        return hammed_count

--- a/osf/external/askismet/client.py
+++ b/osf/external/askismet/client.py
@@ -137,6 +137,9 @@ class AkismetClient:
     def get_flagged_count(self, start_date, end_date, category='node'):
         from osf.models import NodeLog, PreprintLog
 
+        if category not in ['node', 'preprint']:
+            raise ValueError(f"Invalid category '{category}'. Expected 'node' or 'preprint'.")
+
         log_model = NodeLog if category == 'node' else PreprintLog
 
         flagged_count = log_model.objects.filter(
@@ -150,6 +153,9 @@ class AkismetClient:
 
     def get_hammed_count(self, start_date, end_date, category='node'):
         from osf.models import NodeLog, PreprintLog
+
+        if category not in ['node', 'preprint']:
+            raise ValueError(f"Invalid category '{category}'. Expected 'node' or 'preprint'.")
 
         log_model = NodeLog if category == 'node' else PreprintLog
 

--- a/osf/external/askismet/client.py
+++ b/osf/external/askismet/client.py
@@ -141,7 +141,7 @@ class AkismetClient:
             action=NodeLog.FLAG_SPAM,
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='akismet'
+            node__spam_data__who_flagged__in=['akismet', 'both']
         ).count()
 
         return flagged_count
@@ -153,7 +153,7 @@ class AkismetClient:
             action=NodeLog.CONFIRM_HAM,
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='akismet'
+            node__spam_data__who_flagged__in=['akismet', 'both']
         ).count()
 
         return hammed_count

--- a/osf/external/askismet/client.py
+++ b/osf/external/askismet/client.py
@@ -134,26 +134,30 @@ class AkismetClient:
         if res.status_code != requests.codes.ok:
             raise AkismetClientError(reason=res.text)
 
-    def get_flagged_count(self, start_date, end_date):
-        from osf.models import NodeLog
+    def get_flagged_count(self, start_date, end_date, category='node'):
+        from osf.models import NodeLog, PreprintLog
 
-        flagged_count = NodeLog.objects.filter(
-            action=NodeLog.FLAG_SPAM,
+        log_model = NodeLog if category == 'node' else PreprintLog
+
+        flagged_count = log_model.objects.filter(
+            action=log_model.FLAG_SPAM,
             created__gt=start_date,
             created__lt=end_date,
-            node__spam_data__who_flagged__in=['akismet', 'both']
+            **{f'{category}__spam_data__who_flagged__in': ['akismet', 'both']}
         ).count()
 
         return flagged_count
 
-    def get_hammed_count(self, start_date, end_date):
-        from osf.models import NodeLog
+    def get_hammed_count(self, start_date, end_date, category='node'):
+        from osf.models import NodeLog, PreprintLog
 
-        hammed_count = NodeLog.objects.filter(
-            action=NodeLog.CONFIRM_HAM,
+        log_model = NodeLog if category == 'node' else PreprintLog
+
+        hammed_count = log_model.objects.filter(
+            action=log_model.CONFIRM_HAM,
             created__gt=start_date,
             created__lt=end_date,
-            node__spam_data__who_flagged__in=['akismet', 'both']
+            **{f'{category}__spam_data__who_flagged__in': ['akismet', 'both']}
         ).count()
 
         return hammed_count

--- a/osf/external/oopspam/client.py
+++ b/osf/external/oopspam/client.py
@@ -46,26 +46,30 @@ class OOPSpamClient:
         #  OOPSpam returns a spam score out of 6. 3 or higher indicates spam
         return spam_score >= settings.OOPSPAM_SPAM_LEVEL, resp_json
 
-    def get_flagged_count(self, start_date, end_date):
-        from osf.models import NodeLog
+    def get_flagged_count(self, start_date, end_date, category='node'):
+        from osf.models import NodeLog, PreprintLog
 
-        flagged_count = NodeLog.objects.filter(
-            action=NodeLog.FLAG_SPAM,
+        log_model = NodeLog if category == 'node' else PreprintLog
+
+        flagged_count = log_model.objects.filter(
+            action=log_model.FLAG_SPAM,
             created__gt=start_date,
             created__lt=end_date,
-            node__spam_data__who_flagged__in=['oopspam', 'both']
+            **{f'{category}__spam_data__who_flagged__in': ['oopspam', 'both']}
         ).count()
 
         return flagged_count
 
-    def get_hammed_count(self, start_date, end_date):
-        from osf.models import NodeLog
+    def get_hammed_count(self, start_date, end_date, category='node'):
+        from osf.models import NodeLog, PreprintLog
 
-        hammed_count = NodeLog.objects.filter(
-            action=NodeLog.CONFIRM_HAM,
+        log_model = NodeLog if category == 'node' else PreprintLog
+
+        hammed_count = log_model.objects.filter(
+            action=log_model.CONFIRM_HAM,
             created__gt=start_date,
             created__lt=end_date,
-            node__spam_data__who_flagged__in=['oopspam', 'both']
+            **{f'{category}__spam_data__who_flagged__in': ['oopspam', 'both']}
         ).count()
 
         return hammed_count

--- a/osf/external/oopspam/client.py
+++ b/osf/external/oopspam/client.py
@@ -45,3 +45,27 @@ class OOPSpamClient:
 
         #  OOPSpam returns a spam score out of 6. 3 or higher indicates spam
         return spam_score >= settings.OOPSPAM_SPAM_LEVEL, resp_json
+
+    def get_flagged_count(self, start_date, end_date):
+        from osf.models import NodeLog
+
+        flagged_count = NodeLog.objects.filter(
+            action=NodeLog.FLAG_SPAM,
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='oopspam'
+        ).count()
+
+        return flagged_count
+
+    def get_hammed_count(self, start_date, end_date):
+        from osf.models import NodeLog
+
+        hammed_count = NodeLog.objects.filter(
+            action=NodeLog.CONFIRM_HAM,
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='oopspam'
+        ).count()
+
+        return hammed_count

--- a/osf/external/oopspam/client.py
+++ b/osf/external/oopspam/client.py
@@ -49,6 +49,9 @@ class OOPSpamClient:
     def get_flagged_count(self, start_date, end_date, category='node'):
         from osf.models import NodeLog, PreprintLog
 
+        if category not in ['node', 'preprint']:
+            raise ValueError(f"Invalid category '{category}'. Expected 'node' or 'preprint'.")
+
         log_model = NodeLog if category == 'node' else PreprintLog
 
         flagged_count = log_model.objects.filter(
@@ -62,6 +65,9 @@ class OOPSpamClient:
 
     def get_hammed_count(self, start_date, end_date, category='node'):
         from osf.models import NodeLog, PreprintLog
+
+        if category not in ['node', 'preprint']:
+            raise ValueError(f"Invalid category '{category}'. Expected 'node' or 'preprint'.")
 
         log_model = NodeLog if category == 'node' else PreprintLog
 

--- a/osf/external/oopspam/client.py
+++ b/osf/external/oopspam/client.py
@@ -53,7 +53,7 @@ class OOPSpamClient:
             action=NodeLog.FLAG_SPAM,
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='oopspam'
+            node__spam_data__who_flagged__in=['oopspam', 'both']
         ).count()
 
         return flagged_count
@@ -65,7 +65,7 @@ class OOPSpamClient:
             action=NodeLog.CONFIRM_HAM,
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='oopspam'
+            node__spam_data__who_flagged__in=['oopspam', 'both']
         ).count()
 
         return hammed_count

--- a/osf/metrics/reporters/__init__.py
+++ b/osf/metrics/reporters/__init__.py
@@ -10,6 +10,7 @@ from .osfstorage_file_count import OsfstorageFileCountReporter
 from .preprint_count import PreprintCountReporter
 from .user_count import UserCountReporter
 from .spam_count import SpamCountReporter
+from .private_spam_metrics import PrivateSpamMetricsReporter
 
 
 class AllDailyReporters(enum.Enum):
@@ -26,3 +27,4 @@ class AllDailyReporters(enum.Enum):
 
 class AllMonthlyReporters(enum.Enum):
     SPAM_COUNT = SpamCountReporter
+    PRIVATE_SPAM_METRICS = PrivateSpamMetricsReporter

--- a/osf/metrics/reporters/private_spam_metrics.py
+++ b/osf/metrics/reporters/private_spam_metrics.py
@@ -1,0 +1,28 @@
+from osf.metrics.reports import SpamSummaryReport
+from osf.external.oopspam.client import OOPSpamClient
+from osf.external.askismet.client import AkismetClient
+from ._base import MonthlyReporter
+
+class PrivateSpamMetricsReporter(MonthlyReporter):
+    report_name = 'Private Spam Metrics'
+
+    def report(self, report_yearmonth):
+        target_month = report_yearmonth.target_month()
+        next_month = report_yearmonth.next_month()
+
+        oopspam_client = OOPSpamClient()
+        akismet_client = AkismetClient()
+
+        report = SpamSummaryReport(
+            report_yearmonth=str(report_yearmonth),
+            node_oopspam_flagged=oopspam_client.get_flagged_count(target_month, next_month, category='node'),
+            node_oopspam_hammed=oopspam_client.get_hammed_count(target_month, next_month, category='node'),
+            node_akismet_flagged=akismet_client.get_flagged_count(target_month, next_month, category='node'),
+            node_akismet_hammed=akismet_client.get_hammed_count(target_month, next_month, category='node'),
+            preprint_oopspam_flagged=oopspam_client.get_flagged_count(target_month, next_month, category='preprint'),
+            preprint_oopspam_hammed=oopspam_client.get_hammed_count(target_month, next_month, category='preprint'),
+            preprint_akismet_flagged=akismet_client.get_flagged_count(target_month, next_month, category='preprint'),
+            preprint_akismet_hammed=akismet_client.get_hammed_count(target_month, next_month, category='preprint')
+        )
+
+        return [report]

--- a/osf/metrics/reporters/spam_count.py
+++ b/osf/metrics/reporters/spam_count.py
@@ -4,24 +4,12 @@ from osf.metrics.reports import SpamSummaryReport
 from ._base import MonthlyReporter
 from osf.models import PreprintLog, NodeLog
 from osf.models.spam import SpamStatus
-from osf.external.oopspam.client import OOPSpamClient
-from osf.external.askismet.client import AkismetClient
-
 
 class SpamCountReporter(MonthlyReporter):
 
     def report(self, report_yearmonth):
         target_month = report_yearmonth.target_month()
         next_month = report_yearmonth.next_month()
-
-        oopspam_client = OOPSpamClient()
-        akismet_client = AkismetClient()
-
-        oopspam_flagged = oopspam_client.get_flagged_count(target_month, next_month)
-        oopspam_hammed = oopspam_client.get_hammed_count(target_month, next_month)
-
-        akismet_flagged = akismet_client.get_flagged_count(target_month, next_month)
-        akismet_hammed = akismet_client.get_hammed_count(target_month, next_month)
 
         report = SpamSummaryReport(
             report_yearmonth=str(report_yearmonth),
@@ -44,10 +32,6 @@ class SpamCountReporter(MonthlyReporter):
                 created__lt=next_month,
                 node__type='osf.node',
             ).count(),
-            oopspam_flagged=oopspam_flagged,
-            oopspam_hammed=oopspam_hammed,
-            akismet_flagged=akismet_flagged,
-            akismet_hammed=akismet_hammed,
             # Registration Log entries
             registration_confirmed_spam=NodeLog.objects.filter(
                 action=NodeLog.CONFIRM_SPAM,

--- a/osf/metrics/reports.py
+++ b/osf/metrics/reports.py
@@ -214,3 +214,7 @@ class SpamSummaryReport(MonthlyReport):
     preprint_flagged = metrics.Integer()
     user_marked_as_spam = metrics.Integer()
     user_marked_as_ham = metrics.Integer()
+    oopspam_flagged = metrics.Integer()
+    oopspam_hammed = metrics.Integer()
+    akismet_flagged = metrics.Integer()
+    akismet_hammed = metrics.Integer()

--- a/osf/metrics/reports.py
+++ b/osf/metrics/reports.py
@@ -214,7 +214,3 @@ class SpamSummaryReport(MonthlyReport):
     preprint_flagged = metrics.Integer()
     user_marked_as_spam = metrics.Integer()
     user_marked_as_ham = metrics.Integer()
-    oopspam_flagged = metrics.Integer()
-    oopspam_hammed = metrics.Integer()
-    akismet_flagged = metrics.Integer()
-    akismet_hammed = metrics.Integer()

--- a/osf_tests/external/akismet/test_akismet.py
+++ b/osf_tests/external/akismet/test_akismet.py
@@ -243,40 +243,33 @@ class TestSpam:
         from osf.external.askismet.client import AkismetClient
         from datetime import datetime
 
-        mock_filter.return_value.count.return_value = 7
-
         client = AkismetClient()
         start_date = datetime(2024, 10, 1)
         end_date = datetime(2024, 10, 31)
 
-        flagged_count = client.get_flagged_count(start_date, end_date)
+        client.get_flagged_count(start_date, end_date)
 
         mock_filter.assert_called_with(
             action='flag_spam',
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='akismet'
+            node__spam_data__who_flagged__in=['akismet', 'both']
         )
-        assert flagged_count == 7
 
     @mock.patch('osf.models.NodeLog.objects.filter')
     def test_get_hammed_count(self, mock_filter, user):
         from osf.external.askismet.client import AkismetClient
         from datetime import datetime
 
-        mock_filter.return_value.count.return_value = 4
-
         client = AkismetClient()
         start_date = datetime(2024, 10, 1)
         end_date = datetime(2024, 10, 31)
 
-        hammed_count = client.get_hammed_count(start_date, end_date)
+        client.get_hammed_count(start_date, end_date)
 
         mock_filter.assert_called_with(
             action='confirm_ham',
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='akismet'
+            node__spam_data__who_flagged__in=['akismet', 'both']
         )
-        assert hammed_count == 4
-

--- a/osf_tests/external/oopspam/test_oopspam.py
+++ b/osf_tests/external/oopspam/test_oopspam.py
@@ -131,39 +131,33 @@ class TestSpam:
         from osf.external.oopspam.client import OOPSpamClient
         from datetime import datetime
 
-        mock_filter.return_value.count.return_value = 5
-
         client = OOPSpamClient()
         start_date = datetime(2024, 10, 1)
         end_date = datetime(2024, 10, 31)
 
-        flagged_count = client.get_flagged_count(start_date, end_date)
+        client.get_flagged_count(start_date, end_date)
 
         mock_filter.assert_called_with(
             action='flag_spam',
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='oopspam'
+            node__spam_data__who_flagged__in=['oopspam', 'both']
         )
-        assert flagged_count == 5
 
     @mock.patch('osf.models.NodeLog.objects.filter')
     def test_get_hammed_count(self, mock_filter, user):
         from osf.external.oopspam.client import OOPSpamClient
         from datetime import datetime
 
-        mock_filter.return_value.count.return_value = 3
-
         client = OOPSpamClient()
         start_date = datetime(2024, 10, 1)
         end_date = datetime(2024, 10, 31)
 
-        hammed_count = client.get_hammed_count(start_date, end_date)
+        client.get_hammed_count(start_date, end_date)
 
         mock_filter.assert_called_with(
             action='confirm_ham',
             created__gt=start_date,
             created__lt=end_date,
-            spam_data__who_flagged='oopspam'
+            node__spam_data__who_flagged__in=['oopspam', 'both']
         )
-        assert hammed_count == 3

--- a/osf_tests/external/oopspam/test_oopspam.py
+++ b/osf_tests/external/oopspam/test_oopspam.py
@@ -125,3 +125,45 @@ class TestSpam:
         )
 
         assert user.spam_status == SpamStatus.UNKNOWN
+
+    @mock.patch('osf.models.NodeLog.objects.filter')
+    def test_get_flagged_count(self, mock_filter, user):
+        from osf.external.oopspam.client import OOPSpamClient
+        from datetime import datetime
+
+        mock_filter.return_value.count.return_value = 5
+
+        client = OOPSpamClient()
+        start_date = datetime(2024, 10, 1)
+        end_date = datetime(2024, 10, 31)
+
+        flagged_count = client.get_flagged_count(start_date, end_date)
+
+        mock_filter.assert_called_with(
+            action='flag_spam',
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='oopspam'
+        )
+        assert flagged_count == 5
+
+    @mock.patch('osf.models.NodeLog.objects.filter')
+    def test_get_hammed_count(self, mock_filter, user):
+        from osf.external.oopspam.client import OOPSpamClient
+        from datetime import datetime
+
+        mock_filter.return_value.count.return_value = 3
+
+        client = OOPSpamClient()
+        start_date = datetime(2024, 10, 1)
+        end_date = datetime(2024, 10, 31)
+
+        hammed_count = client.get_hammed_count(start_date, end_date)
+
+        mock_filter.assert_called_with(
+            action='confirm_ham',
+            created__gt=start_date,
+            created__lt=end_date,
+            spam_data__who_flagged='oopspam'
+        )
+        assert hammed_count == 3

--- a/osf_tests/metrics/test_spam_count_reporter.py
+++ b/osf_tests/metrics/test_spam_count_reporter.py
@@ -1,28 +1,12 @@
 import pytest
 from datetime import datetime
-from osf.metrics.reporters.spam_count import SpamCountReporter
-from unittest import mock
+from osf.metrics.reporters.private_spam_metrics import PrivateSpamMetricsReporter
 from osf.metrics.utils import YearMonth
 from osf_tests.factories import NodeLogFactory, NodeFactory
-
-@pytest.fixture
-def mock_oopspam_client():
-    with mock.patch('osf.external.oopspam.client.OOPSpamClient') as mock_client:
-        instance = mock_client.return_value
-        instance.get_flagged_count.return_value = 10
-        instance.get_hammed_count.return_value = 5
-        yield instance
-
-@pytest.fixture
-def mock_akismet_client():
-    with mock.patch('osf.external.askismet.client.AkismetClient') as mock_client:
-        instance = mock_client.return_value
-        instance.get_flagged_count.return_value = 20
-        instance.get_hammed_count.return_value = 10
-        yield instance
+from unittest.mock import patch
 
 @pytest.mark.django_db
-def test_spam_count_reporter():
+def test_private_spam_metrics_reporter():
     start_date = datetime(2024, 10, 1)
 
     oopspam_node = NodeFactory(spam_data={'who_flagged': 'oopspam'})
@@ -34,10 +18,21 @@ def test_spam_count_reporter():
     NodeLogFactory.create_batch(10, action='confirm_ham', created=start_date, node=akismet_node)
 
     report_yearmonth = YearMonth(2024, 10)
-    reporter = SpamCountReporter()
-    report = reporter.report(report_yearmonth)
 
-    assert report[0].oopspam_flagged == 10
-    assert report[0].oopspam_hammed == 5
-    assert report[0].akismet_flagged == 20
-    assert report[0].akismet_hammed == 10
+    with patch('osf.external.oopspam.client.OOPSpamClient.get_flagged_count') as mock_oopspam_get_flagged_count, \
+         patch('osf.external.oopspam.client.OOPSpamClient.get_hammed_count') as mock_oopspam_get_hammed_count, \
+         patch('osf.external.askismet.client.AkismetClient.get_flagged_count') as mock_akismet_get_flagged_count, \
+         patch('osf.external.askismet.client.AkismetClient.get_hammed_count') as mock_akismet_get_hammed_count:
+
+        mock_oopspam_get_flagged_count.return_value = 10
+        mock_oopspam_get_hammed_count.return_value = 5
+        mock_akismet_get_flagged_count.return_value = 20
+        mock_akismet_get_hammed_count.return_value = 10
+
+        reporter = PrivateSpamMetricsReporter()
+        report = reporter.report(report_yearmonth)[0]
+
+        assert report.node_oopspam_flagged == 10, f"Expected 10, got {report.node_oopspam_flagged}"
+        assert report.node_oopspam_hammed == 5, f"Expected 5, got {report.node_oopspam_hammed}"
+        assert report.node_akismet_flagged == 20, f"Expected 20, got {report.node_akismet_flagged}"
+        assert report.node_akismet_hammed == 10, f"Expected 10, got {report.node_akismet_hammed}"

--- a/osf_tests/metrics/test_spam_count_reporter.py
+++ b/osf_tests/metrics/test_spam_count_reporter.py
@@ -1,0 +1,43 @@
+import datetime
+import pytest
+from osf.metrics.reporters.spam_count import SpamCountReporter
+from osf.external.oopspam.client import OOPSpamClient
+from osf.external.askismet.client import AkismetClient
+
+@pytest.fixture
+def mock_oopspam_client(mocker):
+    mock = mocker.patch('osf.external.oopspam.client.OOPSpamClient')
+    mock.get_flagged_count.return_value = 10
+    mock.get_hammed_count.return_value = 5
+    return mock
+
+@pytest.fixture
+def mock_akismet_client(mocker):
+    mock = mocker.patch('osf.external.askismet.client.AkismetClient')
+    mock.get_flagged_count.return_value = 20
+    mock.get_hammed_count.return_value = 10
+    return mock
+
+@pytest.fixture
+def mock_nodelog_model(mocker):
+    mock = mocker.patch('osf.models.NodeLog')
+    mock.filter.return_value.count.return_value = 100
+    return mock
+
+@pytest.fixture
+def mock_preprintlog_model(mocker):
+    mock = mocker.patch('osf.models.PreprintLog')
+    mock.filter.return_value.count.return_value = 50
+    return mock
+
+def test_spam_count_reporter(mock_oopspam_client, mock_akismet_client, mock_nodelog_model, mock_preprintlog_model):
+    report_month = datetime.datetime(2024, 10, 1)
+    reporter = SpamCountReporter()
+    report = reporter.report(report_month)
+
+    assert report[0].oopspam_flagged == 10
+    assert report[0].oopspam_hammed == 5
+    assert report[0].akismet_flagged == 20
+    assert report[0].akismet_hammed == 10
+    assert report[0].node_confirmed_spam == 100
+    assert report[0].preprint_confirmed_spam == 50


### PR DESCRIPTION
## Purpose

Add OOPSpam and Akismet metrics to track flagged and hammed content

## Changes

- SpamCountReporter: Added OOPSpam and Akismet spam/ham metrics for nodes, registrations, preprints, and users.
- SpamSummaryReport: Added new fields for OOPSpam and Akismet flagged/hammed counts.
- OOPSpamClient & AkismetClient: Added methods to get flagged and hammed content counts.

## Ticket

(https://openscience.atlassian.net/browse/ENG-4438)

Deployment Note: Because the metric report has changed, it will be necessary to run sync_metrics to apply these changes to the updated spam metrics report.