### PR TITLE
[ENG-5004][ENG-6969] Add pageload logging for datacite (#10940)

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -345,6 +345,10 @@ DATACITE_PASSWORD = None
 DATACITE_URL = 'https://mds.datacite.org'
 DATACITE_PREFIX = '10.70102'  # Datacite's test DOI prefix -- update in production
 
+
+# OSF's RepoId on Datacite to track stats for DOIs. See https://support.datacite.org/docs/datacite-usage-tracker.
+DATACITE_TRACKER_REPO_ID = None
+
 # crossref
 CROSSREF_USERNAME = None
 CROSSREF_PASSWORD = None

--- a/website/static/js/components/tracker.js
+++ b/website/static/js/components/tracker.js
@@ -1,0 +1,25 @@
+function trackView(doi) {
+
+    const payload = {
+        n: 'view',
+        u: window.location.href,
+        i: window.contextVars.dataciteTrackerRepoId,
+        p: doi,
+    };
+    const r = new XMLHttpRequest();
+    r.open('POST', `https://analytics.datacite.org/api/metric`, true);
+    r.setRequestHeader('Content-Type', 'application/json');
+    r.send(JSON.stringify(payload));
+    r.onreadystatechange = () => {
+        if (r.readyState !== 4)
+            return;
+        if (r.status === 400) {
+            console.error('[DataCiteTracker] ' + r.responseText);
+        }
+
+    };
+}
+
+module.exports = {
+    trackView: trackView,
+};

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -29,7 +29,7 @@ var node = window.contextVars.node;
 var nodeApiUrl = ctx.node.urls.api;
 var nodeCategories = ctx.nodeCategories || [];
 var currentUserRequestState = ctx.currentUserRequestState;
-
+const tracker = require('js/components/tracker');
 
 // Listen for the nodeLoad event (prevents multiple requests for data)
 $('body').on('nodeLoad', function(event, data) {
@@ -42,6 +42,11 @@ $('body').on('nodeLoad', function(event, data) {
         new CitationList('#citationList');
         new CitationWidget('#citationStyleInput', '#citationText');
     }
+
+    if (data.node.identifiers.doi) {
+        tracker.trackView(data.node.identifiers.doi);
+    }
+
     // Initialize nodeControl
     new NodeControl.NodeControl('#projectScope', data, {categories: nodeCategories, currentUserRequestState: currentUserRequestState});
 

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -288,6 +288,14 @@
             </script>
         % endif
 
+        % if settings.DATACITE_TRACKER_REPO_ID:
+            <script>
+                window.contextVars = $.extend(true, {}, window.contextVars, {
+                    dataciteTrackerRepoId: ${ settings.DATACITE_TRACKER_REPO_ID | sjson, n },
+                });
+            </script>
+        % endif
+
 
         ${self.javascript_bottom()}
     </body>


### PR DESCRIPTION
## Purpose

Log views on projects with DOIs to datacite. This PR covers legacy pages only.

## Changes

For the overview page, if the project has a DOI, log a view count metrics to Datacite.

## QA Notes

* Tested on staging2
* Pages with DOIs should log a view metric payload to datacite
* Pages without DOIs should not log view metric.

## Documentation

Nope!

## Side Effects

None expected!

## Ticket

https://openscience.atlassian.net/browse/ENG-5004
https://openscience.atlassian.net/browse/ENG-6969
