### PR TITLE
[ENG-6928] Add new tests in `TestPreprintVersionsListRetrieve`

### DIFF
--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -1,16 +1,14 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.fields import Field
-from django.contrib.auth.models import Group
 
 from addons.osfstorage import settings as osfstorage_settings
 from addons.osfstorage.models import OsfStorageFile
 from api.base.settings.defaults import API_BASE
-
 from framework.auth.core import Auth
 from osf.models import Preprint
 from osf.utils import permissions
-
-from osf_tests.factories import ProjectFactory, PreprintFactory, AuthUserFactory, PreprintProviderFactory
+from osf.utils.workflows import DefaultStates, RequestTypes
+from osf_tests.factories import ProjectFactory, PreprintFactory, AuthUserFactory, PreprintRequestFactory
 from tests.base import ApiTestCase
 
 
@@ -159,359 +157,194 @@ class TestPreprintVersionsListCreate(ApiTestCase):
 
 class TestPreprintVersionsListRetrieve(ApiTestCase):
 
-    def add_contributors_for_preprint(self, preprint):
-        preprint.add_contributor(self.admin, permissions=permissions.ADMIN)
-        preprint.add_contributor(self.write_user, permissions=permissions.WRITE)
-        preprint.add_contributor(self.read_user, permissions=permissions.READ)
-
     def setUp(self):
+
         super().setUp()
-        self.user = AuthUserFactory()
-        self.read_user = AuthUserFactory()
-        self.write_user = AuthUserFactory()
-        self.admin = AuthUserFactory()
-        osf_admin = Group.objects.get(name='osf_admin')
-        self.admin.groups.add(osf_admin)
 
+        self.creator = AuthUserFactory()
+        self.read_contrib = AuthUserFactory()
+        self.write_contrib = AuthUserFactory()
+        self.admin_contrib = AuthUserFactory()
         self.moderator = AuthUserFactory()
