### PR TITLE
[ICA][ENG-6995] Add Curator with Correct Permissions

### DIFF
--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -201,7 +201,9 @@ class NodeRequestMachine(BaseMachine):
 
         if ev.event.name == DefaultTriggers.ACCEPT.value:
             if not self.machineable.target.is_contributor(self.machineable.creator):
-                contributor_permissions = ev.kwargs.get('permissions', permissions.READ)
+                contributor_permissions = (
+                    self.machineable.requested_permissions or ev.kwargs.get('permissions') or permissions.READ
+                )
                 try:
                     self.machineable.target.add_contributor(
                         self.machineable.creator,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This will make sure curator is added with listed permisssions. While permissions are currenlt displayed correct this PR will better pass them from the access request object to the node better, in a way that follows the business logic where `requested_permissions` defines the given permission when the request is accepted.

## Changes

- change add_contributor logic
- add tests

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-6995