### PR TITLE
[ENG-6206] Try to handle an unknown error for async email confirmation

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -970,39 +970,42 @@ def resend_confirmation_post(auth):
     View for user to submit resend confirmation form.
     HTTP Method: POST
     """
+    try:
+        # If user is already logged in, log user out
+        if auth.logged_in:
+            return auth_logout(redirect_url=request.url)
 
-    # If user is already logged in, log user out
-    if auth.logged_in:
-        return auth_logout(redirect_url=request.url)
+        form = ResendConfirmationForm(request.form)
 
-    form = ResendConfirmationForm(request.form)
-
-    if form.validate():
-        clean_email = form.email.data
-        user = get_user(email=clean_email)
-        status_message = (
-            f'If there is an OSF account associated with this unconfirmed email address {clean_email}, '
-            'a confirmation email has been resent to it. If you do not receive an email and believe '
-            'you should have, please contact OSF Support.'
-        )
-        kind = 'success'
-        if user:
-            if throttle_period_expired(user.email_last_sent, settings.SEND_EMAIL_THROTTLE):
-                try:
-                    send_confirm_email(user, clean_email, renew=True)
-                except KeyError:
-                    # already confirmed, redirect to dashboard
-                    status_message = f'This email {clean_email} has already been confirmed.'
-                    kind = 'warning'
-                user.email_last_sent = timezone.now()
-                user.save()
-            else:
-                status_message = ('You have recently requested to resend your confirmation email. '
-                                 'Please wait a few minutes before trying again.')
-                kind = 'error'
-        status.push_status_message(status_message, kind=kind, trust=False)
-    else:
-        forms.push_errors_to_status(form.errors)
+        if form.validate():
+            clean_email = form.email.data
+            user = get_user(email=clean_email)
+            status_message = (
+                f'If there is an OSF account associated with this unconfirmed email address {clean_email}, '
+                'a confirmation email has been resent to it. If you do not receive an email and believe '
+                'you should have, please contact OSF Support.'
+            )
+            kind = 'success'
+            if user:
+                if throttle_period_expired(user.email_last_sent, settings.SEND_EMAIL_THROTTLE):
+                    try:
+                        send_confirm_email_async(user, clean_email, renew=True)
+                        # send_confirm_email(user, clean_email, renew=True)
+                    except KeyError:
+                        # already confirmed, redirect to dashboard
+                        status_message = f'This email {clean_email} has already been confirmed.'
+                        kind = 'warning'
+                    user.email_last_sent = timezone.now()
+                    user.save()
+                else:
+                    status_message = ('You have recently requested to resend your confirmation email. '
+                                    'Please wait a few minutes before trying again.')
+                    kind = 'error'
+            status.push_status_message(status_message, kind=kind, trust=False)
+        else:
+            forms.push_errors_to_status(form.errors)
+    except Exception as err:
+        sentry.log_exception(f'Async email confirmation failed because of the error: {err}')
 
     # Don't go anywhere
     return {'form': form}


### PR DESCRIPTION
## Purpose

This isn't actual solution, just a way to handle error as it isn't reproducible locally, potentially because of smtp that is not used locally

## Changes

Added exception handler, swapped sync call for async version

## Ticket

https://openscience.atlassian.net/browse/ENG-6206?atlOrigin=eyJpIjoiMjQ1MDJjNmEwMDlkNDFlM2E5MTBhOTA4MWViY2NkNTciLCJwIjoiaiJ9