### PR TITLE
[ENG-6989] Get CrossRef metadata for preprints working

### DIFF
--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -165,14 +165,6 @@ class TestCrossRefClient:
         assert intra_work_relation.get('relationship-type') == 'isPreprintOf'
         assert intra_work_relation.get('identifier-type') == 'doi'
 
-        doi = related_item_preprint_version.find('.//{%s}doi' % crossref.CROSSREF_RELATIONS)
-        assert doi is not None
-        assert doi.text == settings.DOI_FORMAT.format(prefix=preprint_version.provider.doi_prefix, guid=preprint_version._id)
-
-        description = related_item_preprint_version.find('.//{%s}description' % crossref.CROSSREF_RELATIONS)
-        assert description is not None
-        assert description.text == 'Updated version of preprint'
-
         intra_work_relation = related_item_preprint_version.find('.//{%s}intra_work_relation' % crossref.CROSSREF_RELATIONS)
         assert intra_work_relation is not None
         assert intra_work_relation.get('relationship-type') == 'isVersionOf'

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -130,12 +130,6 @@ class CrossRefClient(AbstractIdentifierClient):
                     )
                 )
             )
-        doi = self.build_doi(preprint)
-        doi_data = [
-            element.doi(doi),
-            element.resource(settings.DOMAIN + preprint._id)
-        ]
-        posted_content.append(element.doi_data(*doi_data))
 
         preprint_versions = preprint.get_preprint_versions()
         if preprint_versions:
@@ -143,17 +137,22 @@ class CrossRefClient(AbstractIdentifierClient):
                 if preprint_version.version > preprint.version:
                     continue
                 related_item = element.related_item(
-                    element.doi(self.build_doi(preprint_version)),
-                    element.description('Updated version of preprint'),
                     element.intra_work_relation(
                         self.build_doi(previous_version),
                         **{'relationship-type': 'isVersionOf', 'identifier-type': 'doi'}
                     )
                 )
                 relations_program.append(related_item)
-
         if len(relations_program) > 0:
             posted_content.append(relations_program)
+
+        doi = self.build_doi(preprint)
+        doi_data = [
+            element.doi(doi),
+            element.resource(settings.DOMAIN + preprint._id)
+        ]
+        posted_content.append(element.doi_data(*doi_data))
+
         return posted_content
 
     def _process_crossref_name(self, contributor):


### PR DESCRIPTION
## Purpose

Get CrossRef metadata for preprints working

## Changes

Removed `<doi>` and `<description>` from `<related_item>`

## QA Notes

TBD

## Documentation

TBD

## Side Effects

TBD

## Ticket

(https://openscience.atlassian.net/browse/ENG-6989)
