### PR TITLE
[ENG-6476] Updated `build_posted_content` to include DOI version relationship

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -553,7 +553,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
 
     def get_preprint_versions(self):
         guids = self.versioned_guids.first().guid.versions.all()
-        preprint_versions = Preprint.objects.filter(id__in=[vg.object_id for vg in guids])
+        preprint_versions = Preprint.objects.filter(id__in=[vg.object_id for vg in guids]).order_by('-id')
         return preprint_versions
 
     def web_url_for(self, view_name, _absolute=False, _guid=False, *args, **kwargs):

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -551,6 +551,12 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
 
         return csl
 
+    def get_preprint_versions(self):
+        guid = self.guids.first()
+        versioned_guids = guid.versions.all()
+        preprint_versions = Preprint.objects.filter(id__in=[vg.object_id for vg in versioned_guids])
+        return preprint_versions
+
     def web_url_for(self, view_name, _absolute=False, _guid=False, *args, **kwargs):
         return web_url_for(view_name, pid=self._id,
                            _absolute=_absolute, _guid=_guid, *args, **kwargs)

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -552,9 +552,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         return csl
 
     def get_preprint_versions(self):
-        guid = self.guids.first()
-        versioned_guids = guid.versions.all()
-        preprint_versions = Preprint.objects.filter(id__in=[vg.object_id for vg in versioned_guids])
+        guids = self.versioned_guids.first().guid.versions.all()
+        preprint_versions = Preprint.objects.filter(id__in=[vg.object_id for vg in guids])
         return preprint_versions
 
     def web_url_for(self, view_name, _absolute=False, _guid=False, *args, **kwargs):

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -138,6 +138,23 @@ class CrossRefClient(AbstractIdentifierClient):
         ]
         posted_content.append(element.doi_data(*doi_data))
 
+        preprint_versions = preprint.get_preprint_versions()
+        for preprint_version in preprint_versions:
+            preprint_identifier = preprint_version.identifiers.first().value
+            if doi != preprint_identifier:
+                doi_relations = element.doi_relations(
+                    element.doi(doi),
+                    element.program(
+                        element.related_item(
+                            element.description('Updated version'),
+                            element.intra_work_relation(
+                                preprint_identifier,
+                                **{'relationship-type': 'isVersionOf', 'identifier-type': 'doi'}
+                            )
+                        ), xmlns=CROSSREF_RELATIONS
+                    )
+                )
+                posted_content.append(doi_relations)
         return posted_content
 
     def _process_crossref_name(self, contributor):

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -140,21 +140,22 @@ class CrossRefClient(AbstractIdentifierClient):
 
         preprint_versions = preprint.get_preprint_versions()
         for preprint_version in preprint_versions:
+            if preprint_version == preprint:
+                continue
             preprint_identifier = preprint_version.identifiers.first().value
