### PR TITLE
[ENG-7280] Fix registrations not public after embargo

### DIFF
--- a/admin/base/utils.py
+++ b/admin/base/utils.py
@@ -140,6 +140,7 @@ def change_embargo_date(registration, user, end_date):
 
     if registration.embargo:
         registration.embargo.end_date = end_date
+        registration.embargo.mark_as_approved()
     else:
         registration._initiate_embargo(
             user,

--- a/admin_tests/base/test_utils.py
+++ b/admin_tests/base/test_utils.py
@@ -150,10 +150,16 @@ class TestNodeChanges(AdminTestCase):
         self.registration.reload()
         assert not self.registration.is_public
 
+        # Ensure the embargo is not marked as approved initially
+        assert not self.registration.embargo.is_approved
+
         # Update an embargo end date
         change_embargo_date(self.registration, self.user, self.date_valid2)
         assert abs(self.registration.embargo.end_date - self.date_valid2) <= delta
         assert Embargo.objects.count() == 1
+
+        # Ensure `mark_as_approved()` was applied and embargo is approved
+        assert self.registration.embargo.is_approved
 
         # Test invalid dates
         with pytest.raises(ValidationError):

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -632,6 +632,9 @@ class Embargo(SanctionCallbackMixin, EmailApprovableSanction):
         # self.state = Sanction.COMPLETED
         self.to_COMPLETED()
 
+    def mark_as_approved(self):
+        self.to_APPROVED()
+
 class Retraction(EmailApprovableSanction):
     """
     Retraction object for public registrations.


### PR DESCRIPTION
## Purpose

Fix issue when registrations are not public once embargo ends

## Changes

TBD

## QA Notes

TBD

## Documentation

TBD

## Side Effects

TBD

## Ticket
(https://openscience.atlassian.net/browse/ENG-7280)
