### PR TITLE
[ENG-6417] Added resync crossref button on preprint page in admin app

### DIFF
--- a/admin/preprints/urls.py
+++ b/admin/preprints/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     re_path(r'^(?P<guid>\w+)/reindex_elastic_preprint/$', views.PreprintReindexElastic.as_view(), name='reindex-elastic-preprint'),
     re_path(r'^(?P<guid>\w+)/approve_withdrawal/$', views.PreprintApproveWithdrawalRequest.as_view(), name='approve-withdrawal'),
     re_path(r'^(?P<guid>\w+)/reject_withdrawal/$', views.PreprintRejectWithdrawalRequest.as_view(), name='reject-withdrawal'),
+    re_path(r'^(?P<guid>\w+)/resync_crossref/$', views.PreprintResyncCrossRefView.as_view(), name='resync-crossref'),
 ]

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -538,3 +538,14 @@ class PreprintMakePublic(PreprintMixin, View):
             messages.error(self.request, str(e))
 
         return redirect(self.get_success_url())
+
+
+class PreprintResyncCrossRefView(PreprintMixin, View):
+    """ Allows an authorized user to run resync with CrossRef for a single object.
+    """
+    permission_required = 'osf.change_node'
+
+    def post(self, request, *args, **kwargs):
+        preprint = self.get_object()
+        preprint.request_identifier_update('doi', create=True)
+        return redirect(self.get_success_url())

--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -22,6 +22,7 @@
                     {% include "preprints/mark_spam.html" with preprint=preprint %}
                     {% include "preprints/reindex_preprint_share.html" with preprint=preprint %}
                     {% include "preprints/reindex_preprint_elastic.html" with preprint=preprint %}
+                    {% include "preprints/resync_crossref.html" with preprint=preprint %}
                     {% include "preprints/make_private.html" with preprint=preprint %}
                     {% include "preprints/make_public.html" with preprint=preprint %}
                 </div>

--- a/admin/templates/preprints/resync_crossref.html
+++ b/admin/templates/preprints/resync_crossref.html
@@ -1,0 +1,24 @@
+{% if preprint.article_doi %}
+    <a data-toggle="modal" data-target="#confirmResyncCrossRef" class="btn btn-info">
+        Resync with Crossref
+    </a>
+    <div class="modal" id="confirmResyncCrossRef">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form class="well" method="post" action="{% url 'preprints:resync-crossref' guid=preprint.guid %}">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal">x</button>
+                        <h3>Are you sure you want to resync with CrossRef?</h3>
+                    </div>
+                    {% csrf_token %}
+                    <div class="modal-footer">
+                        <input class="btn btn-danger" type="submit" value="Confirm" />
+                        <button type="button" class="btn btn-default" data-dismiss="modal">
+                            Cancel
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
## Purpose

User should be able to run resync with CrossRef in admin app for preprints that have DOI

## Changes

Added a separate endpoint and template to process this request

## Notes
1. I have implemented this functionality using the approach Matthew mentioned in this ticket, however I'm worried about this requirement: This is not creating a new DOI version. From what I see calling request_identifier_update just uploads a new version of file for a specific preprint without DOI changes.
2. In order to test it I need CROSSREF_URL to set it in settings. Do we have a test account? But in general I used the existing functionality for update, so it should work correctly.

## Ticket
https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-6417
