### PR TITLE
[ENG-6418] Added a resync with DataCite button on registration page 

### DIFF
--- a/admin/nodes/urls.py
+++ b/admin/nodes/urls.py
@@ -41,4 +41,5 @@ urlpatterns = [
     re_path(r'^(?P<guid>[a-z0-9]+)/make_public/$', views.NodeMakePublic.as_view(), name='make-public'),
     re_path(r'^(?P<guid>[a-z0-9]+)/remove_notifications/$', views.NodeRemoveNotificationView.as_view(), name='node-remove-notifications'),
     re_path(r'^(?P<guid>[a-z0-9]+)/update_moderation_state/$', views.NodeUpdateModerationStateView.as_view(), name='node-update-mod-state'),
+    re_path(r'^(?P<guid>[a-z0-9]+)/resync_datacite/$', views.NodeResyncDataCiteView.as_view(), name='resync-datacite'),
 ]

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -719,3 +719,14 @@ class RemoveStuckRegistrationsView(NodeMixin, TemplateView):
                                     ' if the problem persists get a developer to fix it.')
 
         return redirect(self.get_success_url())
+
+
+class NodeResyncDataCiteView(NodeMixin, View):
+    """ Allows an authorized user to run resync with DataCite for a single registration object.
+    """
+    permission_required = 'osf.change_node'
+
+    def post(self, request, *args, **kwargs):
+        registration = self.get_object()
+        registration.request_identifier_update('doi', create=True)
+        return redirect(self.get_success_url())

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -23,6 +23,9 @@
                     {% include "nodes/mark_spam.html" with node=node %}
                     {% include "nodes/reindex_node_share.html" with node=node %}
                     {% include "nodes/reindex_node_elastic.html" with node=node %}
+                    {% if node.is_registration %}
+                        {% include "nodes/resync_datacite.html" with node=node %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/admin/templates/nodes/resync_datacite.html
+++ b/admin/templates/nodes/resync_datacite.html
@@ -1,0 +1,24 @@
+{% if node.article_doi %}
+    <a data-toggle="modal" data-target="#confirmResyncDataCite" class="btn btn-info">
+        Resync with DataCite
+    </a>
+    <div class="modal" id="confirmResyncDataCite">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form class="well" method="post" action="{% url 'nodes:resync-datacite' guid=node.guid %}">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal">x</button>
+                        <h3>Are you sure you want to resync with DataCite?</h3>
+                    </div>
+                    {% csrf_token %}
+                    <div class="modal-footer">
+                        <input class="btn btn-danger" type="submit" value="Confirm" />
+                        <button type="button" class="btn btn-default" data-dismiss="modal">
+                            Cancel
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
## Purpose

User should be able to run resync with DataCite in admin app for registrations that have DOI

## Changes

Added a separate endpoint and template to process this request

## Ticket
https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?search=resync&selectedIssue=ENG-6418
