### PR TITLE
[ENG-7716] Allow for reinstatement of previous preprint versions (with date uploaded) via the admin app

### DIFF
--- a/admin/preprints/urls.py
+++ b/admin/preprints/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     re_path(r'^(?P<guid>\w+)/change_provider/$', views.PreprintProviderChangeView.as_view(), name='preprint-provider'),
     re_path(r'^(?P<guid>\w+)/machine_state/$', views.PreprintMachineStateView.as_view(), name='preprint-machine-state'),
     re_path(r'^(?P<guid>\w+)/reindex_share_preprint/$', views.PreprintReindexShare.as_view(), name='reindex-share-preprint'),
+    re_path(r'^(?P<guid>\w+)/reversion_preprint/$', views.PreprintReVersion.as_view(), name='re-version-preprint'),
     re_path(r'^(?P<guid>\w+)/remove_user/(?P<user_id>[a-z0-9]+)/$', views.PreprintRemoveContributorView.as_view(), name='remove-user'),
     re_path(r'^(?P<guid>\w+)/make_private/$', views.PreprintMakePrivate.as_view(), name='make-private'),
     re_path(r'^(?P<guid>\w+)/fix_editing/$', views.PreprintFixEditing.as_view(), name='fix-editing'),

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -213,7 +213,6 @@ class PreprintReVersion(PreprintMixin, View):
         )
         primary_file = copy_files(preprint.primary_file, target_node=new_preprint, identifier__in=file_versions)
         data_to_update['primary_file'] = primary_file
-        breakpoint()
 
         # FIXME: currently it's not possible to ignore permission when update subjects
         # via serializer, remove this logic if deprecated

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.db import transaction
 from django.db.models import F
 from django.core.exceptions import PermissionDenied
@@ -199,15 +197,9 @@ class PreprintReVersion(PreprintMixin, View):
     def post(self, request, *args, **kwargs):
         preprint = self.get_object()
 
-        file_versions_date = request.POST.get('date')
-        file_versions_date = datetime.datetime.strptime(file_versions_date, '%Y-%m-%d').date()
-        file_versions = (
-            preprint.primary_file.versions
-            .filter(created__date=file_versions_date)
-            .values_list('identifier', flat=True)
-        )
+        file_versions = request.POST.getlist('file_versions')
         if not file_versions:
-            return HttpResponse(f"No available file versions found on {file_versions_date}.", status=400)
+            return HttpResponse('At least one file version should be attached.', status=400)
 
         versions = preprint.get_preprint_versions()
         for version in versions:
@@ -221,6 +213,7 @@ class PreprintReVersion(PreprintMixin, View):
         )
         primary_file = copy_files(preprint.primary_file, target_node=new_preprint, identifier__in=file_versions)
         data_to_update['primary_file'] = primary_file
+        breakpoint()
 
         # FIXME: currently it's not possible to ignore permission when update subjects
         # via serializer, remove this logic if deprecated

--- a/admin/static/js/preprints/preprints.js
+++ b/admin/static/js/preprints/preprints.js
@@ -1,0 +1,23 @@
+$(document).ready(function() {
+
+    $("#confirmReversion").on("submit", function (event) {
+        event.preventDefault();
+        console.log(123);
+
+        $.ajax({
+            url: window.templateVars.reVersionPreprint,
+            type: "post",
+            data: $("#re-version-preprint-form").serialize(),
+        }).success(function (response) {
+            console.log(response);
+        }).fail(function (jqXHR, textStatus, error) {
+            $("#date-validation").text(jqXHR.responseText);
+        });
+    });
+
+    $(".datepicker").datepicker({
+        format: "yyyy-mm-dd",
+        startDate: "+0d",
+    });
+
+});