-            if doi != preprint_identifier:
-                doi_relations = element.doi_relations(
-                    element.doi(doi),
-                    element.program(
-                        element.related_item(
-                            element.description('Updated version'),
-                            element.intra_work_relation(
-                                preprint_identifier,
-                                **{'relationship-type': 'isVersionOf', 'identifier-type': 'doi'}
-                            )
-                        ), xmlns=CROSSREF_RELATIONS
-                    )
+            doi_relations = element.doi_relations(
+                element.doi(doi),
+                element.program(
+                    element.related_item(
+                        element.description('Updated version'),
+                        element.intra_work_relation(
+                            preprint_identifier,
+                            **{'relationship-type': 'isVersionOf', 'identifier-type': 'doi'}
+                        )
+                    ), xmlns=CROSSREF_RELATIONS
                 )
-                posted_content.append(doi_relations)
+            )
+            posted_content.append(doi_relations)
         return posted_content
 
     def _process_crossref_name(self, contributor):

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -140,7 +140,7 @@ class CrossRefClient(AbstractIdentifierClient):
 
         preprint_versions = preprint.get_preprint_versions()
         for preprint_version, previous_version in zip(preprint_versions, preprint_versions[1:]):
-            if preprint_version.id > preprint.id:
+            if preprint_version.version > preprint.version:
                 continue
             doi_relations = element.doi_relations(
                 element.doi(self.build_doi(preprint_version)),

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -139,17 +139,16 @@ class CrossRefClient(AbstractIdentifierClient):
         posted_content.append(element.doi_data(*doi_data))
 
         preprint_versions = preprint.get_preprint_versions()
-        for preprint_version in preprint_versions:
-            if preprint_version == preprint:
+        for preprint_version, previous_version in zip(preprint_versions, preprint_versions[1:]):
+            if preprint_version.id > preprint.id:
                 continue
-            preprint_identifier = preprint_version.identifiers.first().value
             doi_relations = element.doi_relations(
-                element.doi(doi),
+                element.doi(self.build_doi(preprint_version)),
                 element.program(
                     element.related_item(
                         element.description('Updated version'),
                         element.intra_work_relation(
-                            preprint_identifier,
+                            self.build_doi(previous_version),
                             **{'relationship-type': 'isVersionOf', 'identifier-type': 'doi'}
                         )
                     ), xmlns=CROSSREF_RELATIONS


### PR DESCRIPTION
## Purpose

Updated `build_posted_content` to include DOI version relationship

## Changes

Updated method `build_posted_content` to include information about DOI version for preprint

## QA Notes

Note: product needs to verify this on staging server with CrossRef

## Documentation

How posted content looks like with includint information about DOI version for preprint

* Only 1 version

```
  | <posted_content xmlns="http://www.crossref.org/schema/5.3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="preprint">
api-1  |   <group_title>Open Science Framework</group_title>
api-1  |   <contributors>
api-1  |     <person_name sequence="first" contributor_role="author">
api-1  |       <surname>Bohdan</surname>
api-1  |     </person_name>
api-1  |   </contributors>
api-1  |   <titles>
api-1  |     <title>test</title>
api-1  |   </titles>
api-1  |   <posted_date>
api-1  |     <month>11</month>
api-1  |     <day>21</day>
api-1  |     <year>2024</year>
api-1  |   </posted_date>
api-1  |   <item_number>osf.io/efgxs_v1</item_number>
api-1  |   <abstract xmlns="http://www.ncbi.nlm.nih.gov/JATS1">
api-1  |     <p>test rnklwfernlkvnwkrvkl</p>
api-1  |   </abstract>
api-1  |   <program xmlns="http://www.crossref.org/AccessIndicators.xsd">
api-1  |     <license_ref start_date="2024-11-21">http://opensource.org/licenses/AFL-3.0</license_ref>
api-1  |   </program>
api-1  |   <doi_data>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v1</doi>
api-1  |     <resource>http://localhost:5000/efgxs_v1</resource>
api-1  |   </doi_data>
api-1  | </posted_content>
```

* 2 versions of preprint

```
 ---main Posted Content part
api-1  |   <doi_data>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v2</doi>
api-1  |     <resource>http://localhost:5000/efgxs_v2</resource>
api-1  |   </doi_data>
api-1  |   <doi_relations>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v2</doi>
api-1  |     <program xmlns="http://www.crossref.org/relations.xsd">
api-1  |       <related_item>
api-1  |         <description>Updated version</description>
api-1  |         <intra_work_relation relationship-type="isVersionOf" identifier-type="doi">fakeosf/FK2osf.io/efgxs_v1</intra_work_relation>
api-1  |       </related_item>
api-1  |     </program>
api-1  |   </doi_relations>
api-1  | </posted_content>
```

* 3 versions of preprint.

```
 ---main Posted Content part
api-1  |   <doi_data>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v3</doi>
api-1  |     <resource>http://localhost:5000/efgxs_v3</resource>
api-1  |   </doi_data>
api-1  |   <doi_relations>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v3</doi>
api-1  |     <program xmlns="http://www.crossref.org/relations.xsd">
api-1  |       <related_item>
api-1  |         <description>Updated version</description>
api-1  |         <intra_work_relation relationship-type="isVersionOf" identifier-type="doi">fakeosf/FK2osf.io/efgxs_v2</intra_work_relation>
api-1  |       </related_item>
api-1  |     </program>
api-1  |   </doi_relations>
api-1  |   <doi_relations>
api-1  |     <doi>fakeosf/FK2osf.io/efgxs_v2</doi>
api-1  |     <program xmlns="http://www.crossref.org/relations.xsd">
api-1  |       <related_item>
api-1  |         <description>Updated version</description>
api-1  |         <intra_work_relation relationship-type="isVersionOf" identifier-type="doi">fakeosf/FK2osf.io/efgxs_v1</intra_work_relation>
api-1  |       </related_item>
api-1  |     </program>
api-1  |   </doi_relations>
api-1  | </posted_content>
```

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6476
