### PR TITLE
[ENG-7298][ENG-7336] Password Reset API 

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -433,6 +433,15 @@ class UserChangePasswordSerializer(BaseAPISerializer):
         type_ = 'user_passwords'
 
 
+class UserResetPasswordSerializer(BaseAPISerializer):
+    uid = ser.CharField(write_only=True, required=True)
+    token = ser.CharField(write_only=True, required=True)
+    password = ser.CharField(write_only=True, required=True)
+
+    class Meta:
+        type_ = 'user_reset_password'
+
+
 class UserSettingsSerializer(JSONAPISerializer):
     id = IDField(source='_id', read_only=True)
     type = TypeField()

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -4,6 +4,7 @@ from . import views
 app_name = 'osf'
 
 urlpatterns = [
+    re_path(r'^reset_password/$', views.ResetPassword.as_view(), name=views.ResetPassword.view_name),
     re_path(r'^$', views.UserList.as_view(), name=views.UserList.view_name),
     re_path(r'^(?P<user_id>\w+)/$', views.UserDetail.as_view(), name=views.UserDetail.view_name),
     re_path(r'^(?P<user_id>\w+)/addons/$', views.UserAddonList.as_view(), name=views.UserAddonList.view_name),

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -26,7 +26,7 @@ from api.base.utils import (
     is_truthy,
 )
 from api.base.views import JSONAPIBaseView
-from api.base.throttling import SendEmailThrottle, SendEmailDeactivationThrottle, NonCookieAuthThrottle, BurstRateThrottle
+from api.base.throttling import SendEmailThrottle, SendEmailDeactivationThrottle, NonCookieAuthThrottle, BurstRateThrottle, RootAnonThrottle
 from api.institutions.serializers import InstitutionSerializer
 from api.nodes.filters import NodesFilterMixin, UserNodesFilterMixin
 from api.nodes.serializers import DraftRegistrationLegacySerializer
@@ -751,6 +751,7 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
     serializer_class = UserResetPasswordSerializer
     view_category = 'users'
     view_name = 'request-reset-password'
+    throttle_classes = (NonCookieAuthThrottle, BurstRateThrottle, RootAnonThrottle, SendEmailThrottle)
 
     def get(self, request, *args, **kwargs):
         email = request.query_params.get('email', None)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -47,6 +47,7 @@ from api.users.serializers import (
     UserDetailSerializer,
     UserIdentitiesSerializer,
     UserInstitutionsRelationshipSerializer,
+    UserResetPasswordSerializer,
     UserSerializer,
     UserEmail,
     UserEmailsSerializer,
@@ -61,7 +62,7 @@ from api.users.serializers import (
 from django.contrib.auth.models import AnonymousUser
 from django.http import JsonResponse
 from django.utils import timezone
-from framework.auth.core import get_user
+from framework.auth.core import generate_verification_key, get_user
 from framework.auth.views import send_confirm_email_async
 from framework.auth.oauth_scopes import CoreScopes, normalize_scopes
 from framework.auth.exceptions import ChangePasswordError
@@ -85,9 +86,13 @@ from osf.models import (
     OSFGroup,
     OSFUser,
     Email,
+    Tag,
 )
 from website import mails, settings
 from website.project.views.contributor import send_claim_email, send_claim_registered_email
+from website.util.metrics import CampaignClaimedTags, CampaignSourceTags
+from framework.auth import exceptions
+
 
 class UserMixin:
     """Mixin with convenience methods for retrieving the current user based on the
@@ -723,6 +728,117 @@ class UserChangePassword(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         user.save()
         remove_sessions_for_user(user)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
+    """
+    View for handling reset password requests.
+
+    GET:
+    - Takes an email as a query parameter.
+    - If the email is associated with an OSF account, sends an email with instructions to reset the password.
+    - If the email is not provided or invalid, returns a validation error.
+    - If the user has recently requested a password reset, returns a throttling error.
+
+    POST:
+    - Takes uid, token, and new password in the request data.
+    - Verifies the token and resets the password if valid.
+    - If the token is invalid or expired, returns an error.
+    - If the request data is incomplete, returns a validation error.
+    """
+    permission_classes = (
+        drf_permissions.AllowAny,
+    )
+    serializer_class = UserResetPasswordSerializer
+    view_category = 'users'
+    view_name = 'request-reset-password'
+
+    def get(self, request, *args, **kwargs):
+        email = request.query_params.get('email', None)
+        if not email:
+            raise ValidationError('Request must include email in query params.')
+
+        status_message = (
+            f'If there is an OSF account associated with {email}, an email with instructions on how to '
+            f'reset the OSF password has been sent to {email}. If you do not receive an email and believe '
+            'you should have, please contact OSF Support. '
+        )
+        kind = 'success'
+        # check if the user exists
+        user_obj = get_user(email=email)
+
+        if user_obj:
+            # rate limit forgot_password_post
+            if not throttle_period_expired(user_obj.email_last_sent, settings.SEND_EMAIL_THROTTLE):
+                status_message = 'You have recently requested to change your password. Please wait a few minutes ' \
+                                 'before trying again.'
+                kind = 'error'
+                return Response({'message': status_message, 'kind': kind}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+            elif user_obj.is_active:
+                # new random verification key (v2)
+                user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
+                user_obj.email_last_sent = timezone.now()
+                user_obj.save()
+                reset_link = f'{settings.RESET_PASSWORD_URL}{user_obj._id}/{user_obj.verification_key_v2['token']}/'
+                mails.send_mail(
+                    to_addr=email,
+                    mail=mails.FORGOT_PASSWORD,
+                    reset_link=reset_link,
+                    can_change_preferences=False,
+                )
+        return Response(status=status.HTTP_200_OK, data={'message': status_message, 'kind': kind})
+
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        uid = request.data.get('uid', None)
+        token = request.data.get('token', None)
+        password = request.data.get('password', None)
+        if not (uid and token and password):
+            error_data = {
+                'message_short': 'Invalid Request.',
+                'message_long': 'The request must include uid, token, and password.',
+            }
+            return JsonResponse(
+                error_data,
+                status=status.HTTP_400_BAD_REQUEST,
+                content_type='application/vnd.api+json; application/json',
+            )
+
+        user_obj = OSFUser.load(uid)
+        if not (user_obj and user_obj.verify_password_token(token=token)):
+            error_data = {
+                'message_short': 'Invalid Request.',
+                'message_long': 'The requested URL is invalid, has expired, or was already used',
+            }
+            return JsonResponse(
+                error_data,
+                status=status.HTTP_400_BAD_REQUEST,
+                content_type='application/vnd.api+json; application/json',
+            )
+
+        else:
+            # clear verification key (v2)
+            user_obj.verification_key_v2 = {}
+            # new verification key (v1) for CAS
+            user_obj.verification_key = generate_verification_key(verification_type=None)
+            try:
+                user_obj.set_password(password)
+                osf4m_source_tag, created = Tag.all_tags.get_or_create(name=CampaignSourceTags.Osf4m.value, system=True)
+                osf4m_claimed_tag, created = Tag.all_tags.get_or_create(name=CampaignClaimedTags.Osf4m.value, system=True)
+                if user_obj.all_tags.filter(id=osf4m_source_tag.id, system=True).exists():
+                    user_obj.add_system_tag(osf4m_claimed_tag)
+                user_obj.save()
+            except exceptions.ChangePasswordError as error:
+                return JsonResponse(
+                    error.messages,
+                    status=status.HTTP_400_BAD_REQUEST,
+                    content_type='application/vnd.api+json; application/json',
+                )
+
+        return Response(
+            status=status.HTTP_200_OK,
+            content_type='application/vnd.api+json; application/json',
+        )
 
 
 class UserSettings(JSONAPIBaseView, generics.RetrieveUpdateAPIView, UserMixin):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -90,7 +90,7 @@ from osf.models import (
     Email,
     Tag,
 )
-from website import mails, settings
+from website import mails, settings, language
 from website.project.views.contributor import send_claim_email, send_claim_registered_email
 from website.util.metrics import CampaignClaimedTags, CampaignSourceTags
 from framework.auth import exceptions
@@ -763,11 +763,7 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
         institutional = bool(request.query_params.get('institutional', None))
         mail_template = mails.FORGOT_PASSWORD if not institutional else mails.FORGOT_PASSWORD_INSTITUTION
 
-        status_message = (
-            f'If there is an OSF account associated with {email}, an email with instructions on how to '
-            f'reset the OSF password has been sent to {email}. If you do not receive an email and believe '
-            'you should have, please contact OSF Support. '
-        )
+        status_message = language.RESET_PASSWORD_SUCCESS_STATUS_MESSAGE.format(email=email)
         kind = 'success'
         # check if the user exists
         user_obj = get_user(email=email)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -757,6 +757,9 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
         if not email:
             raise ValidationError('Request must include email in query params.')
 
+        institutional = bool(request.query_params.get('institutional', None))
+        mail_template = mails.FORGOT_PASSWORD if not institutional else mails.FORGOT_PASSWORD_INSTITUTION
+
         status_message = (
             f'If there is an OSF account associated with {email}, an email with instructions on how to '
             f'reset the OSF password has been sent to {email}. If you do not receive an email and believe '
@@ -781,11 +784,11 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 reset_link = f'{settings.RESET_PASSWORD_URL}{user_obj._id}/{user_obj.verification_key_v2['token']}/'
                 mails.send_mail(
                     to_addr=email,
-                    mail=mails.FORGOT_PASSWORD,
+                    mail=mail_template,
                     reset_link=reset_link,
                     can_change_preferences=False,
                 )
-        return Response(status=status.HTTP_200_OK, data={'message': status_message, 'kind': kind})
+        return Response(status=status.HTTP_200_OK, data={'message': status_message, 'kind': kind, 'institutional': institutional})
 
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -830,8 +830,8 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 user_obj.save()
             except exceptions.ChangePasswordError as error:
                 return JsonResponse(
-                    error.messages,
-                    status=status.HTTP_400_BAD_REQUEST,
+                    {'errors': [{'detail': message} for message in error.messages]},
+                    status=400,
                     content_type='application/vnd.api+json; application/json',
                 )
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -2,6 +2,8 @@ import pytz
 
 from django.apps import apps
 from django.db.models import F
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 from guardian.shortcuts import get_objects_for_user
 from rest_framework.throttling import UserRateThrottle
 
@@ -791,6 +793,7 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 )
         return Response(status=status.HTTP_200_OK, data={'message': status_message, 'kind': kind, 'institutional': institutional})
 
+    @method_decorator(csrf_protect)
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -17,7 +17,7 @@ from api.metrics.views import (
     CountedAuthUsageView,
     MetricsOpenapiView,
 )
-from api.users.views import ClaimUser
+from api.users.views import ClaimUser, ResetPassword
 from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
 from api.base.permissions import TokenHasScope
@@ -60,6 +60,7 @@ class TestApiBaseViews(ApiTestCase):
             RawMetricsView,
             RegistriesModerationMetricsView,
             MetricsOpenapiView,
+            ResetPassword,
         ]
 
     def test_root_returns_200(self):

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -258,18 +258,12 @@ class TestResetPassword:
                 'attributes': {
                     'uid': user_one._id,
                     'token': user_one.verification_key_v2['token'],
-                    'password': '!',
+                    'password': user_one.username,
                 }
             }
         }
         res = app.post_json_api(url, payload, expect_errors=True)
         assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Password should be at least eight characters'
-
-        payload['data']['attributes']['password'] = '!' * 257
-        res = app.post_json_api(url, payload, expect_errors=True)
-        assert res.status_code == 400
-        assert res.json['errors'][0]['detail'] == 'Password should not be longer than 256 characters'
 
 
 @pytest.mark.django_db

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import pytest
+import urllib
 
 from api.base.settings.defaults import API_BASE
 from api.base.utils import hashids
@@ -9,6 +10,7 @@ from osf_tests.factories import (
 )
 from osf.models import Email, NotableDomain
 from framework.auth.views import auth_email_logout
+from website import mails, settings
 
 @pytest.fixture()
 def user_one():
@@ -164,6 +166,110 @@ class TestUserChangePassword:
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Old password is invalid'
         assert res.json['errors'][1]['detail'] == 'Password should be at least eight characters'
+
+
+@pytest.mark.django_db
+class TestResetPassword:
+
+    @pytest.fixture()
+    def user_one(self):
+        user = UserFactory()
+        user.set_password('password1')
+        user.auth = (user.username, 'password1')
+        user.save()
+        return user
+
+    @pytest.fixture()
+    def url(self):
+        return f'/{API_BASE}users/reset_password/'
+
+    def test_get(self, app, url, user_one):
+        encoded_email = urllib.parse.quote(user_one.email)
+        url = f'{url}?email={encoded_email}'
+        with mock.patch.object(mails, 'send_mail', return_value=None) as mock_send_mail:
+            res = app.get(url)
+            assert res.status_code == 200
+
+            user_one.reload()
+            mock_send_mail.assert_called_with(
+                to_addr=user_one.username,
+                mail=mails.FORGOT_PASSWORD,
+                reset_link=f'{settings.RESET_PASSWORD_URL}{user_one._id}/{user_one.verification_key_v2['token']}/',
+                can_change_preferences=False,
+            )
+
+    def test_get_invalid_email(self, app, url):
+        url = f'{url}?email={'invalid_email'}'
+        with mock.patch.object(mails, 'send_mail', return_value=None) as mock_send_mail:
+            res = app.get(url)
+            assert res.status_code == 200
+            assert not mock_send_mail.called
+
+    def test_post(self, app, url, user_one):
+        encoded_email = urllib.parse.quote(user_one.email)
+        url = f'{url}?email={encoded_email}'
+        res = app.get(url)
+        user_one.reload()
+        payload = {
+            'data': {
+                'attributes': {
+                    'uid': user_one._id,
+                    'token': user_one.verification_key_v2['token'],
+                    'password': 'password2',
+                }
+            }
+        }
+
+        res = app.post_json_api(url, payload)
+        user_one.reload()
+        assert res.status_code == 200
+        assert user_one.check_password('password2')
+
+    def test_post_empty_payload(self, app, url):
+        payload = {
+            'data': {
+                'attributes': {
+                }
+            }
+        }
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 400
+
+    def test_post_invalid_token(self, app, url, user_one):
+        payload = {
+            'data': {
+                'attributes': {
+                    'uid': user_one._id,
+                    'token': 'invalid_token',
+                    'password': 'password2',
+                }
+            }
+        }
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 400
+
+    def test_post_invalid_password(self, app, url, user_one):
+        encoded_email = urllib.parse.quote(user_one.email)
+        url = f'{url}?email={encoded_email}'
+        res = app.get(url)
+        user_one.reload()
+        payload = {
+            'data': {
+                'attributes': {
+                    'uid': user_one._id,
+                    'token': user_one.verification_key_v2['token'],
+                    'password': '!',
+                }
+            }
+        }
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Password should be at least eight characters'
+
+        payload['data']['attributes']['password'] = '!' * 257
+        res = app.post_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Password should not be longer than 256 characters'
 
 
 @pytest.mark.django_db

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1102,7 +1102,6 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         had_existing_password = bool(self.has_usable_password() and self.is_confirmed)
         if self.username == raw_password:
             raise ChangePasswordError(['Password cannot be the same as your email address'])
-
         super().set_password(raw_password)
         if had_existing_password and notify:
             mails.send_mail(

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1099,9 +1099,18 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         :rtype: list
         :returns: Changed fields from the user save
         """
+        issues = []
         had_existing_password = bool(self.has_usable_password() and self.is_confirmed)
         if self.username == raw_password:
-            raise ChangePasswordError(['Password cannot be the same as your email address'])
+            issues.append('Password cannot be the same as your email address')
+        elif len(raw_password) < 8:
+            issues.append('Password should be at least eight characters')
+        elif len(raw_password) > 256:
+            issues.append('Password should not be longer than 256 characters')
+
+        if issues:
+            raise ChangePasswordError(issues)
+
         super().set_password(raw_password)
         if had_existing_password and notify:
             mails.send_mail(

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1099,17 +1099,9 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         :rtype: list
         :returns: Changed fields from the user save
         """
-        issues = []
         had_existing_password = bool(self.has_usable_password() and self.is_confirmed)
         if self.username == raw_password:
-            issues.append('Password cannot be the same as your email address')
-        elif len(raw_password) < 8:
-            issues.append('Password should be at least eight characters')
-        elif len(raw_password) > 256:
-            issues.append('Password should not be longer than 256 characters')
-
-        if issues:
-            raise ChangePasswordError(issues)
+            raise ChangePasswordError(['Password cannot be the same as your email address'])
 
         super().set_password(raw_password)
         if had_existing_password and notify:

--- a/website/language.py
+++ b/website/language.py
@@ -215,3 +215,9 @@ DISK_SAVING_MODE = 'Forks, registrations, and uploads to OSF Storage uploads are
 CONFIRM_ALTERNATE_EMAIL_ERROR = 'The email address has <b>NOT</b> been added to your account. Please log out and revisit the link in your email. Thank you.'
 SWITCH_VALIDATOR_ERROR = 'You do not have the ability to edit this field at this time.'
 EMPTY_REQUEST_INSTITUTIONAL_ACCESS_REQUEST_TEXT = 'User has left custom message field empty'
+
+RESET_PASSWORD_SUCCESS_STATUS_MESSAGE = (
+    'If there is an OSF account associated with {email}, an email with instructions on how to '
+    'reset the OSF password has been sent to {email}. If you do not receive an email and believe '
+    'you should have, please contact OSF Support. '
+)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -87,6 +87,7 @@ PROTOCOL = 'https://' if SECURE_MODE else 'http://'
 DOMAIN = PROTOCOL + 'localhost:5000/'
 INTERNAL_DOMAIN = DOMAIN
 API_DOMAIN = PROTOCOL + 'localhost:8000/'
+RESET_PASSWORD_URL = PROTOCOL + 'localhost:5000/resetpassword/' # TODO set angular reset password url
 
 PREPRINT_PROVIDER_DOMAINS = {
     'enabled': False,


### PR DESCRIPTION
## Purpose

Added API view for handling reset password requests

## Changes

Added view for handling reset password requests (both institutional and non-institutional)
Added serializer for reset password requests

## QA Notes

N/A

## Documentation

v2/users/reset_password/?email=(email)&institutional=(bool default=False)
TBD

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7298
https://openscience.atlassian.net/browse/ENG-7336