### PR TITLE
[ENG-7678] Remove deleted registrations from queryset

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -180,7 +180,7 @@ def default_node_list_permission_queryset(user, model_cls, **annotations):
     qs = default_node_permission_queryset(user, model_cls) & default_node_list_queryset(model_cls)
     if annotations:
         qs = qs.annotate(**annotations)
-    return qs
+    return qs.filter(deleted=None)
 
 
 def extend_querystring_params(url, params):

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -111,6 +111,29 @@ class TestRegistrationList(ApiTestCase):
         assert self.public_project._id not in ids
         assert self.project._id not in ids
 
+    def test_deleted_registrations_are_hidden(self):
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert len(res.json['data']) == 2
+
+        new_registration = RegistrationFactory(
+            creator=self.user, project=self.project
+        )
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert len(res.json['data']) == 3
+
+        new_registration.confirm_spam()
+        assert new_registration.deleted
+
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert len(res.json['data']) == 2
+
+        self.public_registration.deleted = timezone.now()
+        self.public_registration.save()
+
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert len(res.json['data']) == 1
+
+
 class TestSparseRegistrationList(ApiTestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Purpose

When user's registration is spammed, it's still shown on the UI that causes 410 and 404 errors on `/schema_responses/` endpoint because `/registrations/` endpoint returns deleted registrations
Issue is that these registrations were spammed in some way. When it happens, `Registration` model calls `confirm_spam` method of `SpamOverrideMixin`

https://github.com/CenterForOpenScience/osf.io/blob/a9022a2cbd504bd296b7f848615f5802cc5a119b/osf/models/mixins.py#L2099-L2107

where we set only `self.deleted = now`, but `is_deleted` is not updated to `True`, thus it's `False`

However to form queryset on `v2/registrations/` we call `default_node_list_permission_queryset` method

https://github.com/CenterForOpenScience/osf.io/blob/a9022a2cbd504bd296b7f848615f5802cc5a119b/api/registrations/views.py#L157-L164

https://github.com/CenterForOpenScience/osf.io/blob/a9022a2cbd504bd296b7f848615f5802cc5a119b/api/base/utils.py#L176-L183

that calls `default_node_list_queryset`

https://github.com/CenterForOpenScience/osf.io/blob/a9022a2cbd504bd296b7f848615f5802cc5a119b/api/base/utils.py#L158-L162

which uses `is_deleted = False` filter (that is not updated to `True` when we spam records in `confirm_spam` above, thus they are present here) to filter records. The other method doesn't have similar filtering at all. So, we added filtering at the end of forming queryset using `deleted` parameter that is correctly set when we spam registration unlike `is_deleted`

## Changes

Added `deleted = None` filtering that will fix this issue for all registrations

## Notes

I'm not adding `self.is_deleted = True` in `confirm_spam` because it won't fix this issue for the existing nodes. Also I see that Preprint model hasn't this field, but it inherits from SpamOverrideMixin, thus we can spam preprint, but cannot set this field. 
And we have `is_deleted`, `deleted`, `deleted_date` fields in AbstractNode, thus it's confusing what is the purpose of having them all instead of one

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-7678