--- a/admin/static/js/preprints/preprints.js
+++ b/admin/static/js/preprints/preprints.js
@@ -2,14 +2,15 @@ $(document).ready(function() {
 
     $("#confirmReversion").on("submit", function (event) {
         event.preventDefault();
-        console.log(123);
 
         $.ajax({
             url: window.templateVars.reVersionPreprint,
             type: "post",
             data: $("#re-version-preprint-form").serialize(),
         }).success(function (response) {
-            console.log(response);
+            if (response.redirect) {
+                window.location.href = response.redirect;
+            }
         }).fail(function (jqXHR, textStatus, error) {
             $("#date-validation").text(jqXHR.responseText);
         });

--- a/admin/static/js/preprints/preprints.js
+++ b/admin/static/js/preprints/preprints.js
@@ -12,13 +12,7 @@ $(document).ready(function() {
                 window.location.href = response.redirect;
             }
         }).fail(function (jqXHR, textStatus, error) {
-            $("#date-validation").text(jqXHR.responseText);
+            $("#version-validation").text(jqXHR.responseText);
         });
     });
-
-    $(".datepicker").datepicker({
-        format: "yyyy-mm-dd",
-        startDate: "+0d",
-    });
-
 });

--- a/admin/templates/preprints/assign_new_version.html
+++ b/admin/templates/preprints/assign_new_version.html
@@ -1,0 +1,27 @@
+{% load node_extras %}
+<a data-toggle="modal" data-target="#confirmReversion" class="btn btn-default">
+    Create new version 1
+</a>
+<div class="modal" id="confirmReversion">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="re-version-preprint-form", class="well">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">x</button>
+                    <h3>Are you sure you want to create new version 1 for <a href="{{ preprint | reverse_preprint }}">({{ preprint.title }})</a> preprint</h3>
+                </div>
+                <label for="datepicker">Select date when required file version was uploaded:</label>
+                <input id="datepicker" type="date" name="date" class="form-control" />
+                <p id="date-validation"></p>
+                {% csrf_token %}
+                <div class="modal-footer">
+                    <input class="btn btn-danger" type="submit" value="Confirm" />
+                    <button type="button" class="btn btn-default" data-dismiss="modal">
+                        Cancel
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+

--- a/admin/templates/preprints/assign_new_version.html
+++ b/admin/templates/preprints/assign_new_version.html
@@ -10,9 +10,14 @@
                     <button type="button" class="close" data-dismiss="modal">x</button>
                     <h3>Are you sure you want to create new version 1 for <a href="{{ preprint | reverse_preprint }}">({{ preprint.title }})</a> preprint</h3>
                 </div>
-                <label for="datepicker">Select date when required file version was uploaded:</label>
-                <input id="datepicker" type="date" name="date" class="form-control" />
-                <p id="date-validation"></p>
+                <p>Select file versions to attach:</p>
+                {% for version in preprint.primary_file.versions.all %}
+                    <label>
+                        <input type="checkbox" name="file_versions" value="{{ version.identifier }}"> Version: {{ version.identifier }} | {{ version.created|date:"Y-m-d H:i" }}
+                    </label>
+                    <br/>
+                {% endfor %}
+                <p id="version-validation"></p>
                 {% csrf_token %}
                 <div class="modal-footer">
                     <input class="btn btn-danger" type="submit" value="Confirm" />

--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -27,6 +27,7 @@
                     {% include "preprints/make_public.html" with preprint=preprint %}
                     {% include "preprints/make_published.html" with preprint=preprint %}
                     {% include "preprints/fix_editing.html" with preprint=preprint %}
+                    {% include "preprints/assign_new_version.html" with preprint=preprint %}
                 </div>
             </div>
         </div>
@@ -123,3 +124,11 @@
         </div>
     </div>
 {% endblock content %}
+{% block bottom_js %}
+    <script src="/static/js/preprints/preprints.js"></script>
+    <script>
+        window.templateVars = {
+            'reVersionPreprint': '{% url 'preprints:re-version-preprint' guid=preprint.guid %}',
+        }
+    </script>
+{% endblock %}

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest import mock
-from datetime import datetime
 
 from django.test import RequestFactory
 from django.urls import reverse
