### PR TITLE
[ENG-7761] Edit scopes with Personal Access Tokens

### DIFF
--- a/api_tests/tokens/views/test_token_detail_relationships.py
+++ b/api_tests/tokens/views/test_token_detail_relationships.py
@@ -59,7 +59,11 @@ class TestTokenDetailScopesAsRelationships:
 
     @pytest.fixture()
     def read_scope(self):
-        return ApiOAuth2ScopeFactory()
+        return ApiOAuth2ScopeFactory(name='osf.full_read')
+
+    @pytest.fixture()
+    def private_scope(self):
+        return ApiOAuth2ScopeFactory(is_public=False)
 
     def test_owner_can_view(
             self,
@@ -328,14 +332,12 @@ class TestTokenDetailScopesAsRelationships:
             url_token_detail,
             token_user_one,
             user_one,
-            user_two
+            user_two,
+            private_scope
     ):
-        fake_scope = ApiOAuth2ScopeFactory()
-        fake_scope.is_public = False
-        fake_scope.save()
+        assert not private_scope.is_public
         nonsense_scope = self.post_payload(
-            name='A shiny invalid token',
-            scopes=fake_scope.name
+            scopes=private_scope.name
         )
         res = app.post_json_api(
             url_token_list,
@@ -377,15 +379,15 @@ class TestTokenDetailScopesAsRelationships:
             url_token_detail,
             user_one,
             app,
-            fake_scope
+            private_scope
     ):
-        nonsense_scope = self.post_payload(
+        private_scope = self.post_payload(
             name='A shiny invalid token',
-            scopes=fake_scope.name
+            scopes=private_scope.name
         )
         res = app.put_json_api(
             url_token_detail,
-            nonsense_scope,
+            private_scope,
             auth=user_one.auth,
             expect_errors=True
         )

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -342,6 +342,7 @@ class ComposedScopes:
                  + REVIEWS_WRITE\
                  + PREPRINT_ALL_WRITE\
                  + GROUP_WRITE\
+                 + TOKENS_WRITE\
                  + (
                      CoreScopes.CEDAR_METADATA_RECORD_WRITE,
                      CoreScopes.WRITE_COLLECTION_SUBMISSION_ACTION,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow integrator to change the scope of their PAT. So that full token read/write scopes fall under full_write scope.

## Changes

- clean of test_token_detail test, splitting them up into files <500 ln
- Add a test for editing PAT scopes with a PAT
- Add permission to make possible: https://github.com/CenterForOpenScience/osf.io/pull/11070/files#r2025067543

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7761