### PR TITLE
[Hotfix][ENG-6675] Assume default  for `global_` notifications

### DIFF
--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -176,7 +176,7 @@ def get_user_subscriptions(user, event):
     if user_subscription:
         return {key: list(getattr(user_subscription, key).all().values_list('guids___id', flat=True)) for key in constants.NOTIFICATION_TYPES}
     else:
-        return {key: [] for key in constants.NOTIFICATION_TYPES}
+        return {key: [user._id] if (event in constants.USER_SUBSCRIPTIONS_AVAILABLE and key == 'email_transactional') else [] for key in constants.NOTIFICATION_TYPES}
 
 
 def get_node_lineage(node):


### PR DESCRIPTION
## Purpose
Ensure deliverability of reviews notifications

## Changes
- If no preferences are configured, assume `email_transactional` for `global_` notifications.
  - This behavior is congruent with expectations detailed in [this comment](https://github.com/CenterForOpenScience/osf.io/blob/d68a07b26d3d79ced42113e8c4b16984f7a9a86c/website/notifications/constants.py#L6-L8)

## QA Notes
- Review actions (accept/reject) should generate notification emails in the absence of configured `NotificationSubscriptions`

## Side Effects
None expected

## Ticket
https://openscience.atlassian.net/browse/ENG-6675
