### PR TITLE
[ENG-7557] Ignore deleted nodes when do gdpr deletion in admin

### DIFF
--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -141,6 +141,16 @@ class TestGDPRDeleteUser(AdminTestCase):
         response = self.view.as_view()(request, guid=user._id)
         self.assertEqual(response.status_code, 302)
 
+    def test_user_with_deleted_node_is_deleted(self):
+        patch_messages(self.request)
+
+        project = ProjectFactory(creator=self.user, is_deleted=True)
+        assert self.user.nodes.filter(id=project.id, is_deleted=True).count()
+
+        self.view().post(self.request)
+        self.user.reload()
+        assert self.user.deleted
+
 
 class TestDisableUser(AdminTestCase):
     def setUp(self):

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1986,7 +1986,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             is_active=True
         ).exclude(id=self.id).exists()
 
-        if not alternate_admins:
+        if not resource.deleted and not alternate_admins:
             raise UserStateError(
                 f'You cannot delete {resource.__class__.__name__} {resource._id} because it would be '
                 f'a {resource.__class__.__name__} with contributors, but with no admin.'


### PR DESCRIPTION
## Purpose

When user has a deleted node where he is the only admin, osf admin can't gdpr delete this user because of this error
![image](https://github.com/user-attachments/assets/b764aaf7-fff0-4224-bf47-96e6183c1a7c)

## Changes

Ignore this message for deleted nodes. Added a test

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145/backlog?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&selectedIssue=ENG-7557