### PR TITLE
[ENG-6546] add report_yearmonth to insti-metrics serializers

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -330,6 +330,7 @@ class NewInstitutionUserMetricsSerializer(JSONAPISerializer):
     })
 
     id = IDField(source='meta.id', read_only=True)
+    report_yearmonth = YearmonthField(read_only=True)
     user_name = ser.CharField(read_only=True)
     department = ser.CharField(read_only=True, source='department_name')
     orcid_id = ser.CharField(read_only=True)
@@ -372,6 +373,7 @@ class NewInstitutionSummaryMetricsSerializer(JSONAPISerializer):
 
     id = IDField(read_only=True)
 
+    report_yearmonth = YearmonthField(read_only=True)
     user_count = ser.IntegerField(read_only=True)
     public_project_count = ser.IntegerField(read_only=True)
     private_project_count = ser.IntegerField(read_only=True)

--- a/api_tests/institutions/views/test_institution_summary_metrics.py
+++ b/api_tests/institutions/views/test_institution_summary_metrics.py
@@ -188,6 +188,7 @@ class TestNewInstitutionSummaryMetricsList:
         assert data['type'] == 'institution-summary-metrics'
 
         attributes = data['attributes']
+        assert attributes['report_yearmonth'] == '2024-08'
         assert attributes['user_count'] == 200
         assert attributes['public_project_count'] == 150
         assert attributes['private_project_count'] == 125
@@ -254,6 +255,7 @@ class TestNewInstitutionSummaryMetricsList:
 
         attributes = data['attributes']
 
+        assert attributes['report_yearmonth'] == '2024-09'
         assert attributes['user_count'] == 250
         assert attributes['public_project_count'] == 200
         assert attributes['private_project_count'] == 150

--- a/api_tests/institutions/views/test_institution_user_metric_list.py
+++ b/api_tests/institutions/views/test_institution_user_metric_list.py
@@ -445,6 +445,7 @@ class TestNewInstitutionUserMetricList:
         response_body = resp.text
         expected_response = [
             [
+                'report_yearmonth',
                 'account_creation_date',
                 'department',
                 'embargoed_registration_count',
@@ -460,6 +461,7 @@ class TestNewInstitutionUserMetricList:
                 'user_name'
             ],
             [
+                '2024-08',
                 '2018-02',
                 'Center, \t Greatest Ever',
                 '1',
@@ -512,6 +514,7 @@ class TestNewInstitutionUserMetricList:
                 month_last_login='2018-02',
             )
             expected_data.append([
+                '2024-08',
                 '2018-02',
                 'QBatman',
                 '1',
@@ -552,6 +555,7 @@ class TestNewInstitutionUserMetricList:
                 response_rows = list(reader)
                 # Validate header row
                 expected_header = [
+                    'report_yearmonth',
                     'account_creation_date',
                     'department',
                     'embargoed_registration_count',
@@ -606,6 +610,7 @@ class TestNewInstitutionUserMetricList:
         response_data = json.loads(resp.body)
         expected_data = [
             {
+                'report_yearmonth': '2024-08',
                 'account_creation_date': '2018-02',
                 'department': 'Safety "The Wolverine" Weapon X',
                 'embargoed_registration_count': 1,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
displaying data date on the dashboard
<!-- Describe the purpose of your changes -->

## Changes
add `report_yearmonth` field to institution summary and user metrics serializers
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify `api.osf.example/v2/institutions/metrics/users/` and `api.osf.example/v2/institutions/metrics/summary/` include a `report_yearmonth` attribute
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
