### PR TITLE
ENG-4255 do not pass admin node set privacy to allow set privacy for site admins not only contributors

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -25,7 +25,6 @@ from admin.notifications.views import detect_duplicate_notifications, delete_sel
 
 from api.share.utils import update_share
 from api.caching.tasks import update_storage_usage_cache
-from framework.auth import Auth
 
 from osf.exceptions import NodeStateError
 from osf.models import (
@@ -674,8 +673,7 @@ class NodeMakePublic(NodeMixin, View):
     def post(self, request, *args, **kwargs):
         node = self.get_object()
         try:
-            auth = Auth(request.user._wrapped, private_key=None)
-            node.set_privacy('public', auth=auth)
+            node.set_privacy('public')
         except NodeStateError as e:
             messages.error(request, str(e))
         return redirect(self.get_success_url())


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

the site admins must have the ability to set the privacy of a node, either directly in the admin via the Make Public/Make Private button

## Changes

update to the previous approach (current code was made to not stuck in embergoed if public is set but there is another approach for embergoed reset )

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
