### PR TITLE
[ENG-6825] make gv helpers less storage-centric

### DIFF
--- a/osf/external/gravy_valet/request_helpers.py
+++ b/osf/external/gravy_valet/request_helpers.py
@@ -65,18 +65,18 @@ def create_addon(requested_resource, requesting_user, attributes: dict, relation
         json_data={'data': json_data},
     )
 
-def delete_addon(pk, requesting_user, requested_resource):
+def delete_addon(pk, requesting_user, requested_resource, addon_type: str):
     return _make_gv_request(
-        ADDON_ENDPOINT.format(pk=pk),
+        ADDON_ENDPOINT.format(pk=pk, addon_type=addon_type),
         requesting_user=requesting_user,
         requested_resource=requested_resource,
-        request_method='DELETE'
+        request_method='DELETE',
     )
 
-def get_addon(gv_addon_pk, requested_resource, requesting_user):  # -> JSONAPIResultEntry
+def get_addon(gv_addon_pk, requested_resource, requesting_user, addon_type: str):  # -> JSONAPIResultEntry
     '''Return a JSONAPIResultEntry representing a known ConfiguredStorageAddon.'''
     return get_gv_result(
-        endpoint_url=ADDON_ENDPOINT.format(pk=gv_addon_pk),
+        endpoint_url=ADDON_ENDPOINT.format(pk=gv_addon_pk, addon_type=addon_type),
         requesting_user=requesting_user,
         requested_resource=requested_resource,
         params={'include': ADDON_EXTERNAL_SERVICE_PATH},

--- a/osf/external/gravy_valet/request_helpers.py
+++ b/osf/external/gravy_valet/request_helpers.py
@@ -18,7 +18,7 @@ API_BASE = urljoin(settings.GRAVYVALET_URL, 'v1/')
 ACCOUNT_ENDPOINT = f'{API_BASE}authorized-storage-accounts/{{pk}}'
 ADDONS_ENDPOINT = f'{API_BASE}configured-storage-addons'
 GENERIC_ADDONS_ENDPOINT = f'{API_BASE}{{addon_type}}'
-ADDON_ENDPOINT = f'{ADDONS_ENDPOINT}/{{pk}}'
+ADDON_ENDPOINT = f'{GENERIC_ADDONS_ENDPOINT}/{{pk}}'
 WB_CONFIG_ENDPOINT = f'{ADDON_ENDPOINT}/waterbutler-credentials'
 
 USER_LIST_ENDPOINT = f'{API_BASE}user-references'
@@ -32,6 +32,8 @@ ACCOUNT_OWNER_PATH = 'base_account.account_owner'
 ADDON_EXTERNAL_SERVICE_PATH = 'base_account.external_storage_service'
 ACCOUNT_EXTERNAL_CITATION_SERVICE_PATH = 'external_citation_service'
 ADDON_EXTERNAL_CITATIONS_SERVICE_PATH = 'base_account.external_citation_service'
+ACCOUNT_EXTERNAL_COMPUTING_SERVICE_PATH = 'external_computing_service'
+ADDON_EXTERNAL_COMPUTING_SERVICE_PATH = 'base_account.external_computing_service'
 
 CITATION_ITEM_TYPE_ALIASES = {
     'COLLECTION': 'folder',
@@ -100,6 +102,11 @@ def iterate_accounts_for_user(requesting_user):  # -> typing.Iterator[JSONAPIRes
         requesting_user=requesting_user,
         params={'include': f'{ACCOUNT_EXTERNAL_CITATION_SERVICE_PATH}'}
     )
+    yield from iterate_gv_results(
+        endpoint_url=user_result.get_related_link('authorized_computing_accounts'),
+        requesting_user=requesting_user,
+        params={'include': f'{ACCOUNT_EXTERNAL_COMPUTING_SERVICE_PATH}'}
+    )
 
 
 def iterate_addons_for_resource(requested_resource, requesting_user):  # -> typing.Iterator[JSONAPIResultEntry]
@@ -124,11 +131,17 @@ def iterate_addons_for_resource(requested_resource, requesting_user):  # -> typi
         requested_resource=requested_resource,
         params={'include': f'{ADDON_EXTERNAL_CITATIONS_SERVICE_PATH},{ACCOUNT_OWNER_PATH}'}
     )
