### PR TITLE
[ENG-6878] Fix API filter for versioned guids/preprints

### DIFF
--- a/api/actions/views.py
+++ b/api/actions/views.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from api.actions.permissions import ReviewActionPermission
 from api.actions.serializers import NodeRequestActionSerializer, ReviewActionSerializer, PreprintRequestActionSerializer
 from api.base.exceptions import Conflict
-from api.base.filters import ListFilterMixin
+from api.base.filters import ReviewActionFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
@@ -110,7 +110,7 @@ class ActionDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         return action
 
 
-class ReviewActionListCreate(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixin):
+class ReviewActionListCreate(JSONAPIBaseView, generics.ListCreateAPIView, ReviewActionFilterMixin):
     """List of review actions viewable by this user
 
     Actions represent state changes and/or comments on a reviewable object (e.g. a preprint)

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -291,39 +291,7 @@ class FilterMixin:
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id']:
-                        # TODO: this is broken since value can be a multi-value str separated by comma; in addition,
-                        #       as for a single-versioned-guid value, the filter is `or` but we need `and`; this will
-                        #       be fixed in [ENG-6878](https://openscience.atlassian.net/browse/ENG-6878).
-                        base_guid, version = Guid.split_guid(value)
-                        if base_guid is None and version is None:
-                            raise InvalidFilterValue(
-                                value=value,
-                                field_type='guid',
-                            )
-                        guid_filters = {
-                            field_name: {
-                                'op': 'in',
-                                'value': self.bulk_get_values(value, field),
-                                'source_field_name': source_field_name,
-                            },
-                        }
-                        if version is not None:
-                            guid_filters = {
-                                field_name: {
-                                    'op': 'eq',
-                                    'value': base_guid,
-                                    'source_field_name': 'versioned_guids___id',
-                                },
-                                'versioned_guids__version': {
-                                    'op': 'eq',
-                                    'value': version,
-                                    'source_field_name': 'versioned_guids__version',
-                                },
-                            }
-
-                        query.get(key).update(guid_filters)
-                    elif not isinstance(value, int) and source_field_name in ['journal_id', 'moderation_state']:
+                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id', 'moderation_state']:
                         query.get(key).update({
                             field_name: {
                                 'op': 'in',

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -21,7 +21,7 @@ from api.actions.views import get_review_actions_queryset
 from api.base.pagination import PreprintContributorPagination
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
-from api.base.filters import ListFilterMixin, PreprintFilterMixin
+from api.base.filters import ListFilterMixin, PreprintFilterMixin, PreprintActionFilterMixin
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
@@ -587,7 +587,7 @@ class PreprintSubjectsRelationship(PreprintOldVersionsImmutableMixin, SubjectRel
         return obj
 
 
-class PreprintActionList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixin, PreprintMixin):
+class PreprintActionList(JSONAPIBaseView, generics.ListCreateAPIView, PreprintActionFilterMixin, PreprintMixin):
     """Action List *Read-only*
 
     Actions represent state changes and/or comments on a reviewable object (e.g. a preprint)


### PR DESCRIPTION
## Purpose

Fix API filter for versioned guids/prepirnts

## Changes

* Revert incorrect fix that broke Preprint filter by _id
* Implement filter mixin for preprint action and review action to filter by _id

### Tests Fixed

```
FAILED api_tests/preprints/views/test_preprint_actions.py::TestPreprintActionFilters::test_filter_actions[moderator] - AssertionError
FAILED api_tests/preprints/views/test_preprint_actions.py::TestPreprintActionFilters::test_filter_actions[node_admin] - AssertionError
FAILED api_tests/users/views/test_user_actions.py::TestReviewActionFilters::test_filter_actions - AssertionError
```

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6878
