### PR TITLE
[ENG-6314] Set private title instead of an empty string when sync with CrossRef

### DIFF
--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -86,6 +86,8 @@ class CrossRefClient(AbstractIdentifierClient):
         preprint - preprint to build posted_content for
         element - namespace element to use when building parts of the XML structure
         """
+        from osf.models import SpamStatus
+
         posted_content = element.posted_content(
             element.group_title(preprint.provider.name),
             type='preprint'
@@ -94,7 +96,8 @@ class CrossRefClient(AbstractIdentifierClient):
         if status == 'public':
             posted_content.append(element.contributors(*self._crossref_format_contributors(element, preprint)))
 
-        title = element.title(remove_control_characters(preprint.title)) if status == 'public' else element.title('')
+        private_title = 'REMOVED DUE TO POLICY VIOLATIONS' if preprint.spam_status == SpamStatus.SPAM else 'WITHDRAWN'
+        title = element.title(remove_control_characters(preprint.title)) if status == 'public' else element.title(private_title)
         posted_content.append(element.titles(title))
 
         posted_content.append(element.posted_date(*self._crossref_format_date(element, preprint.date_published)))


### PR DESCRIPTION
## Purpose

CrossRef fails silently when a status of preprint is not public. In this case we should pass a specific string instead of an empty string

## Notes

1. Matt's comment: "The XML file that we send has an empty <title>, which causes CrossRef to (silently) not accept it. If preprint spam_status is.SPAM, title should be REMOVED DUE TO POLICY VIOLATIONS, otherwise WITHDRAWN."
2. Import is not moved at the top of the file because of circular imports

## Ticket

https://openscience.atlassian.net/browse/ENG-6314