### PR TITLE
[ENG-6732] Rework version creation for model and factory

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -38,7 +38,7 @@ from api.nodes.serializers import (
 from api.base.metrics import MetricsSerializerMixin
 from api.institutions.utils import update_institutions_if_user_associated
 from api.taxonomies.serializers import TaxonomizableSerializerMixin
-from framework.exceptions import PermissionsError, PendingPreprintVersionExists
+from framework.exceptions import PermissionsError, UnpublishedPendingPreprintVersionExists
 from website.project import signals as project_signals
 from osf.exceptions import NodeStateError, PreprintStateError
 from osf.models import (
@@ -591,7 +591,7 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
             preprint, update_data = Preprint.create_version(create_from_guid, auth)
         except PermissionsError:
             raise PermissionDenied(detail='You must have admin permissions to create new version.')
-        except PendingPreprintVersionExists:
+        except UnpublishedPendingPreprintVersionExists:
             raise Conflict(detail='Before creating a new version, you must publish the latest version.')
         # TODO add more checks
         return self.update(preprint, update_data)

--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -111,7 +111,7 @@ class TemplateHTTPError(HTTPError):
         self.template = template
         super().__init__(code, message, redirect_url, data)
 
-class PendingPreprintVersionExists(FrameworkError):
-    """Raised if an pending preprint version exists
+class UnpublishedPendingPreprintVersionExists(FrameworkError):
+    """Raised if an unpublished pending preprint version exists
     """
     pass

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -820,7 +820,7 @@ class PreprintFactory(DjangoModelFactory):
             title=latest_version.title,
             description=latest_version.description,
             creator=creator,
-            node=latest_version.mode,
+            node=latest_version.node,
         )
         instance.machine_state = 'initial'
         instance.provider = latest_version.provider

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -5,7 +5,6 @@ import datetime
 from random import randint
 from unittest import mock
 
-from datacite.schema42 import contributors
 from factory import SubFactory
 from factory.fuzzy import FuzzyDateTime, FuzzyAttribute, FuzzyChoice
 from unittest.mock import patch, Mock

--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -42,7 +42,7 @@ def preprint():
 
 @pytest.fixture()
 def preprint_version(preprint):
-    versioned_preprint = PreprintFactory.create_version(preprint=preprint)
+    versioned_preprint = PreprintFactory.create_version(preprint)
     return versioned_preprint
 
 @pytest.fixture()


### PR DESCRIPTION
## Purpose

Rework version creation for model and factory

## Changes

* Update version creation in model to support rejected versions
* Fix "pending" version check, which should be "pending and unpublished"
* Fix last version number
* Combine/group data-to-update dictionary
* Rewrote version creation in factories, which doesn't need follow how `_create()` works
* Fix tests

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6732
