### PR TITLE
[ENG-7460] Unpublished preprints in pre-moderation return 404

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -134,6 +134,11 @@ class PreprintMixin(NodeMixin):
         if preprint.deleted is not None:
             sentry.log_message(f'Preprint deleted: [guid={base_guid_id}, version={preprint_version}]')
             raise NotFound
+
+        # May raise a permission denied
+        if check_object_permissions:
+            self.check_object_permissions(self.request, preprint)
+
         if (
             preprint.provider.reviews_workflow == Workflows.PRE_MODERATION.value and
             not preprint.actions.filter(to_state='accepted').exists() and
@@ -141,10 +146,6 @@ class PreprintMixin(NodeMixin):
             not preprint.provider.get_group('moderator').user_set.filter(id=self.request.user.id).exists()
         ):
             raise NotFound
-
-        # May raise a permission denied
-        if check_object_permissions:
-            self.check_object_permissions(self.request, preprint)
 
         return preprint
 

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -134,6 +134,12 @@ class PreprintMixin(NodeMixin):
         if preprint.deleted is not None:
             sentry.log_message(f'Preprint deleted: [guid={base_guid_id}, version={preprint_version}]')
             raise NotFound
+        if (
+            preprint.provider.reviews_workflow == Workflows.PRE_MODERATION.value and
+            not preprint.actions.filter(to_state='accepted').exists() and
+            not preprint.contributors.filter(id=self.request.user.id).exists()
+        ):
+            raise NotFound
 
         # May raise a permission denied
         if check_object_permissions:

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -137,7 +137,8 @@ class PreprintMixin(NodeMixin):
         if (
             preprint.provider.reviews_workflow == Workflows.PRE_MODERATION.value and
             not preprint.actions.filter(to_state='accepted').exists() and
-            not preprint.contributors.filter(id=self.request.user.id).exists()
+            not preprint.contributors.filter(id=self.request.user.id).exists() and
+            not preprint.provider.get_group('moderator').user_set.filter(id=self.request.user.id).exists()
         ):
             raise NotFound
 

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -165,8 +165,9 @@ class TestPreprintDetail:
         assert res.status_code == 404
         res = app.get(url, auth=user.auth, expect_errors=True)
         assert res.status_code == 404
-        res = app.get(url, auth=moderator.auth)
-        assert res.status_code == 200
+        # moderator can't see preprint with initial machine state. see test_moderator_does_not_see_initial_preprint
+        res = app.get(url, auth=moderator.auth, expect_errors=True)
+        assert res.status_code == 404
 
         ## retracted and ever_public (True)
         preprint_pre_mod.ever_public = True

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -21,7 +21,7 @@ from osf.models import (
     PreprintLog
 )
 from osf.utils import permissions as osf_permissions
