### PR TITLE
[IAC][ENG-6998] Infinite Resubmits For IAC

### DIFF
--- a/api/requests/serializers.py
+++ b/api/requests/serializers.py
@@ -1,4 +1,4 @@
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from rest_framework import exceptions
 from rest_framework import serializers as ser
 
@@ -209,17 +209,32 @@ class NodeRequestCreateSerializer(NodeRequestSerializer):
         comment = validated_data.get('comment', '')
         requested_permissions = validated_data.get('requested_permissions')
         try:
-            node_request = NodeRequest.objects.create(
-                target=node,
-                creator=creator,
-                comment=comment,
-                machine_state=DefaultStates.INITIAL.value,
-                request_type=request_type,
-                requested_permissions=requested_permissions,
-            )
-            node_request.save()
+            with transaction.atomic():
+                node_request = NodeRequest.objects.create(
+                    target=node,
+                    creator=creator,
+                    comment=comment,
+                    machine_state=DefaultStates.INITIAL.value,
+                    request_type=request_type,
+                    requested_permissions=requested_permissions,
+                )
+                node_request.save()
         except IntegrityError:
-            raise Conflict(f"Users may not have more than one {request_type} request per node.")
+            # if INSTITUTIONAL_REQUEST updates and restarts the request
+            with transaction.atomic():
+                if request_type == NodeRequestTypes.INSTITUTIONAL_REQUEST.value:
+                    node_request = NodeRequest.objects.filter(
+                        target=node,
+                        creator=creator,
+                        request_type=NodeRequestTypes.INSTITUTIONAL_REQUEST.value,
+                    ).first()
+                else:
+                    raise Conflict(f"Users may not have more than one {request_type} request per node.")
+                if node_request:
+                    node_request.comment = comment
+                    node_request.machine_state = DefaultStates.INITIAL.value
+                    node_request.requested_permissions = requested_permissions
+                    node_request.save()
 
         node_request.run_submit(creator)
         return node_request

--- a/api_tests/requests/views/test_node_request_institutional_access.py
+++ b/api_tests/requests/views/test_node_request_institutional_access.py
@@ -395,3 +395,20 @@ class TestNodeRequestListInstitutionalAccess(NodeRequestTestMixin):
         )
         assert res.status_code == 403
         assert f"{node_with_disabled_access_requests._id} does not have Access Requests enabled" in res.json['errors'][0]['detail']
+
+    def test_requester_can_resubmit(self, app, project, institutional_admin, url, create_payload):
+        """
+        Test that a requester cannot submit another access request for the same node.
+        """
+        # Create the first request
+        app.post_json_api(url, create_payload, auth=institutional_admin.auth)
+        node_request = project.requests.get()
+        node_request.run_reject(project.creator, 'test comment2')
+        node_request.refresh_from_db()
+        assert node_request.machine_state == 'rejected'
+
+        # Attempt to create a second request
+        res = app.post_json_api(url, create_payload, auth=institutional_admin.auth)
+        assert res.status_code == 201
+        node_request.refresh_from_db()
+        assert node_request.machine_state == 'pending'

--- a/api_tests/requests/views/test_node_request_institutional_access.py
+++ b/api_tests/requests/views/test_node_request_institutional_access.py
@@ -398,7 +398,7 @@ class TestNodeRequestListInstitutionalAccess(NodeRequestTestMixin):
 
     def test_requester_can_resubmit(self, app, project, institutional_admin, url, create_payload):
         """
-        Test that a requester cannot submit another access request for the same node.
+        Test that a requester can submit another access request for the same node.
         """
         # Create the first request
         app.post_json_api(url, create_payload, auth=institutional_admin.auth)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allows a institutional access user to resubmit node requests. Before curator would get rejected accidently and be banned outside the node without way of making new request, This feature allows admin to update and re-new their request an infinite number of times.

## Changes

- add resubmit behavior and testing

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-6998