### PR TITLE
[ENG-6855] Avoid updating share during version creation

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -296,7 +296,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             doi = client.build_doi(preprint=obj) if client else None
         return f'https://doi.org/{doi}' if doi else None
 
-    def update(self, preprint, validated_data, update_search=True):
+    def update(self, preprint, validated_data, skip_share=False):
         assert isinstance(preprint, Preprint), 'You must specify a valid preprint to be updated'
 
         auth = get_user_auth(self.context['request'])
@@ -475,7 +475,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
 
         if 'subjects' in validated_data:
             subjects = validated_data.pop('subjects', None)
-            self.update_subjects(preprint, subjects, auth, update_search=update_search)
+            self.update_subjects(preprint, subjects, auth, skip_share=skip_share)
             save_preprint = True
 
         if 'title' in validated_data:
@@ -599,7 +599,7 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
             raise NotFound(detail='Failed to create a new preprint version due to source preprint not found.')
         if data_to_update:
             # Share should not be updated during version creation
-            return self.update(preprint, data_to_update, update_search=False)
+            return self.update(preprint, data_to_update, skip_share=True)
         return preprint
 
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -296,7 +296,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             doi = client.build_doi(preprint=obj) if client else None
         return f'https://doi.org/{doi}' if doi else None
 
-    def update(self, preprint, validated_data):
+    def update(self, preprint, validated_data, update_search=True):
         assert isinstance(preprint, Preprint), 'You must specify a valid preprint to be updated'
 
         auth = get_user_auth(self.context['request'])
@@ -475,7 +475,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
 
         if 'subjects' in validated_data:
             subjects = validated_data.pop('subjects', None)
-            self.update_subjects(preprint, subjects, auth)
+            self.update_subjects(preprint, subjects, auth, update_search=update_search)
             save_preprint = True
 
         if 'title' in validated_data:
@@ -598,7 +598,8 @@ class PreprintCreateVersionSerializer(PreprintSerializer):
         if not preprint:
             raise NotFound(detail='Failed to create a new preprint version due to source preprint not found.')
         if data_to_update:
-            return self.update(preprint, data_to_update)
+            # Share should not be updated during version creation
+            return self.update(preprint, data_to_update, update_search=False)
         return preprint
 
 

--- a/api/subjects/serializers.py
+++ b/api/subjects/serializers.py
@@ -15,11 +15,11 @@ from osf.exceptions import NodeStateError, ValidationValueError
 
 
 class UpdateSubjectsMixin:
-    def update_subjects_method(self, resource, subjects, auth, update_search=True):
+    def update_subjects_method(self, resource, subjects, auth, skip_share=False):
         # Method to update subjects on resource
         raise NotImplementedError()
 
-    def update_subjects(self, resource, subjects, auth, update_search=True):
+    def update_subjects(self, resource, subjects, auth, skip_share=False):
         """Updates subjects on resource and handles errors.
 
         :param object resource: Object for which you want to update subjects
@@ -27,7 +27,7 @@ class UpdateSubjectsMixin:
         :param object Auth object
         """
         try:
-            self.update_subjects_method(resource, subjects, auth, update_search=update_search)
+            self.update_subjects_method(resource, subjects, auth, skip_share=skip_share)
         except PermissionsError as e:
             raise exceptions.PermissionDenied(detail=str(e))
         except ValueError as e:
@@ -106,9 +106,9 @@ class SubjectsRelationshipSerializer(BaseAPISerializer, UpdateSubjectsMixin):
     def format_subjects(self, subjects):
         return [subj['_id'] for subj in subjects]
 
-    def update_subjects_method(self, resource, subjects, auth, update_search=True):
+    def update_subjects_method(self, resource, subjects, auth, skip_share=False):
         # Overrides UpdateSubjectsMixin
-        return resource.set_subjects_from_relationships(subjects, auth, update_search=update_search)
+        return resource.set_subjects_from_relationships(subjects, auth, skip_share=skip_share)
 
     def update(self, instance, validated_data):
         resource = instance['self']

--- a/api/subjects/serializers.py
+++ b/api/subjects/serializers.py
@@ -15,11 +15,11 @@ from osf.exceptions import NodeStateError, ValidationValueError
 
 
 class UpdateSubjectsMixin:
-    def update_subjects_method(self, resource, subjects, auth):
+    def update_subjects_method(self, resource, subjects, auth, update_search=True):
         # Method to update subjects on resource
         raise NotImplementedError()
 
-    def update_subjects(self, resource, subjects, auth):
+    def update_subjects(self, resource, subjects, auth, update_search=True):
         """Updates subjects on resource and handles errors.
 
         :param object resource: Object for which you want to update subjects
@@ -27,7 +27,7 @@ class UpdateSubjectsMixin:
         :param object Auth object
         """
         try:
