### PR TITLE
[ENG-7873] CLONE - SPAM - When Hamming a Spammed user, preprints and registrations remain private

### DIFF
--- a/osf/management/commands/force_archive.py
+++ b/osf/management/commands/force_archive.py
@@ -380,6 +380,7 @@ def archive_registrations(*args, **kwargs):
         VERIFIED.remove(reg)
 
 def verify(registration, permissible_addons=DEFAULT_PERMISSIBLE_ADDONS, raise_error=False):
+    permissible_addons = set(permissible_addons)
     maybe_suppress_error = contextlib.suppress(ValidationError) if not raise_error else contextlib.nullcontext(enter_result=False)
 
     for reg in registration.node_and_primary_descendants():

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -995,10 +995,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             )
         except mailchimp_utils.OSFError as error:
             sentry.log_exception(error)
-            sentry.log_message(error)
         except Exception as error:
             sentry.log_exception(error)
-            sentry.log_message(error)
         # Call to `unsubscribe` above saves, and can lead to stale data
         self.reload()
         self.is_disabled = True
@@ -1022,10 +1020,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             subscribe_on_confirm(self)
         except OSFError as error:
             sentry.log_exception(error)
-            sentry.log_message(error)
         except Exception as error:
             sentry.log_exception(error)
-            sentry.log_message(error)
         signals.user_account_reactivated.send(self)
 
     def update_is_active(self):

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -2428,6 +2428,23 @@ class TestNodeSpam:
         assert project.is_spammy
         assert project.is_public is False
 
+    @mock.patch.object(settings, 'SPAM_FLAGGED_MAKE_NODE_PRIVATE', True)
+    def test_project_remains_recoverable_after_multiple_spam_flags(self, project):
+        project.set_privacy('public')
+        assert project.is_public
+
+        project.confirm_spam()
+        assert project.is_public is False
+        assert project.was_public_at_spam is True
+
+        project.flag_spam()
+        assert project.is_public is False
+        assert project.was_public_at_spam is True
+
+        project.confirm_spam()
+        assert project.is_public is False
+        assert project.was_public_at_spam is True
+
 
 # copied from tests/test_models.py
 class TestPrivateLinks:

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -2445,6 +2445,25 @@ class TestNodeSpam:
         assert project.is_public is False
         assert project.was_public_at_spam is True
 
+    def test_multiple_privacy_changing(self, project):
+        project.set_privacy('public')
+        assert project.is_public
+
+        project.confirm_spam()
+        assert not project.is_public
+
+        project.confirm_ham()
+        assert project.is_public
+
+        project.set_privacy('private')
+        assert not project.is_public
+
+        project.confirm_spam()
+        assert not project.is_public
+
+        project.confirm_ham()
+        assert not project.is_public
+
 
 # copied from tests/test_models.py
 class TestPrivateLinks:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

fix was_public state when flag spam

## Changes

- correct check if node was public when flag_spam
- use earliest confirm/flag spam log to check if node was public instead of the latest one
---
- fix TypeError when check archiving status for stuck registrations (not related to ticket ENG-7873, but it's just one line `permissible_addons = set(permissible_addons)`, so no additional testing is required)

## QA Notes

I couldn't reproduce this issue via UI, but combination `confirm_spam()` -> `flag_spam()` -> `...` breaks this feature. I'm not sure if it's exactly what's happening in our case, but since `flag_spam()` is used with automatic spam checks during node/preprint updates, it's quite possible.

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7873
