### PR TITLE
[ENG-6987] feature/ENG-6987-updates-v1 set 'view_basefilenode' permission for admin files search

### DIFF
--- a/admin/files/views.py
+++ b/admin/files/views.py
@@ -13,7 +13,7 @@ class FileSearchView(PermissionRequiredMixin, FormView):
     """ Allows authorized users to search for a specific file by guid.
     """
     template_name = 'files/search.html'
-    permission_required = 'osf.view_file'
+    permission_required = 'osf.view_basefilenode'
     raise_exception = True
     form_class = GuidForm
 
@@ -40,7 +40,7 @@ class FileMixin(PermissionRequiredMixin):
 class FileView(FileMixin, GuidView):
     """ Allows authorized users to view file info."""
     template_name = 'files/file.html'
-    permission_required = 'osf.view_file'
+    permission_required = 'osf.view_basefilenode'
     raise_exception = True
 
     def get_context_data(self, **kwargs):

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -134,7 +134,7 @@
                   </div>
               </li>
           {% endif %}
-          {% if perms.osf.view_file %}
+          {% if perms.osf.view_basefilenode %}
                 <li><a role="button" data-toggle="collapse" href="#collapseFiles">
                   <i class='fa fa-caret-down'></i> Files</a></li>
             <li>


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow file admin search if 'view_basefilenode' for user is set and user is not superadmin

## Changes

Updated view and html permissions

![image](https://github.com/user-attachments/assets/bb516e1c-8433-4d9c-bd8e-fcb5526d0b25)

![image](https://github.com/user-attachments/assets/d0f92b4d-8cb4-4516-8689-b2c28ac2fed0)

![image](https://github.com/user-attachments/assets/816b5894-d824-4e1e-9e4c-2d4ec8b553ed)



## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-6987?focusedCommentId=83742
