### PR TITLE
[ENG-6809] [ENG-6817] Handle orphaned version during creation + Fix issues surfaced from Sentry

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -599,8 +599,7 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
             message = 'Fail to create a new version since an unpublished pending version already exists.'
             sentry.log_message(message)
             raise Conflict(detail=message)
-        # TODO add more checks
-        return self.update(preprint, update_data)
+        return self.update(preprint, update_data) if update_data else preprint
 
 
 class PreprintCitationSerializer(NodeCitationSerializer):

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -590,11 +590,9 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
         auth = get_user_auth(self.context['request'])
         try:
             preprint, date_for_update = Preprint.create_version(create_from_guid, auth)
-        except PermissionsError as e:
-            sentry.log_exception(e)
+        except PermissionsError:
             raise PermissionDenied(detail='User must have ADMIN permission to create a new preprint version.')
-        except UnpublishedPendingPreprintVersionExists as e:
-            sentry.log_exception(e)
+        except UnpublishedPendingPreprintVersionExists:
             raise Conflict(detail='Failed to create a new preprint version due to unpublished pending version exists.')
         if not preprint:
             raise NotFound(detail='Failed to create a new preprint version due to source preprint not found.')

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -563,6 +563,7 @@ class PreprintDraftSerializer(PreprintSerializer):
 
 class PreprintCreateSerializer(PreprintSerializer):
     # Overrides PreprintSerializer to make id nullable, adds `create`
+    # TODO: add better Docstrings
     id = IDField(source='_id', required=False, allow_null=True)
 
     def create(self, validated_data):
@@ -580,6 +581,7 @@ class PreprintCreateSerializer(PreprintSerializer):
 
 class PreprintCreateVersionSerializer(PreprintSerializer):
     # Overrides PreprintSerializer to make title nullable and customize version creation
+    # TODO: add better Docstrings
     id = IDField(source='_id', required=False, allow_null=True)
     title = ser.CharField(required=False)
     create_from_guid = ser.CharField(required=True, write_only=True)
@@ -588,15 +590,15 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
         create_from_guid = validated_data.pop('create_from_guid', None)
         auth = get_user_auth(self.context['request'])
         try:
-            preprint, date_for_update = Preprint.create_version(create_from_guid, auth)
+            preprint, data_to_update = Preprint.create_version(create_from_guid, auth)
         except PermissionsError:
             raise PermissionDenied(detail='User must have ADMIN permission to create a new preprint version.')
         except UnpublishedPendingPreprintVersionExists:
             raise Conflict(detail='Failed to create a new preprint version due to unpublished pending version exists.')
         if not preprint:
             raise NotFound(detail='Failed to create a new preprint version due to source preprint not found.')
-        if date_for_update:
-            return self.update(preprint, date_for_update)
+        if data_to_update:
+            return self.update(preprint, data_to_update)
         return preprint
 
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -4,7 +4,6 @@ from rest_framework import serializers as ser
 from rest_framework.fields import empty
 from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError as DRFValidationError
 
-from framework import sentry
 from website import settings
 
 from api.base.exceptions import Conflict, JSONAPIException

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -527,7 +527,12 @@ class VersionedGuidMixin(GuidMixin):
         try:
             versioned_guid = self.versioned_guids
             if not versioned_guid.exists():
-                sentry.log_message(f'`self.versioned_guids` does not exist: [self={self}]')
+                # This can happen during the gap AFTER preprint version is created and BEFORE versioned guid is created.
+                # This happens every time recursively inside `.super().save()` when the `preprint.save()` is called for
+                # the first time during preprint creation and new preprint version creation.
+                sentry.log_message(
+                    f'`self.versioned_guids` does not exist: [self={self.pk}, type={type(self).__name__}]'
+                )
                 return None
             guid = versioned_guid.first().guid
             version = versioned_guid.first().version

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -317,18 +317,25 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         return preprint
 
     def get_last_not_rejected_version(self):
-        guid_obj = self.get_guid()
-        return guid_obj.versions.filter(is_rejected=False).order_by('-version').first().referent
+        return self.get_guid().versions.filter(is_rejected=False).order_by('-version').first().referent
 
-    def check_unpublished_pending_version(self):
+    def has_unpublished_pending_version(self):
+        last_not_rejected_version = self.get_last_not_rejected_version()
+        return not last_not_rejected_version.date_published and last_not_rejected_version.machine_state == 'pending'
+
+    def has_initiated_but_unfinished_version(self):
+        last_not_rejected_version = self.get_last_not_rejected_version()
+        return not last_not_rejected_version.date_published and last_not_rejected_version.machine_state == 'initial'
+
+    def check_unfinished_or_unpublished_version(self):
         last_not_rejected_version = self.get_last_not_rejected_version()
         if last_not_rejected_version.date_published:
