### PR TITLE
[Feature] Adding indication for comments on projects

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -337,6 +337,9 @@ class BaseFileSerializer(JSONAPISerializer):
             return 0
         return Comment.find_n_unread(user=user, node=obj.target, page='files', root_id=obj.get_guid()._id)
 
+    def get_comments_count(self, obj):
+        return Comment.find_count(node=obj.target, page='files', root_id=obj.get_guid()._id)
+
     def user_id(self, obj):
         # NOTE: obj is the user here, the meta field for
         # Hyperlinks is weird

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -244,7 +244,7 @@ class BaseFileSerializer(JSONAPISerializer):
         FileRelationshipField(
             related_view='nodes:node-comments',
             related_view_kwargs={'node_id': '<target._id>'},
-            related_meta={'unread': 'get_unread_comments_count'},
+            related_meta={'unread': 'get_unread_comments_count', 'comment_count': 'get_comments_count'},
             filter={'target': 'get_file_guid'},
         ),
     )

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -327,7 +327,7 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
     comments = RelationshipField(
         related_view='nodes:node-comments',
         related_view_kwargs={'node_id': '<_id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
+        related_meta={'unread': 'get_unread_comments_count', 'comment_count': 'get_comments_count'},
         filter={'target': '<_id>'},
     )
 
@@ -722,6 +722,13 @@ class NodeSerializer(TaxonomizableSerializerMixin, JSONAPISerializer):
 
         return {
             'node': node_comments,
+        }
+
+    def get_comments_count(self, obj):
+        node_comment_count = Comment.find_count(node=obj, page='node')
+
+        return {
+            'node_comment_count': node_comment_count,
         }
 
     def get_region_id(self, obj):

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -223,6 +223,7 @@ class RegistrationSerializer(NodeSerializer):
             related_meta={
                 'unread': 'get_unread_comments_count',
                 'count': 'get_total_comments_count',
+                'comment_count': 'get_comments_count',
             },
             filter={'target': '<_id>'},
         ),
@@ -948,7 +949,7 @@ class RegistrationFileSerializer(OsfStorageFileSerializer):
     comments = FileRelationshipField(
         related_view='registrations:registration-comments',
         related_view_kwargs={'node_id': '<target._id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
+        related_meta={'unread': 'get_unread_comments_count', 'comment_count': 'get_comments_count'},
         filter={'target': 'get_file_guid'},
     )
 

--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -102,7 +102,7 @@ class NodeWikiSerializer(WikiSerializer):
     comments = RelationshipField(
         related_view='nodes:node-comments',
         related_view_kwargs={'node_id': '<node._id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
+        related_meta={'unread': 'get_unread_comments_count', 'comment_count': 'get_comments_count'},
         filter={'target': '<_id>'},
     )
 
@@ -158,7 +158,7 @@ class RegistrationWikiSerializer(WikiSerializer):
     comments = RelationshipField(
         related_view='registrations:registration-comments',
         related_view_kwargs={'node_id': '<node._id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
+        related_meta={'unread': 'get_unread_comments_count', 'comment_count': 'get_comments_count'},
         filter={'target': '<_id>'},
     )
 

--- a/osf/models/comment.py
+++ b/osf/models/comment.py
@@ -135,6 +135,21 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
         return 0
 
     @classmethod
+    def find_count(cls, node, page, root_id=None):
+        if page == Comment.OVERVIEW:
+            root_target = Guid.load(node._id)
+        elif page == Comment.FILES or page == Comment.WIKI:
+            root_target = Guid.load(root_id)
+        else:
+            raise ValueError('Invalid page')
+
+        return cls.objects.filter(
+            Q(node=node) & 
+            Q(is_deleted=False) &
+            Q(root_target=root_target)
+        ).count()
+
+    @classmethod
     def create(cls, auth, **kwargs):
         comment = cls(**kwargs)
         if not comment.node.can_comment(auth):

--- a/osf_tests/test_comment.py
+++ b/osf_tests/test_comment.py
@@ -457,6 +457,37 @@ class TestCommentModel:
         n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert n_unread == 0
 
+    #Comment count tests
+    def test_find_count_is_zero_when_no_comments(self):
+        n_count = Comment.find_count(node=ProjectFactory(), page='node')
+        assert n_count == 0
+
+    def test_find_count_new_comments(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.add_contributor(user, save=True)
+        CommentFactory(node=project, user=project.creator)
+        n_count = Comment.find_count(node=project, page='node')
+        assert n_count == 1
+
+    def test_find_count_includes_comment_replies(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.add_contributor(user, save=True)
+        comment = CommentFactory(node=project, user=user)
+        CommentFactory(node=project, target=Guid.load(comment._id), user=project.creator)
+        n_count = Comment.find_count(node=project, page='node')
+        assert n_count == 1
+
+    def test_find_count_does_not_include_deleted_comments(self):
+        project = ProjectFactory()
+        user = AuthUserFactory()
+        project.add_contributor(user)
+        project.save()
+        CommentFactory(node=project, user=project.creator, is_deleted=True)
+        n_count = Comment.find_count(node=project, page='node')
+        assert n_count == 0
+
 
 # copied from tests/test_comments.py
 class FileCommentMoveRenameTestMixin:

--- a/website/static/css/commentpane.css
+++ b/website/static/css/commentpane.css
@@ -54,9 +54,13 @@
 
 .comment-handle-icon {
     padding-top: 2px;
-    color: #428bca;
+    color: #333333;
     cursor: pointer;
     position: relative;
+}
+
+.comment-handle-icon.has-comments {
+    color: #428bca;
 }
 
 .cp-bar {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -291,6 +291,9 @@ BaseComment.prototype.fetchNext = function(url, comments, setUnread) {
             self.$root.unreadComments(response.links.meta.unread);
             setUnread = false;
         }
+        if (response.links.meta.comment_count) {
+            self.$root.totalComments(response.links.meta.comment_count);
+        }
         comments.forEach(function(comment) {
             self.comments.push(
                 new CommentModel(comment, self, self.$root)
@@ -777,6 +780,15 @@ var CommentListModel = function(options) {
             return self.unreadComments().toString();
         } else {
             return ' ';
+        }
+    });
+
+    self.totalComments = ko.observable(0);
+    self.hasComments = ko.pureComputed(function() {
+        if (self.totalComments() !== 0) {
+            return true;
+        } else {
+            return false;
         }
     });
 

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -4,7 +4,8 @@
         <span data-bind="if: unreadComments() !== 0">
             <span data-bind="text: displayCount" class="badge unread-comments-count"></span>
         </span>
-        <i class="fa fa-comments-o fa-2x comment-handle-icon"></i>
+        <i class="fa fa-comments-o fa-2x comment-handle-icon"
+            data-bind="css: { 'has-comments': hasComments }"></i>
     </div>
     <div class="cp-bar"></div>
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

Responding to feature request #9681. On project pages, comments are only indicated to contributors or group members and only when they are unread. Often, the only way to know if a project has comments is to open the comment panel. This PR adds an indication of comments that is accessible to all users. 

## Changes

<!-- Briefly describe or list your changes  -->
Checks if there are comments on a page regardless of who the user is. The comment icon will now be black if there are no comments, and will turn blue (which is what the current icon defaults to) if there are comments. This does not track read status, it only indicates if a project has comments. 

## QA Notes

While the project compiles correctly on my machine, and I don't foresee any issues, there always seems to be risk of compilation issues. Tests were written to ensure that the code worked. 

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
Documentation won't need to be updated. 

## Side Effects

<!-- Any possible side effects? -->
There should not be any side effects. 

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
N/A