### PR TITLE
[ENG-6721] Fixed `api3_and_osf` tests - Part 2

### DIFF
--- a/api_tests/actions/views/test_action_list.py
+++ b/api_tests/actions/views/test_action_list.py
@@ -154,7 +154,6 @@ class TestReviewActionCreateRoot:
                 ('initial', 'edit_comment'),
                 ('initial', 'reject'),
                 ('initial', 'withdraw'),
-                ('pending', 'submit'),
                 ('rejected', 'reject'),
                 ('rejected', 'submit'),
                 ('rejected', 'withdraw'),

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -58,7 +58,7 @@ def coerce_guid(maybe_guid, create_if_needed=False):
         return guid
     if isinstance(maybe_guid, str):
         try:
-            return Guid.objects.get(_id=maybe_guid)
+            return Guid.load(maybe_guid)
         except Guid.DoesNotExist:
             raise InvalidGuid(f'guid does not exist ({maybe_guid})')
     raise InvalidGuid(f'cannot coerce {type(maybe_guid)} ({maybe_guid}) into Guid')

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -57,10 +57,10 @@ def coerce_guid(maybe_guid, create_if_needed=False):
             raise InvalidGuid(f'guid does not exist ({maybe_guid})')
         return guid
     if isinstance(maybe_guid, str):
-        try:
-            return Guid.load(maybe_guid)
-        except Guid.DoesNotExist:
+        guid = Guid.load(maybe_guid)
+        if not guid:
             raise InvalidGuid(f'guid does not exist ({maybe_guid})')
+        return guid
     raise InvalidGuid(f'cannot coerce {type(maybe_guid)} ({maybe_guid}) into Guid')
 
 

--- a/osf_tests/management_commands/test_check_crossref_dois.py
+++ b/osf_tests/management_commands/test_check_crossref_dois.py
@@ -22,7 +22,7 @@ class TestCheckCrossrefDOIs:
 
     @pytest.fixture()
     def stuck_preprint(self):
-        preprint = PreprintFactory(set_doi=False)
+        preprint = PreprintFactory(set_doi=False, set_guid='guid0')
         preprint.date_published = preprint.date_published - timedelta(days=settings.DAYS_CROSSREF_DOIS_MUST_BE_STUCK_BEFORE_EMAIL + 1)
         # match guid to the fixture crossref_works_response.json
         guid = preprint.guids.first()

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
@@ -48,7 +48,7 @@
   ],
   "fundingReferences": [],
   "identifier": {
-    "identifier": "11.pp/FK2osf.io/w4ibb",
+    "identifier": "11.pp/FK2osf.io/w4ibb_v1",
     "identifierType": "DOI"
   },
   "publicationYear": "2123",

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.5/metadata.xsd">
-  <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb</identifier>
+  <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</identifier>
   <creators>
     <creator>
       <creatorName nameType="Personal">Person McNamington</creatorName>

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
@@ -13,7 +13,7 @@
     dcterms:description "this is a preprint description!" ;
     dcterms:hasVersion <https://doi.org/11.111/something-or-other> ;
     dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+        "https://doi.org/11.pp/FK2osf.io/w4ibb_v1" ;
     dcterms:modified "2123-05-04" ;
     dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
     dcterms:subject <http://localhost:8000/v2/subjects/subjwibb>,
@@ -22,7 +22,7 @@
         <http://localhost:8000/v2/subjects/subjwobbb> ;
     dcterms:title "this is a preprint title!" ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4/#Preprint> ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> ;
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb_v1> ;
     dcat:accessService <http://localhost:5000> ;
     osf:hostingInstitution <https://cos.io/> ;
     osf:isSupplementedBy <http://localhost:5000/w2ibb> ;
@@ -94,4 +94,3 @@
 <http://localhost:8000/v2/subjects/subjwibbb> a skos:Concept ;
     skos:inScheme <https://bepress.com/reference_guide_dc/disciplines/> ;
     skos:prefLabel "wibbble" .
-

--- a/osf_tests/metadata/expected_metadata_files/preprint_full.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_full.datacite.json
@@ -48,7 +48,7 @@
   ],
   "fundingReferences": [],
   "identifier": {
-    "identifier": "11.pp/FK2osf.io/w4ibb",
+    "identifier": "11.pp/FK2osf.io/w4ibb_v1",
     "identifierType": "DOI"
   },
   "publicationYear": "2123",

--- a/osf_tests/metadata/expected_metadata_files/preprint_full.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/preprint_full.datacite.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.5/metadata.xsd">
-  <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb</identifier>
+  <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</identifier>
   <creators>
     <creator>
       <creatorName nameType="Personal">Person McNamington</creatorName>

