### PR TITLE
[Hotfix][ENG-6698] Add internal policy views, rather than just linking to GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ RUN set -ex \
         libffi-dev
 
 WORKDIR /code
+
+# Policies
+ADD https://github.com/CenterForOpenScience/cos.io.git#master ./COS_POLICIES/
+
 COPY pyproject.toml .
 COPY poetry.lock .
 # Fix: https://github.com/CenterForOpenScience/osf.io/pull/6783

--- a/website/policies/views.py
+++ b/website/policies/views.py
@@ -1,0 +1,19 @@
+import markdown
+
+from website.settings import \
+    PRIVACY_POLICY_PATH, PRIVACY_POLICY_GITHUB_LINK, \
+    TERMS_POLICY_PATH, TERMS_POLICY_GITHUB_LINK
+
+def privacy_policy():
+    with open(PRIVACY_POLICY_PATH, 'r') as policy_file:
+        return {
+            'policy_content': markdown.markdown(policy_file.read(), extensions=['toc']),
+            'POLICY_GITHUB_LINK': PRIVACY_POLICY_GITHUB_LINK
+        }
+
+def terms_policy():
+    with open(TERMS_POLICY_PATH, 'r') as policy_file:
+        return {
+            'policy_content': markdown.markdown(policy_file.read(), extensions=['toc']),
+            'POLICY_GITHUB_LINK': TERMS_POLICY_GITHUB_LINK
+        }

--- a/website/routes.py
+++ b/website/routes.py
@@ -53,6 +53,7 @@ from website.project import views as project_views
 from addons.base import views as addon_views
 from website.discovery import views as discovery_views
 from website.conferences import views as conference_views
+from website.policies import views as policy_views
 from website.preprints import views as preprint_views
 from website.registries import views as registries_views
 from website.reviews import views as reviews_views
@@ -1142,6 +1143,18 @@ def make_url_map(app):
 
         Rule('/goodbye/', 'get', goodbye, notemplate),
 
+        Rule(
+            '/privacy_policy/',
+            'get',
+            policy_views.privacy_policy,
+            OsfWebRenderer('policies/generic_policy.mako', trust=True)
+        ),
+        Rule(
+            '/terms_of_use/',
+            'get',
+            policy_views.terms_policy,
+            OsfWebRenderer('policies/generic_policy.mako', trust=True)
+        ),
         Rule(
             [
                 '/project/<pid>/',

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -26,6 +26,9 @@ ADDON_PATH = os.path.join(APP_PATH, 'addons')
 STATIC_FOLDER = os.path.join(BASE_PATH, 'static')
 STATIC_URL_PATH = '/static'
 ASSET_HASH_PATH = os.path.join(APP_PATH, 'webpack-assets.json')
+POLICY_PATH = os.path.join(APP_PATH, 'COS_POLICIES')
+PRIVACY_POLICY_PATH = os.path.join(POLICY_PATH, 'PRIVACY_POLICY.md')
+TERMS_POLICY_PATH = os.path.join(POLICY_PATH, 'TERMS_OF_USE.md')
 ROOT = os.path.join(BASE_PATH, '..')
 BCRYPT_LOG_ROUNDS = 12
 LOG_LEVEL = logging.INFO
@@ -2048,10 +2051,12 @@ OSF_PREREG_LOGO = 'osf_prereg'
 OSF_REGISTRIES_LOGO = 'osf_registries'
 OSF_LOGO_LIST = [OSF_LOGO, OSF_PREPRINTS_LOGO, OSF_MEETINGS_LOGO, OSF_PREREG_LOGO, OSF_REGISTRIES_LOGO]
 
+PRIVACY_POLICY_GITHUB_LINK = 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md'
+TERMS_POLICY_GITHUB_LINK = 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md'
 FOOTER_LINKS = {
-    'terms': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md',
-    'privacyPolicy': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md',
-    'cookies': 'https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies',
+    'terms': 'https://osf.io/terms_of_use/',
+    'privacyPolicy': 'https://osf.io/privacy_policy/',
+    'cookies': 'https://osf.io/privacy_policy/#f-cookies',
     'cos': 'https://cos.io',
     'statusPage': 'https://status.cos.io/',
     'apiDocs': 'https://developer.osf.io/',

--- a/website/templates/policies/generic_policy.mako
+++ b/website/templates/policies/generic_policy.mako
@@ -1,0 +1,16 @@
+<%inherit file="base.mako"/>
+
+<%def name="content()">
+<div id="policy" class="container">
+    <div class="row">
+        <div class="col-md-12">
+            <br>
+            ${policy_content}
+        </div>
+        <div class="col-md-12">
+            <br>
+            Version history for this policy is available <a href='${POLICY_GITHUB_LINK}'>here</a>
+        </div>
+    </div>
+</div><!-- end container policy -->
+</%def>


### PR DESCRIPTION
## Purpose
Third parties prefer policies to be accessible on the same domain that the policy covers.

## Changes
- `ADD` policies during Docker build
- Add links, views for rendering policies on OSF pages

![Screenshot 2024-12-09 at 15 27 01](https://github.com/user-attachments/assets/19841cca-f3a8-41cf-a990-d9c271505cdf)

## Side Effects
- EOW will also need footer links updated in https://github.com/CenterForOpenScience/ember-osf-web/pull/2425
- This adds new pages to emberize

## Ticket
ENG-6698