### PR TITLE
[ENG-6815][ENG-6881] Fix missing original admin contributor + Sync BE/FE permission logic for edit

### DIFF
--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -170,7 +170,6 @@ class TestReviewActionCreateRelated:
                 ('initial', 'accept'),
                 ('initial', 'edit_comment'),
                 ('initial', 'reject'),
-                ('pending', 'submit'),
                 ('rejected', 'reject'),
                 ('rejected', 'submit'),
             ],

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -429,7 +429,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         preprint.save(guid_ready=True, first_save=True)
 
         # Add contributors
-        for contributor in latest_version.contributor_set.exclude(user=latest_version.creator):
+        for contributor in latest_version.contributor_set.exclude(user=preprint.creator):
             try:
                 preprint.add_contributor(
                     contributor.user,


### PR DESCRIPTION
## Purpose

Fix missing original admin contributor and sync BE/FE permission logic for edit

## Changes

* Exclude the new version's creator instead of the latest version's creator when adding contributor to a new version
* Update BE permission check and sync with FE for whether to allow edit

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

* https://openscience.atlassian.net/browse/ENG-6881
* Supports: https://openscience.atlassian.net/browse/ENG-6815
