### PR TITLE
[Hotfix] Add Admin button to update moderation state

### DIFF
--- a/admin/nodes/urls.py
+++ b/admin/nodes/urls.py
@@ -38,4 +38,5 @@ urlpatterns = [
     re_path(r'^(?P<guid>[a-z0-9]+)/make_private/$', views.NodeMakePrivate.as_view(), name='make-private'),
     re_path(r'^(?P<guid>[a-z0-9]+)/make_public/$', views.NodeMakePublic.as_view(), name='make-public'),
     re_path(r'^(?P<guid>[a-z0-9]+)/remove_notifications/$', views.NodeRemoveNotificationView.as_view(), name='node-remove-notifications'),
+    re_path(r'^(?P<guid>[a-z0-9]+)/update_moderation_state/$', views.NodeUpdateModerationStateView.as_view(), name='node-update-mod-state'),
 ]

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -118,6 +118,17 @@ class NodeRemoveNotificationView(View):
 
         return redirect('nodes:node', guid=kwargs.get('guid'))
 
+
+class NodeUpdateModerationStateView(View):
+    def post(self, request, *args, **kwargs):
+        guid = kwargs.get('guid')
+        node = AbstractNode.load(guid)
+        node.update_moderation_state()
+        messages.success(request, 'Moderation state successfully updated.')
+
+        return redirect('nodes:node', guid=kwargs.get('guid'))
+
+
 class NodeSearchView(PermissionRequiredMixin, FormView):
     """ Allows authorized users to search for a node by it's guid.
     """

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -64,7 +64,12 @@
                     </tr>
                     <tr>
                         <td>Moderation State</td>
-                        <td>{{ node.moderation_state }}</td>
+                        <td>{{ node.moderation_state }}
+                        <form method="post" action="{% url 'nodes:node-update-mod-state' node.guid %}">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-primary">Update Moderation State</button>
+                        </form>
+                        </td>
                     </tr>
                     <tr>
                         <td>Creator</td>


### PR DESCRIPTION
## Purpose
Allow Product Support to call `update_moderation_state` manually when state transitions don't happen as they should.

## Changes
- Add view, form to `update_moderation_state`

![Screenshot 2025-01-09 at 10 59 23](https://github.com/user-attachments/assets/8d04092a-aa76-40b1-ace7-b57e1c2fdf9c)

![Screenshot 2025-01-09 at 11 07 40](https://github.com/user-attachments/assets/4bd66c6e-cf3f-4b51-9505-46a4afe4eac8)


## Side Effects
None expected. `update_moderation_state` is a no-op when the state is correct.

## Ticket
[ENG-6292](https://openscience.atlassian.net/browse/ENG-6292)

[ENG-6292]: https://openscience.atlassian.net/browse/ENG-6292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