### PR TITLE
fixed case when article_doi is empty

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -486,7 +486,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             self.set_field(preprint.set_description, description, auth)
             save_preprint = True
 
-        if 'article_doi' in validated_data:
+        if validated_data.get('article_doi'):
             article_doi = validated_data['article_doi']
             # use different regex from what we use in validate_doi as we should find and set full correct doi string.
             # it should start with "10." and have at least one group of any characters with a not required slash
@@ -505,6 +505,9 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
                 )
 
             preprint.article_doi = stripped_article_doi
+            save_preprint = True
+        else:
+            preprint.article_doi = None
             save_preprint = True
 
         if 'license_type' in validated_data or 'license' in validated_data:

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -631,6 +631,8 @@ class TestPreprintUpdate:
             ),
         )
         dois = [
+            ('', False),
+            (None, False),
             ('10.1235/', False),
             ('10.1235/test', False),
             ('doi.org/10.1235/test', False),


### PR DESCRIPTION
## Purpose

When publication doi is not set, frontend sends empty string that doesn't pass regex

## Changes

Handle empty article_doi case, improved test so that empty string and None don't cause 400 error

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?selectedIssue=ENG-7551