### PR TITLE
[ENG-6802] Allow resubmission for the POST_MODERATION workflow

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -75,7 +75,7 @@ class PreprintOldVersionsImmutableMixin:
     """
     def update(self, request, *args, **kwargs):
         preprint = self.get_preprint(check_object_permissions=False)
-        if preprint.is_latest_version or preprint.machine_state == 'initial':
+        if preprint.is_latest_version or preprint.machine_state in ['initial', 'pending']:
             return super().update(request, *args, **kwargs)
         message = f'User can not edit previous versions of a preprint: [_id={preprint._id}]'
         sentry.log_message(message)
@@ -83,7 +83,7 @@ class PreprintOldVersionsImmutableMixin:
 
     def create(self, request, *args, **kwargs):
         preprint = self.get_preprint(check_object_permissions=False)
-        if preprint.is_latest_version or preprint.machine_state == 'initial':
+        if preprint.is_latest_version or preprint.machine_state in ['initial', 'pending']:
             return super().create(request, *args, **kwargs)
         message = f'User can not edit previous versions of a preprint: [_id={preprint._id}]'
         sentry.log_message(message)
@@ -91,7 +91,7 @@ class PreprintOldVersionsImmutableMixin:
 
     def destroy(self, request, *args, **kwargs):
         preprint = self.get_preprint(check_object_permissions=False)
-        if preprint.is_latest_version or preprint.machine_state == 'initial':
+        if preprint.is_latest_version or preprint.machine_state in ['initial', 'pending']:
             return super().destroy(request, *args, **kwargs)
         message = f'User can not edit previous versions of a preprint: [_id={preprint._id}]'
         sentry.log_message(message)

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -123,6 +123,10 @@ class ReviewsMachine(BaseMachine):
         self.machineable.save()
 
     def resubmission_allowed(self, ev):
+        '''
+        Allow resubmission if the preprint uses the PRE_MODERATION workflow or
+        uses the POST_MODERATION workflow and is in a pending state
+        '''
         workflow = self.machineable.provider.reviews_workflow
         result = any(
             [

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -123,7 +123,14 @@ class ReviewsMachine(BaseMachine):
         self.machineable.save()
 
     def resubmission_allowed(self, ev):
-        return self.machineable.provider.reviews_workflow == Workflows.PRE_MODERATION.value
+        workflow = self.machineable.provider.reviews_workflow
+        result = any(
+            [
+                workflow == Workflows.PRE_MODERATION.value,
+                workflow == Workflows.POST_MODERATION.value and self.machineable.machine_state == 'pending'
+            ]
+        )
+        return result
 
     def perform_withdraw(self, ev):
         self.machineable.date_withdrawn = self.action.created if self.action is not None else timezone.now()


### PR DESCRIPTION
## Purpose

- Update checks to allow editing of pending preprints
- Allow resubmission for the POST_MODERATION workflow

## Changes
See diff
## QA Notes
N/A

## Documentation
N/A

## Side Effects
N/A

## Ticket
https://openscience.atlassian.net/browse/ENG-6802
