### PR TITLE
[ENG-7262] Remove preprint versions from links in serializer

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -225,13 +225,11 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         allow_null=True,
     )
 
-    # TODO: Remove 'preprint_versions' once https://openscience.atlassian.net/browse/ENG-7174 has been released
     links = LinksField(
         {
             'self': 'get_preprint_url',
             'html': 'get_absolute_html_url',
             'doi': 'get_article_doi_url',
-            'preprint_versions': 'get_preprint_versions',
             'preprint_doi': 'get_preprint_doi_url',
         },
     )
@@ -263,16 +261,6 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
     def subjects_self_view(self):
         # Overrides TaxonomizableSerializerMixin
         return 'preprints:preprint-relationships-subjects'
-
-    # TODO: Remove this method once https://openscience.atlassian.net/browse/ENG-7174 has been released
-    def get_preprint_versions(self, obj):
-        return absolute_reverse(
-            'preprints:preprint-versions',
-            kwargs={
-                'preprint_id': obj._id,
-                'version': self.context['request'].parser_context['kwargs']['version'],
-            },
-        )
 
     def get_preprint_url(self, obj):
         return absolute_reverse(

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -120,10 +120,6 @@ class TestPreprintDetail:
         #  test versions in relationships
         assert data['relationships']['versions']['links']['related']['href'].endswith(versions_url)
 
-        #  test versions in links
-        #TODO: Remove this assertion once https://openscience.atlassian.net/browse/ENG-7174 has been released
-        assert data['links']['preprint_versions'].endswith(versions_url)
-
         #   test_preprint_node_deleted doesn't affect preprint
         deleted_node = ProjectFactory(creator=user, is_deleted=True)
         deleted_preprint = PreprintFactory(project=deleted_node, creator=user)


### PR DESCRIPTION
## Purpose

Remove preprint versions from links in serializer

## Changes

Remove preprint versions from links in serializer

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7262
