### PR TITLE
[ENG-6884] Fix filter for PreprintProviderWithdrawRequestList view and refactored versioned target list filter

### DIFF
--- a/api/actions/views.py
+++ b/api/actions/views.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied
 from api.actions.permissions import ReviewActionPermission
 from api.actions.serializers import NodeRequestActionSerializer, ReviewActionSerializer, PreprintRequestActionSerializer
 from api.base.exceptions import Conflict
-from api.base.filters import ReviewActionFilterMixin
+from api.base.filters import TargetFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
@@ -110,7 +110,7 @@ class ActionDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         return action
 
 
-class ReviewActionListCreate(JSONAPIBaseView, generics.ListCreateAPIView, ReviewActionFilterMixin):
+class ReviewActionListCreate(JSONAPIBaseView, generics.ListCreateAPIView, TargetFilterMixin):
     """List of review actions viewable by this user
 
     Actions represent state changes and/or comments on a reviewable object (e.g. a preprint)

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -663,3 +663,25 @@ class ReviewActionFilterMixin(ListFilterMixin):
                 return
         else:
             super().postprocess_query_param(key, field_name, operation)
+
+
+class PreprintProviderWithdrawRequestFilterMixin(ListFilterMixin):
+    """View mixin for `PreprintProviderWithdrawRequestList`. It inherits from `ListFilterMixin` and uses
+    `PreprintActionFilterMixin` to customized postprocessing for handling versioned preprint.
+
+    Note: Subclasses must define `get_default_queryset()`.
+    """
+    def postprocess_query_param(self, key, field_name, operation):
+        """Handles a special case when filtering on `target` and when `target` is a versioned Preprint.
+        """
+        if field_name == 'target':
+            referent, version = Guid.load_referent(operation['value'])
+            if referent:
+                if version:
+                    PreprintActionFilterMixin.postprocess_versioned_guid_target_query_param(operation)
+                else:
+                    super().postprocess_query_param(key, field_name, operation)
+            else:
+                return
+        else:
+            super().postprocess_query_param(key, field_name, operation)

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -22,7 +22,7 @@ from api.actions.views import get_review_actions_queryset
 from api.base.pagination import PreprintContributorPagination
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
-from api.base.filters import ListFilterMixin, PreprintFilterMixin, PreprintActionFilterMixin
+from api.base.filters import ListFilterMixin, PreprintAsTargetFilterMixin, PreprintFilterMixin
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
@@ -590,7 +590,7 @@ class PreprintSubjectsRelationship(PreprintOldVersionsImmutableMixin, SubjectRel
         return obj
 
 
-class PreprintActionList(JSONAPIBaseView, generics.ListCreateAPIView, PreprintActionFilterMixin, PreprintMixin):
+class PreprintActionList(JSONAPIBaseView, generics.ListCreateAPIView, PreprintAsTargetFilterMixin, PreprintMixin):
     """Action List *Read-only*
 
     Actions represent state changes and/or comments on a reviewable object (e.g. a preprint)

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -15,7 +15,7 @@ from api.base.exceptions import (
     InvalidFilterOperator,
     InvalidFilterValue,
 )
-from api.base.filters import ListFilterMixin, PreprintFilterMixin, PreprintProviderWithdrawRequestFilterMixin
+from api.base.filters import ListFilterMixin, PreprintAsTargetFilterMixin, PreprintFilterMixin
 from api.base.metrics import PreprintMetricsViewMixin
 from api.base.pagination import MaxSizePagination, IncreasedPageSizePagination
 from api.base.settings import BULK_SETTINGS
@@ -571,7 +571,7 @@ class RegistrationProviderSubmissionList(JSONAPIBaseView, generics.ListCreateAPI
         raise ValidationError(f'Provider {provider.name} has no primary collection to submit to.')
 
 
-class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView, PreprintProviderWithdrawRequestFilterMixin, ProviderMixin):
+class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView, PreprintAsTargetFilterMixin, ProviderMixin):
     provider_class = PreprintProvider
     permission_classes = (
         drf_permissions.IsAuthenticated,

--- a/api/providers/views.py
+++ b/api/providers/views.py
@@ -15,7 +15,7 @@ from api.base.exceptions import (
     InvalidFilterOperator,
     InvalidFilterValue,
 )
-from api.base.filters import PreprintFilterMixin, ListFilterMixin
+from api.base.filters import ListFilterMixin, PreprintFilterMixin, PreprintProviderWithdrawRequestFilterMixin
 from api.base.metrics import PreprintMetricsViewMixin
 from api.base.pagination import MaxSizePagination, IncreasedPageSizePagination
 from api.base.settings import BULK_SETTINGS
@@ -571,7 +571,7 @@ class RegistrationProviderSubmissionList(JSONAPIBaseView, generics.ListCreateAPI
         raise ValidationError(f'Provider {provider.name} has no primary collection to submit to.')
 
 
-class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, ProviderMixin):
+class PreprintProviderWithdrawRequestList(JSONAPIBaseView, generics.ListAPIView, PreprintProviderWithdrawRequestFilterMixin, ProviderMixin):
     provider_class = PreprintProvider
     permission_classes = (
         drf_permissions.IsAuthenticated,


### PR DESCRIPTION
## Purpose

Fix filter for PreprintProviderWithdrawRequestList view and refactored versioned target list filter

## Changes


* Fix filter for PreprintProviderWithdrawRequestList view which inherits from `PreprintAsTargetFilterMixin`
* Refactored versioned target list filter by replacing `PreprintActionFilterMixin`, `ReviewActionFilterMixin` and `PreprintProviderWithdrawRequestFilterMixin` with `TargetFilterMixin` and `PreprintAsTargetFilterMixin`. 

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6884
