### PR TITLE
ENG-6733 fix the issue of sorting for gitlab is related to Serializer source=‘modified’ in comparison to dropbox it failed so have added the possibility.

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -651,6 +651,12 @@ class WaterButlerMixin:
 
             try:
                 file_obj = base_class.objects.get(**query)
+                # it is needed to update modified attribute explicitly in case
+                # there will be another commit for the file so it will have another update date
+                # somehow it is not updated for gitlab implicitly using .
+                if attrs.get('provider') == 'gitlab' and attrs.get('modified_utc'):
+                    file_obj.modified = attrs.get('modified_utc')
+
             except base_class.DoesNotExist:
                 # create method on BaseFileNode appends provider, bulk_create bypasses this step so it is added here
                 file_obj = base_class(target=node, _path=_path, provider=base_class._provider)

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -415,6 +415,16 @@ class FileSerializer(BaseFileSerializer):
             raise NotImplementedError()
 
 
+class GitlabFileSerializer(FileSerializer):
+    date_modified = VersionedDateTimeField(
+        source='modified',
+        read_only=True,
+        help_text='Timestamp when the file was last modified',
+        required=False,
+        allow_null=True,
+    )
+
+
 class OsfStorageFileSerializer(FileSerializer):
     """ Overrides `filterable_fields` to make `last_touched` non-filterable
     """

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -71,7 +71,7 @@ from api.comments.serializers import (
 )
 from api.draft_registrations.serializers import DraftRegistrationSerializer, DraftRegistrationDetailSerializer
 from api.draft_registrations.permissions import DraftRegistrationPermission
-from api.files.serializers import FileSerializer, OsfStorageFileSerializer
+from api.files.serializers import FileSerializer, OsfStorageFileSerializer, GitlabFileSerializer
 from api.files import annotations as file_annotations
 from api.identifiers.serializers import NodeIdentifierSerializer
 from api.identifiers.views import IdentifierList
@@ -1130,6 +1130,9 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     def serializer_class(self):
         if self.kwargs[self.provider_lookup_url_kwarg] == 'osfstorage':
             return OsfStorageFileSerializer
+        if self.kwargs[self.provider_lookup_url_kwarg] == 'gitlab':
+            # use source='modified' explicitly for gitlab sorting
+            return GitlabFileSerializer
         return FileSerializer
 
     def get_resource(self):


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix the issue of gitlab addon files sorting by "date_modified"  

![image](https://github.com/user-attachments/assets/8c6c28de-6c4b-4c8d-b30d-ffb22855c4f9)


## Changes

Implemented `GitlabFileSerializer` with `date_modified(source=‘modified)` attribute for gitlab.

`modified` attribute reseting if new commit with corresponding file is added.

![image](https://github.com/user-attachments/assets/5f36d138-c36a-4fb4-90f4-1b5b5ea8e930)


## QA Notes


Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-6733