--- a/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_full.turtle
@@ -13,7 +13,7 @@
     dcterms:description "this is a preprint description!" ;
     dcterms:hasVersion <https://doi.org/11.111/something-or-other> ;
     dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+        "https://doi.org/11.pp/FK2osf.io/w4ibb_v1" ;
     dcterms:modified "2123-05-04" ;
     dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
     dcterms:subject <http://localhost:8000/v2/subjects/subjwibb>,
@@ -22,7 +22,7 @@
         <http://localhost:8000/v2/subjects/subjwobbb> ;
     dcterms:title "this is a preprint title!" ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4/#Preprint> ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> ;
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb_v1> ;
     dcat:accessService <http://localhost:5000> ;
     osf:hostingInstitution <https://cos.io/> ;
     osf:isSupplementedBy <http://localhost:5000/w2ibb> ;
@@ -124,4 +124,3 @@
 <http://localhost:8000/v2/subjects/subjwibbb> a skos:Concept ;
     skos:inScheme <https://bepress.com/reference_guide_dc/disciplines/> ;
     skos:prefLabel "wibbble" .
-

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
@@ -60,7 +60,7 @@
       "relationType": "HasVersion"
     },
     {
-      "relatedIdentifier": "11.pp/FK2osf.io/w4ibb",
+      "relatedIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
       "relatedIdentifierType": "DOI",
       "relationType": "IsSupplementTo"
     }
@@ -85,7 +85,7 @@
       "publicationYear": "2123",
       "publisher": "PP the Preprint Provider",
       "relatedItemIdentifier": {
-        "relatedItemIdentifier": "11.pp/FK2osf.io/w4ibb",
+        "relatedItemIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
         "relatedItemIdentifierType": "DOI"
       },
       "relatedItemType": "Preprint",

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
@@ -37,7 +37,7 @@
   <fundingReferences/>
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="HasVersion">http://localhost:5000/w5ibb</relatedIdentifier>
-    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb_v1</relatedIdentifier>
   </relatedIdentifiers>
   <relatedItems>
     <relatedItem relationType="HasVersion" relatedItemType="StudyRegistration">
@@ -49,7 +49,7 @@
       <publisher>RegiProvi the Registration Provider</publisher>
     </relatedItem>
     <relatedItem relationType="IsSupplementTo" relatedItemType="Preprint">
-      <relatedItemIdentifier relatedItemIdentifierType="DOI">11.pp/FK2osf.io/w4ibb</relatedItemIdentifier>
+      <relatedItemIdentifier relatedItemIdentifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</relatedItemIdentifier>
       <titles>
         <title>this is a preprint title!</title>
       </titles>

--- a/osf_tests/metadata/expected_metadata_files/project_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.turtle
@@ -33,11 +33,11 @@
     dcterms:created "2123-05-04" ;
     dcterms:creator <http://localhost:5000/w1ibb> ;
     dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+        "https://doi.org/11.pp/FK2osf.io/w4ibb_v1" ;
     dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
     dcterms:title "this is a preprint title!" ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4/#Preprint> ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb_v1> .
 
 <http://localhost:5000/w5ibb> a osf:Registration ;
     dcterms:created "2123-05-04" ;

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
@@ -94,7 +94,7 @@
       "relationType": "HasVersion"
     },
     {
-      "relatedIdentifier": "11.pp/FK2osf.io/w4ibb",
+      "relatedIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
       "relatedIdentifierType": "DOI",
       "relationType": "IsSupplementTo"
     }
@@ -119,7 +119,7 @@
       "publicationYear": "2123",
       "publisher": "PP the Preprint Provider",
       "relatedItemIdentifier": {
-        "relatedItemIdentifier": "11.pp/FK2osf.io/w4ibb",
+        "relatedItemIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
         "relatedItemIdentifierType": "DOI"
       },
       "relatedItemType": "Preprint",

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
@@ -55,7 +55,7 @@
   </fundingReferences>
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="HasVersion">http://localhost:5000/w5ibb</relatedIdentifier>
-    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb_v1</relatedIdentifier>
   </relatedIdentifiers>
   <relatedItems>
     <relatedItem relationType="HasVersion" relatedItemType="StudyRegistration">
@@ -67,7 +67,7 @@
       <publisher>RegiProvi the Registration Provider</publisher>
     </relatedItem>
     <relatedItem relationType="IsSupplementTo" relatedItemType="Preprint">
-      <relatedItemIdentifier relatedItemIdentifierType="DOI">11.pp/FK2osf.io/w4ibb</relatedItemIdentifier>
+      <relatedItemIdentifier relatedItemIdentifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</relatedItemIdentifier>
       <titles>
         <title>this is a preprint title!</title>
       </titles>

--- a/osf_tests/metadata/expected_metadata_files/project_full.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_full.turtle
@@ -39,11 +39,11 @@
     dcterms:created "2123-05-04" ;
     dcterms:creator <http://localhost:5000/w1ibb> ;
     dcterms:identifier "http://localhost:5000/w4ibb",
