### PR TITLE
[ENG-7879] Ability to resync preprints that have missing doi with Crossref

### DIFF
--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -150,10 +150,12 @@ class IngestCedarMetadataTemplates(ManagementCommandPermissionView):
 class BulkResync(ManagementCommandPermissionView):
 
     def post(self, request):
+        missing_dois_only = request.POST.get('missing_preprint_dois_only', False)
         sync_doi_metadata.apply_async(kwargs={
             'modified_date': timezone.now(),
             'batch_size': None,
-            'dry_run': False
+            'dry_run': False,
+            'missing_preprint_dois_only': missing_dois_only
         })
         messages.success(request, 'Resyncing with CrossRef and DataCite! It will take some time.')
         return redirect(reverse('management:commands'))

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -74,7 +74,7 @@
                     <label>Nodes:</label>   <input type="checkbox" name="node_ban" checked /><br>
                     <label>Registrations:</label>   <input type="checkbox" name="registration_ban" checked /><br>
                     <label>Preprints:</label>  <input type="checkbox" name="preprint_ban" checked /><br>
-                    <input class="btn btn-danger" type="submit" value="Run" style="color: red" />
+                    <input class="btn btn-danger" type="submit" value="Run" style="color: white" />
                 </form>
             </ul>
             <section>
@@ -133,6 +133,7 @@
                 <form method="post"
                       action="{% url 'management:bulk-resync'%}">
                     {% csrf_token %}
+                    <label>Only preprints missing DOI:</label>  <input type="checkbox" name="missing_preprint_dois_only"/><br>
                     <nav>
                         <input class="btn btn-success" type="submit" value="Run" />
                     </nav>

--- a/osf/management/commands/sync_doi_metadata.py
+++ b/osf/management/commands/sync_doi_metadata.py
@@ -5,7 +5,7 @@ import logging
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
-from osf.models import GuidMetadataRecord, Identifier, Registration
+from osf.models import GuidMetadataRecord, Identifier, Registration, Preprint
 from framework.celery_tasks import app
 
 logger = logging.getLogger(__name__)
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_RETRY_DELAY = 60 * 5
 
 
-@app.task(name='osf.management.commands.sync_doi_metadata', max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)
-def sync_identifier_doi(identifier_id):
+@app.task(name='osf.management.commands.sync_doi_metadata', bind=True, acks_late=True, max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)
+def sync_identifier_doi(self, identifier_id):
     try:
         identifier = Identifier.objects.get(id=identifier_id)
         identifier.referent.request_identifier_update('doi')
@@ -23,17 +23,21 @@ def sync_identifier_doi(identifier_id):
         logger.info(f'Doi update for {identifier.value} complete')
     except Exception as err:
         logger.warning(f'[{err.__class__.__name__}] Doi update for {identifier.value} failed because of error: {err}')
-        sync_identifier_doi.retry(exc=err, countdown=RATE_LIMIT_RETRY_DELAY)
+        self.retry()
 
 
 @app.task(name='osf.management.commands.sync_doi_metadata_command', max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)
-def sync_doi_metadata(modified_date, batch_size=100, dry_run=True, sync_private=False, rate_limit=100):
+def sync_doi_metadata(modified_date, batch_size=100, dry_run=True, sync_private=False, rate_limit=100, missing_preprint_dois_only=False):
     identifiers = Identifier.objects.filter(
         category='doi',
         deleted__isnull=True,
         modified__lte=modified_date,
         object_id__isnull=False,
     )
+    if missing_preprint_dois_only:
+        sync_preprint_missing_dois.apply_async()
+        identifiers = identifiers.exclude(content_type=ContentType.objects.get_for_model(Preprint))
+
     if batch_size:
         identifiers = identifiers[:batch_size]
         rate_limit = batch_size if batch_size > rate_limit else rate_limit
@@ -53,6 +57,17 @@ def sync_doi_metadata(modified_date, batch_size=100, dry_run=True, sync_private=
 
         if (identifier.referent.is_public and not identifier.referent.deleted and not identifier.referent.is_retracted) or sync_private:
             sync_identifier_doi.apply_async(kwargs={'identifier_id': identifier.id})
+
+
+@app.task(name='osf.management.commands.sync_preprint_missing_dois', bind=True, acks_late=True, max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)
+def sync_preprint_missing_dois(self):
+    preprints = Preprint.objects.filter(preprint_doi_created=None)
+    for preprint in preprints:
+        try:
+            preprint.request_identifier_update('doi', create=True)
+        except Exception as err:
+            logger.warning(f'[{err.__class__.__name__}] Doi creation failed for the preprint with id {preprint._id} because of error: {err}')
+            self.retry()
 
 
 @app.task(name='osf.management.commands.sync_doi_empty_metadata_dataarchive_registrations_command', max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)


### PR DESCRIPTION
## Purpose

Admins should be able to resync preprints without minted doi with Crossref instead of all preprints.

## Changes

1. Added check mark for syncing only preprints without minted DOI. Fixed text coloring that has red background and red text color
2. Improved retry functionality for sync_identifier_doi task
3. Created a new celery task to resync preprints missing DOI and after that exclude all preprints from identifiers queryset

## Ticket

https://openscience.atlassian.net/browse/ENG-7879?atlOrigin=eyJpIjoiZWRiM2Q0ZWI4YzZlNGRlOTg5NDMzMmRjZWQ5YjQ2NjkiLCJwIjoiaiJ9