+    yield from iterate_gv_results(
+        endpoint_url=resource_result.get_related_link('configured_computing_addons'),
+        requesting_user=requesting_user,
+        requested_resource=requested_resource,
+        params={'include': f'{ADDON_EXTERNAL_COMPUTING_SERVICE_PATH},{ACCOUNT_OWNER_PATH}'}
+    )
 
 
-def get_waterbutler_config(gv_addon_pk, requested_resource, requesting_user):  # -> JSONAPIResultEntry
+def get_waterbutler_config(gv_addon_pk, requested_resource, requesting_user, addon_type):  # -> JSONAPIResultEntry
     return get_gv_result(
-        endpoint_url=WB_CONFIG_ENDPOINT.format(pk=gv_addon_pk),
+        endpoint_url=WB_CONFIG_ENDPOINT.format(pk=gv_addon_pk, addon_type=addon_type),
         requesting_user=requesting_user,
         requested_resource=requested_resource
     )

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -227,6 +227,7 @@ class EphemeralNodeSettings:
             gv_addon_pk=self.gv_data.resource_id,
             requested_resource=self.configured_resource,
             requesting_user=self.active_user,
+            addon_type=self.gv_data.resource_type,
         )
         self._credentials = result.get_attribute('credentials')
         self._config = result.get_attribute('config')

--- a/osf/external/gravy_valet/translations.py
+++ b/osf/external/gravy_valet/translations.py
@@ -252,7 +252,12 @@ class EphemeralNodeSettings:
 
     def after_remove_contributor(self, node, removed, auth):
         if self.user_settings.owner == removed:
-            gv_requests.delete_addon(self.id, requesting_user=auth.user, requested_resource=node)
+            gv_requests.delete_addon(
+                self.id,
+                requesting_user=auth.user,
+                requested_resource=node,
+                addon_type=self.gv_data.resource_type
+            )
             message = f'''
                  Because the {self.config.full_name} add-on for {markupsafe.escape(node.category_display)}
                  {markupsafe.escape(node.title)}" was authenticated by {markupsafe.escape(removed.fullname)},

--- a/osf_tests/test_gv_utils.py
+++ b/osf_tests/test_gv_utils.py
@@ -157,7 +157,10 @@ class TestFakeGV:
         assert json_data['relationships']['external_storage_service']['data']['id'] == account_one.external_storage_service.pk
 
     def test_addon_route(self, fake_gv, addon_one):
-        gv_addon_detail_url = gv_requests.ADDON_ENDPOINT.format(pk=addon_one.pk)
+        gv_addon_detail_url = gv_requests.ADDON_ENDPOINT.format(
+            pk=addon_one.pk,
+            addon_type='configured-storage-addons',
+        )
         with fake_gv.run_fake():
             resp = requests.get(gv_addon_detail_url)
         assert resp.status_code == HTTPStatus.OK
@@ -424,6 +427,7 @@ class TestRequestHelpers:
                 gv_addon_pk=external_account.pk,
                 requested_resource=resource,
                 requesting_user=contributor,
+                addon_type='configured-storage-addons',
             )
         retrieved_id = result.resource_id
         assert retrieved_id == configured_addon.pk
@@ -536,6 +540,7 @@ class TestEphemeralSettings:
                 gv_addon_pk=fake_box_addon.pk,
                 requesting_user=contributor,
                 requested_resource=project,
+                addon_type='configured-storage-addons',
             )
             ephemeral_config = translations.make_ephemeral_node_settings(
                 addon_data, requesting_user=contributor, requested_resource=project


### PR DESCRIPTION
## Purpose

Enable submission of jobs to boa by correctly pulling creds from GV.

## Changes

 * Include computing addons in the addons list from gravyvalet.

 * Support other addon types when fetching wb credentials.

## QA Notes

Should enable remainder testing of gravyboa.

## Documentation

Nope.

## Side Effects

None expected.

## Ticket
[ENG-6825](https://openscience.atlassian.net/browse/ENG-6825)


[ENG-6825]: https://openscience.atlassian.net/browse/ENG-6825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