@@ -816,7 +815,7 @@ class TestPreprintReVersionView:
         request = RequestFactory().post(
             reverse('preprints:re-version-preprint',
             kwargs={'guid': preprint._id}),
-            data={'date': datetime.today().date()}
+            data={'file_versions': ['1']}
         )
         request.user = user
 

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -69,7 +69,9 @@ def get_user_auth(request):
     authenticated user attached to it.
     """
     user = request.user
-    private_key = request.query_params.get('view_only', None)
+    private_key = None
+    if hasattr(request, 'query_params'):  # allows django WSGIRequest to be used as well
+        private_key = request.query_params.get('view_only', None)
     if user.is_anonymous:
         auth = Auth(None, private_key=private_key)
     else:

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1116,25 +1116,26 @@ class TaxonomizableMixin(models.Model):
     def subjects_url(self):
         return self.absolute_api_v2_url + 'subjects/'
 
-    def check_subject_perms(self, auth):
+    def check_subject_perms(self, auth, ignore_permission=False):
         AbstractNode = apps.get_model('osf.AbstractNode')
         Preprint = apps.get_model('osf.Preprint')
         CollectionSubmission = apps.get_model('osf.CollectionSubmission')
         DraftRegistration = apps.get_model('osf.DraftRegistration')
 
-        if isinstance(self, AbstractNode):
-            if not self.has_permission(auth.user, ADMIN):
-                raise PermissionsError('Only admins can change subjects.')
-        elif isinstance(self, Preprint):
-            if not self.has_permission(auth.user, WRITE):
-                raise PermissionsError('Must have admin or write permissions to change a preprint\'s subjects.')
-        elif isinstance(self, DraftRegistration):
-            if not self.has_permission(auth.user, WRITE):
-                raise PermissionsError('Must have write permissions to change a draft registration\'s subjects.')
-        elif isinstance(self, CollectionSubmission):
-            if not self.guid.referent.has_permission(auth.user, ADMIN) and not auth.user.has_perms(
-                    self.collection.groups[ADMIN], self.collection):
-                raise PermissionsError('Only admins can change subjects.')
+        if not ignore_permission:
+            if isinstance(self, AbstractNode):
+                if not self.has_permission(auth.user, ADMIN):
+                    raise PermissionsError('Only admins can change subjects.')
+            elif isinstance(self, Preprint):
+                if not self.has_permission(auth.user, WRITE):
+                    raise PermissionsError('Must have admin or write permissions to change a preprint\'s subjects.')
+            elif isinstance(self, DraftRegistration):
+                if not self.has_permission(auth.user, WRITE):
+                    raise PermissionsError('Must have write permissions to change a draft registration\'s subjects.')
+            elif isinstance(self, CollectionSubmission):
+                if not self.guid.referent.has_permission(auth.user, ADMIN) and not auth.user.has_perms(
+                        self.collection.groups[ADMIN], self.collection):
+                    raise PermissionsError('Only admins can change subjects.')
         return
 
     def add_subjects_log(self, old_subjects, auth):
@@ -1157,7 +1158,7 @@ class TaxonomizableMixin(models.Model):
         if (expect_list and not is_list) or (not expect_list and is_list):
             raise ValidationValueError(f'Subjects are improperly formatted. {error_msg}')
 
-    def set_subjects(self, new_subjects, auth, add_log=True):
+    def set_subjects(self, new_subjects, auth, add_log=True, **kwargs):
         """ Helper for setting M2M subjects field from list of hierarchies received from UI.
         Only authorized admins may set subjects.
 
