### PR TITLE
[Hotfix] Fix Preprint Affiliation backfill, PrivateSpamMetricsReport

### DIFF
--- a/osf/management/commands/migrate_preprint_affiliation.py
+++ b/osf/management/commands/migrate_preprint_affiliation.py
@@ -9,6 +9,8 @@ from osf.models import PreprintContributor, InstitutionAffiliation
 
 logger = logging.getLogger(__name__)
 
+AFFILIATION_TARGET_DATE = datetime.datetime(2024, 9, 19, 14, 37, 48, tzinfo=datetime.timezone.utc)
+
 
 class Command(BaseCommand):
     """Assign affiliations from users to preprints where they have write or admin permissions, with optional exclusion by user GUIDs."""
@@ -96,6 +98,9 @@ def assign_affiliations_to_preprints(exclude_guids=None, dry_run=True, batch_siz
             for contributor in batch_contributors:
                 user = contributor.user
                 preprint = contributor.preprint
+
+                if preprint.created > AFFILIATION_TARGET_DATE:
+                    continue
 
                 user_institutions = user.get_affiliated_institutions()
                 processed_count += 1

--- a/osf/metrics/reporters/private_spam_metrics.py
+++ b/osf/metrics/reporters/private_spam_metrics.py
@@ -25,4 +25,4 @@ class PrivateSpamMetricsReporter(MonthlyReporter):
             preprint_akismet_hammed=akismet_client.get_hammed_count(target_month, next_month, category='preprint')
         )
 
-        return [report]
+        return report

--- a/osf_tests/metrics/test_spam_count_reporter.py
+++ b/osf_tests/metrics/test_spam_count_reporter.py
@@ -30,7 +30,7 @@ def test_private_spam_metrics_reporter():
         mock_akismet_get_hammed_count.return_value = 10
 
         reporter = PrivateSpamMetricsReporter(report_yearmonth)
-        report = reporter.report()[0]
+        report = reporter.report()
 
         assert report.node_oopspam_flagged == 10, f"Expected 10, got {report.node_oopspam_flagged}"
         assert report.node_oopspam_hammed == 5, f"Expected 5, got {report.node_oopspam_hammed}"


### PR DESCRIPTION
## Purpose
- Product has opted to only backfill affiliations on preprints created before the initial release of the Preprints Affiliation project.
- Fix an issue preventing the metric reports' execution

## Changes
- Circuit-break the backfill for preprints created past a threshold
- Fix `.report` behavior
- Update tests

## Side Effects
None expected 

## Ticket
None