-        "https://doi.org/11.pp/FK2osf.io/w4ibb" ;
+        "https://doi.org/11.pp/FK2osf.io/w4ibb_v1" ;
     dcterms:publisher <http://localhost:5000/preprints/preprovi> ;
     dcterms:title "this is a preprint title!" ;
     dcterms:type <https://schema.datacite.org/meta/kernel-4/#Preprint> ;
-    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb> .
+    owl:sameAs <https://doi.org/11.pp/FK2osf.io/w4ibb_v1> .
 
 <http://localhost:5000/w5ibb> a osf:Registration ;
     dcterms:created "2123-05-04" ;

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -124,7 +124,7 @@ class TestOsfGathering(TestCase):
         assert self.registrationfocus.iri == OSFIO[self.registration._id]
         assert self.registrationfocus.rdftype == OSF.Registration
         assert self.registrationfocus.dbmodel is self.registration
-        assert self.preprintfocus.iri == OSFIO[self.preprint._id]
+        assert self.preprintfocus.iri == OSFIO[self.preprint.get_guid()._id]
         assert self.preprintfocus.rdftype == OSF.Preprint
         assert self.preprintfocus.dbmodel is self.preprint
         assert self.filefocus.iri == OSFIO[self.file.get_guid()._id]

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -250,6 +250,7 @@ class TestSerializers(OsfTestCase):
             subjects=[
                 [parent_subject._id, child_subject._id],
             ],
+            use_guid=osfguid_sequence.get_or_create(id=-1)[0]
         )
         self.registration = factories.RegistrationFactory(
             is_public=True,

--- a/osf_tests/metrics/reporters/test_public_item_usage_reporter.py
+++ b/osf_tests/metrics/reporters/test_public_item_usage_reporter.py
@@ -28,7 +28,11 @@ class TestPublicItemUsageReporter:
     @pytest.fixture
     def item0(self):
         _item0 = factories.PreprintFactory(is_public=True)
-        _item0._id = 'item0'
+        guid = _item0.get_guid()
+        guid._id = 'item0'
+        guid.save()
+
+        _item0._id = None
         return _item0
 
     @pytest.fixture
@@ -186,7 +190,7 @@ class TestPublicItemUsageReporter:
         _sparse_item0, _sparse_item1, _sparse_item2 = sorted(_sparse, key=attrgetter('item_osfid'))
         # sparse-month item0
         assert isinstance(_sparse_item0, PublicItemUsageReport)
-        assert _sparse_item0.item_osfid == 'item0'
+        assert _sparse_item0.item_osfid == 'item0_v1'
         assert _sparse_item0.provider_id == [item0.provider._id]
         assert _sparse_item0.platform_iri == ['http://osf.example']
         assert _sparse_item0.view_count == 3
@@ -217,7 +221,7 @@ class TestPublicItemUsageReporter:
         _busy_item0, _busy_item1, _busy_item2 = sorted(_busy, key=attrgetter('item_osfid'))
         # busy-month item0
         assert isinstance(_busy_item0, PublicItemUsageReport)
-        assert _busy_item0.item_osfid == 'item0'
+        assert _busy_item0.item_osfid == 'item0_v1'
         assert _busy_item0.provider_id == [item0.provider._id]
         assert _busy_item0.platform_iri == ['http://osf.example']
         assert _busy_item0.view_count == 4 * 7

--- a/osf_tests/metrics/reporters/test_public_item_usage_reporter.py
+++ b/osf_tests/metrics/reporters/test_public_item_usage_reporter.py
@@ -27,12 +27,7 @@ class TestPublicItemUsageReporter:
 
     @pytest.fixture
     def item0(self):
-        _item0 = factories.PreprintFactory(is_public=True)
-        guid = _item0.get_guid()
-        guid._id = 'item0'
-        guid.save()
-
-        _item0._id = None
+        _item0 = factories.PreprintFactory(is_public=True, set_guid='item0')
         return _item0
 
     @pytest.fixture

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -505,7 +505,7 @@ class TestGuidVersionsThrough:
         preprint_guid = preprint.guids.first()
 
         preprint_metadata = {
-            'subjects': [[el] for el in preprint.subjects.all().values_list('_id', flat=True)],
+            'subjects': [el for el in preprint.subjects.all().values_list('_id', flat=True)],
             'original_publication_date': preprint.original_publication_date,
             'custom_publication_citation': preprint.custom_publication_citation,
             'article_doi': preprint.article_doi,

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -565,5 +565,6 @@ class TestGuidVersionsThrough:
         assert preprint._id == expected_guid
 
         GuidVersionsThrough.objects.filter(guid=preprint_guid).delete()
+        preprint._id = None
 
         assert preprint._id is None


### PR DESCRIPTION
## Purpose

Fix the rest of the failures in `api3_and_osf`. Most of them are caused by fixtures assigning fixed guid id.

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6721