@@ -1168,7 +1169,7 @@ class TaxonomizableMixin(models.Model):
         :return: None
         """
         if auth:
-            self.check_subject_perms(auth)
+            self.check_subject_perms(auth, **kwargs)
         self.assert_subject_format(new_subjects, expect_list=True, error_msg='Expecting list of lists.')
 
         old_subjects = list(self.subjects.values_list('id', flat=True))

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 from urllib.parse import urljoin
 import logging
 import re
@@ -145,6 +146,35 @@ class RejectedPreprintManager(PreprintManager):
 class EverPublishedPreprintManager(PreprintManager):
     def get_queryset(self):
         return super().get_queryset().filter(date_published__isnull=False)
+
+
+def require_permission(permissions: list):
+    """
+    Preprint-specific decorator for permission checks.
+
+    This decorator adds an implicit `ignore_permission` argument to the decorated function,
+    allowing you to bypass the permission check when set to `True`.
+
+    Usage example:
+        preprint.some_method(..., ignore_permission=True)  # Skips permission check
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, ignore_permission=False, **kwargs):
+            sig = inspect.signature(func)
+            bound_args = sig.bind_partial(self, *args, **kwargs)
+            bound_args.apply_defaults()
+
+            auth = bound_args.arguments.get('auth', None)
+
+            if not ignore_permission and auth is not None:
+                for permission in permissions:
+                    if not self.has_permission(auth.user, permission):
+                        raise PermissionsError(f'Must have following permissions to change a preprint: {permissions}')
+            return func(self, *args, ignore_permission=ignore_permission, **kwargs)
+        return wrapper
+    return decorator
+
 
 class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, ReviewableMixin, BaseModel, TitleMixin, DescriptionMixin,
         Loggable, Taggable, ContributorMixin, GuardianMixin, SpamOverrideMixin, TaxonomizableMixin, AffiliatedInstitutionMixin):
@@ -374,7 +404,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         return None, None
 
     @classmethod
