### PR TITLE
[ENG-6845][ENG-6864] Fix contributors during preprint version creation

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1383,15 +1383,14 @@ class ContributorMixin(models.Model):
                 )
             if save:
                 self.save()
-            # TODO: Remove this comment after `Preprint.save()` has been fixed. There is a bug for Preprint when the
-            #       first `.save()` is called. It triggers a series of events which includes adding creator as one
-            #       contributor. However, with versioned guid, there is a gap between when preprint os saved and when
-            #       guid and versioned guid are saved. During this gap, `self._id` is unfortunately `None` and the
-            #       signal can not be be sent.
             if self._id and contrib_to_add:
-                project_signals.contributor_added.send(self,
-                                                       contributor=contributor,
-                                                       auth=auth, email_template=send_email, permissions=permissions)
+                project_signals.contributor_added.send(
+                    self,
+                    contributor=contributor,
+                    auth=auth,
+                    email_template=send_email,
+                    permissions=permissions
+                )
 
             # enqueue on_node_updated/on_preprint_updated to update DOI metadata when a contributor is added
             if getattr(self, 'get_identifier_value', None) and self.get_identifier_value('doi'):


### PR DESCRIPTION
## Purpose

Fix the bug where contributors were not completely copied when creating a new version

## Changes

* Use `add_contributor` instead of modify the through table directly
* Skipped failed contributors and log errors to Sentry, which doesn't stop the version creation flow

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

* https://openscience.atlassian.net/browse/ENG-6845
* https://openscience.atlassian.net/browse/ENG-6864