### PR TITLE
[ENG-4032] hide preprints for anonymous node

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -526,53 +526,54 @@
     </div>
 % endif
 
-% for i, preprint in enumerate(node['visible_preprints']):
-<div class="row">
-   <div class="col-xs-12 col-md-6" style="margin-bottom:5px;">
-       <div style="margin-top: 5px; margin-bottom: 5px;">
-           Has supplemental materials for <a href="${preprint['url']}" target="_blank">${preprint['title']}</a>
-           on ${preprint['provider']['name']}
-         % if user['is_admin_parent_contributor_or_group_member'] or user['is_contributor_or_group_member']:
-            &nbsp;<span id="metadatapreprint${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadatapreprint${i}"></span>
-        % endif
-       </div>
-       % if user['is_admin_parent_contributor_or_group_member'] or user['is_contributor_or_group_member']:
-           <div id="metadatapreprint${i}" class="collection-details collapse">
-               <ul style="margin-left: 30px; padding: 0; margin-bottom: 5;" class="list-unstyled">
-                    <li>
-                        Status:&nbsp;&nbsp;
-                            <b>
-                                % if preprint['is_withdrawn']:
-                                    Withdrawn
+% if not node['anonymous']:
+    % for i, preprint in enumerate(node['visible_preprints']):
+    <div class="row">
+    <div class="col-xs-12 col-md-6" style="margin-bottom:5px;">
+        <div style="margin-top: 5px; margin-bottom: 5px;">
+            Has supplemental materials for <a href="${preprint['url']}" target="_blank">${preprint['title']}</a>
+            on ${preprint['provider']['name']}
+            % if user['is_admin_parent_contributor_or_group_member'] or user['is_contributor_or_group_member']:
+                &nbsp;<span id="metadatapreprint${i}-toggle" class="fa bk-toggle-icon fa-angle-down" data-toggle="collapse" data-target="#metadatapreprint${i}"></span>
+            % endif
+        </div>
+        % if user['is_admin_parent_contributor_or_group_member'] or user['is_contributor_or_group_member']:
+            <div id="metadatapreprint${i}" class="collection-details collapse">
+                <ul style="margin-left: 30px; padding: 0; margin-bottom: 5;" class="list-unstyled">
+                        <li>
+                            Status:&nbsp;&nbsp;
+                                <b>
+                                    % if preprint['is_withdrawn']:
+                                        Withdrawn
+                                    % else:
+                                        ${preprint['state'].capitalize()}
+                                    % endif
+                                </b>
+                            % if preprint['is_moderated'] and not preprint['is_withdrawn']:
+                                <% icon_tooltip = ''%>
+                                % if preprint['state'] == 'pending':
+                                    % if preprint['provider']['workflow'] == 'post-moderation':
+                                        <% icon_tooltip = 'This {preprint_word} is publicly available and searchable but is subject to' \
+                                        ' removal by a moderator.'.format(preprint_word=preprint['word'])%>
+                                    % else:
+                                        <% icon_tooltip = 'This {preprint_word} is not publicly available or searchable until approved ' \
+                                        'by a moderator.'.format(preprint_word=preprint['word'])%>
+                                    % endif
+                                % elif preprint['state'] == 'accepted':
+                                    <% icon_tooltip = 'This {preprint_word} is publicly available and searchable.'.format(preprint_word=preprint['word'])%>
                                 % else:
-                                    ${preprint['state'].capitalize()}
+                                    <% icon_tooltip = 'This {preprint_word} is not publicly available or searchable.'.format(preprint_word=preprint['word'])%>
                                 % endif
-                            </b>
-                        % if preprint['is_moderated'] and not preprint['is_withdrawn']:
-                            <% icon_tooltip = ''%>
-                            % if preprint['state'] == 'pending':
-                                % if preprint['provider']['workflow'] == 'post-moderation':
-                                    <% icon_tooltip = 'This {preprint_word} is publicly available and searchable but is subject to' \
-                                    ' removal by a moderator.'.format(preprint_word=preprint['word'])%>
-                                % else:
-                                    <% icon_tooltip = 'This {preprint_word} is not publicly available or searchable until approved ' \
-                                    'by a moderator.'.format(preprint_word=preprint['word'])%>
-                                % endif
-                            % elif preprint['state'] == 'accepted':
-                                <% icon_tooltip = 'This {preprint_word} is publicly available and searchable.'.format(preprint_word=preprint['word'])%>
-                            % else:
-                                <% icon_tooltip = 'This {preprint_word} is not publicly available or searchable.'.format(preprint_word=preprint['word'])%>
+                                <i class="fa fa-question-circle text-muted" data-toggle="tooltip" data-placement="bottom" title="${icon_tooltip}"></i>
                             % endif
-                            <i class="fa fa-question-circle text-muted" data-toggle="tooltip" data-placement="bottom" title="${icon_tooltip}"></i>
-                        % endif
-                    </li>
-               </ul>
-           </div>
-         % endif
-   </div>
-</div>
-% endfor
-
+                        </li>
+                </ul>
+            </div>
+            % endif
+    </div>
+    </div>
+    % endfor
+% endif
 
 <div class="row">
 


### PR DESCRIPTION
## Purpose

Connected preprints should not be revealed on projects when user views it via anonymous link (here preprint name is vbvs)

![image](https://github.com/user-attachments/assets/bf693b7e-f049-420c-a4b8-47ad8ecaca03)

## Changes

Added if statement that checks if it's anonymous link. Result:

![image](https://github.com/user-attachments/assets/380034ca-ef1c-4106-a3dd-5020030e40ef)

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-4032