### PR TITLE
[ENG-7297] Re-adding the same user to registration providers as moderator/admin creates duplicate records

### DIFF
--- a/admin/providers/views.py
+++ b/admin/providers/views.py
@@ -29,6 +29,11 @@ class AddAdminOrModerator(TemplateView):
             messages.error(request, f'User for guid: {data["add-moderators-form"][0]} could not be found')
             return redirect(f'{self.url_namespace}:add_admin_or_moderator', provider_id=provider.id)
 
+        groups = [provider.format_group(name) for name in provider.groups.keys()]
+        if target_user.has_groups(groups):
+            messages.error(request, f'User with guid: {data["add-moderators-form"][0]} is already a moderator or admin')
+            return redirect(f'{self.url_namespace}:add_admin_or_moderator', provider_id=provider.id)
+
         if 'admin' in data:
             provider.add_to_group(target_user, 'admin')
             target_type = 'admin'

--- a/admin_tests/registration_providers/test_views.py
+++ b/admin_tests/registration_providers/test_views.py
@@ -321,3 +321,14 @@ class TestEditModerators:
         res = add_moderator_view.post(req)
         assert res.status_code == 302
         assert user in provider.get_group('moderator').user_set.all()
+
+        # try to add the same user, but another group
+        req.POST = {
+            'csrfmiddlewaretoken': 'fake csfr',
+            'add-moderators-form': [user._id],
+            'admin': ['Add Admin']
+        }
+        res = add_moderator_view.post(req)
+        assert res.status_code == 302
+        assert user in provider.get_group('moderator').user_set.all()
+        assert user not in provider.get_group('admin').user_set.all()

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -689,6 +689,12 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         else:
             return None
 
+    def has_groups(self, groups):
+        """
+        Checks if user is a member of the group(s).
+        """
+        return self.groups.filter(name__in=groups).exists()
+
     def get_absolute_url(self):
         return self.absolute_api_v2_url
 


### PR DESCRIPTION
## Purpose

fix re-adding the same user to providers as moderator/admin

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7297
