### PR TITLE
[ENG-7295] feature/ENG-7295-v2 return default 'Dataset' value of 'dataarchive registration without setting/saving it in database

### DIFF
--- a/api/custom_metadata/views.py
+++ b/api/custom_metadata/views.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.http import Http404
 import rest_framework
 
@@ -59,5 +60,12 @@ class CustomItemMetadataDetail(JSONAPIBaseView, rest_framework.generics.Retrieve
             )
         except osfdb.base.InvalidGuid:
             raise Http404
+        # return 'resource_type_general'='Dataset' if Registration provider is 'dataarchive'
+        if (
+            metadata_record.resource_type_general == ''
+            and metadata_record.guid.content_type_id == ContentType.objects.get_for_model(osfdb.Registration).id
+            and osfdb.Registration.objects.get(id=metadata_record.guid.object_id).provider._id == 'dataarchive'
+        ):
+            metadata_record.resource_type_general = 'Dataset'
         self.check_object_permissions(self.request, metadata_record)
         return metadata_record

--- a/api/custom_metadata/views.py
+++ b/api/custom_metadata/views.py
@@ -60,7 +60,7 @@ class CustomItemMetadataDetail(JSONAPIBaseView, rest_framework.generics.Retrieve
             )
         except osfdb.base.InvalidGuid:
             raise Http404
-        # return 'resource_type_general'='Dataset' if Registration provider is 'dataarchive'
+        # return 'resource_type_general'='Dataset' if Registration provider is  'dataarchive'
         if (
             metadata_record.resource_type_general == ''
             and metadata_record.guid.content_type_id == ContentType.objects.get_for_model(osfdb.Registration).id

--- a/api/custom_metadata/views.py
+++ b/api/custom_metadata/views.py
@@ -65,7 +65,7 @@ class CustomItemMetadataDetail(JSONAPIBaseView, rest_framework.generics.Retrieve
             metadata_record.resource_type_general == ''
             and metadata_record.guid.content_type_id == ContentType.objects.get_for_model(osfdb.Registration).id
         ):
-            registration = osfdb.Registration.objects.get(id=metadata_record.guid.object_id)
+            registration = osfdb.Registration.objects.filter(id=metadata_record.guid.object_id).first()
             if registration and registration.provider and registration.provider._id == 'dataarchive':
                 metadata_record.resource_type_general = 'Dataset'
         self.check_object_permissions(self.request, metadata_record)

--- a/api/custom_metadata/views.py
+++ b/api/custom_metadata/views.py
@@ -65,7 +65,7 @@ class CustomItemMetadataDetail(JSONAPIBaseView, rest_framework.generics.Retrieve
             metadata_record.resource_type_general == ''
             and metadata_record.guid.content_type_id == ContentType.objects.get_for_model(osfdb.Registration).id
         ):
-            registration = osfdb.Registration.objects.filter(id=metadata_record.guid.object_id).first()
+            registration = osfdb.Registration.objects.get(id=metadata_record.guid.object_id)
             if registration and registration.provider and registration.provider._id == 'dataarchive':
                 metadata_record.resource_type_general = 'Dataset'
         self.check_object_permissions(self.request, metadata_record)

--- a/api/custom_metadata/views.py
+++ b/api/custom_metadata/views.py
@@ -64,8 +64,9 @@ class CustomItemMetadataDetail(JSONAPIBaseView, rest_framework.generics.Retrieve
         if (
             metadata_record.resource_type_general == ''
             and metadata_record.guid.content_type_id == ContentType.objects.get_for_model(osfdb.Registration).id
-            and osfdb.Registration.objects.get(id=metadata_record.guid.object_id).provider._id == 'dataarchive'
         ):
-            metadata_record.resource_type_general = 'Dataset'
+            registration = osfdb.Registration.objects.filter(id=metadata_record.guid.object_id).first()
+            if registration and registration.provider and registration.provider._id == 'dataarchive':
+                metadata_record.resource_type_general = 'Dataset'
         self.check_object_permissions(self.request, metadata_record)
         return metadata_record

--- a/osf/metadata/gather/focus.py
+++ b/osf/metadata/gather/focus.py
@@ -10,12 +10,13 @@ class Focus:
     iri: URIRef
     rdftype: URIRef  # TODO: allow multiple types, but don't make a big deal about it
 
-    def __init__(self, iri, rdftype):
+    def __init__(self, iri, rdftype, provider_id=None):
         assert (iri and rdftype)
         assert isinstance(iri, URIRef)
         assert isinstance(rdftype, URIRef)
         self.iri = iri
         self.rdftype = rdftype
+        self.provider_id = provider_id
 
     def __eq__(self, other):
         return (

--- a/osf/metadata/osf_gathering.py
+++ b/osf/metadata/osf_gathering.py
@@ -306,7 +306,10 @@ DATACITE_RESOURCE_TYPES_GENERAL = {
 }
 DATACITE_RESOURCE_TYPE_BY_OSF_TYPE = {
     OSF.Preprint: 'Preprint',
-    OSF.Registration: 'StudyRegistration',
+    OSF.Registration: {
+        'all': 'StudyRegistration',
+        'dataarchive': 'Dataset'
+    },
 }
 
 
@@ -352,6 +355,7 @@ class OsfFocus(gather.Focus):
         super().__init__(
             iri=osf_iri(osf_item),
             rdftype=get_rdf_type(osf_item),
+            provider_id=osf_item.provider._id if (osf_item and getattr(osf_item, 'type', '') == 'osf.registration' and osf_item.provider) else None
         )
         self.dbmodel = osf_item
         try:
@@ -433,6 +437,8 @@ def gather_flexible_types(focus):
         pass
     if not _type_label:
         _type_label = DATACITE_RESOURCE_TYPE_BY_OSF_TYPE.get(focus.rdftype)
+        if isinstance(_type_label, dict):
+            _type_label = _type_label.get('dataarchive') if focus.provider_id == 'dataarchive' else _type_label.get('all')
     if _type_label in DATACITE_RESOURCE_TYPES_GENERAL:
         _type_ref = DATACITE[_type_label]
         yield (DCTERMS.type, _type_ref)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For all registrations that on the OSF Data Archive only, should have their resourcetype defaulted to dataset.

Possible workaround for the following ticket
https://github.com/CenterForOpenScience/osf.io/pull/11030#issuecomment-2738051489


## Changes

Check if registration provider is 'dataarchive' and there is no set 'resourcetype', if yes - return 'resource_type_general'= 'Dataset' to Front End without saving it in database (show it for OSF provider not Dataarchive registration because did not succeed to set dataarchive locally)


https://github.com/user-attachments/assets/d8ada0e4-a585-46cd-8924-3e70d924269f



## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
