### PR TITLE
[ENG-7173] API: Serialize Preprint versions list as relationships in Preprint Serializer

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -230,7 +230,6 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             'self': 'get_preprint_url',
             'html': 'get_absolute_html_url',
             'doi': 'get_article_doi_url',
-            'preprint_versions': 'get_preprint_versions',
             'preprint_doi': 'get_preprint_doi_url',
         },
     )
@@ -262,15 +261,6 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
     def subjects_self_view(self):
         # Overrides TaxonomizableSerializerMixin
         return 'preprints:preprint-relationships-subjects'
-
-    def get_preprint_versions(self, obj):
-        return absolute_reverse(
-            'preprints:preprint-versions',
-            kwargs={
-                'preprint_id': obj._id,
-                'version': self.context['request'].parser_context['kwargs']['version'],
-            },
-        )
 
     def get_preprint_url(self, obj):
         return absolute_reverse(

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -225,6 +225,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         allow_null=True,
     )
 
+    # TODO: Remove 'preprint_versions' once https://openscience.atlassian.net/browse/ENG-7174 has been released
     links = LinksField(
         {
             'self': 'get_preprint_url',
@@ -263,6 +264,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         # Overrides TaxonomizableSerializerMixin
         return 'preprints:preprint-relationships-subjects'
 
+    # TODO: Remove this method once https://openscience.atlassian.net/browse/ENG-7174 has been released
     def get_preprint_versions(self, obj):
         return absolute_reverse(
             'preprints:preprint-versions',

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -230,6 +230,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             'self': 'get_preprint_url',
             'html': 'get_absolute_html_url',
             'doi': 'get_article_doi_url',
+            'preprint_versions': 'get_preprint_versions',
             'preprint_doi': 'get_preprint_doi_url',
         },
     )
@@ -261,6 +262,15 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
     def subjects_self_view(self):
         # Overrides TaxonomizableSerializerMixin
         return 'preprints:preprint-relationships-subjects'
+
+    def get_preprint_versions(self, obj):
+        return absolute_reverse(
+            'preprints:preprint-versions',
+            kwargs={
+                'preprint_id': obj._id,
+                'version': self.context['request'].parser_context['kwargs']['version'],
+            },
+        )
 
     def get_preprint_url(self, obj):
         return absolute_reverse(

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -146,6 +146,12 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
     version = ser.IntegerField(read_only=True)
     is_latest_version = ser.BooleanField(read_only=True)
 
+    versions = RelationshipField(
+        related_view='preprints:preprint-versions',
+        related_view_kwargs={'preprint_id': '<_id>'},
+        read_only=True,
+    )
+
     citation = NoneIfWithdrawal(
         RelationshipField(
             related_view='preprints:preprint-citation',

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -87,6 +87,10 @@ class TestPreprintDetail:
         return f'/{API_BASE}preprints/{unpublished_preprint._id}/'
 
     @pytest.fixture()
+    def versions_url(self, preprint):
+        return f'/{API_BASE}preprints/{preprint._id}/versions/'
+
+    @pytest.fixture()
     def res(self, app, url):
         return app.get(url)
 
@@ -94,7 +98,7 @@ class TestPreprintDetail:
     def data(self, res):
         return res.json['data']
 
-    def test_preprint_detail(self, app, user, preprint, url, res, data):
+    def test_preprint_detail(self, app, user, preprint, url, versions_url, res, data):
         #   test_preprint_detail_success
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
@@ -112,6 +116,13 @@ class TestPreprintDetail:
 
         #   test no node attached to preprint
         assert data['relationships']['node'].get('data', None) is None
+
+        #  test versions in relationships
+        assert data['relationships']['versions']['links']['related']['href'].endswith(versions_url)
+
+        #  test versions in links
+        #TODO: Remove this assertion once https://openscience.atlassian.net/browse/ENG-7174 has been released
+        assert data['links']['preprint_versions'].endswith(versions_url)
 
         #   test_preprint_node_deleted doesn't affect preprint
         deleted_node = ProjectFactory(creator=user, is_deleted=True)


### PR DESCRIPTION
## Purpose

Serialize Preprint versions list as relationships ion Preprint Serializer

## Changes

- [x] Versions as relationships
- [x] ~~Remove versions from links~~ Keep versions in `links` for backward compatibility and avoid BE/FE dependencies, which will be done in https://openscience.atlassian.net/browse/ENG-7262
- [x] Add/update unit tests

## QA Notes

* Check that preprint versions dropdown on details and tombstone page still work as expected

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7173
