### PR TITLE
[ENG-6571][hotfix] recatalog_metadata --also-decatalog

### DIFF
--- a/osf/management/commands/recatalog_metadata.py
+++ b/osf/management/commands/recatalog_metadata.py
@@ -55,21 +55,6 @@ def _recatalog_all(queryset, chunk_size):
     recatalog(queryset, start_id=0, chunk_count=int(9e9), chunk_size=chunk_size)
 
 
-def _recatalog_datacite_custom_types(chunk_size):
-    logger.info('recataloguing items with datacite custom type...')
-    # all preprints
-    _recatalog_all(Preprint.objects, chunk_size)
-    # objects with custom resource_type_general
-    for _model in {Registration, Node, OsfStorageFile}:
-        _queryset = (
-            _model.objects
-            .exclude(guids__metadata_record__isnull=True)
-            .exclude(guids__metadata_record__resource_type_general='')
-        )
-        _recatalog_all(_queryset, chunk_size)
-    logger.info('done recataloguing items with datacite custom type!')
-
-
 class Command(BaseCommand):
     def add_arguments(self, parser):
         type_group = parser.add_mutually_exclusive_group(required=True)
@@ -102,14 +87,6 @@ class Command(BaseCommand):
             '--users',
             action='store_true',
             help='recatalog metadata for users',
-        )
-        type_group.add_argument(
-            '--datacite-custom-types',
-            action='store_true',
-            help='''recatalog metadata for items with a specific datacite type,
-            including all preprints and items with custom resource_type_general
-            (may be slow for lack of database indexes)
-            ''',
         )
 
         provider_group = parser.add_mutually_exclusive_group()
@@ -161,14 +138,7 @@ class Command(BaseCommand):
         start_id = options['start_id']
         chunk_size = options['chunk_size']
         chunk_count = options['chunk_count']
-        datacite_custom_types = options['datacite_custom_types']
         also_decatalog = options['also_decatalog']
-
-        if datacite_custom_types:  # temporary arg for datacite 4.5 migration
-            assert not start_id, 'oh no, cannot resume with `--datacite-custom-types`'
-            assert not provider_ids, 'oh no, cannot filter providers with `--datacite-custom-types`'
-            _recatalog_datacite_custom_types(chunk_size)
-            return  # end
 
         if pls_all_types:
             assert not start_id, 'choose a specific type to resume with --start-id'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
speedier `manage.py recatalog_metadata` by skipping private/deleted
<!-- Describe the purpose of your changes -->

## Changes
- update `recatalog_metadata` to skip private/deleted items by default
- add `--also-decatalog` to include private/deleted items
- update tests...
- remove `--datacite-custom-types` (comment describes it as a "temporary arg for datacite 4.5 migration" and updating tests for it became annoying)
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
