### PR TITLE
[ENG-5037] Call share update on preprint withdrawal

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -201,6 +201,8 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         'primary_file',
         'contributors',
         'tags',
+        'date_withdrawn',
+        'withdrawal_justification'
     }
 
     PREREG_LINK_INFO_CHOICES = [('prereg_designs', 'Pre-registration of study designs'),


### PR DESCRIPTION
## Purpose

Share update is not called when user withdrawals preprint and updates `date_withdrawn` and `withdrawal_justification` fields

## Changes

Updated SEARCH_UPDATE_FIELDS, added a test

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?assignee=712020%3A7c7368dc-40cb-475f-bae8-b07a8bd2dd6c&assignee=557058%3A5fafb22b-df22-41bd-8ed5-d7701be68048&selectedIssue=ENG-5037