### PR TITLE
[ENG-7749] admin user can publish preprint in admin app even if he isn't a contributor

### DIFF
--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -558,7 +558,7 @@ class PreprintMakePublishedView(PreprintMixin, View):
 
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
-        preprint.set_published(True, request, True)
+        preprint.set_published(True, request, True, True)
         return redirect(self.get_success_url())
 
 class PreprintUnwithdrawView(PreprintMixin, View):

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -560,7 +560,12 @@ class PreprintMakePublishedView(PreprintMixin, View):
 
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
-        preprint.set_published(True, request, True, True)
+        preprint.set_published(
+            published=True,
+            auth=request,
+            save=True,
+            ignore_permission=True
+        )
         if preprint.provider and preprint.provider.reviews_workflow == Workflows.POST_MODERATION.value:
             on_preprint_updated.apply_async(kwargs={'preprint_id': preprint._id})
 

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -43,6 +43,7 @@ from osf.models.admin_log_entry import (
 )
 from osf.utils.workflows import DefaultStates
 from website import search
+from website.preprints.tasks import on_preprint_updated
 
 
 class PreprintMixin(PermissionRequiredMixin):
@@ -559,6 +560,7 @@ class PreprintMakePublishedView(PreprintMixin, View):
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
         preprint.set_published(True, request, True, True)
+        on_preprint_updated.apply_async(kwargs={'preprint_id': preprint._id})
         return redirect(self.get_success_url())
 
 class PreprintUnwithdrawView(PreprintMixin, View):

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -18,6 +18,7 @@ from admin.nodes.views import NodeRemoveContributorView
 from admin.preprints.forms import ChangeProviderForm, MachineStateForm
 
 from api.share.utils import update_share
+from api.providers.workflows import Workflows
 
 from osf.exceptions import PreprintStateError
 
@@ -560,7 +561,9 @@ class PreprintMakePublishedView(PreprintMixin, View):
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
         preprint.set_published(True, request, True, True)
-        on_preprint_updated.apply_async(kwargs={'preprint_id': preprint._id})
+        if preprint.provider and preprint.provider.reviews_workflow == Workflows.POST_MODERATION.value:
+            on_preprint_updated.apply_async(kwargs={'preprint_id': preprint._id})
+
         return redirect(self.get_success_url())
 
 class PreprintUnwithdrawView(PreprintMixin, View):

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -21,6 +21,7 @@ from osf_tests.factories import (
 from osf.models.admin_log_entry import AdminLogEntry
 from osf.models.spam import SpamStatus
 from osf.utils.workflows import DefaultStates, RequestTypes
+from osf.utils.permissions import ADMIN
 
 from admin_tests.utilities import setup_view, setup_log_view, handle_post_view_request
 
@@ -768,3 +769,31 @@ class TestPreprintMachineStateView:
         request.user = req.user
         with pytest.raises(PermissionDenied):
             views.PreprintMachineStateView.as_view()(request, guid=preprint._id)
+
+
+@pytest.mark.urls('admin.base.urls')
+class TestPreprintMakePublishedView:
+
+    @pytest.fixture()
+    def plain_view(self):
+        return views.PreprintMakePublishedView
+
+    def test_admin_user_can_publish_preprint(self, user, preprint, plain_view):
+        admin_group = Group.objects.get(name='osf_admin')
+        preprint.is_published = False
+        preprint.save()
+
+        # user isn't admin contributor in the preprint
+        assert preprint.contributors.filter(id=user.id).exists() is False
+        assert preprint.has_permission(user, ADMIN) is False
+
+        request = RequestFactory().post(reverse('preprints:make-published', kwargs={'guid': preprint._id}))
+        request.user = user
+
+        admin_group.permissions.add(Permission.objects.get(codename='change_node'))
+        user.groups.add(admin_group)
+
+        plain_view.as_view()(request, guid=preprint._id)
+        preprint.reload()
+
+        assert preprint.is_published

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -785,8 +785,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             self.save()
         update_or_enqueue_on_preprint_updated(preprint_id=self._id, saved_fields=['primary_file'])
 
-    def set_published(self, published, auth, save=False):
-        if not self.has_permission(auth.user, ADMIN):
+    def set_published(self, published, auth, save=False, ignore_permission=False):
+        if not ignore_permission and not self.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can publish a preprint.')
 
         if self.is_published and not published:


### PR DESCRIPTION
## Purpose

`set_published` method checks if this action is performed by admin contributor, however admins in admin app should be able to perform this action without the permission

## Changes

Handle this case with an additional parameter in method because if we add check like "if is_admin or is_admin_contributor" there may be a case when admin user opens preprint and publishes it via API that he shouldn't be able to do

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145/backlog?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-7749
