### PR TITLE
[ENG-7461] Update DOI validation regex

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -492,7 +492,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
             # it should start with "10." and have at least one group of any characters with a not required slash
             # e.g. 10.12/, 10.1234/test, 10.798797789/test/, 10.1234/test1/test2/random
             # e.g.2. from http://doi.com/10.32/test/random we fetch 10.32/test/random
-            stripped_article_doi = re.search(r'10\.\w+\/(\w*\/?)+', article_doi)
+            stripped_article_doi = re.search(r'10\.\w+\/([\w\-\.]*\/?)+', article_doi)
             if not stripped_article_doi:
                 raise exceptions.ValidationError('The `article_doi` format is incorrect')
 

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -641,6 +641,8 @@ class TestPreprintUpdate:
             ('https://10.1235/test', False),
             ('https://doi.org/10.1235/', False),
             ('https://doi.org/10.1235/test', False),
+            ('https://doi.org/10.1235/osf.io/12345', False),
+            ('https://doi.org/10.1235/test-1234-01-02', False),
             ('10.1235', True),
             ('9.1234/test', True),
             ('https://doi.org/9.1234/test', True),
@@ -681,7 +683,9 @@ class TestPreprintUpdate:
             ('10.123/456/789', '10.123/456/789'),
             ('10.word/', '10.word/'),
             ('word.10.1234/word2', '10.1234/word2'),
-            ('10.word/word2/', '10.word/word2/')
+            ('10.word/word2/', '10.word/word2/'),
+            ('https://doi.org/10.1235/osf.io/12345', '10.1235/osf.io/12345'),
+            ('https://doi.org/10.1235/test-1234-01-02', '10.1235/test-1234-01-02'),
         ]
         for doi, stripped_doi in original_and_stripped_dois:
             update_payload = build_preprint_update_payload(


### PR DESCRIPTION
## Purpose
- Prevent BE from truncating DOIs entered by users

## Changes
- Update DOI validation regex
  - Update tests

## QA Notes

- In the Preprint Submit and Preprint Edit workflow, verify that entering DOIs like `10.1038/s41586-020-2649-2` and `10.31235/osf.io/rw978` into the "Publication DOI" (on the Metadata page) does not cause any issues and saves. Then going to the Preprint Detail page and verifying that the "Peer-reviewed Publication DOI" link goes to the the appropriate locations
- Test other DOI formats (like `https://doi.org/10.31235`) as above and make sure they work as well

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-7461]