-from osf.utils.permissions import WRITE
+from osf.utils.permissions import WRITE, ADMIN
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import (
     PreprintFactory,
@@ -147,6 +147,7 @@ class TestPreprintDetail:
     def test_withdrawn_preprint(self, app, user, moderator, preprint_pre_mod):
         # test_retracted_fields
         url = f'/{API_BASE}preprints/{preprint_pre_mod._id}/'
+        preprint_pre_mod.add_contributor(user, ADMIN)
         res = app.get(url, auth=user.auth)
         data = res.json['data']
 

--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -154,14 +154,195 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         res = self.app.post_json_api(self.post_mod_version_create_url, auth=user_write.auth, expect_errors=True)
         assert res.status_code == 403
 
-    def test_not_published_preprint_in_pre_moderation_without_version_is_visible(self):
-        id = self.pre_mod_preprint._id.split('_')[0]
-        res = self.app.get(f'/{API_BASE}preprints/{id}/', auth=self.user.auth)
-        assert res.status_code == 200
-
     def test_incorrect_preprint_id_without_version_returns_404(self):
         res = self.app.get(f'/{API_BASE}preprints/1234/', auth=self.user.auth, expect_errors=True)
         assert res.status_code == 404
+
+    def test_not_approved_preprint_in_pre_moderation_is_shown_for_contributors_only(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+        preprint_version_id = self.pre_mod_preprint._id
+
+        # unapproved original preprint is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'initial'
+
+        # unapproved preprint version is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_version_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'initial'
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+
+        # unapproved original preprint is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'initial'
+
+        # unapproved preprint version is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_version_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'initial'
+
+        random_user = AuthUserFactory()
+        # unapproved original preprint is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 404
+
+        # unapproved preprint version is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_version_id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 404
+
+    def test_pending_preprint_in_pre_moderation_is_shown_for_contributors_only(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+
+        # pending original preprint is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+
+        # pending preprint version is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+        assert res.status_code == 200
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+
+        # pending original preprint is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+
+        # pending preprint version is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+
+        random_user = AuthUserFactory()
+        # pending original preprint is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 404
+
+        # pending preprint version is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 404
+
+    def test_accepted_preprint_in_pre_moderation_but_not_withdrawn_is_shown_for_everyone(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+        pre_mod_preprint_v2.run_accept(self.moderator, 'comment')
+
+        # accepted original preprint is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+        # accepted preprint version is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+        assert res.status_code == 200
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+
+        # accepted original preprint is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+        # accepted preprint version is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+        random_user = AuthUserFactory()
+        # accepted original preprint is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+        # accepted preprint version is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+    def test_accepted_preprint_in_pre_moderation_and_withdrawn_is_shown_for_everyone(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+        pre_mod_preprint_v2.run_accept(self.moderator, 'comment')
+
+        withdrawal_request = PreprintRequestFactory(
+            creator=self.user,
+            target=pre_mod_preprint_v2,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value)
+        withdrawal_request.run_submit(self.user)
+        withdrawal_request.run_accept(self.moderator, withdrawal_request.comment)
+
+        # accepted and withdrawn original preprint is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        # accepted and withdrawn preprint version is shown for owner
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+        assert res.status_code == 200
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+
+        # accepted and withdrawn original preprint is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        # accepted and withdrawn preprint version is shown for contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        random_user = AuthUserFactory()
+        # accepted and withdrawn original preprint is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        # accepted and withdrawn preprint version is hidden for non-contributors
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
 
 class TestPreprintVersionsListRetrieve(ApiTestCase):
 

--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -188,11 +188,11 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         random_user = AuthUserFactory()
         # unapproved original preprint is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
         # unapproved preprint version is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{preprint_version_id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
     def test_pending_preprint_in_pre_moderation_is_shown_for_contributors_only(self):
         preprint_id = self.pre_mod_preprint._id.split('_')[0]
@@ -233,11 +233,11 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         random_user = AuthUserFactory()
         # pending original preprint is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
         # pending preprint version is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
     def test_pending_preprint_in_pre_moderation_withdrawn_is_shown_for_contributors_only(self):
         preprint_id = self.pre_mod_preprint._id.split('_')[0]
@@ -251,6 +251,7 @@ class TestPreprintVersionsListCreate(ApiTestCase):
             set_doi=False
         )
         pre_mod_preprint_v2.run_submit(self.user)
+        assert pre_mod_preprint_v2.machine_state == 'pending'
 
         withdrawal_request = PreprintRequestFactory(
             creator=self.user,
@@ -286,11 +287,11 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         random_user = AuthUserFactory()
         # pending withdrawn original preprint is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
         # pending withdrawn preprint version is hidden for non-contributors
         res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
-        assert res.status_code == 404
+        assert res.status_code == 403
 
     def test_accepted_preprint_in_pre_moderation_but_not_withdrawn_is_shown_for_everyone(self):
         preprint_id = self.pre_mod_preprint._id.split('_')[0]
@@ -395,6 +396,137 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=random_user.auth, expect_errors=True)
         assert res.status_code == 200
         assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+    def test_moderator_sees_pending_preprint(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+
+        # preprint
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+
+        # preprint version
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'pending'
+
+    def test_moderator_sees_pending_withdrawn_preprint(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+        assert pre_mod_preprint_v2.machine_state == 'pending'
+
+        withdrawal_request = PreprintRequestFactory(
+            creator=self.user,
+            target=pre_mod_preprint_v2,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value)
+        withdrawal_request.run_submit(self.user)
+        withdrawal_request.run_accept(self.moderator, withdrawal_request.comment)
+
+        # preprint
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        # preprint version
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+    def test_moderator_sees_accepted_preprint(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+        pre_mod_preprint_v2.run_accept(self.moderator, 'comment')
+
+        # preprint
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+        # preprint version
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'accepted'
+
+    def test_moderator_sees_withdrawn_preprint(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+        pre_mod_preprint_v2.run_submit(self.user)
+        pre_mod_preprint_v2.run_accept(self.moderator, 'comment')
+
+        withdrawal_request = PreprintRequestFactory(
+            creator=self.user,
+            target=pre_mod_preprint_v2,
+            request_type=RequestTypes.WITHDRAWAL.value,
+            machine_state=DefaultStates.INITIAL.value)
+        withdrawal_request.run_submit(self.user)
+        withdrawal_request.run_accept(self.moderator, withdrawal_request.comment)
+
+        # preprint
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+        # preprint version
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.moderator.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['reviews_state'] == 'withdrawn'
+
+    def test_moderator_does_not_see_initial_preprint(self):
+        preprint_id = self.pre_mod_preprint._id.split('_')[0]
+
+        contributor = AuthUserFactory()
+        self.pre_mod_preprint.add_contributor(contributor, permissions.READ)
+        pre_mod_preprint_v2 = PreprintFactory.create_version(
+            create_from=self.pre_mod_preprint,
+            final_machine_state='initial',
+            creator=self.user,
+            set_doi=False
+        )
+
+        # preprint
+        res = self.app.get(f'/{API_BASE}preprints/{preprint_id}/', auth=self.moderator.auth, expect_errors=True)
+        assert res.status_code == 404
+
+        # preprint version
+        res = self.app.get(f'/{API_BASE}preprints/{pre_mod_preprint_v2._id}/', auth=self.moderator.auth, expect_errors=True)
+        assert res.status_code == 404
 
 
 class TestPreprintVersionsListRetrieve(ApiTestCase):

--- a/api_tests/preprints/views/test_preprint_versions.py
+++ b/api_tests/preprints/views/test_preprint_versions.py
@@ -154,6 +154,14 @@ class TestPreprintVersionsListCreate(ApiTestCase):
         res = self.app.post_json_api(self.post_mod_version_create_url, auth=user_write.auth, expect_errors=True)
         assert res.status_code == 403
 
+    def test_not_published_preprint_in_pre_moderation_without_version_is_visible(self):
+        id = self.pre_mod_preprint._id.split('_')[0]
+        res = self.app.get(f'/{API_BASE}preprints/{id}/', auth=self.user.auth)
+        assert res.status_code == 200
+
+    def test_incorrect_preprint_id_without_version_returns_404(self):
+        res = self.app.get(f'/{API_BASE}preprints/1234/', auth=self.user.auth, expect_errors=True)
+        assert res.status_code == 404
 
 class TestPreprintVersionsListRetrieve(ApiTestCase):
 


### PR DESCRIPTION
## Purpose

The current `get_preprint` method filters preprints by `is_published = True` that is incorrect in case `pre-moderation` is enabled as in this case preprints have `is_published = False` but still should be visible by users

## Changes

Fixed queryset, added tests

## Ticket

https://openscience.atlassian.net/browse/ENG-7460