### PR TITLE
ENG-5864 BE disable creator self removal and permission change before preprint is not submitted

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -535,14 +535,6 @@ class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestro
         auth = get_user_auth(self.request)
         if node.visible_contributors.count() == 1 and instance.visible:
             raise ValidationError('Must have at least one visible contributor')
-        if (
-            isinstance(node, Preprint) and node.machine_state == 'initial'
-            and node.creator_id == instance.user.id == auth.user.id
-        ):
-            raise ValidationError(
-                'You cannot delete yourself at this time. '
-                'Have another admin contributor to do that after you’ve submitted your preprint',
-            )
         removed = node.remove_contributor(instance, auth)
         if not removed:
             raise ValidationError('Must have at least one registered admin contributor')

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -535,6 +535,14 @@ class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestro
         auth = get_user_auth(self.request)
         if node.visible_contributors.count() == 1 and instance.visible:
             raise ValidationError('Must have at least one visible contributor')
+        if (
+            isinstance(node, Preprint) and node.machine_state == 'initial'
+            and node.creator_id == instance.user.id == auth.user.id
+        ):
+            raise ValidationError(
+                'You cannot delete yourself at this time. '
+                'Have another admin contributor to do that after you’ve submitted your preprint',
+            )
         removed = node.remove_contributor(instance, auth)
         if not removed:
             raise ValidationError('Must have at least one registered admin contributor')

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -525,7 +525,7 @@ class PreprintContributorDetail(PreprintOldVersionsImmutableMixin, NodeContribut
         if preprint.machine_state == DefaultStates.INITIAL.value and preprint.creator_id == user.id:
             raise ValidationError(
                 'You cannot change your permission setting at this time. '
-                'Have another admin contributor to edit your permission after you’ve submitted your preprint',
+                'Have another admin contributor edit your permission after you’ve submitted your preprint',
             )
         return super().patch(*args, **kwargs)
 
@@ -537,7 +537,7 @@ class PreprintContributorDetail(PreprintOldVersionsImmutableMixin, NodeContribut
         if preprint.machine_state == DefaultStates.INITIAL.value and preprint.creator_id == instance.user.id == auth.user.id:
             raise ValidationError(
                 'You cannot delete yourself at this time. '
-                'Have another admin contributor to do that after you’ve submitted your preprint',
+                'Have another admin contributor do that after you’ve submitted your preprint',
             )
         removed = preprint.remove_contributor(instance, auth)
         if not removed:

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2760,13 +2760,19 @@ class TestPreprintCreatorStateChangings:
         request = RequestFactory().delete('/fake_path')
         request.user = creator
         request.query_params = {}
+        request.parser_context = {
+            'kwargs': {
+                'preprint_id': new_version._id,
+                'user_id': creator._id
+            },
+        }
         view = PreprintContributorDetail()
         view = setup_view(view, request, preprint_id=new_version._id, user_id=creator._id)
         try:
             view.perform_destroy(request)
         except Exception as error:
             assert error.args[0] == ('You cannot delete yourself at this time. '
-                                     'Have another admin contributor to do that after you’ve submitted your preprint')
+                                     'Have another admin contributor do that after you’ve submitted your preprint')
         else:
             assert False
 
@@ -2781,13 +2787,19 @@ class TestPreprintCreatorStateChangings:
         request = RequestFactory().patch('/fake_path')
         request.user = creator
         request.query_params = {}
+        request.parser_context = {
+            'kwargs': {
+                'preprint_id': new_version._id,
+                'user_id': creator._id
+            },
+        }
         view = PreprintContributorDetail()
         view = setup_view(view, request, preprint_id=new_version._id, user_id=creator._id)
         try:
             view.patch(request)
         except Exception as error:
             assert error.args[0] == ('You cannot change your permission setting at this time. '
-                                     'Have another admin contributor to edit your permission '
+                                     'Have another admin contributor edit your permission '
                                      'after you’ve submitted your preprint')
         else:
             assert False


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

preventing the Creator of the preprint, while it’s a draft from changing their permissions or removing themselves as a contributor. 

## Changes

updating back end patch and delete views with restriction conditions

## QA Notes

Front end behaviour does not look the same in two different contributor update requests while creating a preprint. 

On the first one it was created a request to back end side and the answer to front end was returned (it is needed to investigate why it is not returned the error message that is on backend side). 

On second attempt a request for backend is not done (may see it on chrome dev tools on the video below).

it was tested on branch feature/b-and-i-25-01 (EMBER / OSF)


https://github.com/user-attachments/assets/022479a6-93fe-4b68-b895-8e488de9c79d



## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-5864?focusedCommentId=83086