-            return None
-        return last_not_rejected_version if last_not_rejected_version.machine_state == 'pending' else None
-
-    def check_initiated_but_unfinished_version(self):
-        last_not_rejected_version = self.get_last_not_rejected_version()
-        return last_not_rejected_version if last_not_rejected_version.machine_state == 'initial' else None
+            return None, None
+        if last_not_rejected_version.machine_state == 'initial':
+            return last_not_rejected_version, None
+        if last_not_rejected_version.machine_state == 'pending':
+            return None, last_not_rejected_version
+        return None, None
 
     @classmethod
     def create_version(cls, create_from_guid, auth):
@@ -345,20 +352,19 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if not source_preprint.has_permission(auth.user, ADMIN):
             sentry.log_message('User must have admin permissions to create new version.')
             raise PermissionsError
-        unpublished_pending_version = source_preprint.check_unpublished_pending_version()
-        if unpublished_pending_version:
+        unfinished_version, unpublished_version = source_preprint.check_unfinished_or_unpublished_version()
+        if unpublished_version:
             sentry.log_message('Unpublished pending version found; failed to create a new one: '
-                               f'[version={unpublished_pending_version.version}, '
-                               f'_id={unpublished_pending_version._id}, '
-                               f'state={unpublished_pending_version.machine_state}].')
+                               f'[version={unpublished_version.version}, '
+                               f'_id={unpublished_version._id}, '
+                               f'state={unpublished_version.machine_state}].')
             raise UnpublishedPendingPreprintVersionExists
-        initiated_but_unfinished_version = source_preprint.check_initiated_but_unfinished_version()
-        if initiated_but_unfinished_version:
+        if unfinished_version:
             sentry.log_message(f'Unfinished version found, using it instead of creating a new one: '
-                               f'[version={initiated_but_unfinished_version.version}, '
-                               f'_id={initiated_but_unfinished_version._id}, '
-                               f'state={initiated_but_unfinished_version.machine_state}].')
-            return initiated_but_unfinished_version, None
+                               f'[version={unfinished_version.version}, '
+                               f'_id={unfinished_version._id}, '
+                               f'state={unfinished_version.machine_state}].')
+            return unfinished_version, None
 
         # Note: last version may not be the latest version
         last_version_number = guid_obj.versions.order_by('-version').first().version

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -820,6 +820,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             return None
 
     def save(self, *args, **kwargs):
+        # TODO: document how `.save()` is customized for preprint
+        # TODO: insert a bare-minimum condition for saving preprint before guid and/or versioned guid is created
         first_save = not bool(self.pk)
         saved_fields = self.get_dirty_fields() or []
 

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -289,8 +289,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
     def create(cls, provider, title, creator, description):
         """Customized creation process to support preprint versions and versioned guid.
         """
-        # Create the preprint and base guid object manually
-        base_guid_obj = Guid.objects.create()
+        # Step 1: Create the preprint obj
         preprint = cls(
             provider=provider,
             title=title,
@@ -298,12 +297,13 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             description=description,
         )
         preprint.save()
+        # Step 2: Create the base guid obj
+        base_guid_obj = Guid.objects.create()
         base_guid_obj.referent = preprint
         base_guid_obj.object_id = preprint.pk
         base_guid_obj.content_type = ContentType.objects.get_for_model(preprint)
         base_guid_obj.save()
