### PR TITLE
[ENG-7295] feature/ENG-7295 default resourcetype to dataset for OSF Data Archive registration

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -215,8 +215,17 @@ class RegistrationList(JSONAPIBaseView, generics.ListCreateAPIView, bulk_views.B
         if draft.has_permission(user, ADMIN):
             try:
                 obj = serializer.save(draft=draft)
-                if obj.provider._id == 'dataarchive':
-                    guid_metadata_record = GuidMetadataRecord(guid=obj.guids.first(), resource_type_general='Dataset')
+                guid = obj.guids.first()
+                guid_metadata_record = GuidMetadataRecord.objects.filter(guid=guid).first()
+                if obj.provider._id == 'dataarchive' and not guid_metadata_record:
+                    guid_metadata_record = GuidMetadataRecord(guid=guid, resource_type_general='Dataset')
+                    guid_metadata_record.save()
+                    # breakpoint()
+                elif (
+                    obj.provider._id == 'dataarchive' and guid_metadata_record
+                    and not guid_metadata_record.resource_type_general
+                ):
+                    guid_metadata_record.resource_type_general = 'Dataset'
                     guid_metadata_record.save()
             except ValidationError as e:
                 log_exception(e)


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For all registrations that on the OSF Data Archive only, should have their resourcetype defaulted to dataset.

## Changes

Check if registration provider is 'dataarchive' on creation, if yes - set related `resource_type_general` to 'Dataset'

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7295