### PR TITLE
ENG-6987 enable file by guid searching via osf admin

### DIFF
--- a/admin/base/urls.py
+++ b/admin/base/urls.py
@@ -37,6 +37,7 @@ urlpatterns = [
             re_path(r'^registration_schemas/', include('admin.registration_schemas.urls', namespace='registration_schemas')),
             re_path(r'^cedar_metadata_templates/', include('admin.cedar.urls', namespace='cedar_metadata_templates')),
             re_path(r'^draft_registrations/', include('admin.draft_registrations.urls', namespace='draft_registrations')),
+            re_path(r'^files/', include('admin.files.urls', namespace='files')),
         ]),
     ),
 ]

--- a/admin/files/urls.py
+++ b/admin/files/urls.py
@@ -1,0 +1,9 @@
+from django.urls import re_path
+from admin.files import views
+
+app_name = 'admin'
+
+urlpatterns = [
+    re_path(r'^$', views.FileSearchView.as_view(), name='search'),
+    re_path(r'^(?P<guid>\w+)/$', views.FileView.as_view(), name='file')
+]

--- a/admin/files/views.py
+++ b/admin/files/views.py
@@ -1,11 +1,7 @@
 from django.urls import NoReverseMatch
 from django.contrib import messages
 from django.shortcuts import redirect
-from django.views.generic import (
-    View,
-    ListView,
-    FormView,
-)
+from django.views.generic import FormView
 from django.urls import reverse_lazy
 from admin.base.forms import GuidForm
 from django.contrib.auth.mixins import PermissionRequiredMixin

--- a/admin/files/views.py
+++ b/admin/files/views.py
@@ -1,0 +1,67 @@
+from django.urls import NoReverseMatch
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.views.generic import (
+    View,
+    ListView,
+    FormView,
+)
+from django.urls import reverse_lazy
+from admin.base.forms import GuidForm
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from admin.base.views import GuidView
+from osf.models import Guid, GuidMetadataRecord, BaseFileNode
+
+
+class FileSearchView(PermissionRequiredMixin, FormView):
+    """ Allows authorized users to search for a specific file by guid.
+    """
+    template_name = 'files/search.html'
+    permission_required = 'osf.view_file'
+    raise_exception = True
+    form_class = GuidForm
+
+    def form_valid(self, form):
+        guid = form.cleaned_data['guid']
+        if guid:
+            try:
+                return redirect(reverse_lazy('files:file', kwargs={'guid': guid}))
+            except NoReverseMatch as e:
+                messages.error(self.request, str(e))
+        return super().form_valid(form)
+
+
+class FileMixin(PermissionRequiredMixin):
+
+    def get_object(self):
+        target_file = Guid.load(self.kwargs['guid']).referent
+        return target_file
+
+    def get_success_url(self):
+        return reverse_lazy('files:file', kwargs={'guid': self.kwargs['guid']})
+
+
+class FileView(FileMixin, GuidView):
+    """ Allows authorized users to view file info."""
+    template_name = 'files/file.html'
+    permission_required = 'osf.view_file'
+    raise_exception = True
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        guid = self.kwargs['guid']
+        metadata_record = GuidMetadataRecord.objects.for_guid(
+            guid,
+            allowed_referent_models=(BaseFileNode,),
+        )
+        file = context['object']
+        node = file.target
+        latest_modified = file.versions.latest('created')
+        context.update({
+            'guid': guid,
+            'node_id': node._id if node else None,
+            'node': node,
+            'file_metadata': metadata_record,
+            'version': latest_modified.location.get('version', '')
+        })
+        return context

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -134,6 +134,17 @@
                   </div>
               </li>
           {% endif %}
+          {% if perms.osf.view_file %}
+                <li><a role="button" data-toggle="collapse" href="#collapseFiles">
+                  <i class='fa fa-caret-down'></i> Files</a></li>
+            <li>
+                <div class="collapse" id="collapseFiles">
+                    <ul class="sidebar-menu sidebar-menu-inner">
+                        <li><a href="{% url 'files:search' %}"><i class='fa fa-link'></i><span>Search Files</span> </a></li>
+                    </ul>
+                </div>
+            </li>
+          {% endif %}
           {% if perms.osf.view_osfuser %}
               <li><a role="button" data-toggle="collapse" href="#collapseUsers">
                   <i class='fa fa-caret-down'></i> Users

--- a/admin/templates/files/file.html
+++ b/admin/templates/files/file.html
@@ -1,0 +1,72 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load node_extras %}
+{% block title %}
+    <title>File</title>
+{% endblock title %}
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            <table class="table table-striped">
+                <h2>File: <b>{{ object.name }}</b></h2>
+                <thead>
+                    <tr>
+                        <th>Field</th>
+                        <th>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Guid</td>
+                        <td>{{ guid }}</td>
+                    </tr>
+                    <tr>
+                        <td>Name</td>
+                        <td>{{ object.name }}</td>
+                    </tr>
+                    <tr>
+                        <td>Provider</td>
+                        <td>{{ object.provider }}</td>
+                    </tr>
+                    <tr>
+                        <td>Version</td>
+                        <td>{{ version }}</td>
+                    </tr>
+                    {% if node_id %}
+                    <tr>
+                       <td>Parent</td>
+                        <td>
+                         <a href="{{ node | reverse_node }}">
+                            {{ node.title }}
+                        </a>
+                        </td>
+                    </tr>
+                    {% endif %}
+                    {% if file_metadata %}
+                    <tr>
+                       <td>File Metadata</td>
+                        <td>
+                         <b>Title:</b>
+                            <p>{{file_metadata.title}}</p>
+                         <b>Description:</b>
+                            <p>{{file_metadata.description}}</p>
+                         <b>Resource type:</b>
+                            <p>{{file_metadata.resource_type_general}}</p>
+                         <b>Resource language:</b>
+                            <p>{{file_metadata.language}}</p>
+                        </td>
+                    </tr>
+                    {% endif %}
+                    <tr>
+                        <td>Date Created</td>
+                        <td>{{ object.created | date }}</td>
+                    </tr>
+                    <tr>
+                        <td>Date Modified</td>
+                        <td>{{ object.modified | date }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock content %}

--- a/admin/templates/files/search.html
+++ b/admin/templates/files/search.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% load static %}
+{#{% load node_extras %}#}
+{% block title %}
+    <title>File Search</title>
+{% endblock title %}
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            <form action="{% url 'files:search' %}" method="post">
+                {% csrf_token %}
+                {% if form.errors %}
+                    <div class="alert alert-danger">{{ form.errors }}</div>
+                {% endif %}
+                <div class="form-group">
+                    <label for="guid">File GUID:</label>
+                    {{ form.guid }}
+                </div>
+                <input type="submit" class="btn btn-primary" value="Submit" />
+            </form>
+        </div>
+    </div>
+{% endblock content %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

As with nodes, preprints, and users, a lookup is available for files.  The admin detail page includes all available metadata including contributors from the node, the node title and link, version information, and file name.

## Changes

Adding in osf admin dashboard a page for searching files by guid and for showing the response

![image](https://github.com/user-attachments/assets/b6c784f8-5c31-4f0c-a22c-7049ee5b8ee7)

![image](https://github.com/user-attachments/assets/3713069b-aee8-4189-aaab-54409498f6dd)


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-6987