### PR TITLE
[ENG-7799] Update authors' names format in metadata

### DIFF
--- a/osf/metadata/serializers/google_dataset_json_ld.py
+++ b/osf/metadata/serializers/google_dataset_json_ld.py
@@ -76,10 +76,12 @@ class GoogleDatasetJsonLdSerializer(_base.MetadataSerializer):
 
 def format_creators(basket):
     creator_data = []
-    for creator_iri in basket[DCTERMS.creator]:
+    for creator in basket.focus.dbmodel.contributors.all():
         creator_data.append({
             '@type': 'Person',
-            'name': next(basket[creator_iri:FOAF.name]),
+            'name': creator.fullname,
+            'givenName': creator.given_name,
+            'familyName': creator.family_name
         })
     return creator_data
 

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -31,6 +31,7 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False, i
         'id': str(user._id),
         'registered': user.is_registered,
         'surname': user.family_name,
+        'given_name': user.given_name,
         'fullname': fullname,
         'shortname': fullname if len(fullname) < 50 else fullname[:23] + '...' + fullname[-23:],
         'profile_image_url': user.profile_image_url(size=settings.PROFILE_IMAGE_MEDIUM),

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -75,8 +75,8 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="OSF" />
 
-    %for author in self.authors_meta()[:10]:
-        <meta name="dc.creator" content="${author}" />
+    %for author, creator in list(zip(self.authors_meta()[:10], self.creator_meta()[:10])):
+        <meta name="dc.creator" content="${creator}" />
         <meta name="citation_author" content="${author}" />
     %endfor
     %for tag in self.keywords_meta()[:10]:
@@ -327,6 +327,10 @@
 
 <%def name="authors_meta()">
     ### The list of project contributors ###
+</%def>
+
+<%def name="creator_meta()">
+    ### The list of project creators ###
 </%def>
 
 <%def name="datemodified_meta()">

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -76,6 +76,14 @@
     %endif
 </%def>
 
+<%def name="creator_meta()">
+    %if node['contributors'] and not node['anonymous']:
+        <%
+            return [contrib['fullname'] for contrib in node['contributors'] if isinstance(contrib, dict)]
+        %>
+    %endif
+</%def>
+
 <%def name="institutions_meta()">
     %if node['institutions']:
         <%

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -71,7 +71,7 @@
 <%def name="authors_meta()">
     %if node['contributors'] and not node['anonymous']:
         <%
-            return [contrib['fullname'] for contrib in node['contributors'] if isinstance(contrib, dict)]
+            return [f'{contrib['surname']}, {contrib['given_name']}'for contrib in node['contributors'] if isinstance(contrib, dict)]
         %>
     %endif
 </%def>


### PR DESCRIPTION
## Purpose

In metadata we return authors' names as full names. We should use this format instead: "{family name}, {given name}"
Also added givenName and familyName in JSON-LD schema

## Changes

Updated function that generates names, added `given_name` attribute when serialize contributors in mako templates

## Ticket

https://openscience.atlassian.net/browse/ENG-7799