### PR TITLE
ENG-7296 implementing a management command to set dataarchive registration resourcetype with no choice previously to 'Dataset'

### DIFF
--- a/admin/management/urls.py
+++ b/admin/management/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
     re_path(r'^monthly_reporters_go', views.MonthlyReportersGo.as_view(), name='monthly_reporters_go'),
     re_path(r'^ingest_cedar_metadata_templates', views.IngestCedarMetadataTemplates.as_view(), name='ingest_cedar_metadata_templates'),
     re_path(r'^bulk_resync', views.BulkResync.as_view(), name='bulk-resync')
+    re_path(r'^set_empty_resource_type_general_for_dataarchive_registrations', views.SetEmptyResourceTypeGeneralForDataarchiveRegistrations.as_view(), name='set_empty_resource_type_general_for_dataarchive_registrations'),
 ]

--- a/admin/management/urls.py
+++ b/admin/management/urls.py
@@ -15,6 +15,6 @@ urlpatterns = [
     re_path(r'^daily_reporters_go', views.DailyReportersGo.as_view(), name='daily_reporters_go'),
     re_path(r'^monthly_reporters_go', views.MonthlyReportersGo.as_view(), name='monthly_reporters_go'),
     re_path(r'^ingest_cedar_metadata_templates', views.IngestCedarMetadataTemplates.as_view(), name='ingest_cedar_metadata_templates'),
-    re_path(r'^bulk_resync', views.BulkResync.as_view(), name='bulk-resync')
+    re_path(r'^bulk_resync', views.BulkResync.as_view(), name='bulk-resync'),
     re_path(r'^set_empty_resource_type_general_for_dataarchive_registrations', views.SetEmptyResourceTypeGeneralForDataarchiveRegistrations.as_view(), name='set_empty_resource_type_general_for_dataarchive_registrations'),
 ]

--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -167,18 +167,8 @@ class SetEmptyResourceTypeGeneralForDataarchiveRegistrations(ManagementCommandPe
             Guid.objects.filter(content_type__model='abstractnode', object_id__in=registration_ids).
             values_list('id', flat=True)
         )
-        guid_ids_with_metadata = list(
-            GuidMetadataRecord.objects.filter(guid_id__in=guid_ids).values_list('guid_id', flat=True)
-        )
-        # create metadata records if there is default ''
+        # update metadata records if there is default ''
         GuidMetadataRecord.objects.filter(guid_id__in=guid_ids, resource_type_general='').update(
             resource_type_general='Dataset'
         )
-        guid_ids_with_no_metadata = set(guid_ids) - set(guid_ids_with_metadata)
-        # create metadata records if there was no previously
-        if guid_ids_with_no_metadata:
-            GuidMetadataRecord.objects.bulk_create(
-                [GuidMetadataRecord(guid_id=guid_id_with_no_metadata, resource_type_general='Dataset')
-                 for guid_id_with_no_metadata in guid_ids_with_no_metadata]
-            )
         return redirect(reverse('management:commands'))

--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -167,7 +167,18 @@ class SetEmptyResourceTypeGeneralForDataarchiveRegistrations(ManagementCommandPe
             Guid.objects.filter(content_type__model='abstractnode', object_id__in=registration_ids).
             values_list('id', flat=True)
         )
+        guid_ids_with_metadata = list(
+            GuidMetadataRecord.objects.filter(guid_id__in=guid_ids).values_list('guid_id', flat=True)
+        )
+        # create metadata records if there is default ''
         GuidMetadataRecord.objects.filter(guid_id__in=guid_ids, resource_type_general='').update(
             resource_type_general='Dataset'
         )
+        guid_ids_with_no_metadata = set(guid_ids) - set(guid_ids_with_metadata)
+        # create metadata records if there was no previously
+        if guid_ids_with_no_metadata:
+            GuidMetadataRecord.objects.bulk_create(
+                [GuidMetadataRecord(guid_id=guid_id_with_no_metadata, resource_type_general='Dataset')
+                 for guid_id_with_no_metadata in guid_ids_with_no_metadata]
+            )
         return redirect(reverse('management:commands'))

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -125,13 +125,13 @@
                     </nav>
                 </form>
             </section>
-            <section>
-                <h4><u>Resync with CrossRef and DataCite</u></h4>
+             <section>
+                <h4><u>Set dataarchive Registrations to 'Dataset'</u></h4>
                 <p>
-                    Use this management command to resync all preprints with CrossRef and public nodes/registrations with DataCite.
+                    Use this management command to set dataarchive registration resourcetype with no choice previously to 'Dataset'.
                 </p>
                 <form method="post"
-                      action="{% url 'management:bulk-resync'%}">
+                      action="{% url 'management:set_empty_resource_type_general_for_dataarchive_registrations'%}">
                     {% csrf_token %}
                     <nav>
                         <input class="btn btn-success" type="submit" value="Run" />

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -125,7 +125,20 @@
                     </nav>
                 </form>
             </section>
