### PR TITLE
Fix google drive short name in translations

### DIFF
--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -24,7 +24,7 @@ class _LegacyConfigsForWBKey(enum.Enum):
     figshare = FigshareAddonAppConfig
     github = GitHubAddonConfig
     gitlab = GitLabAddonConfig
-    google_drive = GoogleDriveAddonConfig
+    googledrive = GoogleDriveAddonConfig
     s3 = S3AddonAppConfig
 
 

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -12,6 +12,7 @@ from addons.github.apps import GitHubAddonConfig
 from addons.gitlab.apps import GitLabAddonConfig
 from addons.googledrive.apps import GoogleDriveAddonConfig
 from addons.s3.apps import S3AddonAppConfig
+from addons.onedrive.apps import OneDriveAddonAppConfig
 from . import request_helpers as gv_requests
 
 
@@ -26,6 +27,7 @@ class _LegacyConfigsForWBKey(enum.Enum):
     gitlab = GitLabAddonConfig
     googledrive = GoogleDriveAddonConfig
     s3 = S3AddonAppConfig
+    onedrive = OneDriveAddonAppConfig
 
 
 def make_ephemeral_user_settings(gv_account_data, requesting_user):


### PR DESCRIPTION
## Purpose

Google drive had an underscore in the short name (`google_drive`) in the translations file, but in waterbutler it is just `googledrive`. So this fixes it to match waterbutler. Also adds onedrive.

## Changes

1. Rename google_drive.
2. Add onedrive