### PR TITLE
[ENG-7171] Fix registrations by fetching addons from GV directly

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -33,7 +33,7 @@ from framework import status
 from framework.auth import oauth_scopes
 from framework.celery_tasks.handlers import enqueue_task, get_task_from_queue
 from framework.exceptions import PermissionsError, HTTPError
-from framework.sentry import log_exception, log_message
+from framework.sentry import log_exception
 from osf.exceptions import (InvalidTagError, NodeStateError,
                             TagNotFoundError)
 from .contributor import Contributor
@@ -2468,8 +2468,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request = get_current_request()
         # This is to avoid making multiple requests to GV
         # within the lifespan of one request on the OSF side
-        log_message(f'the request is {request}')
-        log_message(f'the user of the request is {request.user}')
         try:
             gv_addons = request.gv_addons
         except AttributeError:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2468,6 +2468,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request = get_current_request()
         # This is to avoid making multiple requests to GV
         # within the lifespan of one request on the OSF side
+        from osf.utils.requests import DummyRequest
+        if isinstance(request, DummyRequest):
+            logger.info(f'the request is {request}')
+            logger.info(f'the user of the request is {request.user}')
         try:
             gv_addons = request.gv_addons
         except AttributeError:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -33,7 +33,7 @@ from framework import status
 from framework.auth import oauth_scopes
 from framework.celery_tasks.handlers import enqueue_task, get_task_from_queue
 from framework.exceptions import PermissionsError, HTTPError
-from framework.sentry import log_exception
+from framework.sentry import log_exception, log_message
 from osf.exceptions import (InvalidTagError, NodeStateError,
                             TagNotFoundError)
 from .contributor import Contributor
@@ -2468,8 +2468,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request = get_current_request()
         # This is to avoid making multiple requests to GV
         # within the lifespan of one request on the OSF side
-        log_exception(f'the request is {request}')
-        log_exception(f'the user of the request is {request.user}')
+        log_message(f'the request is {request}')
+        log_message(f'the user of the request is {request.user}')
         try:
             gv_addons = request.gv_addons
         except AttributeError:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2468,10 +2468,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request = get_current_request()
         # This is to avoid making multiple requests to GV
         # within the lifespan of one request on the OSF side
-        from osf.utils.requests import DummyRequest
-        if isinstance(request, DummyRequest):
-            logger.info(f'the request is {request}')
-            logger.info(f'the user of the request is {request.user}')
+        log_exception(f'the request is {request}')
+        log_exception(f'the user of the request is {request.user}')
         try:
             gv_addons = request.gv_addons
         except AttributeError:

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -12,6 +12,7 @@ from framework.celery_tasks.utils import logged
 from framework.exceptions import HTTPError
 
 from api.base.utils import waterbutler_api_url_for
+from api.waffle.utils import flag_is_active
 
 from website.archiver import (
     ARCHIVER_SUCCESS,
@@ -35,7 +36,9 @@ from osf.models import (
     AbstractNode,
     DraftRegistration,
 )
+from osf import features
 from osf.utils.requests import get_current_request
+from osf.external.gravy_valet import request_helpers, translations
 
 
 def create_app_context():
@@ -108,6 +111,19 @@ class ArchiverTask(celery.Task):
         dst.save()
         archiver_signals.archive_fail.send(dst, errors=errors)
 
+def get_addon_from_gv(src_node, addon_name, requesting_user):
+    addon_data = request_helpers.get_addon(
+        gv_addon_pk=f'{src_node._id}:{addon_name}',
+        requested_resource=src_node,
+        requesting_user=requesting_user,
+        addon_type='configured-storage-addons'
+    )
+    return translations.make_ephemeral_node_settings(
+        gv_addon_data=addon_data,
+        requested_resource=src_node,
+        requesting_user=requesting_user
+    )
+
 
 @celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('stat_addon')
@@ -128,9 +144,12 @@ def stat_addon(addon_short_name, job_pk):
     create_app_context()
     job = ArchiveJob.load(job_pk)
     src, dst, user = job.info()
-    request = get_current_request()
-    request.user = user
-    src_addon = src.get_addon(addon_name)
+
+    src_addon = None
+    if addon_name != 'osfstorage' and flag_is_active(get_current_request(), features.ENABLE_GV):
+        src_addon = get_addon_from_gv(src, addon_name, user)
+    else:
+        src_addon = src.get_addon(addon_name)
     if hasattr(src_addon, 'configured') and not src_addon.configured:
         # Addon enabled but not configured - no file trees, nothing to archive.
         return AggregateStatResult(src_addon._id, addon_short_name)
@@ -208,9 +227,11 @@ def archive_addon(addon_short_name, job_pk):
         params['revision'] = 'latest' if addon_short_name.split('-')[-1] == 'draft' else 'latest-published'
         rename_suffix = ' (draft)' if addon_short_name.split('-')[-1] == 'draft' else ' (published)'
         addon_short_name = 'dataverse'
-    request = get_current_request()
-    request.user = user
-    src_provider = src.get_addon(addon_short_name)
+    src_provider = None
+    if addon_short_name != 'osfstorage' and flag_is_active(get_current_request(), features.ENABLE_GV):
+        src_provider = get_addon_from_gv(src, addon_short_name, user)
+    else:
+        src_provider = src.get_addon(addon_short_name)
     folder_name_nfd, folder_name_nfc = normalize_unicode_filenames(src_provider.archive_folder_name)
     rename = f'{folder_name_nfd}{rename_suffix}'
     url = waterbutler_api_url_for(src._id, addon_short_name, _internal=True, base_url=src.osfstorage_region.waterbutler_url, **params)

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -208,6 +208,8 @@ def archive_addon(addon_short_name, job_pk):
         params['revision'] = 'latest' if addon_short_name.split('-')[-1] == 'draft' else 'latest-published'
         rename_suffix = ' (draft)' if addon_short_name.split('-')[-1] == 'draft' else ' (published)'
         addon_short_name = 'dataverse'
+    request = get_current_request()
+    request.user = user
     src_provider = src.get_addon(addon_short_name)
     folder_name_nfd, folder_name_nfc = normalize_unicode_filenames(src_provider.archive_folder_name)
     rename = f'{folder_name_nfd}{rename_suffix}'


### PR DESCRIPTION
## Purpose

It seems like the aggressive caching we do may have a negative side-effect for registration archiving tasks. My suspicion is that the app context and/or the `DummyRequest` context is not clear sufficiently, if at all, in between tasks, resulting in `node.get_addon` failures in the context of a celery task.
Hence, instead of running through the long pipeline of `node.get_addon()`, we fetch directly from GV the configured storage addon using pk in `<guid>:<addon_name>` format. Of course, [a PR to GV](https://github.com/CenterForOpenScience/gravyvalet/pull/237) is also opened to support this new form of querying for configured addons.

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
