### PR TITLE
[ENG-5668] fixed ham functionality

### DIFF
--- a/api_tests/registries_moderation/test_submissions.py
+++ b/api_tests/registries_moderation/test_submissions.py
@@ -21,6 +21,7 @@ from osf_tests.factories import (
 from tests.base import get_default_metaschema
 
 from osf.models import NodeRequest
+from django.contrib.auth.models import Group
 
 from osf.migrations import update_provider_auth_groups
 
@@ -600,3 +601,82 @@ class TestRegistriesModerationSubmissions:
         # ham the project creator
         user.confirm_ham(save=True)
         assert user.spam_status == 4
+
+    def test_registration_privacy_after_spam_and_ham(self, app, registration, moderator, registration_actions_url, actions_payload_base, provider):
+
+        def run_subtest(privacy, is_embargo, should_be_public):
+            user = AuthUserFactory()
+            user.is_staff = True
+            user.groups.add(Group.objects.get(name='osf_admin'))
+            user.save()
+            node = ProjectFactory(creator=user)
+
+            node.set_privacy(privacy)
+            node.confirm_spam(save=True)
+            node.confirm_ham(save=True)
+
+            # register the project
+            if is_embargo:
+                one_month_from_now = datetime.datetime.now() + datetime.timedelta(seconds=1)
+                embargo = EmbargoFactory(end_date=one_month_from_now, user=user)
+                registration = embargo.target_registration
+                registration.provider = provider
+                registration.update_moderation_state()
+                registration.save()
+            else:
+                registration = RegistrationFactory(provider=provider, project=node, creator=user)
+
+            registration.confirm_spam(save=True)
+            registration.confirm_ham(save=True)
+
+            # approve the project
+            registration.require_approval(user=registration.creator)
+            registration.registration_approval.accept()
+            registration.refresh_from_db()
+            if is_embargo:
+                assert registration.moderation_state == RegistrationModerationStates.INITIAL.db_name
+            else:
+                assert registration.moderation_state == RegistrationModerationStates.PENDING.db_name
+
+            if is_embargo:
+                registration.sanction.accept()
+                registration.refresh_from_db()
+                assert registration.moderation_state == RegistrationModerationStates.PENDING.db_name
+
+            # approve in moderation
+            actions_payload_base['data']['attributes']['trigger'] = RegistrationModerationTriggers.ACCEPT_SUBMISSION.db_name
+            actions_payload_base['data']['attributes']['comment'] = 'The best registration Ive ever seen'
+            actions_payload_base['data']['relationships']['target']['data']['id'] = registration._id
+
+            resp = app.post_json_api(registration_actions_url, actions_payload_base, auth=moderator.auth)
+            assert resp.status_code == 201
+            assert resp.json['data']['attributes']['trigger'] == RegistrationModerationTriggers.ACCEPT_SUBMISSION.db_name
+            registration.refresh_from_db()
+
+            if is_embargo:
+                assert registration.moderation_state == RegistrationModerationStates.EMBARGO.db_name
+            else:
+                assert registration.moderation_state == RegistrationModerationStates.ACCEPTED.db_name
+
+            assert registration.is_public == should_be_public
+
+        run_subtest(
+            privacy='private',
+            is_embargo=True,
+            should_be_public=False
+        )
+        run_subtest(
+            privacy='public',
+            is_embargo=True,
+            should_be_public=False
+        )
+        run_subtest(
+            privacy='private',
+            is_embargo=False,
+            should_be_public=True
+        )
+        run_subtest(
+            privacy='public',
+            is_embargo=False,
+            should_be_public=True
+        )

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1455,7 +1455,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         registered.registered_schema.add(schema)
 
         # Clone each log from the original node for this registration.
-        self.clone_logs(registered)
+        self.clone_logs(registered, is_registration=True)
 
         registered.access_requests_enabled = False
 
@@ -1720,14 +1720,15 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         return forked
 
-    def clone_logs(self, node, page_size=100):
+    def clone_logs(self, node, is_registration=False, page_size=100):
         paginator = Paginator(self.logs.order_by('pk').all(), page_size)
         for page_num in paginator.page_range:
             page = paginator.page(page_num)
             # Instantiate NodeLogs "manually"
             # because BaseModel#clone() is too slow for large projects
-            logs_to_create = [
-                NodeLog(
+            logs_to_create = []
+            for log in page:
+                instance = NodeLog(
                     _id=bson.ObjectId(),
                     action=log.action,
                     date=log.date,
@@ -1740,8 +1741,14 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     user_id=log.user_id,
                     original_node_id=log.original_node_id
                 )
-                for log in page
-            ]
+                # after registration creation we clone logs from project to id, including spam logs
+                # and if project is public, cloned logs will have was_public = True
+                # however registration is private until all approvals, thus we shouldn't run set_privacy
+                if is_registration and instance.action in [log.FLAG_SPAM, log.CONFIRM_SPAM]:
+                    instance.params['was_public'] = False
+
+                logs_to_create.append(instance)
+
             NodeLog.objects.bulk_create(logs_to_create)
 
     def use_as_template(self, auth, changes=None, top_level=True, parent=None):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1741,7 +1741,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     user_id=log.user_id,
                     original_node_id=log.original_node_id
                 )
-                # after registration creation we clone logs from project to id, including spam logs
+                # after registration creation we clone logs from project to it, including spam logs
                 # and if project is public, cloned logs will have was_public = True
                 # however registration is private until all approvals, thus we shouldn't run set_privacy
                 if is_registration and instance.action in [log.FLAG_SPAM, log.CONFIRM_SPAM]:


### PR DESCRIPTION
## Purpose

After creation of a registration of a spammed and hammed project and rejecting it as a moderator, we cannot ham project's creator

## Changes

When we clone logs to a registration, spam logs have `was_public = True` in `params` that is inaccurate as registration is private until all approvals and embargo. When it's True we run Node.SpamOverrideMixin.confirm_ham.undelete.set_privacy sequence of methods when ham a user that causes an error after rejecting the registration in moderation.

## Ticket

https://openscience.atlassian.net/browse/ENG-5668