-    def create_version(cls, create_from_guid, auth, assign_version_number=None):
+    def create_version(cls, create_from_guid, auth, assign_version_number=None, ignore_permission=False):
         """Create a new version for a given preprint. `create_from_guid` can be any existing versions of the preprint
         but `create_version` always finds the latest version and creates a new version from it. In addition, this
         creates an "incomplete" new preprint version object using the model class and returns both the new object and
@@ -391,7 +421,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if not latest_version:
             sentry.log_message(f'Preprint not found: [guid={guid_obj._id}, create_from_guid={create_from_guid}]')
             return None, None
-        if not latest_version.has_permission(auth.user, ADMIN):
+        if not ignore_permission and not latest_version.has_permission(auth.user, ADMIN):
             sentry.log_message(f'ADMIN permission for the latest version is required to create a new version: '
                                f'[user={auth.user._id}, guid={guid_obj._id}, latest_version={latest_version._id}]')
             raise PermissionsError
@@ -439,9 +469,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         preprint.save(guid_ready=False)
 
         # Note: version number bumps from the last version number instead of the latest version number
-        # if no assign_version_number specified
-        last_version_number = guid_obj.versions.order_by('-version').first().version
-        version = last_version_number + 1
+        # if assign_version_number is not specified
         if assign_version_number:
             if not isinstance(assign_version_number, int) or assign_version_number <= 0:
                 raise ValueError(
@@ -451,7 +479,10 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             if GuidVersionsThrough.objects.filter(guid=guid_obj, version=assign_version_number).first():
                 raise ValueError(f"Version {assign_version_number} for preprint {guid_obj} already exists.")
 
-            version = assign_version_number
+            version_number = assign_version_number
+        else:
+            last_version_number = guid_obj.versions.order_by('-version').first().version
+            version_number = last_version_number + 1
 
         # Create a new entry in the `GuidVersionsThrough` table to store version information, which must happen right
         # after the first `.save()` of the new preprint version object, which enables `preprint._id` to be computed.
@@ -459,7 +490,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             referent=preprint,
             object_id=guid_obj.object_id,
             content_type=guid_obj.content_type,
-            version=version,
+            version=version_number,
             guid=guid_obj
         )
         guid_version.save()
@@ -498,7 +529,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             preprint.add_affiliated_institution(institution, auth.user, ignore_user_affiliation=True)
 
         # Update Guid obj to point to the new version if there is no moderation and new version is bigger
-        if not preprint.provider.reviews_workflow and version > guid_obj.referent.version:
+        if not preprint.provider.reviews_workflow and version_number > guid_obj.referent.version:
             guid_obj.referent = preprint
             guid_obj.object_id = preprint.pk
             guid_obj.content_type = ContentType.objects.get_for_model(preprint)
@@ -737,7 +768,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             .order_by('-latest_version')
         )
         if include_rejected is False:
-            preprint_versions = preprint_versions.exclude(machine_state='rejected')
+            preprint_versions = preprint_versions.exclude(machine_state=DefaultStates.REJECTED.value)
         return preprint_versions
 
     def web_url_for(self, view_name, _absolute=False, _guid=False, *args, **kwargs):
@@ -796,12 +827,10 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         )
         return
 
-    def set_primary_file(self, preprint_file, auth, save=False):
+    @require_permission([WRITE])
+    def set_primary_file(self, preprint_file, auth, save=False, **kwargs):
         if not self.root_folder:
             raise PreprintStateError('Preprint needs a root folder.')
-
-        if not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('Must have admin or write permissions to change a preprint\'s primary file.')
 
         if preprint_file.target != self or preprint_file.provider != 'osfstorage':
             raise ValueError('This file is not a valid primary file for this preprint.')
@@ -828,10 +857,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             self.save()
         update_or_enqueue_on_preprint_updated(preprint_id=self._id, saved_fields=['primary_file'])
 
-    def set_published(self, published, auth, save=False, ignore_permission=False):
-        if not ignore_permission and not self.has_permission(auth.user, ADMIN):
-            raise PermissionsError('Only admins can publish a preprint.')
-
+    @require_permission([ADMIN])
+    def set_published(self, published, auth, save=False, **kwargs):
         if self.is_published and not published:
             raise ValueError('Cannot unpublish preprint.')
 
@@ -848,7 +875,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
                 raise ValueError('Preprint must have at least one subject to be published.')
             self.date_published = timezone.now()
             # For legacy preprints, not logging
-            self.set_privacy('public', log=False, save=False)
+            self.set_privacy('public', log=False, save=False, **kwargs)
 
             # In case this provider is ever set up to use a reviews workflow, put this preprint in a sensible state
             self.machine_state = ReviewStates.ACCEPTED.value
@@ -1070,10 +1097,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             update_or_enqueue_on_preprint_updated(preprint_id=self._id, saved_fields=['tags'])
             return True
 
-    def set_supplemental_node(self, node, auth, save=False, ignore_node_permissions=False):
-        if not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('You must have write permissions to set a supplemental node.')
-
+    @require_permission([WRITE])
+    def set_supplemental_node(self, node, auth, save=False, ignore_node_permissions=False, **kwargs):
         if not node.has_permission(auth.user, WRITE) and not ignore_node_permissions:
             raise PermissionsError('You must have write permissions on the supplemental node to attach.')
 
@@ -1095,10 +1120,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def unset_supplemental_node(self, auth, save=False):
-        if not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('You must have write permissions to set a supplemental node.')
-
+    @require_permission([WRITE])
+    def unset_supplemental_node(self, auth, save=False, **kwargs):
         current_node_id = self.node._id if self.node else None
         self.node = None
 
@@ -1115,27 +1138,23 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def set_title(self, title, auth, save=False):
+    @require_permission([WRITE])
+    def set_title(self, title, auth, save=False, **kwargs):
         """Set the title of this Preprint and log it.
 
         :param str title: The new title.
         :param auth: All the auth information including user, API key.
         """
-        if not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('Must have admin or write permissions to edit a preprint\'s title.')
-
         return super().set_title(title, auth, save)
 
-    def set_description(self, description, auth, save=False):
+    @require_permission([WRITE])
+    def set_description(self, description, auth, save=False, **kwargs):
         """Set the description and log the event.
 
         :param str description: The new description
         :param auth: All the auth informtion including user, API key.
         :param bool save: Save self after updating.
         """
-        if not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('Must have admin or write permissions to edit a preprint\'s title.')
-
         return super().set_description(description, auth, save)
 
     def get_spam_fields(self, saved_fields=None):
@@ -1143,7 +1162,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             return self.SPAM_CHECK_FIELDS
         return self.SPAM_CHECK_FIELDS.intersection(saved_fields)
 
-    def set_privacy(self, permissions, auth=None, log=True, save=True, check_addons=False, force=False, should_hide=False):
+    @require_permission([WRITE])
+    def set_privacy(self, permissions, auth=None, log=True, save=True, check_addons=False, force=False, should_hide=False, **kwargs):
         """Set the permissions for this preprint - mainly for spam purposes.
 
         :param permissions: A string, either 'public' or 'private'
