### PR TITLE
[Bug} Fix sendgrid email for Institutional Access

### DIFF
--- a/framework/email/tasks.py
+++ b/framework/email/tasks.py
@@ -5,7 +5,7 @@ from email.mime.text import MIMEText
 from io import BytesIO
 
 from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Attachment, Mail, FileContent, Category
+from sendgrid.helpers.mail import Mail, Bcc, ReplyTo, Category, Attachment, FileContent
 
 from framework import sentry
 from framework.celery_tasks import app
@@ -155,10 +155,12 @@ def _send_with_sendgrid(
     )
 
     if reply_to:
-        mail.reply_to = [{'email': reply_to}]
+        mail.reply_to = ReplyTo(reply_to)
 
     if bcc_addr:
-        mail.add_bcc([{'email': email} for email in bcc_addr])
+        if isinstance(bcc_addr, str):
+            bcc_addr = [bcc_addr]
+        mail.bcc = [Bcc(email) for email in bcc_addr]
 
     if categories:
         mail.category = [Category(x) for x in categories]


### PR DESCRIPTION
## Purpose
🐛 
https://staging-sentry2.cos.io/organizations/cos/issues/1780/?query=is%3Aunresolved&referrer=issue-stream&stream_index=0

Unfortunately because of some of the loose mocking and not wanting to get a sendgrid API key our sendgrid code to allow BCC and reply emails did not work, this PR aims to fix it.

## Changes

- uses up to date methods for Bcc and replyto for sendgrid

## QA Notes

**I did finally get a sendgrid API key as a free trial so I validated the client worked, but no actual email could be sent with SMTP server. However it should work in production.**

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
