### PR TITLE
[ENG-7338] fix/ENG-7338-v2 point to the version of preprint on redirect where it was set 'Make Publish' on pre-moderation last time

### DIFF
--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -559,6 +559,7 @@ class PreprintMakePublishedView(PreprintMixin, View):
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
         preprint.set_published(True, request, True)
+        preprint.run_accept(request.user, '', skip_parent_run_accept=True)
         return redirect(self.get_success_url())
 
 class PreprintUnwithdrawView(PreprintMixin, View):

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1571,7 +1571,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             user: The user triggering this transition.
             comment: Text describing why.
         """
-        ret = super().run_accept(user=user, comment=comment, **kwargs)
+        ret = None if kwargs.get('skip_parent_run_accept') else super().run_accept(user=user, comment=comment, **kwargs)
         reviews_workflow = self.provider.reviews_workflow
         if reviews_workflow == Workflows.PRE_MODERATION.value or reviews_workflow == Workflows.HYBRID_MODERATION.value:
             base_guid_obj = self.versioned_guids.first().guid


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

additional case (the another one was resolved by the following PR https://github.com/CenterForOpenScience/osf.io/pull/11021)

Preprint with pre-moderation provider does not point to last preprint version on 'Make Publish' set in admin panel

## Changes

call `run_accept` preprint method on admin 'Make Publish' set to make it point to the last published preprint version on redirection




https://github.com/user-attachments/assets/01eebc10-ccbd-445c-bdf0-020e70a92302


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7338?focusedCommentId=83843