### PR TITLE
Feature/ENG-6134

### DIFF
--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -190,6 +190,15 @@ class ContributorDetailPermissions(permissions.BasePermission):
 
     def load_resource(self, context, view):
         return AbstractNode.load(context[view.node_lookup_url_kwarg])
+    
+    def has_permission(self, request, view):
+        auth = get_user_auth(request)
+        context = request.parser_context['kwargs']
+        resource = self.load_resource(context, view)
+        if request.method == 'POST' and not resource.has_permission(auth.user, osf_permissions.ADMIN):
+            return False
+
+        return super().has_permission(request, view)
 
     def has_object_permission(self, request, view, obj):
         assert_resource_type(obj, self.acceptable_models)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -361,6 +361,19 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
             raise PermissionDenied(str(err))
 
 
+class NodeContributorRemoveMixin:
+    
+    # remove contributor's permissions
+    def perform_destroy(self, instance):
+        node = self.get_resource()
+        auth = get_user_auth(self.request)
+        if len(node.visible_contributors) == 1 and instance.visible:
+            raise ValidationError('Must have at least one visible contributor')
+        removed = node.remove_contributor(instance, auth)
+        if not removed:
+            raise ValidationError('Must have at least one registered admin contributor')
+
+
 class NodeDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMixin, WaterButlerMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_read).
     """
@@ -501,7 +514,7 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
         return context
 
 
-class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestroyAPIView, NodeMixin, UserMixin):
+class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestroyAPIView, NodeContributorRemoveMixin, NodeMixin, UserMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/nodes_contributors_read).
     """
     permission_classes = (
@@ -520,16 +533,6 @@ class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestro
 
     def get_resource(self):
         return self.get_node()
-
-    # overrides DestroyAPIView
-    def perform_destroy(self, instance):
-        node = self.get_resource()
-        auth = get_user_auth(self.request)
-        if len(node.visible_contributors) == 1 and instance.visible:
-            raise ValidationError('Must have at least one visible contributor')
-        removed = node.remove_contributor(instance, auth)
-        if not removed:
-            raise ValidationError('Must have at least one registered admin contributor')
 
     def get_serializer_context(self):
         context = JSONAPIBaseView.get_serializer_context(self)

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -83,7 +83,7 @@ class RegistrationSerializer(NodeSerializer):
 
     ia_url = ser.URLField(read_only=True)
     reviews_state = ser.CharField(source='moderation_state', read_only=True)
-    title = ser.CharField(read_only=True)
+    title = ser.CharField(required=False)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True)
     category_choices = NodeSerializer.category_choices
     category_choices_string = NodeSerializer.category_choices_string

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -21,6 +21,7 @@ from api.nodes.serializers import (
     NodeLinksSerializer,
     NodeLicenseSerializer,
     NodeContributorsSerializer,
+    NodeContributorsCreateSerializer,
     RegistrationProviderRelationshipField,
     get_license_details,
 )
@@ -916,6 +917,16 @@ class RegistrationContributorsSerializer(NodeContributorsSerializer):
                 'version': self.context['request'].parser_context['kwargs']['version'],
             },
         )
+
+
+class RegistrationContributorsCreateSerializer(NodeContributorsCreateSerializer, RegistrationContributorsSerializer):
+    """
+    Overrides RegistrationContributorsSerializer to add email, full_name, send_email, and non-required index and users field.
+
+    id and index redefined because of the two serializers we've inherited
+    """
+    id = IDField(source='_id', required=False, allow_null=True)
+    index = ser.IntegerField(required=False, source='_order')
 
 
 class RegistrationFileSerializer(OsfStorageFileSerializer):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -309,7 +309,7 @@ class RegistrationContributorsList(BaseContributorList, mixins.CreateModelMixin,
         return context
 
 
-class RegistrationContributorDetail(BaseContributorDetail, mixins.DestroyModelMixin, NodeContributorRemoveMixin, RegistrationMixin, UserMixin):
+class RegistrationContributorDetail(BaseContributorDetail, NodeContributorRemoveMixin, mixins.DestroyModelMixin, RegistrationMixin, UserMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/registrations_contributors_read).
     """
     view_category = 'registrations'

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2117,6 +2117,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     continue
             # Title, description, and category have special methods for logging purposes
             if key == 'title':
+                # not all nodes have this attribute but it's possible to update their title (e.g. Registration)
+                if not hasattr(self, 'is_bookmark_collection'):
+                    self.set_title(title=value, auth=auth, save=False)
+                    continue
                 if not self.is_bookmark_collection or not self.is_quickfiles:
                     self.set_title(title=value, auth=auth, save=False)
                 else:

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -87,6 +87,7 @@ class Registration(AbstractNode):
     }
 
     WRITABLE_WHITELIST = [
+        'title',
         'article_doi',
         'description',
         'is_public',


### PR DESCRIPTION
## Purpose

Contributors added to a registration should be able to edit title. Admins should be able to edit contributors on registration page

## Changes

1. Common perform_destroy for NodeContributorDetail and RegistrationContributorDetail views moved to a separate NodeContributorRemoveMixin
2. Added has_permission method to ContributorDetailPermissions for RegistrationList so that contributors cannot do POST request (adding contributors)
3. Title field of Registration is not read only right now and added in WRITABLE_WHITELIST of Registration
4. Added tests

## Notes:

1. In RegistrationContributorsList.get_serializer_context I set default email = default assuming this is correct as we don't have a separate email template for registrations
2. I inherited from CreateModelMixin and DestroyModelMixin for some classes because didn't want to update base class as it may impact on v1 version

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-6134