-             <section>
+            <section>
+                <h4><u>Resync with CrossRef and DataCite</u></h4>
+                <p>
+                    Use this management command to resync all preprints with CrossRef and public nodes/registrations with DataCite.
+                </p>
+                <form method="post"
+                      action="{% url 'management:bulk-resync'%}">
+                    {% csrf_token %}
+                    <nav>
+                        <input class="btn btn-success" type="submit" value="Run" />
+                    </nav>
+                </form>
+            </section>
+            <section>
                 <h4><u>Set dataarchive Registrations to 'Dataset'</u></h4>
                 <p>
                     Use this management command to set dataarchive registration resourcetype with no choice previously to 'Dataset'.

--- a/admin_tests/management/test_managemant.py
+++ b/admin_tests/management/test_managemant.py
@@ -3,7 +3,7 @@ from django.test import RequestFactory
 from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory
 from admin.management import views
 from admin_tests.utilities import setup_view
-from osf.models import Guid, GuidMetadataRecord
+from osf.models import GuidMetadataRecord
 
 
 class TestManagement(AdminTestCase):
@@ -15,18 +15,19 @@ class TestManagement(AdminTestCase):
         self.request = RequestFactory().get('/fake_path')
         self.request.user = self.user
         self.view = views.SetEmptyResourceTypeGeneralForDataarchiveRegistrations()
-        self.view = setup_view(self.view, self.request, user_id=self.user._id)
+        self.view = setup_view(self.view, self.request)
         self.registration = RegistrationFactory(project=self.project, is_public=True)
         self.registration.provider._id = 'dataarchive'
         self.registration.provider.save()
 
-    def test_dataarchive_registration_resource_type_general_management_command_set_with_no_metadata(self):
+    def test_dataarchive_registration_resource_type_management_command_set_with_empty_string_metadata_record_in_database(self):
+        self.guid_metadata_record = GuidMetadataRecord(guid_id=self.registration.guids.first().id)
+        self.guid_metadata_record.save()
+        assert self.guid_metadata_record.resource_type_general == ''
         self.view.post(self.request)
         assert GuidMetadataRecord.objects.get(guid___id=self.registration._id).resource_type_general == 'Dataset'
 
-    def test_dataarchive_registration_resource_type_general_management_command_set_with_metadata(self):
-        guid = Guid.objects.get(_id=self.registration._id)
-        guid_metadata_record = GuidMetadataRecord(guid_id=guid.id, resource_type_general='Book')
-        guid_metadata_record.save()
+    def test_dataarchive_registration_resource_type_management_command_set_with_no_metadata_record_in_database(
+            self):
         self.view.post(self.request)
-        assert GuidMetadataRecord.objects.get(guid_id=guid.id).resource_type_general == 'Book'
+        assert GuidMetadataRecord.objects.filter(guid___id=self.registration._id).first() is None

--- a/admin_tests/management/test_managemant.py
+++ b/admin_tests/management/test_managemant.py
@@ -1,0 +1,32 @@
+from tests.base import AdminTestCase
+from django.test import RequestFactory
+from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory
+from admin.management import views
+from admin_tests.utilities import setup_view
+from osf.models import Guid, GuidMetadataRecord
+
+
+class TestManagement(AdminTestCase):
+
+    def setUp(self):
+        self.project = ProjectFactory(is_public=True)
+        self.user = AuthUserFactory()
+        self.project.add_contributor(self.user)
+        self.request = RequestFactory().get('/fake_path')
+        self.request.user = self.user
+        self.view = views.SetEmptyResourceTypeGeneralForDataarchiveRegistrations()
+        self.view = setup_view(self.view, self.request, user_id=self.user._id)
+        self.registration = RegistrationFactory(project=self.project, is_public=True)
+        self.registration.provider._id = 'dataarchive'
+        self.registration.provider.save()
+
+    def test_dataarchive_registration_resource_type_general_management_command_set_with_no_metadata(self):
+        self.view.post(self.request)
+        assert GuidMetadataRecord.objects.get(guid___id=self.registration._id).resource_type_general == 'Dataset'
+
+    def test_dataarchive_registration_resource_type_general_management_command_set_with_metadata(self):
+        guid = Guid.objects.get(_id=self.registration._id)
+        guid_metadata_record = GuidMetadataRecord(guid_id=guid.id, resource_type_general='Book')
+        guid_metadata_record.save()
+        self.view.post(self.request)
+        assert GuidMetadataRecord.objects.get(guid_id=guid.id).resource_type_general == 'Book'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For all registrations that on the OSF Data Archive only and HAVE NOT made a resourcetype choice previously should have their resourcetype changed to dataset.

## Changes

Admin Management command is implemented to change not set `resource_type_general` for `dataarchive` Registrations

![image](https://github.com/user-attachments/assets/0561620d-55c3-4518-9db0-aac5735edde5)


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7296