### PR TITLE
[ENG-7716] Allow for reinstatement of previous preprint versions (with date uploaded) via the admin app

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -897,8 +897,9 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         if save:
             self.save()
 
-    def set_preprint_license(self, license_detail, auth, save=False):
-        license_record, license_changed = set_license(self, license_detail, auth, node_type='preprint')
+    @require_permission([WRITE])
+    def set_preprint_license(self, license_detail, auth, save=False, **kwargs):
+        license_record, license_changed = set_license(self, license_detail, auth, node_type='preprint', **kwargs)
 
         if license_changed:
             self.add_log(

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -6,7 +6,7 @@ from osf import exceptions as osf_exceptions
 from osf.utils import permissions
 
 
-def set_license(node, license_detail, auth, node_type='node'):
+def set_license(node, license_detail, auth, node_type='node', ignore_permission=False):
     NodeLicense = apps.get_model('osf.NodeLicense')
     NodeLicenseRecord = apps.get_model('osf.NodeLicenseRecord')
 
@@ -26,7 +26,7 @@ def set_license(node, license_detail, auth, node_type='node'):
     ):
         return {}, False
 
-    if not node.has_permission(auth.user, permissions.WRITE):
+    if not ignore_permission and not node.has_permission(auth.user, permissions.WRITE):
         raise framework_exceptions.PermissionsError(f'You need admin or write permissions to change a {node_type}\'s license')
 
     try:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

fix for non-contributor admin

## Changes
- add ignore_permission to set_license
- prevent creating new preprint version when serializer raises error

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
