### PR TITLE
[ENG-6435] fix: duplicate reports when run for past years

### DIFF
--- a/osf/metrics/utils.py
+++ b/osf/metrics/utils.py
@@ -46,6 +46,16 @@ class YearMonth:
         else:
             raise ValueError(f'expected YYYY-MM format, got "{input_str}"')
 
+    @classmethod
+    def from_any(cls, data) -> YearMonth:
+        if isinstance(data, YearMonth):
+            return data
+        elif isinstance(data, str):
+            return YearMonth.from_str(data)
+        elif isinstance(data, (datetime.datetime, datetime.date)):
+            return YearMonth.from_date(data)
+        raise ValueError(f'cannot coerce {data} into YearMonth')
+
     def __str__(self):
         """convert to string of "YYYY-MM" format"""
         return f'{self.year}-{self.month:0>2}'

--- a/osf_tests/metrics/test_daily_report.py
+++ b/osf_tests/metrics/test_daily_report.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime
 from unittest import mock
 
 import pytest
@@ -21,7 +21,13 @@ class TestDailyReportKey:
             class Meta:
                 app_label = 'osf'
 
-        today = date(2022, 5, 18)
+        today = datetime.date(2022, 5, 18)
+        expected_timestamp = datetime.datetime(
+            today.year,
+            today.month,
+            today.day,
+            tzinfo=datetime.UTC,
+        )
 
         reports = [
             UniqueByDate(report_date=today),
@@ -35,6 +41,7 @@ class TestDailyReportKey:
             assert mock_save.call_count == 1
             assert mock_save.call_args[0][0] is report
             assert report.meta.id == expected_key
+            assert report.timestamp == expected_timestamp
             mock_save.reset_mock()
 
     def test_with_unique_together(self, mock_save):
@@ -46,7 +53,13 @@ class TestDailyReportKey:
             class Meta:
                 app_label = 'osf'
 
-        today = date(2022, 5, 18)
+        today = datetime.date(2022, 5, 18)
+        expected_timestamp = datetime.datetime(
+            today.year,
+            today.month,
+            today.day,
+            tzinfo=datetime.UTC,
+        )
 
         expected_blah = 'dca57e6cde89b19274ea24bc713971dab137a896b8e06d43a11a3f437cd1d151'
         blah_report = UniqueByDateAndField(report_date=today, uniquefield='blah')
@@ -54,6 +67,7 @@ class TestDailyReportKey:
         assert mock_save.call_count == 1
         assert mock_save.call_args[0][0] is blah_report
         assert blah_report.meta.id == expected_blah
+        assert blah_report.timestamp == expected_timestamp
         mock_save.reset_mock()
 
         expected_fleh = 'e7dd5ff6b087807efcfa958077dc713878f21c65af79b3ccdb5dc2409bf5ad99'
@@ -62,6 +76,7 @@ class TestDailyReportKey:
         assert mock_save.call_count == 1
         assert mock_save.call_args[0][0] is fleh_report
         assert fleh_report.meta.id == expected_fleh
+        assert fleh_report.timestamp == expected_timestamp
         mock_save.reset_mock()
 
         for _bad_report in (

--- a/osf_tests/metrics/test_monthly_report.py
+++ b/osf_tests/metrics/test_monthly_report.py
@@ -23,6 +23,7 @@ class TestMonthlyReportKey:
                 app_label = 'osf'
 
         yearmonth = YearMonth(2022, 5)
+        expected_timestamp = datetime.datetime(yearmonth.year, yearmonth.month, 1, tzinfo=datetime.UTC)
 
         reports = [
             UniqueByMonth(report_yearmonth=yearmonth),
@@ -36,6 +37,7 @@ class TestMonthlyReportKey:
             assert mock_save.call_count == 1
             assert mock_save.call_args[0][0] is report
             assert report.meta.id == expected_key
+            assert report.timestamp == expected_timestamp
             mock_save.reset_mock()
 
     def test_with_unique_together(self, mock_save):
@@ -48,6 +50,7 @@ class TestMonthlyReportKey:
                 app_label = 'osf'
 
         yearmonth = YearMonth(2022, 5)
+        expected_timestamp = datetime.datetime(yearmonth.year, yearmonth.month, 1, tzinfo=datetime.UTC)
 
         expected_blah = '62ebf38317cd8402e27a50ce99f836d1734b3f545adf7d144d0e1cf37a0d9d08'
         blah_report = UniqueByMonthAndField(report_yearmonth=yearmonth, uniquefield='blah')
@@ -55,6 +58,7 @@ class TestMonthlyReportKey:
         assert mock_save.call_count == 1
         assert mock_save.call_args[0][0] is blah_report
         assert blah_report.meta.id == expected_blah
+        assert blah_report.timestamp == expected_timestamp
         mock_save.reset_mock()
 
         expected_fleh = '385700db282f6d6089a0d21836db5ee8423f548615e515b6e034bcc90a14500f'
@@ -63,6 +67,7 @@ class TestMonthlyReportKey:
         assert mock_save.call_count == 1
         assert mock_save.call_args[0][0] is fleh_report
         assert fleh_report.meta.id == expected_fleh
+        assert fleh_report.timestamp == expected_timestamp
         mock_save.reset_mock()
 
         for _bad_report in (

--- a/osf_tests/metrics/test_yearmonth.txt
+++ b/osf_tests/metrics/test_yearmonth.txt
@@ -24,6 +24,24 @@ YearMonth(year=1974, month=3)
 >>> YearMonth.from_str('2000-12')
 YearMonth(year=2000, month=12)
 
+`from_any` constructor, accepts YearMonth, "YYYY-MM", or date/datetime
+>>> YearMonth.from_any('2000-12')
+YearMonth(year=2000, month=12)
+>>> YearMonth.from_any(_) is _
+True
+>>> YearMonth.from_any(datetime.date(1973, 1, 1))
+YearMonth(year=1973, month=1)
+>>> YearMonth.from_any(datetime.datetime(1974, 3, 2))
+YearMonth(year=1974, month=3)
+>>> YearMonth.from_any(None)
+Traceback (most recent call last):
+    ...
+ValueError: cannot coerce None into YearMonth
+>>> YearMonth.from_any(7)
+Traceback (most recent call last):
+    ...
+ValueError: cannot coerce 7 into YearMonth
+
 `__str__` method gives "YYYY-MM" format:
 >>> str(YearMonth(1491, 7))
 '1491-07'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
prevent duplicate reports when monthly/daily reports are run for past years
<!-- Describe the purpose of your changes -->

## Changes
set `timestamp` based on `report_date`/`report_yearmonth`, so it's indexed by reporting period rather than when the reporter is run
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
