### PR TITLE
[ENG-6850] Update old version mix-in check to allow 'rejected'

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1547,6 +1547,11 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             base_guid_obj.object_id = self.pk
             base_guid_obj.content_type = ContentType.objects.get_for_model(self)
             base_guid_obj.save()
+
+        versioned_guid = self.versioned_guids.first()
+        if versioned_guid.is_rejected:
+            versioned_guid.is_rejected = False
+            versioned_guid.save()
         return ret
 
     # Override ReviewableMixin


### PR DESCRIPTION
## Purpose

Update old version mix-in check to allow 'rejected'

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6850