@@ -1152,8 +1172,6 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         :param bool meeting_creation: Whether this was created due to a meetings email.
         :param bool check_addons: Check and collect messages for addons?
         """
-        if auth and not self.has_permission(auth.user, WRITE):
-            raise PermissionsError('Must have admin or write permissions to change privacy settings.')
         if permissions == 'public' and not self.is_public:
             if (self.is_spam or (settings.SPAM_FLAGGED_MAKE_NODE_PRIVATE and self.is_spammy)) and not force:
                 raise PreprintStateError(
@@ -1219,7 +1237,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
     @classmethod
     def bulk_update_search(cls, preprints, index=None):
         for _preprint in preprints:
-            update_share(_preprint)
+            if _preprint.is_latest_version:
+                update_share(_preprint)
         from website import search
         try:
             serialize = functools.partial(search.search.update_preprint, index=index, bulk=True, async_update=False)
@@ -1297,7 +1316,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         system_tag_to_add, created = Tag.all_tags.get_or_create(name=provider_source_tag(self.provider._id, 'preprint'), system=True)
         contributor.add_system_tag(system_tag_to_add)
 
-    def update_has_coi(self, auth: Auth, has_coi: bool, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_has_coi(self, auth: Auth, has_coi: bool, log: bool = True, save: bool = True, **kwargs):
         """
         This method sets the field `has_coi` to indicate if there's a conflict interest statement for this preprint
         and logs that change.
@@ -1329,7 +1349,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_conflict_of_interest_statement(self, auth: Auth, coi_statement: str, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_conflict_of_interest_statement(self, auth: Auth, coi_statement: str, log: bool = True, save: bool = True, **kwargs):
         """
         This method sets the `conflict_of_interest_statement` field for this preprint and logs that change.
 
@@ -1358,7 +1379,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_has_data_links(self, auth: Auth, has_data_links: bool, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_has_data_links(self, auth: Auth, has_data_links: bool, log: bool = True, save: bool = True, **kwargs):
         """
         This method sets the `has_data_links` field that respresent the availability of links to supplementary data
         for this preprint and logs that change.
@@ -1389,11 +1411,12 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
                 auth=auth
             )
         if not has_data_links:
-            self.update_data_links(auth, data_links=[], log=False)
+            self.update_data_links(auth, data_links=[], log=False, **kwargs)
         if save:
             self.save()
 
