### PR TITLE
Put `user` on the request context to fix `stat_addon` task errors

### DIFF
--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -35,6 +35,7 @@ from osf.models import (
     AbstractNode,
     DraftRegistration,
 )
+from osf.utils.requests import get_current_request
 
 
 def create_app_context():
@@ -127,6 +128,8 @@ def stat_addon(addon_short_name, job_pk):
     create_app_context()
     job = ArchiveJob.load(job_pk)
     src, dst, user = job.info()
+    request = get_current_request()
+    request.user = user
     src_addon = src.get_addon(addon_name)
     if hasattr(src_addon, 'configured') and not src_addon.configured:
         # Addon enabled but not configured - no file trees, nothing to archive.


### PR DESCRIPTION
## Purpose

During execution of the `stat_addon` task, which is the precursor of actually archiving addons, `get_addon` is called to get the correct addon. However because now `get_addon` makes requests to GV for addon info, we must pass GV authentication by putting `user` on the `DummyRequest` context.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