-        self.provider = PreprintProviderFactory(_id='osf', name='osfprovider')
-        self.post_mod_preprint = PreprintFactory(
+        self.non_contrib = AuthUserFactory()
+
+    def test_list_versions_post_mod(self):
+        # Post moderation V1 (Accepted)
+        post_mod_preprint = PreprintFactory(
             reviews_workflow='post-moderation',
-            is_published=True,
-            creator=self.user,
-            provider=self.provider
+            creator=self.creator,
+            is_published=True
         )
+        post_mod_preprint.add_contributor(self.admin_contrib, permissions=permissions.ADMIN)
+        post_mod_preprint.add_contributor(self.write_contrib, permissions=permissions.WRITE)
+        post_mod_preprint.add_contributor(self.read_contrib, permissions=permissions.READ)
+        post_mod_preprint.provider.get_group('moderator').user_set.add(self.moderator)
+        post_mod_versions_list_url = f"/{API_BASE}preprints/{post_mod_preprint.get_guid()._id}/versions/"
 
-        self.pre_mod_preprint = PreprintFactory(
-            reviews_workflow='pre-moderation',
-            is_published=False,
-            creator=self.user,
-            provider=self.provider
+        # Post moderation V2 (Withdrawn)
+        post_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=post_mod_preprint,
+            creator=self.creator,
+            final_machine_state='initial',
+            set_doi=False
         )
-        self.add_contributors_for_preprint(self.pre_mod_preprint)
+        post_mod_preprint_v2.run_submit(self.creator)
+        post_mod_preprint_v2.run_accept(self.moderator, 'comment')
+        withdrawal_request = PreprintRequestFactory(
+            creator=self.creator,
+            target=post_mod_preprint_v2,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value)
+        withdrawal_request.run_submit(self.creator)
+        withdrawal_request.run_accept(self.moderator, withdrawal_request.comment)
 
-        self.pre_mod_preprint_pending = PreprintFactory(
-            reviews_workflow='pre-moderation',
-            is_published=False,
-            creator=self.user,
-            provider=self.provider
+        # Post moderation V3 (Pending)
+        post_mod_preprint_v3 = PreprintFactory.create_version(
+            create_from=post_mod_preprint_v2,
+            creator=self.creator,
+            final_machine_state='initial',
+            set_doi=False
         )
-        self.add_contributors_for_preprint(self.pre_mod_preprint_pending)
-        self.pre_mod_preprint_pending.run_submit(user=self.admin)
-        self.pre_mod_preprint.provider.get_group('moderator').user_set.add(self.moderator)
-        self.post_mod_preprint.provider.get_group('moderator').user_set.add(self.moderator)
-        self.latest_preprint = self.post_mod_preprint
-        self.origin_guid = str(self.post_mod_preprint.guids.first()._id)
-        for _ in range(5):
-            new_version = PreprintFactory.create_version(
-                create_from=self.latest_preprint,
-                creator=self.user,
-                set_doi=False
-            )
-            self.latest_preprint = new_version
-
-        self.version_list_url = f"/{API_BASE}preprints/{self.origin_guid}_v1/versions/"
-
-    def test_list_versions(self):
-        res = self.app.get(self.version_list_url, auth=self.user.auth)
+        post_mod_preprint_v3.run_submit(self.creator)
+        id_set = {post_mod_preprint._id, post_mod_preprint_v2._id, post_mod_preprint_v3._id}
+        res = self.app.get(post_mod_versions_list_url, auth=self.admin_contrib.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert len(data) == 6
-        assert len(set([item['id'] for item in data])) == 6
-
-    def test_public_visibility(self):
-        self.pre_mod_preprint.is_public = True
-        self.pre_mod_preprint.save()
-        res = self.app.get(self.version_list_url)
+        assert len(data) == 3
+        assert set([item['id'] for item in data]) == id_set
+        res = self.app.get(post_mod_versions_list_url, auth=self.write_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 6
+        data = res.json['data']
+        assert len(data) == 3
+        assert set([item['id'] for item in data]) == id_set
+        res = self.app.get(post_mod_versions_list_url, auth=self.read_contrib.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 3
+        assert set([item['id'] for item in data]) == id_set
+        res = self.app.get(post_mod_versions_list_url, auth=self.non_contrib.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 3
+        assert set([item['id'] for item in data]) == id_set
+        res = self.app.get(post_mod_versions_list_url, auth=None)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 3
+        assert set([item['id'] for item in data]) == id_set
 
-    def test_invalid_preprint_id(self):
-        res = self.app.get(f"/{API_BASE}preprints/lkziv_v1010101/versions/", auth=self.user.auth, expect_errors=True)
-        assert res.status_code == 404
+    def test_list_versions_pre_mod(self):
+        # Pre moderation V1 (Accepted)
+        pre_mod_preprint = PreprintFactory(
+            reviews_workflow='pre-moderation',
+            creator=self.creator,
+            is_published=True
+        )
+        pre_mod_preprint.provider.get_group('moderator').user_set.add(self.moderator)
+        pre_mod_preprint.add_contributor(self.admin_contrib, permissions=permissions.ADMIN)
+        pre_mod_preprint.add_contributor(self.write_contrib, permissions=permissions.WRITE)
+        pre_mod_preprint.add_contributor(self.read_contrib, permissions=permissions.READ)
+        pre_mod_versions_list_url = f"/{API_BASE}preprints/{pre_mod_preprint.get_guid()._id}/versions/"
 
-    def test_pagination(self):
-        res = self.app.get(f"{self.version_list_url}?page[size]=2", auth=self.user.auth)
+        for contrib in pre_mod_preprint.contributor_set.all():
+            print(f'>>>> {contrib}:{contrib.permission}')
+
+        # Pre moderation V2 (Withdrawn)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=pre_mod_preprint,
+            creator=self.creator,
+            final_machine_state='initial',
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.creator)
+        pre_mod_preprint_v2.run_accept(self.moderator, 'comment')
+        withdrawal_request = PreprintRequestFactory(
+            creator=self.creator,
+            target=pre_mod_preprint_v2,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value)
+        withdrawal_request.run_submit(self.creator)
+        withdrawal_request.run_accept(self.moderator, withdrawal_request.comment)
+
+        # Pre moderation V3 (Rejected)
+        pre_mod_preprint_v3 = PreprintFactory.create_version(
+            create_from=pre_mod_preprint_v2,
+            creator=self.creator,
+            final_machine_state='initial',
+            is_published=False,
+            set_doi=False,
+        )
+        pre_mod_preprint_v3.run_submit(self.creator)
+        pre_mod_preprint_v3.run_reject(self.moderator, 'comment')
+
+        # Pre moderation V4 (Pending)
+        pre_mod_preprint_v4 = PreprintFactory.create_version(
+            create_from=pre_mod_preprint_v2,
+            creator=self.creator,
+            final_machine_state='initial',
+            is_published=False,
+            set_doi=False
+        )
+        pre_mod_preprint_v4.run_submit(self.creator)
+
+        admin_id_set = {pre_mod_preprint._id, pre_mod_preprint_v2._id, pre_mod_preprint_v3._id, pre_mod_preprint_v4._id}
+        non_admin_id_set = {pre_mod_preprint._id, pre_mod_preprint_v2._id}
+        res = self.app.get(pre_mod_versions_list_url, auth=self.admin_contrib.auth)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 4
+        assert set([item['id'] for item in data]) == admin_id_set
+        res = self.app.get(pre_mod_versions_list_url, auth=self.write_contrib.auth)
         assert res.status_code == 200
         data = res.json['data']
         assert len(data) == 2
-        assert 'links' in res.json
-        assert 'next' in res.json['links']
-
-    def test_new_unpublished_version(self):
-        PreprintFactory.create_version(
-            self.latest_preprint,
-            creator=self.user,
-            set_doi=False,
-            final_machine_state='pending',
-            is_published=False
-        )
-        res = self.app.get(self.version_list_url, auth=self.user.auth)
+        assert set([item['id'] for item in data]) == non_admin_id_set
+        res = self.app.get(pre_mod_versions_list_url, auth=self.read_contrib.auth)
         assert res.status_code == 200
         data = res.json['data']
-        assert len(data) == 7
-        assert len(set([item['id'] for item in data])) == 7
-
-    def test_preprints_version_permissions_for_admin(self):
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
+        assert len(data) == 2
+        assert set([item['id'] for item in data]) == non_admin_id_set
+        res = self.app.get(pre_mod_versions_list_url, auth=self.non_contrib.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 6
+        data = res.json['data']
+        assert len(data) == 2
+        assert set([item['id'] for item in data]) == non_admin_id_set
+        res = self.app.get(pre_mod_versions_list_url, auth=None)
+        assert res.status_code == 200
+        data = res.json['data']
+        assert len(data) == 2
+        assert set([item['id'] for item in data]) == non_admin_id_set
 
-        unpublished_preprint_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
+    def test_invalid_preprint_id(self):
+        versions_url_invalid_guid = f'/{API_BASE}preprints/abcde/versions/'
+        res = self.app.get(versions_url_invalid_guid, auth=None, expect_errors=True)
+        assert res.status_code == 404
+        preprint = PreprintFactory(
+            reviews_workflow='post-moderation',
+            creator=self.creator,
+            is_published=True
         )
-        self.latest_preprint = unpublished_preprint_version
-        unpublished_preprint_version.add_contributor(self.admin, permissions=permissions.ADMIN)
+        versions_url_invalid_version = f'/{API_BASE}preprints/{preprint.get_guid()._id}_v2/versions/'
+        res = self.app.get(versions_url_invalid_version, auth=None, expect_errors=True)
+        assert res.status_code == 404
 
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_submit(user=self.admin)
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_preprint_version.run_accept(user=self.admin, comment='Text')
-
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
+    def test_version_indifference(self):
+        latest_version = PreprintFactory(
+            reviews_workflow='post-moderation',
+            creator=self.creator,
+            is_published=True
         )
-        unpublished_version.add_contributor(self.admin, permissions=permissions.ADMIN)
-
-        unpublished_version.run_submit(user=self.admin)
-
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 8
-
-        unpublished_version.run_reject(user=self.admin, comment='Test')
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 8
-
-    def test_preprints_version_permissions_for_write_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-        self.latest_preprint = unpublished_preprint_version
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_submit(user=self.admin)
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_accept(user=self.admin, comment='Text')
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-
-        unpublished_version.run_submit(user=self.admin)
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version.run_reject(user=self.admin, comment='Test')
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_pre_mod_preprints_version_permissions_for_read_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-        self.latest_preprint = unpublished_preprint_version
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_submit(user=self.admin)
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_accept(user=self.admin, comment='Text')
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-
-        unpublished_version.run_submit(user=self.admin)
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version.run_reject(user=self.admin, comment='Test')
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_pre_mod_preprints_version_permissions_for_other_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-        self.latest_preprint = unpublished_preprint_version
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_submit(user=self.admin)
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        unpublished_preprint_version.run_accept(user=self.admin, comment='Text')
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version = PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='initial',
-            is_published=False,
-            set_doi=False
-        )
-
-        unpublished_version.run_submit(user=self.admin)
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-        unpublished_version.run_reject(user=self.admin, comment='Test')
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_post_mod_preprints_version_permissions_for_admin_user(self):
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='accepted',
-            is_published=True,
-            set_doi=False
-        )
-        res = self.app.get(self.version_list_url, auth=self.admin.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_post_mod_preprints_version_permissions_for_write_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='accepted',
-            is_published=True,
-            set_doi=False
-        )
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_post_mod_preprints_version_permissions_for_read_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='accepted',
-            is_published=True,
-            set_doi=False
-        )
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
-
-    def test_post_mod_preprints_version_permissions_for_other_user(self):
-        new_user = AuthUserFactory()
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 6
-
-        PreprintFactory.create_version(
-            create_from=self.latest_preprint,
-            creator=self.user,
-            final_machine_state='accepted',
-            is_published=True,
-            set_doi=False
-        )
-
-        res = self.app.get(self.version_list_url, auth=new_user.auth)
-        assert res.status_code == 200
-        assert len(res.json['data']) == 7
+        for _ in range(5):
+            new_version = PreprintFactory.create_version(
+                create_from=latest_version,
+                creator=self.creator,
+                set_doi=False
+            )
+            latest_version = new_version
+        versions_url_base_guid = f'/{API_BASE}preprints/{latest_version.get_guid()._id}/versions/'
+        res_1 = self.app.get(versions_url_base_guid, auth=self.creator.auth)
+        assert res_1.status_code == 200
+        versions_url_valid_version = f'/{API_BASE}preprints/{latest_version._id}/versions/'
+        res_2 = self.app.get(versions_url_valid_version, auth=self.creator.auth)
+        assert res_2.status_code == 200
+        assert len(res_1.json['data']) == len(res_2.json['data'])

--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -266,7 +266,7 @@ class TestPreprintVersionsListRetrieve(ApiTestCase):
         unpublished_preprint_version.add_contributor(self.admin, permissions=permissions.ADMIN)
         res = self.app.get(self.version_list_url, auth=self.admin.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 6
+        assert len(res.json['data']) == 7
 
         unpublished_preprint_version.run_submit(user=self.admin)
         res = self.app.get(self.version_list_url, auth=self.admin.auth)

--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -269,7 +269,7 @@ class TestPreprintVersionsListRetrieve(ApiTestCase):
 
         res = self.app.get(self.version_list_url, auth=self.admin.auth)
         assert res.status_code == 200
-        assert len(res.json['data']) == 7
+        assert len(res.json['data']) == 6
 
         unpublished_preprint_version.run_submit(user=self.admin)
         res = self.app.get(self.version_list_url, auth=self.admin.auth)


### PR DESCRIPTION
## Purpose

We have good coverage for `POST`; this PR adds new tests for `GET`

## Changes

Add new tests in `TestPreprintVersionsListRetrieve`

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-6928