### PR TITLE
[Hotfix][No Ticket] Optimize InstitutionalUsersReporter

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -446,6 +446,7 @@ class CeleryConfig:
         'osf.management.commands.daily_reporters_go',
         'osf.management.commands.monthly_reporters_go',
         'osf.management.commands.ingest_cedar_metadata_templates',
+        'osf.metrics.reporters',
     }
 
     med_pri_modules = {


### PR DESCRIPTION
## Purpose
Optimize InstitutionalUsersReporter. 

Currently, each individual task may take up to 5 minutes to complete, which clogs the queues. 
This is due to Postgres' query planner using a sequence scan when evaluating the query in `_public_osfstorage_file_queryset`, specifically the `OR` for `(_target_node_q | _target_preprint_q)`.

```
->  Parallel Seq Scan on osf_basefilenode  (cost=371.82..2546660.14 rows=2926198 width=0) (actual time=560.901..21218.302 rows=248 loops=3)
    Filter: ((deleted IS NULL) AND (purged IS NULL) AND (created < '2024-12-01 00:00:00+00'::timestamp with time zone) AND ((type)::text = 'osf.osfstoragefile'::text) AND ((provider)::text = 'osfstorage'::text) AND (((target_content_type_id = %s) AND (hashed SubPlan 1)) OR ((target_content_type_id = %s) AND (hashed SubPlan 2))))
```

Testing against prod data, execution time for the two new queries dropped to ~1ms each, whereas the one former query took up to ~220s in many cases.

## Changes
- Split the return value `_public_osfstorage_file_queryset(s)` into a tuple of querysets
- Specify the `low` queue for `metrics.reporters` tasks.

## QA Notes
N/A

## Side Effects
None expected

## Ticket
N/A