### PR TITLE
[ENG-7704] Accounts confirmed but not Registered

### DIFF
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -456,9 +456,6 @@ class GetUserLink(UserMixin, TemplateView):
 
 class GetUserConfirmationLink(GetUserLink):
     def get_link(self, user):
-        if user.is_confirmed:
-            return f'User {user._id} is already confirmed'
-
         if user.deleted or user.is_merged:
             return f'User {user._id} is deleted or merged'
 

--- a/osf/management/commands/deactivate_requested_accounts.py
+++ b/osf/management/commands/deactivate_requested_accounts.py
@@ -31,7 +31,6 @@ def deactivate_requested_accounts(dry_run=True):
             logger.info(f'Disabling user {user._id}.')
             if not dry_run:
                 user.deactivate_account()
-                user.is_registered = False
                 mails.send_mail(
                     to_addr=user.username,
                     mail=mails.REQUEST_DEACTIVATION_COMPLETE,

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -2222,7 +2222,6 @@ class SpamOverrideMixin(SpamMixin):
         user.flag_spam()
         if not user.is_disabled:
             user.deactivate_account()
-            user.is_registered = False
             mails.send_mail(
                 to_addr=user.username,
                 mail=mails.SPAM_USER_BANNED,

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1284,7 +1284,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             validate_email(email)
 
         if not external_identity and self.emails.filter(address=email).exists():
-            if not force or self.is_confirmed:
+            if not force and self.is_confirmed:
                 raise ValueError('Email already confirmed to this user.')
 
         # If the unconfirmed email is already present, refresh the token


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

fix broken users

## Changes

- do not unregister users when deactivate spam

## QA Notes

How I was able to recreate it:
In admin go to managment commands -> Ban spam users by regular expression and ban some users (Actually there may be other ways to recreate it using spam feature in different ways like management commands, scheduled spam checks and so on). They will become unregistered, disabled and confirmed. Then we can reactivate account in admin to make it enabled but not registered

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7704