-    def update_data_links(self, auth: Auth, data_links: list, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_data_links(self, auth: Auth, data_links: list, log: bool = True, save: bool = True, **kwargs):
         """
         This method sets the field `data_links` which is a validated list of links to supplementary data for a
         preprint and logs that change.
@@ -1425,7 +1448,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_why_no_data(self, auth: Auth, why_no_data: str, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_why_no_data(self, auth: Auth, why_no_data: str, log: bool = True, save: bool = True, **kwargs):
         """
         This method sets the field `why_no_data` a string that represents a user provided explanation for the
         unavailability of supplementary data for their preprint.
@@ -1457,7 +1481,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_has_prereg_links(self, auth: Auth, has_prereg_links: bool, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_has_prereg_links(self, auth: Auth, has_prereg_links: bool, log: bool = True, save: bool = True, **kwargs):
         """
         This method updates the `has_prereg_links` field, that indicates availability of links to prereg data and logs
         changes to it.
@@ -1489,12 +1514,13 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
                 auth=auth
             )
         if not has_prereg_links:
-            self.update_prereg_links(auth, prereg_links=[], log=False)
-            self.update_prereg_link_info(auth, prereg_link_info=None, log=False)
+            self.update_prereg_links(auth, prereg_links=[], log=False, **kwargs)
+            self.update_prereg_link_info(auth, prereg_link_info=None, log=False, **kwargs)
         if save:
             self.save()
 
-    def update_why_no_prereg(self, auth: Auth, why_no_prereg: str, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_why_no_prereg(self, auth: Auth, why_no_prereg: str, log: bool = True, save: bool = True, **kwargs):
         """
         This method updates the field `why_no_prereg` that contains a user provided explanation of prereg data
         unavailability and logs changes to it.
@@ -1526,7 +1552,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_prereg_links(self, auth: Auth, prereg_links: list, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_prereg_links(self, auth: Auth, prereg_links: list, log: bool = True, save: bool = True, **kwargs):
         """
         This method updates the field `prereg_links` that contains a list of validated URLS linking to prereg data
         and logs changes to it.
@@ -1558,7 +1585,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def update_prereg_link_info(self, auth: Auth, prereg_link_info: str, log: bool = True, save: bool = True):
+    @require_permission([ADMIN])
+    def update_prereg_link_info(self, auth: Auth, prereg_link_info: str, log: bool = True, save: bool = True, **kwargs):
         """
         This method updates the field `prereg_link_info` that contains a one of a finite number of choice strings in
         contained in the list in the static member `PREREG_LINK_INFO_CHOICES` that describe the nature of the preprint's

--- a/website/files/utils.py
+++ b/website/files/utils.py
@@ -1,7 +1,7 @@
 from osf.models.metadata import GuidMetadataRecord
 
 
-def copy_files(src, target_node, parent=None, name=None):
+def copy_files(src, target_node, parent=None, name=None, **version_filters):
     """Copy the files from src to the target node
     :param Folder src: The source to copy children from
     :param Node target_node: The node to copy files to
@@ -18,7 +18,7 @@ def copy_files(src, target_node, parent=None, name=None):
 
     cloned.save()
     if src.is_file and src.versions.exists():
-        fileversions = src.versions.select_related('region').order_by('-created')
+        fileversions = src.versions.filter(**version_filters).select_related('region').order_by('-created')
         most_recent_fileversion = fileversions.first()
         if most_recent_fileversion.region and most_recent_fileversion.region != target_node.osfstorage_region:
             # add all original version except the most recent
@@ -29,7 +29,7 @@ def copy_files(src, target_node, parent=None, name=None):
             new_fileversion.save()
             attach_versions(cloned, [new_fileversion], src)
         else:
-            attach_versions(cloned, src.versions.all(), src)
+            attach_versions(cloned, fileversions, src)
 
         if renaming:
             latest_version = cloned.versions.first()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Add "Create new version 1" button on admin UI

## Changes

- Add button to admin UI
- Extend existing preprint versioning functionality
- Move permission validation logic from serializer to model level to keep everything in one place
    - add required_permission decorator (with ignore_permission functionality) that checks if user has enough permission to call method

[Screencast from 2025-04-22 14-43-05.webm](https://github.com/user-attachments/assets/83081f85-61fb-41ac-865b-e853f9d0d4db)

## QA Notes

Expected behavior:
1. Admin goes the preprint admin page
2. Clicks "Create new version 1", a modal asking to choose date will be displayed
3. If date is valid and file versions exists:
    - a new version 1 will be created
    - admin user will be redirected to v1
    - optionally, admin user can make new preprint published by clicking "Make published" button

(!) Preprint guid should point to the latest version, not the newly created one.
(!) Admin should be able to create new versions of a preprint even if  they are not a contributor.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-7716