### PR TITLE
[ENG-7338] fix some older preprint links fail to resolve post-versioned GUIDs

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2731,12 +2731,14 @@ class TestEmberRedirect(OsfTestCase):
 
     def test_ember_redirect_to_versioned_guid(self):
         pp = PreprintFactory(filename='test.pdf', finish=True)
-
         res = self.app.get(f'preprints/provider/{pp.get_guid()._id}/')
-
+        guid_with_version = pp._id
         assert res.status_code == 302
-        assert res.location == f'{pp._id}'
-
+        assert res.location.endswith(f'{guid_with_version}')
+        guid_with_no_version = guid_with_version.split('_')[0]
+        location_with_no_guid = res.location.replace(guid_with_version, '')
+        # check if location has not wrong format https://osf.io/preprints/socarxiv/3rhyz/3rhyz_v1
+        assert location_with_no_guid == location_with_no_guid.replace(guid_with_no_version, '')
 
 @pytest.mark.django_db
 class TestPreprintCreatorStateChangings:

--- a/website/routes.py
+++ b/website/routes.py
@@ -277,7 +277,7 @@ def ember_app(path=None):
                     if guid_str:
                         preprint = Preprint.load(guid_str)
                         if preprint and preprint._id != guid_str:
-                            return redirect(preprint._id, code=302)
+                            return redirect(f"{settings.DOMAIN}preprints/{path_values[0]}/{preprint._id}", code=302)
                 # For all other cases, let ember app handle it
                 ember_app = EXTERNAL_EMBER_APPS.get('ember_osf_web', False) or ember_app
             break


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

A preprint link with an unversioned GUID that is followed by “/” will construct an improper URL and fail to resolve.  For example, “https://osf.io/preprints/socarxiv/3rhyz/” resolves to “https://osf.io/preprints/socarxiv/3rhyz/3rhyz_v1” and is not an OSF page.

## Changes

A link like “[https://osf.io/preprints/socarxiv/3rhyz/](https://osf.io/preprints/socarxiv/3rhyz/3rhyz_v1)” should resolve to the most recent version of that preprint GUID, the same way that “[https://osf.io/preprints/socarxiv/3rhyz](https://osf.io/preprints/socarxiv/3rhyz/3rhyz_v1)” would.

redirect to explicit url in order to not add 3rhyz_v1 to the end of url and replace 3rhyz with 3rhyz_v1


https://github.com/user-attachments/assets/27b76207-77ea-4cfd-a206-d95c5d551774



## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7338
