### PR TITLE
fixed week/ endpoint that is not used on staging

### DIFF
--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -501,25 +501,25 @@ class NodeAnalyticsQuery(JSONAPIBaseView):
                 },
                 'referer-domain': {
                     'terms': {
-                        'field': 'pageview_info.referer_domain',
+                        'field': 'pageview_info.referer_domain.keyword',
                         'size': 10,
                     },
                 },
                 'popular-pages': {
                     'terms': {
-                        'field': 'pageview_info.page_path',
+                        'field': 'pageview_info.page_path.keyword',
                         'size': 10,
                     },
                     'aggs': {
                         'route-for-path': {
                             'terms': {
-                                'field': 'pageview_info.route_name',
+                                'field': 'pageview_info.route_name.keyword',
                                 'size': 1,
                             },
                         },
                         'title-for-path': {
                             'terms': {
-                                'field': 'pageview_info.page_title',
+                                'field': 'pageview_info.page_title.keyword',
                                 'size': 1,
                             },
                         },


### PR DESCRIPTION
## Purpose

Throughout the onboarding I got 500 error on _/metrics/query/node_analytics/m8dwk/week/ endpoint but not on staging.
Error I got before fix:

> Fielddata is disabled on text fields by default. Set fielddata=true on [pageview_info.referer_domain] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.

Appropriate screenshot
![Screenshot from 2025-01-21 11-41-03](https://github.com/user-attachments/assets/68b7354e-4d78-4a1f-ad07-879ef447e41f)

After the fix at the bottom of this PR I was able to fix it
Locally (fixed):
![Screenshot from 2025-01-21 11-40-05](https://github.com/user-attachments/assets/0098f49d-da6a-48a8-90c5-0b63fee639f7)

Staging (https://staging.osf.io/g78bt/analytics):
![Screenshot from 2025-01-21 11-37-43](https://github.com/user-attachments/assets/5e9a28d5-55a8-4ca4-a485-6ee30a6ddf30)

It appears that on staging we don't make a request to that endpoint at all, thus analytics is never loaded, so potentially we may have the same issue on the staging

## Changes
We had to add ".keyword" to each text field