-
-        # Create a new entry in the `GuidVersionsThrough` table to store version information
+        # Step 3: Create a new entry in the `GuidVersionsThrough` table to store version information
         versioned_guid = GuidVersionsThrough(
             referent=base_guid_obj.referent,
             object_id=base_guid_obj.object_id,
@@ -349,30 +349,32 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
     @classmethod
     def create_version(cls, create_from_guid, auth):
         """Create a new version for a given preprint. `create_from_guid` can be any existing versions of the preprint
-        but `create_version` always finds the latest version and creates the new version from the latest one. This
-        method creates the "incomplete" preprint object from model and returns both the preprint and data_for_update.
-        The API should use the `data_for_update` to "complete" the preprint.
+        but `create_version` always finds the latest version and creates a new version from it. In addition, this
+        creates an "incomplete" new preprint version object using the model class and returns both the new object and
+        the data to be updated. The API, more specifically `PreprintCreateVersionSerializer` must call `.update()` to
+        "completely finish" the new preprint version object creation.
         """
 
+        # Use `Guid.load()` instead of `VersionedGuid.load()` to retrieve the base guid obj, which always points to the
+        # latest (ever-published) version.
         guid_obj = Guid.load(create_from_guid)
-        # Guid object always points to the latest (ever-published) version
-        source_preprint = cls.load(guid_obj._id)
-        if not source_preprint:
-            sentry.log_message(f'Source preprint not found: [guid={guid_obj._id}, create_from_guid ={create_from_guid}]')
+        latest_version = cls.load(guid_obj._id)
+        if not latest_version:
+            sentry.log_message(f'Preprint not found: [guid={guid_obj._id}, create_from_guid={create_from_guid}]')
             return None, None
-        if not source_preprint.has_permission(auth.user, ADMIN):
-            sentry.log_message(f'ADMIN permission is required to create a new version: '
-                               f'[user={auth.user._id}, guid={guid_obj._id}, create_from_guid ={create_from_guid}]')
+        if not latest_version.has_permission(auth.user, ADMIN):
+            sentry.log_message(f'ADMIN permission for the latest version is required to create a new version: '
+                               f'[user={auth.user._id}, guid={guid_obj._id}, latest_version={latest_version._id}]')
             raise PermissionsError
-        unfinished_version, unpublished_version = source_preprint.check_unfinished_or_unpublished_version()
+        unfinished_version, unpublished_version = latest_version.check_unfinished_or_unpublished_version()
         if unpublished_version:
-            sentry.log_message('Unpublished pending version found; failed to create a new one: '
+            sentry.log_message('Failed to create a new version due to unpublished pending version already exists: '
                                f'[version={unpublished_version.version}, '
                                f'_id={unpublished_version._id}, '
                                f'state={unpublished_version.machine_state}].')
             raise UnpublishedPendingPreprintVersionExists
         if unfinished_version:
-            sentry.log_message(f'Unfinished version found, using it instead of creating a new one: '
+            sentry.log_message(f'Use existing initiated but unfinished version instead of creating a new one: '
                                f'[version={unfinished_version.version}, '
                                f'_id={unfinished_version._id}, '
                                f'state={unfinished_version.machine_state}].')
@@ -381,53 +383,38 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         # Note: version number bumps from the last version number instead of the latest version number
         last_version_number = guid_obj.versions.order_by('-version').first().version
 
-        # Prepare data to clone/update
-        data_for_update = {
-            'subjects': [el for el in source_preprint.subjects.all().values_list('_id', flat=True)],
-            'tags': source_preprint.tags.all().values_list('name', flat=True),
-            'original_publication_date': source_preprint.original_publication_date,
-            'custom_publication_citation': source_preprint.custom_publication_citation,
-            'article_doi': source_preprint.article_doi, 'has_coi': source_preprint.has_coi,
-            'conflict_of_interest_statement': source_preprint.conflict_of_interest_statement,
-            'has_data_links': source_preprint.has_data_links, 'why_no_data': source_preprint.why_no_data,
-            'data_links': source_preprint.data_links,
-            'has_prereg_links': source_preprint.has_prereg_links,
-            'why_no_prereg': source_preprint.why_no_prereg, 'prereg_links': source_preprint.prereg_links,
+        # Prepare the data to clone/update
+        data_to_update = {
+            'subjects': [el for el in latest_version.subjects.all().values_list('_id', flat=True)],
+            'tags': latest_version.tags.all().values_list('name', flat=True),
+            'original_publication_date': latest_version.original_publication_date,
+            'custom_publication_citation': latest_version.custom_publication_citation,
+            'article_doi': latest_version.article_doi, 'has_coi': latest_version.has_coi,
+            'conflict_of_interest_statement': latest_version.conflict_of_interest_statement,
+            'has_data_links': latest_version.has_data_links, 'why_no_data': latest_version.why_no_data,
+            'data_links': latest_version.data_links,
+            'has_prereg_links': latest_version.has_prereg_links,
+            'why_no_prereg': latest_version.why_no_prereg, 'prereg_links': latest_version.prereg_links,
         }
-        if source_preprint.license:
-            data_for_update['license_type'] = source_preprint.license.node_license
-            data_for_update['license'] = {
-                'copyright_holders': source_preprint.license.copyright_holders,
-                'year': source_preprint.license.year
+        if latest_version.license:
+            data_to_update['license_type'] = latest_version.license.node_license
+            data_to_update['license'] = {
+                'copyright_holders': latest_version.license.copyright_holders,
+                'year': latest_version.license.year
             }
-        if source_preprint.node:
-            data_for_update['node'] = source_preprint.node
+        if latest_version.node:
+            data_to_update['node'] = latest_version.node
 
         # Create a preprint obj for the new version
         preprint = cls(
-            provider=source_preprint.provider,
-            title=source_preprint.title,
+            provider=latest_version.provider,
+            title=latest_version.title,
             creator=auth.user,
-            description=source_preprint.description,
+            description=latest_version.description,
         )
         preprint.save()
-
-        # Add contributors
-        for contributor_info in source_preprint.contributor_set.exclude(user=source_preprint.creator).values('visible', 'user_id', '_order'):
-            preprint.contributor_set.create(**{**contributor_info, 'preprint_id': preprint.id})
-
-        # Add affiliated institutions
-        for institution in source_preprint.affiliated_institutions.all():
-            preprint.add_affiliated_institution(institution, auth.user, ignore_user_affiliation=True)
-
-        # Update Guid obj to point to the new version if there is no moderation
-        if not preprint.provider.reviews_workflow:
-            guid_obj.referent = preprint
-            guid_obj.object_id = preprint.pk
-            guid_obj.content_type = ContentType.objects.get_for_model(preprint)
-            guid_obj.save()
-
-        # Create an entry in the `GuidVersionsThrough` table
+        # Create a new entry in the `GuidVersionsThrough` table to store version information, which must happen right
+        # after the first `.save()` of the new preprint version object, which enables `preprint._id` to be computed.
         guid_version = GuidVersionsThrough(
             referent=preprint,
             object_id=guid_obj.object_id,
@@ -437,7 +424,22 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         )
         guid_version.save()
 
-        return preprint, data_for_update
+        # Add contributors
+        for contributor_info in latest_version.contributor_set.exclude(user=latest_version.creator).values('visible', 'user_id', '_order'):
+            preprint.contributor_set.create(**{**contributor_info, 'preprint_id': preprint.id})
+
+        # Add affiliated institutions
+        for institution in latest_version.affiliated_institutions.all():
+            preprint.add_affiliated_institution(institution, auth.user, ignore_user_affiliation=True)
+
+        # Update Guid obj to point to the new version if there is no moderation
+        if not preprint.provider.reviews_workflow:
+            guid_obj.referent = preprint
+            guid_obj.object_id = preprint.pk
+            guid_obj.content_type = ContentType.objects.get_for_model(preprint)
+            guid_obj.save()
+
+        return preprint, data_to_update
 
     @property
     def is_deleted(self):

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -800,7 +800,7 @@ class PreprintFactory(DjangoModelFactory):
 
         # Run a few checks
         assert final_machine_state in ['pending', 'accepted', 'initial']
-        assert create_from and not create_from.has_unpublished_pending_version()
+        assert create_from and not create_from.check_unpublished_pending_version()
         guid_obj = create_from.guids.first()
         latest_version = guid_obj.referent
         assert latest_version.is_latest_version

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -800,7 +800,7 @@ class PreprintFactory(DjangoModelFactory):
 
         # Run a few checks
         assert final_machine_state in ['pending', 'accepted', 'initial']
-        assert create_from and not create_from.check_unpublished_pending_version()
+        assert create_from and not create_from.has_unpublished_pending_version()
         guid_obj = create_from.guids.first()
         latest_version = guid_obj.referent
         assert latest_version.is_latest_version


### PR DESCRIPTION
## Purpose

Handle orphaned (initiated but unfinished) version during creation

## Changes

### Primary

* Use orphaned version without creating a new one if an orphan is found

```
api-1  | [framework.sentry]  WARNING: Sentry called to log message, but is not active: Unfinished version found, using it instead of creating a new one: [version=2, _id=pzc5f_v2, state=initial].
api-1  | [31/Dec/2024 16:30:56] "POST /v2/preprints/pzc5f_v1/versions/ HTTP/1.1" 201 2922
```

* In addition, refactored unfinished version check

```
api-1  | [framework.sentry]  WARNING: Sentry called to log message, but is not active: Unpublished pending version found; failed to create a new one: [version=2, _id=dypzs_v2, state=pending].
api-1  | [framework.sentry]  WARNING: Sentry called to log message, but is not active: Fail to create a new version since an unpublished pending version already exists.
api-1  | Conflict: /v2/preprints/dypzs_v1/versions/
api-1  | [django.request]  WARNING: Conflict: /v2/preprints/dypzs_v1/versions/
api-1  | [31/Dec/2024 16:38:25] "POST /v2/preprints/dypzs_v1/versions/ HTTP/1.1" 409 170
```

* Provide quick boolean check for either unfinished or unpublished on their own but also provide a optimized check when both needs to be checked.

### Secondary

* Added docstrings and comments
* Slightly improved code
* Addressed some issues surfaced from sentry

## QA Notes

* New item added to QA Testing and UAT scope

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6809
https://openscience.atlassian.net/browse/ENG-6817