-            self.update_subjects_method(resource, subjects, auth)
+            self.update_subjects_method(resource, subjects, auth, update_search=update_search)
         except PermissionsError as e:
             raise exceptions.PermissionDenied(detail=str(e))
         except ValueError as e:
@@ -106,9 +106,9 @@ class SubjectsRelationshipSerializer(BaseAPISerializer, UpdateSubjectsMixin):
     def format_subjects(self, subjects):
         return [subj['_id'] for subj in subjects]
 
-    def update_subjects_method(self, resource, subjects, auth):
+    def update_subjects_method(self, resource, subjects, auth, update_search=True):
         # Overrides UpdateSubjectsMixin
-        return resource.set_subjects_from_relationships(subjects, auth)
+        return resource.set_subjects_from_relationships(subjects, auth, update_search=update_search)
 
     def update(self, instance, validated_data):
         resource = instance['self']

--- a/api/subjects/serializers.py
+++ b/api/subjects/serializers.py
@@ -15,6 +15,7 @@ from osf.exceptions import NodeStateError, ValidationValueError
 
 
 class UpdateSubjectsMixin:
+
     def update_subjects_method(self, resource, subjects, auth, skip_share=False):
         # Method to update subjects on resource
         raise NotImplementedError()

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -98,7 +98,7 @@ class TaxonomizableSerializerMixin(ser.Serializer, UpdateSubjectsMixin):
         ]
 
     # Overrides UpdateSubjectsMixin
-    def update_subjects_method(self, resource, subjects, auth, update_search=True):
+    def update_subjects_method(self, resource, subjects, auth, skip_share=False):
         """Depending on the request's version, runs a different method
         to update the resource's subjects. Will expect request to be formatted
         differently, depending on the version.
@@ -108,8 +108,8 @@ class TaxonomizableSerializerMixin(ser.Serializer, UpdateSubjectsMixin):
         :param object Auth object
         """
         if self.expect_subjects_as_relationships(self.context['request']):
-            return resource.set_subjects_from_relationships(subjects, auth, update_search=update_search)
-        return resource.set_subjects(subjects, auth, update_search=update_search)
+            return resource.set_subjects_from_relationships(subjects, auth, skip_share=skip_share)
+        return resource.set_subjects(subjects, auth, skip_share=skip_share)
 
     def expect_subjects_as_relationships(self, request):
         """Determines whether subjects should be serialized as a relationship.

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -98,7 +98,7 @@ class TaxonomizableSerializerMixin(ser.Serializer, UpdateSubjectsMixin):
         ]
 
     # Overrides UpdateSubjectsMixin
-    def update_subjects_method(self, resource, subjects, auth):
+    def update_subjects_method(self, resource, subjects, auth, update_search=True):
         """Depending on the request's version, runs a different method
         to update the resource's subjects. Will expect request to be formatted
         differently, depending on the version.
@@ -108,8 +108,8 @@ class TaxonomizableSerializerMixin(ser.Serializer, UpdateSubjectsMixin):
         :param object Auth object
         """
         if self.expect_subjects_as_relationships(self.context['request']):
-            return resource.set_subjects_from_relationships(subjects, auth)
-        return resource.set_subjects(subjects, auth)
+            return resource.set_subjects_from_relationships(subjects, auth, update_search=update_search)
+        return resource.set_subjects(subjects, auth, update_search=update_search)
 
     def expect_subjects_as_relationships(self, request):
         """Determines whether subjects should be serialized as a relationship.

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -602,6 +602,10 @@ class VersionedGuidMixin(GuidMixin):
             raise ValueError(f'no osfid for {self} (cannot build semantic iri)')
         return osfid_iri(_osfid)
 
+    def update_search(self, skip_share=False):
+        """Subclasses must implement `update_search()` with kwarg `skip_share=False`."""
+        raise NotImplementedError()
+
 @receiver(post_save)
 def ensure_guid(sender, instance, **kwargs):
     """Generate guid if it doesn't exist for subclasses of GuidMixin except for subclasses of VersionedGuidMixin

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1135,7 +1135,10 @@ class TaxonomizableMixin(models.Model):
 
         self.save()
         if hasattr(self, 'update_search'):
-            self.update_search(skip_share=skip_share)
+            from osf.models.base import VersionedGuidMixin
+            if isinstance(self, VersionedGuidMixin):
+                self.update_search(skip_share=skip_share)
+            self.update_search()
 
     def set_subjects_from_relationships(self, subjects_list, auth, add_log=True, skip_share=False):
         """ Helper for setting M2M subjects field from list of flattened subjects received from UI.
@@ -1162,7 +1165,10 @@ class TaxonomizableMixin(models.Model):
 
         self.save()
         if hasattr(self, 'update_search'):
