### PR TITLE
[ENG-7300] Allow bulk parsing without ext=bulk in content_type

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -142,7 +142,7 @@ class JSONAPIParser(JSONParser):
                 parsed.update(relationships)
         return parsed
 
-    def parse(self, stream, media_type=None, parser_context=None):
+    def parse(self, stream, media_type=None, parser_context=None, is_bulk=False):
         """
         Parses the incoming bytestream as JSON and returns the resulting data.
         """
@@ -153,7 +153,7 @@ class JSONAPIParser(JSONParser):
         data = result.get('data', {})
 
         if data:
-            if is_bulk_request(parser_context['request']):
+            if is_bulk_request(parser_context['request']) or is_bulk:
                 if not isinstance(data, list):
                     raise ParseError('Expected a list of items but got type "dict".')
 
@@ -356,3 +356,15 @@ class SearchParser(JSONAPIParser):
                     else:
                         res['query']['bool']['filter'].append({'term': {key: val}})
         return res
+
+
+class JSONAPIListParser(JSONAPIParser):
+    media_type = 'application/json'
+
+    # Overrides JSONAPIParser
+    def parse(self, stream, media_type=None, parser_context=None):
+        """
+        Parses the incoming bytestream as JSON and returns the resulting data.
+        """
+        result = super().parse(stream, media_type=media_type, parser_context=parser_context, is_bulk=True)
+        return result

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -359,7 +359,7 @@ class SearchParser(JSONAPIParser):
 
 
 class JSONAPIListParser(JSONAPIParser):
-    media_type = 'application/json'
+    media_type = 'application/vnd.api+json'
 
     # Overrides JSONAPIParser
     def parse(self, stream, media_type=None, parser_context=None):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -31,6 +31,7 @@ from api.base.exceptions import (
 from api.base.filters import ListFilterMixin, PreprintFilterMixin
 from api.base.pagination import CommentPagination, NodeContributorPagination, MaxSizePagination
 from api.base.parsers import (
+    JSONAPIListParser,
     JSONAPIRelationshipParser,
     JSONAPIRelationshipParserForRegularJSON,
     JSONAPIMultipleRelationshipsParser,
@@ -2398,6 +2399,7 @@ class NodeReorderComponents(JSONAPIBaseView, generics.UpdateAPIView, NodeMixin):
 
     view_category = 'nodes'
     view_name = 'node-reorder-components'
+    parser_classes = (JSONAPIListParser,)
 
     def get_object(self):
         return self.get_node()

--- a/api_tests/nodes/views/test_node_reorder_components.py
+++ b/api_tests/nodes/views/test_node_reorder_components.py
@@ -89,13 +89,13 @@ class TestNodeReorderComponents:
     def test_reorder_components_admin(
             self, app, project, admin_contrib, children, url, payload_asc, payload_desc
     ):
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         project.reload()
         component_order = [el.child._id for el in project.node_relations.all()]
         assert res.status_code == 200
         assert component_order == [each._id for each in children]
 
-        res = app.put_json_api(url, payload_desc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.put_json_api(url, payload_desc, auth=admin_contrib.auth, expect_errors=True)
         project.reload()
         component_order = [el.child._id for el in project.node_relations.all()]
         assert res.status_code == 200
@@ -104,17 +104,17 @@ class TestNodeReorderComponents:
     def test_reorder_components_write_read(
             self, app, write_contrib, read_contrib, url, payload_asc
     ):
-        res = app.patch_json_api(url, payload_asc, auth=write_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=write_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
-        res = app.patch_json_api(url, payload_asc, auth=read_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=read_contrib.auth, expect_errors=True)
         assert res.status_code == 403
 
     def test_reorder_invalid_component(
             self, app, project, admin_contrib, url, payload_asc
     ):
         payload_asc['data'][0]['id'] = '12345'
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == f'The 12345 node is not a component of the {project._id} node'
 
@@ -123,7 +123,7 @@ class TestNodeReorderComponents:
     ):
         payload_asc['data'][0]['id'] = '12345'
         payload_asc['data'][1]['id'] = '12345'
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Item 12345 appears multiple times with different _order values.'
 
@@ -134,7 +134,7 @@ class TestNodeReorderComponents:
         payload_asc['data'][0]['attributes']['_order'] = 1
         payload_asc['data'][1]['id'] = '12345'
         payload_asc['data'][1]['attributes']['_order'] = 1
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Item 12345 appears multiple times with the same _order value.'
 
@@ -142,12 +142,12 @@ class TestNodeReorderComponents:
             self, app, project, admin_contrib, url, payload_asc
     ):
         payload_asc['data'][0]['attributes']['_order'] = -1
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == f'Item {payload_asc['data'][0]['id']} has _order -1 which is lower than zero.'
 
         payload_asc['data'][0]['attributes']['_order'] = 5
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == f'Item {payload_asc['data'][0]['id']} has _order 5 which is higher than the list length.'
 
@@ -156,6 +156,6 @@ class TestNodeReorderComponents:
     ):
         payload_asc['data'][0]['attributes']['_order'] = 1
         payload_asc['data'][1]['attributes']['_order'] = 1
-        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True, bulk=True)
+        res = app.patch_json_api(url, payload_asc, auth=admin_contrib.auth, expect_errors=True)
         assert res.status_code == 400
         assert res.json['errors'][0]['detail'] == 'Multiple items have the same _order value 1.'


### PR DESCRIPTION
## Purpose

Allow bulk parsing without ext=bulk in content_type

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7300
