### PR TITLE
[ENG-7294] Add Curator indicator to V2

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1172,6 +1172,8 @@ class NodeContributorsSerializer(JSONAPISerializer):
         related_view_kwargs={'node_id': '<node._id>'},
     )
 
+    is_curator = ser.BooleanField(read_only=True)
+
     class Meta:
         type_ = 'contributors'
 

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -202,6 +202,39 @@ class TestContributorDetail:
         assert res.json['data']['attributes']['index'] == 1
 
 
+class TestNodeContributorDetail(TestContributorDetail):
+
+    def test_detail_includes_is_curator(
+            self,
+            app,
+            user,
+            project_public,
+            make_resource_url,
+            url_public):
+        res = app.get(url_public, auth=user.auth)
+        data = res.json['data']
+        assert 'is_curator' in data['attributes'].keys()
+        assert data['attributes']['is_curator'] is False
+
+        other_contributor = AuthUserFactory()
+        project_public.add_contributor(
+            other_contributor, auth=Auth(user), save=True)
+
+        other_contributor_detail = make_resource_url(project_public._id, other_contributor._id)
+
+        res = app.get(other_contributor_detail, auth=user.auth)
+        assert res.json['data']['attributes']['is_curator'] is False
+
+        curator_contributor = AuthUserFactory()
+        project_public.add_contributor(
+            curator_contributor, auth=Auth(user), save=True, make_curator=True, visible=False)
+
+        curator_contributor_detail = make_resource_url(project_public._id, curator_contributor._id)
+
+        res = app.get(curator_contributor_detail, auth=user.auth)
+        assert res.json['data']['attributes']['is_curator'] is True
+
+
 @pytest.mark.django_db
 class TestNodeContributorOrdering:
 


### PR DESCRIPTION
## Purpose

Add is_curator attribute to v2/nodes/<node_id>/conributors/ to the GET endpoint

## Changes

Added is_curator attribute to v2/nodes/<node_id>/conributors/ to the GET endpoint
Added unit test for is_curator attribute

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7294