### PR TITLE
[ENG-7333] Depreciate Meetings waffle flag

### DIFF
--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -115,3 +115,21 @@ class UnpublishedPendingPreprintVersionExists(FrameworkError):
     """Raised if an unpublished pending preprint version exists
     """
     pass
+
+class ServiceDiscontinuedError(HTTPError):
+    """Raised if the service has been discontinued
+    """
+
+    code = http_status.HTTP_501_NOT_IMPLEMENTED
+    error_msgs = {
+        http_status.HTTP_501_NOT_IMPLEMENTED: {
+            'message_short': 'Service has been discontinued',
+            'message_long': ('This service has been discontinued and is no longer available for new interactions. If this '
+                                'should not have occurred and the issue persists, '
+                                + language.SUPPORT_LINK),
+        },
+    }
+
+    def __init__(self, code=None, message=None, redirect_url=None, data=None):
+        code = code or self.code
+        super().__init__(code, message, redirect_url, data)

--- a/osf/features.yaml
+++ b/osf/features.yaml
@@ -198,6 +198,11 @@ flags:
     note: This flag controls wheter users can create or interact with comments via BE or FE.
     everyone: false
 
+  - flag_name: DISABLE_MEETINGS
+    name: disable_meetings
+    note: This flag controls wheter users can create or interact with meetings via BE or FE.
+    everyone: false
+
 switches:
   - flag_name: DISABLE_ENGAGEMENT_EMAILS
     name: disable_engagement_emails

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -333,6 +333,10 @@ CONFERENCE_FAILED = Mail(
     'conference_failed',
     subject='OSF Error: No files attached',
 )
+CONFERENCE_DEPRECATION = Mail(
+    'conference_deprecation',
+    subject='Meeting Service Discontinued',
+)
 
 DIGEST = Mail(
     'digest', subject='OSF Notifications',

--- a/website/templates/emails/conference_deprecation.html.mako
+++ b/website/templates/emails/conference_deprecation.html.mako
@@ -1,0 +1,17 @@
+<%inherit file="notify_base.mako" />
+
+<%def name="content()">
+<tr>
+  <td style="border-collapse: collapse;">
+    Hello ${fullname},<br>
+    <br>
+    You recently attempted to interact with the Meeting service via email, but this service has been discontinued and is no longer available for new interactions.<br>
+    <br>
+    Existing meetings and past submissions remain unchanged. If you have any questions or need further assistance, please contact our support team at [ ${support_email} ].<br>
+    <br>
+    Sincerely yours,<br>
+    <br>
+    The OSF Robot<br>
+  </td>
+</tr>
+</%def>


### PR DESCRIPTION
## Purpose

Depreciate Meetings waffle flag

## Changes

- Introduced ServiceDiscontinuedError to handle discontinued services.
- Added DISABLE_MEETINGS feature flag to control meeting interactions.
- Updated meeting_hook to raise ServiceDiscontinuedError when meetings are disabled.
- Implemented email notification for users attempting to use the discontinued meeting service.

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7333