-            self.update_search(skip_share=skip_share)
+            from osf.models.base import VersionedGuidMixin
+            if isinstance(self, VersionedGuidMixin):
+                self.update_search(skip_share=skip_share)
+            self.update_search()
 
     def map_subjects_between_providers(self, old_provider, new_provider, auth=None):
         """

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1104,7 +1104,7 @@ class TaxonomizableMixin(models.Model):
         if (expect_list and not is_list) or (not expect_list and is_list):
             raise ValidationValueError(f'Subjects are improperly formatted. {error_msg}')
 
-    def set_subjects(self, new_subjects, auth, add_log=True):
+    def set_subjects(self, new_subjects, auth, add_log=True, update_search=True):
         """ Helper for setting M2M subjects field from list of hierarchies received from UI.
         Only authorized admins may set subjects.
 
@@ -1134,10 +1134,10 @@ class TaxonomizableMixin(models.Model):
             self.add_subjects_log(old_subjects, auth)
 
         self.save()
-        if hasattr(self, 'update_search'):
+        if update_search and hasattr(self, 'update_search'):
             self.update_search()
 
-    def set_subjects_from_relationships(self, subjects_list, auth, add_log=True):
+    def set_subjects_from_relationships(self, subjects_list, auth, add_log=True, update_search=True):
         """ Helper for setting M2M subjects field from list of flattened subjects received from UI.
         Only authorized admins may set subjects.
 
@@ -1161,7 +1161,7 @@ class TaxonomizableMixin(models.Model):
             self.add_subjects_log(old_subjects, auth)
 
         self.save()
-        if hasattr(self, 'update_search'):
+        if update_search and hasattr(self, 'update_search'):
             self.update_search()
 
     def map_subjects_between_providers(self, old_provider, new_provider, auth=None):

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1138,7 +1138,8 @@ class TaxonomizableMixin(models.Model):
             from osf.models.base import VersionedGuidMixin
             if isinstance(self, VersionedGuidMixin):
                 self.update_search(skip_share=skip_share)
-            self.update_search()
+            else:
+                self.update_search()
 
     def set_subjects_from_relationships(self, subjects_list, auth, add_log=True, skip_share=False):
         """ Helper for setting M2M subjects field from list of flattened subjects received from UI.
@@ -1168,7 +1169,8 @@ class TaxonomizableMixin(models.Model):
             from osf.models.base import VersionedGuidMixin
             if isinstance(self, VersionedGuidMixin):
                 self.update_search(skip_share=skip_share)
-            self.update_search()
+            else:
+                self.update_search()
 
     def map_subjects_between_providers(self, old_provider, new_provider, auth=None):
         """

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1104,7 +1104,7 @@ class TaxonomizableMixin(models.Model):
         if (expect_list and not is_list) or (not expect_list and is_list):
             raise ValidationValueError(f'Subjects are improperly formatted. {error_msg}')
 
-    def set_subjects(self, new_subjects, auth, add_log=True, update_search=True):
+    def set_subjects(self, new_subjects, auth, add_log=True, skip_share=False):
         """ Helper for setting M2M subjects field from list of hierarchies received from UI.
         Only authorized admins may set subjects.
 
@@ -1134,10 +1134,10 @@ class TaxonomizableMixin(models.Model):
             self.add_subjects_log(old_subjects, auth)
 
         self.save()
-        if update_search and hasattr(self, 'update_search'):
-            self.update_search()
+        if hasattr(self, 'update_search'):
+            self.update_search(skip_share=skip_share)
 
-    def set_subjects_from_relationships(self, subjects_list, auth, add_log=True, update_search=True):
+    def set_subjects_from_relationships(self, subjects_list, auth, add_log=True, skip_share=False):
         """ Helper for setting M2M subjects field from list of flattened subjects received from UI.
         Only authorized admins may set subjects.
 
@@ -1161,8 +1161,8 @@ class TaxonomizableMixin(models.Model):
             self.add_subjects_log(old_subjects, auth)
 
         self.save()
-        if update_search and hasattr(self, 'update_search'):
-            self.update_search()
+        if hasattr(self, 'update_search'):
+            self.update_search(skip_share=skip_share)
 
     def map_subjects_between_providers(self, old_provider, new_provider, auth=None):
         """

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1141,8 +1141,12 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             logger.exception(e)
             log_exception(e)
 
-    def update_search(self):
-        update_share(self)
+    def update_search(self, skip_share=False):
+        """Update SHARE and OSF search.
+        """
+        if not skip_share:
+            update_share(self)
+
         from website import search
         try:
             search.search.update_preprint(self, bulk=False, async_update=True)


### PR DESCRIPTION
## Purpose

Avoid updating share during version creation

## Changes

* Update `VersionedGuidMixin` to require subclasses implementing `update_search()` with kwargs `skip_share`
* Update `Preprint`'s `update_search()` to handle the new kwarg
* Refactored preprint update API and subject update API to handle the new kwarg
* Set `skip_share=True` when creating a new version
* Only call `update_search()` with the new kwarg if `self` is subclasses of `VersionedGuidMixin`

## QA Notes

N/A

## Documentation

N/A


## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6855
