### PR TITLE
[ENG-2477] "&" Symbol Appears as "&amp;” on for Component Titles on Wiki Sidebar

### DIFF
--- a/website/static/js/wikiMenu.js
+++ b/website/static/js/wikiMenu.js
@@ -83,7 +83,7 @@ function WikiMenu(data, wikiID, canEdit) {
                 columns.push({
                     folderIcons: true,
                     custom: function() {
-                        return m('a.fg-file-links', {href: item.data.page.url}, item.data.page.name);
+                        return m('a.fg-file-links', {href: item.data.page.url}, m.trust(item.data.page.name));
                     }
                 });
             }

--- a/website/static/js/wikiMenu.js
+++ b/website/static/js/wikiMenu.js
@@ -83,7 +83,14 @@ function WikiMenu(data, wikiID, canEdit) {
                 columns.push({
                     folderIcons: true,
                     custom: function() {
-                        return m('a.fg-file-links', {href: item.data.page.url}, m.trust(item.data.page.name));
+                        return m(
+                            'a.fg-file-links',
+                            {href: item.data.page.url},
+                            item.data.page.name
+                                .replace('&gt;', '>')
+                                .replace('&lt;', '<')
+                                .replace('&amp;', '&')
+                        );
                     }
                 });
             }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

fix displaying escaped characters in component pages wiki section

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-2477
