### PR TITLE
[ENG-7839] [ENG-7766] Add celery task to update Datacite metadata + Use new GV API endpoint to retrieve node's verified links + Update unit tests

### DIFF
--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -510,7 +510,8 @@ class TestConfirmApproveBacklogView(AdminTestCase):
             mock_get_links.return_value = []
             yield mock_get_links
 
-    def test_request_approval_is_approved(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_request_approval_is_approved(self):
         now = timezone.now()
         self.approval = RegistrationApprovalFactory(
             initiation_date=now - timezone.timedelta(days=1),

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -504,13 +504,8 @@ class TestConfirmApproveBacklogView(AdminTestCase):
         super().setUp()
         self.user = AuthUserFactory()
         self.node = ProjectFactory(creator=self.user)
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_request_approval_is_approved(self):
         now = timezone.now()
         self.approval = RegistrationApprovalFactory(

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -504,8 +504,13 @@ class TestConfirmApproveBacklogView(AdminTestCase):
         super().setUp()
         self.user = AuthUserFactory()
         self.node = ProjectFactory(creator=self.user)
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
-    def test_request_approval_is_approved(self):
+    def test_request_approval_is_approved(self, mock_gravy_valet_get_links):
         now = timezone.now()
         self.approval = RegistrationApprovalFactory(
             initiation_date=now - timezone.timedelta(days=1),

--- a/admin_tests/registrations/test_registrations.py
+++ b/admin_tests/registrations/test_registrations.py
@@ -130,6 +130,7 @@ class TestRegistrationSpamHam:
         public_registration_from_changed_to_private_project.confirm_ham(save=True)
         assert public_registration_from_changed_to_private_project.is_public
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_unapproved_registration_task(self, embargoed_registration_from_changed_to_public_project):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)

--- a/admin_tests/registrations/test_registrations.py
+++ b/admin_tests/registrations/test_registrations.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from scripts.approve_registrations import main as approve_registrations_runner
 from datetime import timedelta
 import pytest
@@ -70,12 +68,6 @@ class TestRegistrationSpamHam:
     def embargoed_registration_from_changed_to_private_project(self, superuser, private_project_from_public):
         return RegistrationFactory(project=private_project_from_public, creator=superuser, is_embargoed=True)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     def test_embargoed_registration_from_public_project_spam_ham(self, embargoed_registration_from_public_project):
         embargoed_registration_from_public_project.confirm_spam(save=True)
         assert not embargoed_registration_from_public_project.is_public
@@ -100,13 +92,15 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_private_project.confirm_ham(save=True)
         assert not embargoed_registration_from_changed_to_private_project.is_public
 
-    def test_public_registration_from_public_project_spam_ham(self, superuser, public_registration_from_public_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_public_registration_from_public_project_spam_ham(self, superuser, public_registration_from_public_project):
         public_registration_from_public_project.confirm_spam(save=True)
         assert not public_registration_from_public_project.is_public
         public_registration_from_public_project.confirm_ham(save=True)
         assert public_registration_from_public_project.is_public
 
-    def test_public_registration_from_private_project_spam_ham(self, superuser, public_registration_from_private_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_public_registration_from_private_project_spam_ham(self, superuser, public_registration_from_private_project):
         public_registration_from_private_project.confirm_spam(save=True)
         assert not public_registration_from_private_project.is_public
         public_registration_from_private_project.confirm_ham(save=True)
@@ -118,19 +112,21 @@ class TestRegistrationSpamHam:
         private_registration_from_public_project.confirm_ham(save=True)
         assert not private_registration_from_public_project.is_public
 
-    def test_public_registration_from_changed_to_public_project_spam_ham(self, superuser, public_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_public_registration_from_changed_to_public_project_spam_ham(self, superuser, public_registration_from_changed_to_public_project):
         public_registration_from_changed_to_public_project.confirm_spam(save=True)
         assert not public_registration_from_changed_to_public_project.is_public
         public_registration_from_changed_to_public_project.confirm_ham(save=True)
         assert public_registration_from_changed_to_public_project.is_public
 
-    def test_public_registration_from_changed_to_private_project_spam_ham(self, superuser, public_registration_from_changed_to_private_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_public_registration_from_changed_to_private_project_spam_ham(self, superuser, public_registration_from_changed_to_private_project):
         public_registration_from_changed_to_private_project.confirm_spam(save=True)
         assert not public_registration_from_changed_to_private_project.is_public
         public_registration_from_changed_to_private_project.confirm_ham(save=True)
         assert public_registration_from_changed_to_private_project.is_public
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_unapproved_registration_task(self, embargoed_registration_from_changed_to_public_project):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)
@@ -140,7 +136,8 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_public_project.registration_approval.refresh_from_db()
         assert embargoed_registration_from_changed_to_public_project.registration_approval.state == 'approved'
 
-    def test_unapproved_registration_task_after_spam(self, embargoed_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_unapproved_registration_task_after_spam(self, embargoed_registration_from_changed_to_public_project):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)
         embargoed_registration_from_changed_to_public_project.registration_approval.save()
@@ -150,7 +147,8 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_public_project.registration_approval.refresh_from_db()
         assert embargoed_registration_from_changed_to_public_project.registration_approval.state == 'unapproved'
 
-    def test_unapproved_registration_task_after_spam_ham(self, embargoed_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_unapproved_registration_task_after_spam_ham(self, embargoed_registration_from_changed_to_public_project):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)
         embargoed_registration_from_changed_to_public_project.registration_approval.save()

--- a/admin_tests/registrations/test_registrations.py
+++ b/admin_tests/registrations/test_registrations.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from scripts.approve_registrations import main as approve_registrations_runner
 from datetime import timedelta
 import pytest
@@ -68,6 +70,12 @@ class TestRegistrationSpamHam:
     def embargoed_registration_from_changed_to_private_project(self, superuser, private_project_from_public):
         return RegistrationFactory(project=private_project_from_public, creator=superuser, is_embargoed=True)
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_embargoed_registration_from_public_project_spam_ham(self, embargoed_registration_from_public_project):
         embargoed_registration_from_public_project.confirm_spam(save=True)
         assert not embargoed_registration_from_public_project.is_public
@@ -92,13 +100,13 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_private_project.confirm_ham(save=True)
         assert not embargoed_registration_from_changed_to_private_project.is_public
 
-    def test_public_registration_from_public_project_spam_ham(self, superuser, public_registration_from_public_project):
+    def test_public_registration_from_public_project_spam_ham(self, superuser, public_registration_from_public_project, mock_gravy_valet_get_links):
         public_registration_from_public_project.confirm_spam(save=True)
         assert not public_registration_from_public_project.is_public
         public_registration_from_public_project.confirm_ham(save=True)
         assert public_registration_from_public_project.is_public
 
-    def test_public_registration_from_private_project_spam_ham(self, superuser, public_registration_from_private_project):
+    def test_public_registration_from_private_project_spam_ham(self, superuser, public_registration_from_private_project, mock_gravy_valet_get_links):
         public_registration_from_private_project.confirm_spam(save=True)
         assert not public_registration_from_private_project.is_public
         public_registration_from_private_project.confirm_ham(save=True)
@@ -110,13 +118,13 @@ class TestRegistrationSpamHam:
         private_registration_from_public_project.confirm_ham(save=True)
         assert not private_registration_from_public_project.is_public
 
-    def test_public_registration_from_changed_to_public_project_spam_ham(self, superuser, public_registration_from_changed_to_public_project):
+    def test_public_registration_from_changed_to_public_project_spam_ham(self, superuser, public_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
         public_registration_from_changed_to_public_project.confirm_spam(save=True)
         assert not public_registration_from_changed_to_public_project.is_public
         public_registration_from_changed_to_public_project.confirm_ham(save=True)
         assert public_registration_from_changed_to_public_project.is_public
 
-    def test_public_registration_from_changed_to_private_project_spam_ham(self, superuser, public_registration_from_changed_to_private_project):
+    def test_public_registration_from_changed_to_private_project_spam_ham(self, superuser, public_registration_from_changed_to_private_project, mock_gravy_valet_get_links):
         public_registration_from_changed_to_private_project.confirm_spam(save=True)
         assert not public_registration_from_changed_to_private_project.is_public
         public_registration_from_changed_to_private_project.confirm_ham(save=True)
@@ -131,7 +139,7 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_public_project.registration_approval.refresh_from_db()
         assert embargoed_registration_from_changed_to_public_project.registration_approval.state == 'approved'
 
-    def test_unapproved_registration_task_after_spam(self, embargoed_registration_from_changed_to_public_project):
+    def test_unapproved_registration_task_after_spam(self, embargoed_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)
         embargoed_registration_from_changed_to_public_project.registration_approval.save()
@@ -141,7 +149,7 @@ class TestRegistrationSpamHam:
         embargoed_registration_from_changed_to_public_project.registration_approval.refresh_from_db()
         assert embargoed_registration_from_changed_to_public_project.registration_approval.state == 'unapproved'
 
-    def test_unapproved_registration_task_after_spam_ham(self, embargoed_registration_from_changed_to_public_project):
+    def test_unapproved_registration_task_after_spam_ham(self, embargoed_registration_from_changed_to_public_project, mock_gravy_valet_get_links):
         embargoed_registration_from_changed_to_public_project.registration_approval.state = 'unapproved'
         embargoed_registration_from_changed_to_public_project.registration_approval.initiation_date -= timedelta(3)
         embargoed_registration_from_changed_to_public_project.registration_approval.save()

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -58,7 +58,7 @@ class TestSyncDOIs:
         assert registration_identifier.modified.date() < datetime.datetime.now().date()
 
         call_command('sync_doi_metadata', f'-m={datetime.datetime.now()}')
-        assert len(mock_datacite.calls) == 3
+        assert len(mock_datacite.calls) == 2
         update_metadata, update_doi = mock_datacite.calls
         assert update_metadata.request.url == f'{settings.DATACITE_URL}/metadata'
         assert update_doi.request.url == f'{settings.DATACITE_URL}/doi'

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -1,6 +1,5 @@
 import datetime
 
-from unittest import mock
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
@@ -53,12 +52,6 @@ class TestSyncDOIs:
         identifier.modified = timezone.now() - datetime.timedelta(days=1)
         identifier.save(update_modified=False)
         return identifier
-
-    @pytest.fixture(autouse=True)
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @pytest.mark.enable_enqueue_task

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -1,5 +1,6 @@
 import datetime
 
+from unittest import mock
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
@@ -52,6 +53,12 @@ class TestSyncDOIs:
         identifier.modified = timezone.now() - datetime.timedelta(days=1)
         identifier.save(update_modified=False)
         return identifier
+
+    @pytest.fixture(autouse=True)
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
     @pytest.mark.enable_enqueue_task
     def test_doi_synced_datacite(self, app, registration, registration_identifier, mock_datacite):

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -60,6 +60,7 @@ class TestSyncDOIs:
             mock_get_links.return_value = []
             yield mock_get_links
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @pytest.mark.enable_enqueue_task
     def test_doi_synced_datacite(self, app, registration, registration_identifier, mock_datacite):
         assert registration_identifier.modified.date() < datetime.datetime.now().date()
@@ -73,6 +74,7 @@ class TestSyncDOIs:
         registration_identifier.reload()
         assert registration_identifier.modified.date() == datetime.datetime.now().date()
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @pytest.mark.enable_enqueue_task
     def test_doi_synced_crossref(self, app, preprint_identifier, mock_crossref):
         assert preprint_identifier.modified.date() < datetime.datetime.now().date()
@@ -84,6 +86,7 @@ class TestSyncDOIs:
         preprint_identifier.reload()
         assert preprint_identifier.modified.date() == datetime.datetime.now().date()
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @pytest.mark.enable_enqueue_task
     def test_doi_sync_private(self, app, registration_private, registration_identifier, mock_datacite):
 
@@ -98,6 +101,7 @@ class TestSyncDOIs:
         assert registration_identifier.modified.date() < datetime.datetime.now().date()
         assert registration_identifier.modified.date() < datetime.datetime.now().date()
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @pytest.mark.enable_enqueue_task
     def test_doi_sync_public_only(self, app, registration_private, registration_identifier, mock_datacite):
         call_command('sync_doi_metadata', f'-m={datetime.datetime.now()}')

--- a/api_tests/identifiers/managment_commands/test_sync_dois.py
+++ b/api_tests/identifiers/managment_commands/test_sync_dois.py
@@ -58,7 +58,7 @@ class TestSyncDOIs:
         assert registration_identifier.modified.date() < datetime.datetime.now().date()
 
         call_command('sync_doi_metadata', f'-m={datetime.datetime.now()}')
-        assert len(mock_datacite.calls) == 2
+        assert len(mock_datacite.calls) == 3
         update_metadata, update_doi = mock_datacite.calls
         assert update_metadata.request.url == f'{settings.DATACITE_URL}/metadata'
         assert update_doi.request.url == f'{settings.DATACITE_URL}/doi'

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from urllib.parse import urlparse
@@ -475,6 +477,13 @@ class TestNodeIdentifierCreate:
     def client(self, resource):
         return DataCiteClient(resource)
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     @responses.activate
     def test_create_identifier(self, app, resource, client, identifier_url, identifier_payload, user,
             write_contributor, read_contributor, ark_payload):

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from urllib.parse import urlparse
@@ -477,13 +475,7 @@ class TestNodeIdentifierCreate:
     def client(self, resource):
         return DataCiteClient(resource)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     @responses.activate
     def test_create_identifier(self, app, resource, client, identifier_url, identifier_payload, user,
             write_contributor, read_contributor, ark_payload):

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -336,16 +336,11 @@ class TestRegistrationUpdateTestCase:
 @pytest.mark.enable_implicit_clean
 class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_update_registration(
             self, app, user, read_only_contributor,
             read_write_contributor, public_registration,
-            public_url, private_url, make_payload, public_project, mock_gravy_valet_get_links):
+            public_url, private_url, make_payload, public_project):
 
         private_registration_payload = make_payload()
         non_contributor = AuthUserFactory()
@@ -422,10 +417,11 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
             expect_errors=True)
         assert res.status_code == 403
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_fields(
             self, app, user, public_registration,
             private_registration, public_url, institution_one,
-            private_url, make_payload, license_cc0, mock_gravy_valet_get_links):
+            private_url, make_payload, license_cc0):
 
         #   test_field_has_invalid_value
         invalid_public_payload = make_payload(
@@ -568,8 +564,9 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
             expect_errors=True)
         assert res.status_code == 400
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_turning_private_registrations_public(
-            self, app, user, make_payload, mock_gravy_valet_get_links):
+            self, app, user, make_payload):
         private_project = ProjectFactory(creator=user, is_public=False)
         private_registration = RegistrationFactory(
             project=private_project, creator=user, is_public=False)
@@ -718,12 +715,6 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
 class TestRegistrationWithdrawal(TestRegistrationUpdateTestCase):
 
     @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    @pytest.fixture
     def public_payload(self, public_registration, make_payload):
         return make_payload(
             id=public_registration._id,
@@ -789,8 +780,9 @@ class TestRegistrationWithdrawal(TestRegistrationUpdateTestCase):
         assert public_registration.registered_from.logs.first().action == 'retraction_initiated'
         assert mock_send_mail.called
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_initiate_withdrawal_with_embargo_ends_embargo(
-            self, app, user, public_project, public_registration, public_url, public_payload, mock_gravy_valet_get_links):
+            self, app, user, public_project, public_registration, public_url, public_payload):
         public_registration.embargo_registration(
             user,
             (timezone.now() + datetime.timedelta(days=10)),
@@ -947,17 +939,12 @@ class TestRegistrationTags:
             }
         }
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_registration_tags(
             self, app, registration_public, registration_private,
             url_registration_public, url_registration_private,
             new_tag_payload_public, new_tag_payload_private,
-            user_admin, user_non_contrib, read_write_contrib, mock_gravy_valet_get_links):
+            user_admin, user_non_contrib, read_write_contrib):
         # test_registration_starts_with_no_tags
         res = app.get(url_registration_public)
         assert res.status_code == 200

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -335,10 +335,17 @@ class TestRegistrationUpdateTestCase:
 @pytest.mark.django_db
 @pytest.mark.enable_implicit_clean
 class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
+
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_update_registration(
             self, app, user, read_only_contributor,
             read_write_contributor, public_registration,
-            public_url, private_url, make_payload, public_project):
+            public_url, private_url, make_payload, public_project, mock_gravy_valet_get_links):
 
         private_registration_payload = make_payload()
         non_contributor = AuthUserFactory()
@@ -418,7 +425,7 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
     def test_fields(
             self, app, user, public_registration,
             private_registration, public_url, institution_one,
-            private_url, make_payload, license_cc0):
+            private_url, make_payload, license_cc0, mock_gravy_valet_get_links):
 
         #   test_field_has_invalid_value
         invalid_public_payload = make_payload(
@@ -562,7 +569,7 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
         assert res.status_code == 400
 
     def test_turning_private_registrations_public(
-            self, app, user, make_payload):
+            self, app, user, make_payload, mock_gravy_valet_get_links):
         private_project = ProjectFactory(creator=user, is_public=False)
         private_registration = RegistrationFactory(
             project=private_project, creator=user, is_public=False)
@@ -711,6 +718,12 @@ class TestRegistrationUpdate(TestRegistrationUpdateTestCase):
 class TestRegistrationWithdrawal(TestRegistrationUpdateTestCase):
 
     @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    @pytest.fixture
     def public_payload(self, public_registration, make_payload):
         return make_payload(
             id=public_registration._id,
@@ -777,7 +790,7 @@ class TestRegistrationWithdrawal(TestRegistrationUpdateTestCase):
         assert mock_send_mail.called
 
     def test_initiate_withdrawal_with_embargo_ends_embargo(
-            self, app, user, public_project, public_registration, public_url, public_payload):
+            self, app, user, public_project, public_registration, public_url, public_payload, mock_gravy_valet_get_links):
         public_registration.embargo_registration(
             user,
             (timezone.now() + datetime.timedelta(days=10)),
@@ -934,11 +947,17 @@ class TestRegistrationTags:
             }
         }
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_registration_tags(
             self, app, registration_public, registration_private,
             url_registration_public, url_registration_private,
             new_tag_payload_public, new_tag_payload_private,
-            user_admin, user_non_contrib, read_write_contrib):
+            user_admin, user_non_contrib, read_write_contrib, mock_gravy_valet_get_links):
         # test_registration_starts_with_no_tags
         res = app.get(url_registration_public)
         assert res.status_code == 200

--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from api.base.settings.defaults import API_BASE
@@ -57,6 +59,12 @@ def registration_with_children_approved_url(registration_with_children_approved)
 @pytest.mark.django_db
 class TestRegistrationsChildrenList:
 
+    @pytest.fixture()
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_registrations_children_list(self, user, app, registration_with_children, registration_with_children_url):
         component_one, component_two, component_three, component_four = registration_with_children.nodes
 
@@ -68,7 +76,15 @@ class TestRegistrationsChildrenList:
         assert component_one._id in ids
         assert component_two._id in ids
 
-    def test_return_registrations_list_no_auth_approved(self, user, app, registration_with_children_approved, registration_with_children_approved_url):
+    def test_return_registrations_list_no_auth_approved(
+        self,
+        user,
+        app,
+        registration_with_children_approved,
+        registration_with_children_approved_url,
+        mock_gravy_valet_get_links
+    ):
+
         component_one, component_two, component_three, component_four = registration_with_children_approved.nodes
 
         res = app.get(registration_with_children_approved_url)

--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -76,13 +76,13 @@ class TestRegistrationsChildrenList:
         assert component_one._id in ids
         assert component_two._id in ids
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_return_registrations_list_no_auth_approved(
         self,
         user,
         app,
         registration_with_children_approved,
-        registration_with_children_approved_url,
-        mock_gravy_valet_get_links
+        registration_with_children_approved_url
     ):
 
         component_one, component_two, component_three, component_four = registration_with_children_approved.nodes

--- a/api_tests/registrations/views/test_registrations_childrens_list.py
+++ b/api_tests/registrations/views/test_registrations_childrens_list.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from api.base.settings.defaults import API_BASE
@@ -59,12 +57,6 @@ def registration_with_children_approved_url(registration_with_children_approved)
 @pytest.mark.django_db
 class TestRegistrationsChildrenList:
 
-    @pytest.fixture()
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     def test_registrations_children_list(self, user, app, registration_with_children, registration_with_children_url):
         component_one, component_two, component_three, component_four = registration_with_children.nodes
 
@@ -76,7 +68,7 @@ class TestRegistrationsChildrenList:
         assert component_one._id in ids
         assert component_two._id in ids
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_return_registrations_list_no_auth_approved(
         self,
         user,

--- a/api_tests/registrations/views/test_withdrawn_registrations.py
+++ b/api_tests/registrations/views/test_withdrawn_registrations.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from urllib.parse import urlparse
 
@@ -65,12 +63,6 @@ class TestWithdrawnRegistrations(NodeCRUDTestCase):
     def url_withdrawn(self, registration):
         return '/{}registrations/{}/?version=2.2'.format(
             API_BASE, registration._id)
-
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     def test_can_access_withdrawn_contributors(
             self, app, user, registration, withdrawn_registration):
@@ -232,7 +224,7 @@ class TestWithdrawnRegistrations(NodeCRUDTestCase):
         assert res.status_code == 200
         assert res.json['data']['relationships']['contributors']['links']['related']['meta']['count'] == 1
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_child_inherits_withdrawal_justification_and_date_withdrawn(
             self, app, user, withdrawn_registration_with_child, registration_with_child):
 

--- a/api_tests/registrations/views/test_withdrawn_registrations.py
+++ b/api_tests/registrations/views/test_withdrawn_registrations.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from urllib.parse import urlparse
 
@@ -63,6 +65,12 @@ class TestWithdrawnRegistrations(NodeCRUDTestCase):
     def url_withdrawn(self, registration):
         return '/{}registrations/{}/?version=2.2'.format(
             API_BASE, registration._id)
+
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
     def test_can_access_withdrawn_contributors(
             self, app, user, registration, withdrawn_registration):

--- a/api_tests/registrations/views/test_withdrawn_registrations.py
+++ b/api_tests/registrations/views/test_withdrawn_registrations.py
@@ -232,6 +232,7 @@ class TestWithdrawnRegistrations(NodeCRUDTestCase):
         assert res.status_code == 200
         assert res.json['data']['relationships']['contributors']['links']['related']['meta']['count'] == 1
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_child_inherits_withdrawal_justification_and_date_withdrawn(
             self, app, user, withdrawn_registration_with_child, registration_with_child):
 

--- a/api_tests/registries_moderation/test_submissions.py
+++ b/api_tests/registries_moderation/test_submissions.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 import datetime
 
@@ -163,6 +165,12 @@ class TestRegistriesModerationSubmissions:
             }
         }
         return payload
+
+    @pytest.fixture(autouse=True)
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
     def test_get_provider_requests(self, app, provider_requests_url, registration_with_withdraw_request, access_request, moderator, moderator_wrong_provider):
         resp = app.get(provider_requests_url, expect_errors=True)

--- a/api_tests/registries_moderation/test_submissions.py
+++ b/api_tests/registries_moderation/test_submissions.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 import datetime
 
@@ -165,12 +163,6 @@ class TestRegistriesModerationSubmissions:
             }
         }
         return payload
-
-    @pytest.fixture(autouse=True)
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     def test_get_provider_requests(self, app, provider_requests_url, registration_with_withdraw_request, access_request, moderator, moderator_wrong_provider):
         resp = app.get(provider_requests_url, expect_errors=True)

--- a/api_tests/registries_moderation/test_submissions.py
+++ b/api_tests/registries_moderation/test_submissions.py
@@ -320,6 +320,7 @@ class TestRegistriesModerationSubmissions:
         resp = app.get(registration_log_url, auth=moderator.auth)
         assert resp.status_code == 200
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_registries_moderation_post_accept(self, app, registration, moderator, registration_actions_url, actions_payload_base, reg_creator):
         registration.require_approval(user=registration.creator)
         registration.registration_approval.accept()
@@ -386,6 +387,7 @@ class TestRegistriesModerationSubmissions:
         embargo_registration.refresh_from_db()
         assert embargo_registration.moderation_state == RegistrationModerationStates.REJECTED.db_name
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_registries_moderation_post_withdraw_accept(self, app, retract_registration, moderator, retract_registration_actions_url, actions_payload_base, provider):
         retract_registration.sanction.accept()
         retract_registration.refresh_from_db()
@@ -416,6 +418,7 @@ class TestRegistriesModerationSubmissions:
         retract_registration.refresh_from_db()
         assert retract_registration.moderation_state == RegistrationModerationStates.ACCEPTED.db_name
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_registries_moderation_post_force_withdraw(self, app, registration, moderator, registration_actions_url, actions_payload_base, provider, reg_creator):
         registration.require_approval(user=registration.creator)
         registration.registration_approval.accept()
@@ -485,6 +488,7 @@ class TestRegistriesModerationSubmissions:
         resp = app.post_json_api(embargo_registration_actions_url, actions_payload_base, auth=reg_creator.auth, expect_errors=True)
         assert resp.status_code == 403
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_registries_moderation_post_admin_cant_force_withdraw(self, app, registration, moderator, registration_actions_url, actions_payload_base, provider, reg_creator):
         registration.require_approval(user=registration.creator)
 
@@ -517,6 +521,7 @@ class TestRegistriesModerationSubmissions:
             RegistrationModerationTriggers.REJECT_SUBMISSION
         ]
     )
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_post_submission_action_persists_comment(self, app, registration, moderator, registration_actions_url, actions_payload_base, moderator_trigger):
         assert registration.actions.count() == 0
         registration.require_approval(user=registration.creator)
@@ -700,6 +705,7 @@ class TestRegistriesModerationSubmissions:
         assert registration.moderation_state == RegistrationModerationStates.EMBARGO.db_name
         assert registration.is_public is False
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_private_project_without_embargo_is_public_after_spam_and_ham_and_moderation_approval(self, app, registration, moderator, registration_actions_url, actions_payload_base, provider):
         user = AuthUserFactory()
         user.is_staff = True
@@ -736,6 +742,7 @@ class TestRegistriesModerationSubmissions:
         assert registration.moderation_state == RegistrationModerationStates.ACCEPTED.db_name
         assert registration.is_public is True
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_public_project_without_embargo_is_public_after_spam_and_ham_and_moderation_approval(self, app, registration, moderator, registration_actions_url, actions_payload_base, provider):
         user = AuthUserFactory()
         user.is_staff = True

--- a/api_tests/search/serializers/test_serializers.py
+++ b/api_tests/search/serializers/test_serializers.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from api.search.serializers import SearchSerializer
@@ -17,13 +15,9 @@ SCHEMA_VERSION = 2
 
 @pytest.mark.django_db
 class TestSearchSerializer:
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
-    def test_search_serializer_mixed_model(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_search_serializer_mixed_model(self):
 
         user = AuthUserFactory()
         project = ProjectFactory(creator=user, is_public=True)

--- a/api_tests/search/serializers/test_serializers.py
+++ b/api_tests/search/serializers/test_serializers.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from api.search.serializers import SearchSerializer
@@ -15,8 +17,13 @@ SCHEMA_VERSION = 2
 
 @pytest.mark.django_db
 class TestSearchSerializer:
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
-    def test_search_serializer_mixed_model(self):
+    def test_search_serializer_mixed_model(self, mock_gravy_valet_get_links):
 
         user = AuthUserFactory()
         project = ProjectFactory(creator=user, is_public=True)

--- a/api_tests/search/views/test_views.py
+++ b/api_tests/search/views/test_views.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 import uuid
 
@@ -568,13 +566,7 @@ class TestSearchRegistrations(ApiSearchTestCase):
             registration_private.update_search()
             return registration_private
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_search_registrations(
             self, app, url_registration_search, user, user_one, user_two,
             registration, registration_public, registration_private):

--- a/api_tests/search/views/test_views.py
+++ b/api_tests/search/views/test_views.py
@@ -574,9 +574,10 @@ class TestSearchRegistrations(ApiSearchTestCase):
             mock_get_links.return_value = []
             yield mock_get_links
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_search_registrations(
             self, app, url_registration_search, user, user_one, user_two,
-            registration, registration_public, registration_private, mock_gravy_valet_get_links):
+            registration, registration_public, registration_private):
 
         # test_search_public_registration_no_auth
         res = app.get(url_registration_search)

--- a/api_tests/search/views/test_views.py
+++ b/api_tests/search/views/test_views.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 import uuid
 
@@ -566,9 +568,15 @@ class TestSearchRegistrations(ApiSearchTestCase):
             registration_private.update_search()
             return registration_private
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_search_registrations(
             self, app, url_registration_search, user, user_one, user_two,
-            registration, registration_public, registration_private):
+            registration, registration_public, registration_private, mock_gravy_valet_get_links):
 
         # test_search_public_registration_no_auth
         res = app.get(url_registration_search)

--- a/conftest.py
+++ b/conftest.py
@@ -361,6 +361,6 @@ def with_class_scoped_db(_class_scoped_db):
 @pytest.fixture(autouse=True)
 def mock_gravy_valet_get_links():
 
-    with mock.patch('osf.external.gravy_valet.translations.get_links') as mock_get_links:
+    with mock.patch('osf.external.gravy_valet.translations.get_verified_links') as mock_get_links:
         mock_get_links.return_value = []
         yield mock_get_links

--- a/conftest.py
+++ b/conftest.py
@@ -360,7 +360,14 @@ def with_class_scoped_db(_class_scoped_db):
 
 @pytest.fixture
 def mock_gravy_valet_get_verified_links():
-    '''This fix is used to mock a GV request for TreeWalker node metadata'''
+    """This fixture is used to mock a GV request which is made during node's identifier update. More specifically, when
+    the tree walker in datacite metadata building process asks GV for verified links. As a result, this request must be
+    mocked in many tests. The following decoration can be applied to either a test class or individual test methods.
+
+    ```
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    ```
+    """
     with mock.patch('osf.external.gravy_valet.translations.get_verified_links') as mock_get_verified_links:
         mock_get_verified_links.return_value = []
         yield mock_get_verified_links

--- a/conftest.py
+++ b/conftest.py
@@ -357,3 +357,10 @@ def with_class_scoped_db(_class_scoped_db):
     ```
     """
     yield from rolledback_transaction('function_transaction')
+
+@pytest.fixture(autouse=True)
+def mock_gravy_valet_get_links():
+
+    with mock.patch('osf.external.gravy_valet.translations.get_links') as mock_get_links:
+        mock_get_links.return_value = []
+        yield mock_get_links

--- a/conftest.py
+++ b/conftest.py
@@ -359,8 +359,8 @@ def with_class_scoped_db(_class_scoped_db):
     yield from rolledback_transaction('function_transaction')
 
 @pytest.fixture
-def mock_gravy_valet_get_links():
-
-    with mock.patch('osf.external.gravy_valet.translations.get_verified_links') as mock_get_links:
-        mock_get_links.return_value = []
-        yield mock_get_links
+def mock_gravy_valet_get_verified_links():
+    '''This fix is used to mock a GV request for TreeWalker node metadata'''
+    with mock.patch('osf.external.gravy_valet.translations.get_verified_links') as mock_get_verified_links:
+        mock_get_verified_links.return_value = []
+        yield mock_get_verified_links

--- a/conftest.py
+++ b/conftest.py
@@ -358,7 +358,7 @@ def with_class_scoped_db(_class_scoped_db):
     """
     yield from rolledback_transaction('function_transaction')
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_gravy_valet_get_links():
 
     with mock.patch('osf.external.gravy_valet.translations.get_verified_links') as mock_get_links:

--- a/osf/external/gravy_valet/request_helpers.py
+++ b/osf/external/gravy_valet/request_helpers.py
@@ -247,10 +247,9 @@ def iterate_gv_results(
         auth=auth
     )
 
-    if not response and raise_on_error:
-        raise GVException
-
     if not response:
+        if raise_on_error:
+            raise GVException
         return
 
     response_json = response.json()

--- a/osf/metadata/serializers/datacite/datacite_tree_walker.py
+++ b/osf/metadata/serializers/datacite/datacite_tree_walker.py
@@ -113,8 +113,7 @@ class DataciteTreeWalker:
         self._visit_rights(self.root)
         self._visit_descriptions(self.root, self.basket.focus.iri)
         self._visit_funding_references(self.root)
-        self._visit_verified_links(self.root)
-        self._visit_related(self.root)
+        self._visit_related_and_verified_links(self.root)
 
     def _visit_identifier(self, parent_el, *, doi_override=None):
         if doi_override is None:
@@ -374,13 +373,16 @@ class DataciteTreeWalker:
         self._visit_publication_year(related_item_el, related_iri)
         self._visit_publisher(related_item_el, related_iri)
 
-    def _visit_related(self, parent_el):
+    def _visit_related_and_verified_links(self, parent_el):
         relation_pairs = set()
         for relation_iri, datacite_relation in RELATED_IDENTIFIER_TYPE_MAP.items():
             for related_iri in self.basket[relation_iri]:
                 relation_pairs.add((datacite_relation, related_iri))
+
         related_identifiers_el = self.visit(parent_el, 'relatedIdentifiers', is_list=True)
         related_items_el = self.visit(parent_el, 'relatedItems', is_list=True)
+
+        # First add regular related identifiers
         for datacite_relation, related_iri in sorted(relation_pairs):
             self._visit_related_identifier_and_item(
                 related_identifiers_el,
@@ -388,6 +390,24 @@ class DataciteTreeWalker:
                 related_iri,
                 datacite_relation,
             )
+
+        # Then add verified links to same relatedIdentifiers element
+        osf_item = self.basket.focus.dbmodel
+        from osf.models import AbstractNode
+
+        if isinstance(osf_item, AbstractNode):
+            gv_verified_link_list = osf_item.get_links()
+            for item in gv_verified_link_list:
+                verified_link, resource_type = item.get('target_url', None), item.get('resource_type', None)
+                if verified_link and resource_type:
+                    if verified_link and isinstance(verified_link, str) and smells_like_iri(verified_link):
+                        self.visit(related_identifiers_el, 'relatedIdentifier', text=verified_link, attrib={
+                            'relatedIdentifierType': 'URL',
+                            'relationType': 'IsReferencedBy',
+                            'resourceTypeGeneral': resource_type.title()
+                        })
+                    else:
+                        logger.warning('skipping non-URL verified link "%s"', verified_link)
 
     def _visit_name_identifiers(self, parent_el, agent_iri):
         for identifier in sorted(self.basket[agent_iri:DCTERMS.identifier]):
@@ -433,20 +453,3 @@ class DataciteTreeWalker:
             if isinstance(type_term, rdflib.URIRef) and type_term.startswith(DATACITE):
                 return without_namespace(type_term, DATACITE)
         return 'Text'
-
-    def _visit_verified_links(self, parent_el):
-        osf_item = self.basket.focus.dbmodel
-        verified_links = getattr(osf_item, 'verified_links', None)
-        resource_type = getattr(osf_item, 'link_resource_type', 'Text')
-
-        if verified_links and isinstance(verified_links, list):
-            related_identifiers_el = self.visit(parent_el, 'relatedIdentifiers', is_list=True)
-            for link in verified_links:
-                if link and isinstance(link, str) and smells_like_iri(link):
-                    self.visit(related_identifiers_el, 'relatedIdentifier', text=link, attrib={
-                        'relatedIdentifierType': 'URL',
-                        'relationType': 'IsReferencedBy',
-                        'resourceTypeGeneral': resource_type
-                    })
-                else:
-                    logger.warning('skipping non-URL verified link "%s"', link)

--- a/osf/metadata/serializers/datacite/datacite_tree_walker.py
+++ b/osf/metadata/serializers/datacite/datacite_tree_walker.py
@@ -6,7 +6,9 @@ import typing
 
 import rdflib
 
+from framework import sentry
 from osf.exceptions import MetadataSerializationError
+from osf.external.gravy_valet.request_helpers import get_verified_links
 from osf.metadata import gather
 from osf.metadata.rdfutils import (
     RDF,
@@ -396,18 +398,21 @@ class DataciteTreeWalker:
         from osf.models import AbstractNode
 
         if isinstance(osf_item, AbstractNode):
-            gv_verified_link_list = osf_item.get_links()
+            gv_verified_link_list = get_verified_links(node_guid=osf_item._id)
+            non_url_verified_links = []
             for item in gv_verified_link_list:
-                verified_link, resource_type = item.get('target_url', None), item.get('resource_type', None)
+                verified_link, resource_type = item.attributes.get('target_url', None), item.attributes.get('resource_type', None)
                 if verified_link and resource_type:
-                    if verified_link and isinstance(verified_link, str) and smells_like_iri(verified_link):
+                    if smells_like_iri(verified_link):
                         self.visit(related_identifiers_el, 'relatedIdentifier', text=verified_link, attrib={
                             'relatedIdentifierType': 'URL',
                             'relationType': 'IsReferencedBy',
                             'resourceTypeGeneral': resource_type.title()
                         })
                     else:
-                        logger.warning('skipping non-URL verified link "%s"', verified_link)
+                        non_url_verified_links.append(verified_link)
+            if non_url_verified_links:
+                sentry.log_message(f'Skipped - {','.join(non_url_verified_links)} for node {osf_item._id}')
 
     def _visit_name_identifiers(self, parent_el, agent_iri):
         for identifier in sorted(self.basket[agent_iri:DCTERMS.identifier]):

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -86,8 +86,8 @@ class IdentifierMixin(models.Model):
     def request_identifier_update(self, category, create=False):
         '''Noop if no existing identifier value for the category.'''
 
-        # if not self.get_identifier_value(category) and not create:
-        #     return
+        if not self.get_identifier_value(category) and not create:
+            return
 
         client = self.get_doi_client()
         if client:

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -86,8 +86,8 @@ class IdentifierMixin(models.Model):
     def request_identifier_update(self, category, create=False):
         '''Noop if no existing identifier value for the category.'''
 
-        if not self.get_identifier_value(category) and not create:
-            return
+        # if not self.get_identifier_value(category) and not create:
+        #     return
 
         client = self.get_doi_client()
         if client:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1991,10 +1991,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request_headers = string_type_request_headers(request)
         self.update_or_enqueue_on_node_updated(user_id, first_save, saved_fields)
 
-        from website.identifiers.tasks import update_doi_metadata_with_verified_links
-        if self.get_identifier('doi') and bool(self.IDENTIFIER_UPDATE_FIELDS.intersection(set(saved_fields))):
-            update_doi_metadata_with_verified_links(self._id)
-
         user = User.load(user_id)
         if user:
             # Specifically call the super class save method to avoid recursion into model save method.

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1991,6 +1991,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         request_headers = string_type_request_headers(request)
         self.update_or_enqueue_on_node_updated(user_id, first_save, saved_fields)
 
+        from website.identifiers.tasks import update_doi_metadata_with_verified_links
+        if self.get_identifier('doi') and bool(self.IDENTIFIER_UPDATE_FIELDS.intersection(set(saved_fields))):
+            update_doi_metadata_with_verified_links(self._id)
+
         user = User.load(user_id)
         if user:
             # Specifically call the super class save method to avoid recursion into model save method.

--- a/osf_tests/embargoes/test_embargoes.py
+++ b/osf_tests/embargoes/test_embargoes.py
@@ -29,13 +29,8 @@ class TestDraftRegistrations:
         embargo.save()
         return embargo.registrations.last()
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    def test_request_early_termination_too_late(self, registration, user, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_request_early_termination_too_late(self, registration, user):
         """
         This is for an edge case test for where embargos are frozen and never expire when the user requests they be
         terminated with embargo with less then 48 hours before it would expire anyway.

--- a/osf_tests/embargoes/test_embargoes.py
+++ b/osf_tests/embargoes/test_embargoes.py
@@ -29,7 +29,13 @@ class TestDraftRegistrations:
         embargo.save()
         return embargo.registrations.last()
 
-    def test_request_early_termination_too_late(self, registration, user):
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    def test_request_early_termination_too_late(self, registration, user, mock_gravy_valet_get_links):
         """
         This is for an edge case test for where embargos are frozen and never expire when the user requests they be
         terminated with embargo with less then 48 hours before it would expire anyway.

--- a/osf_tests/metadata/expected_metadata_files/preprint_supplement.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_supplement.turtle
@@ -1,5 +1,6 @@
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost:5000/w4ibb> osf:storageByteCount 1337 ;
     osf:storageRegion <http://localhost:8000/v2/regions/us/> .

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
@@ -63,6 +63,12 @@
       "relatedIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
       "relatedIdentifierType": "DOI",
       "relationType": "IsSupplementTo"
+    },
+    {
+      "relatedIdentifier": "https://foo.bar",
+      "relatedIdentifierType": "URL",
+      "relationType": "IsReferencedBy",
+      "resourceTypeGeneral": "Other"
     }
   ],
   "relatedItems": [

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
@@ -38,6 +38,7 @@
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="HasVersion">http://localhost:5000/w5ibb</relatedIdentifier>
     <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb_v1</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsReferencedBy" resourceTypeGeneral="Other">https://foo.bar</relatedIdentifier>
   </relatedIdentifiers>
   <relatedItems>
     <relatedItem relationType="HasVersion" relatedItemType="StudyRegistration">

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.json
@@ -97,6 +97,12 @@
       "relatedIdentifier": "11.pp/FK2osf.io/w4ibb_v1",
       "relatedIdentifierType": "DOI",
       "relationType": "IsSupplementTo"
+    },
+    {
+      "relatedIdentifier": "https://foo.bar",
+      "relatedIdentifierType": "URL",
+      "relationType": "IsReferencedBy",
+      "resourceTypeGeneral": "Other"
     }
   ],
   "relatedItems": [

--- a/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_full.datacite.xml
@@ -56,6 +56,7 @@
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="HasVersion">http://localhost:5000/w5ibb</relatedIdentifier>
     <relatedIdentifier relatedIdentifierType="DOI" relationType="IsSupplementTo">11.pp/FK2osf.io/w4ibb_v1</relatedIdentifier>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsReferencedBy" resourceTypeGeneral="Other">https://foo.bar</relatedIdentifier>
   </relatedIdentifiers>
   <relatedItems>
     <relatedItem relationType="HasVersion" relatedItemType="StudyRegistration">

--- a/osf_tests/metadata/expected_metadata_files/project_supplement.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_supplement.turtle
@@ -1,6 +1,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost:5000/w2ibb> osf:hasOsfAddon <urn:osf.io:addons:gitlab> ;
     osf:storageByteCount 7 ;

--- a/osf_tests/metadata/expected_metadata_files/registration_supplement.turtle
+++ b/osf_tests/metadata/expected_metadata_files/registration_supplement.turtle
@@ -1,5 +1,6 @@
 @prefix osf: <https://osf.io/vocab/2022/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://localhost:5000/w5ibb> osf:storageByteCount 17 ;
     osf:storageRegion <http://localhost:8000/v2/regions/us/> .

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -710,7 +710,8 @@ class TestOsfGathering(TestCase):
             (_collection_ref, DCTERMS.title, Literal(_collection_provider.name)),
         })
 
-    def test_gather_registration_withdrawal(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_gather_registration_withdrawal(self):
         # focus: registration
         assert_triples(osf_gathering.gather_registration_withdrawal(self.registrationfocus), set())
         _retraction = factories.WithdrawnRegistrationFactory(

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import mock
 
+import pytest
 from django.test import TestCase
 import rdflib
 from rdflib import Literal, URIRef
@@ -116,6 +117,12 @@ class TestOsfGathering(TestCase):
         cls.userfocus__admin = osf_gathering.OsfFocus(cls.user__admin)
         cls.userfocus__readwrite = osf_gathering.OsfFocus(cls.user__readwrite)
         cls.userfocus__readonly = osf_gathering.OsfFocus(cls.user__readonly)
+
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
     def test_setupdata(self):
         assert self.projectfocus.iri == OSFIO[self.project._id]
@@ -703,7 +710,7 @@ class TestOsfGathering(TestCase):
             (_collection_ref, DCTERMS.title, Literal(_collection_provider.name)),
         })
 
-    def test_gather_registration_withdrawal(self):
+    def test_gather_registration_withdrawal(self, mock_gravy_valet_get_links):
         # focus: registration
         assert_triples(osf_gathering.gather_registration_withdrawal(self.registrationfocus), set())
         _retraction = factories.WithdrawnRegistrationFactory(

--- a/osf_tests/metadata/test_osf_gathering.py
+++ b/osf_tests/metadata/test_osf_gathering.py
@@ -118,12 +118,6 @@ class TestOsfGathering(TestCase):
         cls.userfocus__readwrite = osf_gathering.OsfFocus(cls.user__readwrite)
         cls.userfocus__readonly = osf_gathering.OsfFocus(cls.user__readonly)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     def test_setupdata(self):
         assert self.projectfocus.iri == OSFIO[self.project._id]
         assert self.projectfocus.rdftype == OSF.Project
@@ -710,7 +704,7 @@ class TestOsfGathering(TestCase):
             (_collection_ref, DCTERMS.title, Literal(_collection_provider.name)),
         })
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_gather_registration_withdrawal(self):
         # focus: registration
         assert_triples(osf_gathering.gather_registration_withdrawal(self.registrationfocus), set())

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -330,7 +330,7 @@ class TestSerializers(OsfTestCase):
         self.project.node_license.year = '2250-2254'
         self.project.node_license.save()
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_serialized_metadata(self):
         self._assert_scenario(BASIC_METADATA_SCENARIO)
         self._setUp_full()

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -330,12 +330,6 @@ class TestSerializers(OsfTestCase):
         self.project.node_license.year = '2250-2254'
         self.project.node_license.save()
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_serialized_metadata(self):
         self._assert_scenario(BASIC_METADATA_SCENARIO)

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -336,7 +336,7 @@ class TestSerializers(OsfTestCase):
             mock_get_links.return_value = []
             yield mock_get_links
 
-    pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_serialized_metadata(self):
         self._assert_scenario(BASIC_METADATA_SCENARIO)
         self._setUp_full()

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -2,6 +2,7 @@ import datetime
 import pathlib
 from unittest import mock
 
+import pytest
 import rdflib
 
 from osf import models as osfdb
@@ -329,6 +330,13 @@ class TestSerializers(OsfTestCase):
         self.project.node_license.year = '2250-2254'
         self.project.node_license.save()
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_serialized_metadata(self):
         self._assert_scenario(BASIC_METADATA_SCENARIO)
         self._setUp_full()

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -436,12 +436,6 @@ class TestStorageAddonBase(ArchiverTestCase):
 
 class TestArchiverTasks(ArchiverTestCase):
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     @mock.patch('celery.chain')
     def test_archive(self, mock_chain, mock_enqueue):
@@ -540,6 +534,7 @@ class TestArchiverTasks(ArchiverTestCase):
             }
         )
 
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success(self):
         node = factories.NodeFactory(creator=self.user)
         file_trees, selected_files, node_index = generate_file_tree([node])
@@ -572,7 +567,7 @@ class TestArchiverTasks(ArchiverTestCase):
 
         assert registration_files == set(selected_files.keys())
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success_escaped_file_names(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
@@ -601,7 +596,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 updated_response = registration.schema_responses.get().all_responses[qid]
                 assert updated_response[0]['file_name'] == fake_file_name
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success_with_components(self):
         node = factories.NodeFactory(creator=self.user)
         comp1 = factories.NodeFactory(parent=node, creator=self.user)
@@ -641,7 +636,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 assert parent_registration._id in file_response['file_urls']['html']
                 registration_files.add(file_sha)
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success_different_name_same_sha(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
@@ -668,7 +663,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 for key, question in registration.registered_meta[schema._id].items():
                     assert question['extra'][0]['selectedFileName'] == fake_file['name']
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_failure_different_name_same_sha(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
@@ -694,7 +689,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 with pytest.raises(ArchivedFileNotFound):
                     archive_success(registration._id, job._id)
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success_same_file_in_component(self):
         file_tree = file_tree_factory(3, 3, 3)
         selected = list(select_files_from_tree(file_tree).values())[0]

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -436,6 +436,12 @@ class TestStorageAddonBase(ArchiverTestCase):
 
 class TestArchiverTasks(ArchiverTestCase):
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     @mock.patch('celery.chain')
     def test_archive(self, mock_chain, mock_enqueue):
@@ -566,7 +572,7 @@ class TestArchiverTasks(ArchiverTestCase):
 
         assert registration_files == set(selected_files.keys())
 
-    def test_archive_success_escaped_file_names(self):
+    def test_archive_success_escaped_file_names(self, mock_gravy_valet_get_links):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
         fake_file_name = normalize_unicode_filenames(fake_file['name'])[0]
@@ -594,7 +600,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 updated_response = registration.schema_responses.get().all_responses[qid]
                 assert updated_response[0]['file_name'] == fake_file_name
 
-    def test_archive_success_with_components(self):
+    def test_archive_success_with_components(self, mock_gravy_valet_get_links):
         node = factories.NodeFactory(creator=self.user)
         comp1 = factories.NodeFactory(parent=node, creator=self.user)
         factories.NodeFactory(parent=comp1, creator=self.user)
@@ -633,7 +639,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 assert parent_registration._id in file_response['file_urls']['html']
                 registration_files.add(file_sha)
 
-    def test_archive_success_different_name_same_sha(self):
+    def test_archive_success_different_name_same_sha(self, mock_gravy_valet_get_links):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
         fake_file2 = file_factory(sha256=fake_file['extra']['hashes']['sha256'])
@@ -659,7 +665,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 for key, question in registration.registered_meta[schema._id].items():
                     assert question['extra'][0]['selectedFileName'] == fake_file['name']
 
-    def test_archive_failure_different_name_same_sha(self):
+    def test_archive_failure_different_name_same_sha(self, mock_gravy_valet_get_links):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
         fake_file2 = file_factory(sha256=fake_file['extra']['hashes']['sha256'])
@@ -684,7 +690,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 with pytest.raises(ArchivedFileNotFound):
                     archive_success(registration._id, job._id)
 
-    def test_archive_success_same_file_in_component(self):
+    def test_archive_success_same_file_in_component(self, mock_gravy_valet_get_links):
         file_tree = file_tree_factory(3, 3, 3)
         selected = list(select_files_from_tree(file_tree).values())[0]
 

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -572,7 +572,8 @@ class TestArchiverTasks(ArchiverTestCase):
 
         assert registration_files == set(selected_files.keys())
 
-    def test_archive_success_escaped_file_names(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_archive_success_escaped_file_names(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory(name='>and&and<')
         fake_file_name = normalize_unicode_filenames(fake_file['name'])[0]
@@ -600,7 +601,8 @@ class TestArchiverTasks(ArchiverTestCase):
                 updated_response = registration.schema_responses.get().all_responses[qid]
                 assert updated_response[0]['file_name'] == fake_file_name
 
-    def test_archive_success_with_components(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_archive_success_with_components(self):
         node = factories.NodeFactory(creator=self.user)
         comp1 = factories.NodeFactory(parent=node, creator=self.user)
         factories.NodeFactory(parent=comp1, creator=self.user)
@@ -639,7 +641,8 @@ class TestArchiverTasks(ArchiverTestCase):
                 assert parent_registration._id in file_response['file_urls']['html']
                 registration_files.add(file_sha)
 
-    def test_archive_success_different_name_same_sha(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_archive_success_different_name_same_sha(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
         fake_file2 = file_factory(sha256=fake_file['extra']['hashes']['sha256'])
@@ -665,7 +668,8 @@ class TestArchiverTasks(ArchiverTestCase):
                 for key, question in registration.registered_meta[schema._id].items():
                     assert question['extra'][0]['selectedFileName'] == fake_file['name']
 
-    def test_archive_failure_different_name_same_sha(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_archive_failure_different_name_same_sha(self):
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
         fake_file2 = file_factory(sha256=fake_file['extra']['hashes']['sha256'])
@@ -690,7 +694,8 @@ class TestArchiverTasks(ArchiverTestCase):
                 with pytest.raises(ArchivedFileNotFound):
                     archive_success(registration._id, job._id)
 
-    def test_archive_success_same_file_in_component(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_archive_success_same_file_in_component(self):
         file_tree = file_tree_factory(3, 3, 3)
         selected = list(select_files_from_tree(file_tree).values())[0]
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3640,12 +3640,6 @@ class TestNodeEditableFieldsMixin:
 @pytest.mark.enable_implicit_clean
 class TestNodeUpdate:
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     def test_update_description(self, fake, node, auth):
         new_title = fake.bs()
 
@@ -3713,7 +3707,8 @@ class TestNodeUpdate:
         last_log = node.logs.latest()
         assert last_log.action == NodeLog.MADE_PRIVATE
 
-    def test_update_can_make_registration_public(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_update_can_make_registration_public(self):
         reg = RegistrationFactory(is_public=False)
         reg.update({'is_public': True})
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3640,6 +3640,12 @@ class TestNodeEditableFieldsMixin:
 @pytest.mark.enable_implicit_clean
 class TestNodeUpdate:
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     def test_update_description(self, fake, node, auth):
         new_title = fake.bs()
 
@@ -3707,7 +3713,7 @@ class TestNodeUpdate:
         last_log = node.logs.latest()
         assert last_log.action == NodeLog.MADE_PRIVATE
 
-    def test_update_can_make_registration_public(self):
+    def test_update_can_make_registration_public(self, mock_gravy_valet_get_links):
         reg = RegistrationFactory(is_public=False)
         reg.update({'is_public': True})
 

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -148,6 +148,12 @@ class TestNotableDomain:
             note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT,
         )
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_check_resource_for_domains_moderation_queue(self, spam_domain, factory):
         obj = factory()
@@ -190,7 +196,7 @@ class TestNotableDomain:
 
     @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, RegistrationFactory, PreprintFactory])
-    def test_spam_check(self, app, factory, spam_domain, marked_as_spam_domain, request_context):
+    def test_spam_check(self, app, factory, spam_domain, marked_as_spam_domain, request_context, mock_gravy_valet_get_links):
         obj = factory()
         obj.is_public = True
         obj.is_published = True

--- a/osf_tests/test_notable_domains.py
+++ b/osf_tests/test_notable_domains.py
@@ -148,12 +148,6 @@ class TestNotableDomain:
             note=NotableDomain.Note.EXCLUDE_FROM_ACCOUNT_CREATION_AND_CONTENT,
         )
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     @pytest.mark.parametrize('factory', [NodeFactory, CommentFactory, PreprintFactory, RegistrationFactory])
     def test_check_resource_for_domains_moderation_queue(self, spam_domain, factory):
         obj = factory()
@@ -196,7 +190,8 @@ class TestNotableDomain:
 
     @pytest.mark.enable_enqueue_task
     @pytest.mark.parametrize('factory', [NodeFactory, RegistrationFactory, PreprintFactory])
-    def test_spam_check(self, app, factory, spam_domain, marked_as_spam_domain, request_context, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_spam_check(self, app, factory, spam_domain, marked_as_spam_domain, request_context):
         obj = factory()
         obj.is_public = True
         obj.is_published = True

--- a/osf_tests/test_pigeon.py
+++ b/osf_tests/test_pigeon.py
@@ -30,12 +30,6 @@ class TestPigeon:
         embargo.accept()
         return embargo
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     @pytest.mark.enable_enqueue_task
     @pytest.mark.enable_implicit_clean
     def test_pigeon_sync_metadata(self, mock_pigeon, registration, mock_celery):
@@ -67,7 +61,8 @@ class TestPigeon:
 
     @pytest.mark.enable_enqueue_task
     @pytest.mark.enable_implicit_clean
-    def test_pigeon_archive_embargo(self, embargo, mock_pigeon, mock_celery, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_pigeon_archive_embargo(self, embargo, mock_pigeon, mock_celery):
         embargo._get_registration().terminate_embargo()
         guid = embargo._get_registration()._id
 

--- a/osf_tests/test_pigeon.py
+++ b/osf_tests/test_pigeon.py
@@ -30,6 +30,12 @@ class TestPigeon:
         embargo.accept()
         return embargo
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     @pytest.mark.enable_enqueue_task
     @pytest.mark.enable_implicit_clean
     def test_pigeon_sync_metadata(self, mock_pigeon, registration, mock_celery):
@@ -61,7 +67,7 @@ class TestPigeon:
 
     @pytest.mark.enable_enqueue_task
     @pytest.mark.enable_implicit_clean
-    def test_pigeon_archive_embargo(self, embargo, mock_pigeon, mock_celery):
+    def test_pigeon_archive_embargo(self, embargo, mock_pigeon, mock_celery, mock_gravy_valet_get_links):
         embargo._get_registration().terminate_embargo()
         guid = embargo._get_registration()._id
 

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -52,7 +52,7 @@ def auth(user):
     return Auth(user)
 
 @pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links(self):
+def mock_gravy_valet_get_links():
     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
         mock_get_links.return_value = []
         yield mock_get_links

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -50,12 +50,6 @@ def project(user, auth, fake):
 @pytest.fixture()
 def auth(user):
     return Auth(user)
-#
-# @pytest.fixture(autouse=True)
-# def mock_gravy_valet_get_links():
-#     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-#         mock_get_links.return_value = []
-#         yield mock_get_links
 
 # copied from tests/test_models.py
 def test_factory(user, project):

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -51,6 +51,11 @@ def project(user, auth, fake):
 def auth(user):
     return Auth(user)
 
+@pytest.fixture(autouse=True)
+def mock_gravy_valet_get_links(self):
+    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+        mock_get_links.return_value = []
+        yield mock_get_links
 
 # copied from tests/test_models.py
 def test_factory(user, project):
@@ -404,7 +409,13 @@ class TestRegisterNodeContributors:
         with mock_archive(project_two, autoapprove=True) as registration:
             return registration
 
-    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email, mock_gravy_valet_get_links):
         contributor_unregistered.refresh_from_db()
         contributor_unregistered_no_email.refresh_from_db()
         assert registration.contributors.filter(id=contributor_unregistered.id).exists()

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -50,12 +50,12 @@ def project(user, auth, fake):
 @pytest.fixture()
 def auth(user):
     return Auth(user)
-
-@pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links():
-    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-        mock_get_links.return_value = []
-        yield mock_get_links
+#
+# @pytest.fixture(autouse=True)
+# def mock_gravy_valet_get_links():
+#     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+#         mock_get_links.return_value = []
+#         yield mock_get_links
 
 # copied from tests/test_models.py
 def test_factory(user, project):
@@ -124,6 +124,7 @@ class TestRegistration:
 
 
 # copied from tests/test_models.py
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestRegisterNode:
 
     @pytest.fixture()
@@ -409,13 +410,8 @@ class TestRegisterNodeContributors:
         with mock_archive(project_two, autoapprove=True) as registration:
             return registration
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
+    def test_unregistered_contributors_unclaimed_records_get_copied(self, user, project, component, registration, contributor_unregistered, contributor_unregistered_no_email):
         contributor_unregistered.refresh_from_db()
         contributor_unregistered_no_email.refresh_from_db()
         assert registration.contributors.filter(id=contributor_unregistered.id).exists()
@@ -428,6 +424,7 @@ class TestRegisterNodeContributors:
 
 
 # copied from tests/test_registrations
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestNodeApprovalStates:
 
     def test_sanction_none(self):
@@ -644,7 +641,7 @@ class TestRegistrationMixin:
 
         assert registration_metadata == veer_condensed
 
-
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestRegistationModerationStates:
 
     @pytest.fixture

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -12,6 +12,12 @@ from osf_tests import factories
 from osf_tests.utils import mock_archive
 from osf.utils import permissions
 
+@pytest.fixture(autouse=True)
+def mock_gravy_valet_get_links(self):
+    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+        mock_get_links.return_value = []
+        yield mock_get_links
+
 
 @pytest.mark.django_db
 class TestRegistrationApprovalHooks:

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -12,14 +12,9 @@ from osf_tests import factories
 from osf_tests.utils import mock_archive
 from osf.utils import permissions
 
-@pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links():
-    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-        mock_get_links.return_value = []
-        yield mock_get_links
-
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestRegistrationApprovalHooks:
 
     # Regression test for https://openscience.atlassian.net/browse/OSF-4940
@@ -35,6 +30,7 @@ class TestRegistrationApprovalHooks:
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestNodeEmbargoTerminations:
 
     @pytest.fixture()
@@ -170,6 +166,7 @@ class TestSanctionEmailRendering:
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestDOICreation:
 
     def make_test_registration(self, embargoed=False, moderated=False):

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -13,7 +13,7 @@ from osf_tests.utils import mock_archive
 from osf.utils import permissions
 
 @pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links(self):
+def mock_gravy_valet_get_links():
     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
         mock_get_links.return_value = []
         yield mock_get_links

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -28,6 +28,7 @@ def _assert_unordered_list_of_dicts_equal(actual_list_of_dicts, expected_list_of
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestDataCiteClient:
 
     @pytest.fixture()
@@ -41,12 +42,6 @@ class TestDataCiteClient:
     @pytest.fixture()
     def registration(self, user):
         return RegistrationFactory(is_public=True, creator=user)
-
-    @pytest.fixture(autouse=True)
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     def test_datacite_create_identifiers(self, registration, datacite_client, mock_datacite):
         identifiers = datacite_client.create_identifier(node=registration, category='doi')
@@ -266,14 +261,8 @@ class TestDataCiteViews(OsfTestCase):
         self.node = RegistrationFactory(creator=self.user, is_public=True)
         self.client = DataCiteClient(self.node)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     @responses.activate
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_datacite_create_identifiers_not_exists(self):
         responses.add(
             responses.Response(

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -1,6 +1,7 @@
 import lxml
 import pytest
 import responses
+from unittest import mock
 
 from datacite import schema40
 from django.utils import timezone
@@ -40,6 +41,12 @@ class TestDataCiteClient:
     @pytest.fixture()
     def registration(self, user):
         return RegistrationFactory(is_public=True, creator=user)
+
+    @pytest.fixture(autouse=True)
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
 
     def test_datacite_create_identifiers(self, registration, datacite_client, mock_datacite):
         identifiers = datacite_client.create_identifier(node=registration, category='doi')

--- a/tests/identifiers/test_datacite.py
+++ b/tests/identifiers/test_datacite.py
@@ -266,7 +266,14 @@ class TestDataCiteViews(OsfTestCase):
         self.node = RegistrationFactory(creator=self.user, is_public=True)
         self.client = DataCiteClient(self.node)
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
     @responses.activate
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_datacite_create_identifiers_not_exists(self):
         responses.add(
             responses.Response(

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -156,7 +156,8 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.registration.save()
         assert self.registration.is_pending_embargo
 
-    def test_embargo_public_project_makes_private_pending_embargo(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_embargo_public_project_makes_private_pending_embargo(self):
         self.registration.is_public = True
         assert self.registration.is_public
         self.registration.embargo_registration(
@@ -433,7 +434,8 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         assert mock_notify.call_count == 0
 
     # Regression for OSF-8840
-    def test_public_embargo_cannot_be_deleted_with_initial_token(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_public_embargo_cannot_be_deleted_with_initial_token(self):
         embargo_termination_approval = EmbargoTerminationApprovalFactory()
         registration = Registration.objects.get(embargo_termination_approval=embargo_termination_approval)
         user = registration.contributors.first()
@@ -709,7 +711,8 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert res.status_code == 200
         assert res.request.path == self.registration.web_url_for('view_project')
 
-    def test_GET_from_unauthorized_user_with_registration_token(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_GET_from_unauthorized_user_with_registration_token(self):
         unauthorized_user = AuthUserFactory()
 
         self.registration.require_approval(self.user)
@@ -759,7 +762,8 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert res.status_code == 200
 
-    def test_GET_from_authorized_user_with_registration_app_token(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_GET_from_authorized_user_with_registration_app_token(self):
         self.registration.require_approval(self.user)
         self.registration.save()
         app_token = self.registration.registration_approval.approval_state[self.user._id]['approval_token']
@@ -978,7 +982,8 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert res.status_code == 302
         assert res.request.path == self.registration.web_url_for('token_action')
 
-    def test_GET_from_unauthorized_user_with_registration_token(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_GET_from_unauthorized_user_with_registration_token(self):
         unauthorized_user = AuthUserFactory()
 
         self.registration.require_approval(self.user)
@@ -1028,7 +1033,8 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert res.status_code == 302
 
-    def test_GET_from_authorized_user_with_registration_app_token(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_GET_from_authorized_user_with_registration_app_token(self):
         self.registration.require_approval(self.user)
         self.registration.save()
         app_token = self.registration.registration_approval.approval_state[self.user._id]['approval_token']

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -45,12 +45,6 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.embargo = EmbargoFactory(user=self.user)
         self.valid_embargo_end_date = timezone.now() + datetime.timedelta(days=3)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     # Node#_initiate_embargo tests
     def test__initiate_embargo_saves_embargo(self):
         initial_count = Embargo.objects.all().count()
@@ -156,7 +150,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.registration.save()
         assert self.registration.is_pending_embargo
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_embargo_public_project_makes_private_pending_embargo(self):
         self.registration.is_public = True
         assert self.registration.is_public
@@ -434,7 +428,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         assert mock_notify.call_count == 0
 
     # Regression for OSF-8840
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_public_embargo_cannot_be_deleted_with_initial_token(self):
         embargo_termination_approval = EmbargoTerminationApprovalFactory()
         registration = Registration.objects.get(embargo_termination_approval=embargo_termination_approval)
@@ -541,12 +535,6 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.user = AuthUserFactory()
         self.project = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(creator=self.user, project=self.project)
-
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     def test_GET_approve_registration_without_embargo_raises_HTTPBad_Request(self):
         assert not self.registration.is_pending_embargo
@@ -711,7 +699,7 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert res.status_code == 200
         assert res.request.path == self.registration.web_url_for('view_project')
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_GET_from_unauthorized_user_with_registration_token(self):
         unauthorized_user = AuthUserFactory()
 
@@ -762,7 +750,7 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert res.status_code == 200
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_GET_from_authorized_user_with_registration_app_token(self):
         self.registration.require_approval(self.user)
         self.registration.save()
@@ -812,12 +800,6 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.user = AuthUserFactory()
         self.project = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(creator=self.user, project=self.project)
-
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
 
     def test_GET_approve_registration_without_embargo_raises_HTTPBad_Request(self):
         assert not self.registration.is_pending_embargo
@@ -982,7 +964,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert res.status_code == 302
         assert res.request.path == self.registration.web_url_for('token_action')
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_GET_from_unauthorized_user_with_registration_token(self):
         unauthorized_user = AuthUserFactory()
 
@@ -1033,7 +1015,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert res.status_code == 302
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_GET_from_authorized_user_with_registration_app_token(self):
         self.registration.require_approval(self.user)
         self.registration.save()

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -120,7 +120,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
             self.registration.registration_approval.approve(user=non_admin, token=approval_token)
         assert self.registration.is_pending_registration
 
-    def test_approval_adds_to_parent_projects_log(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_approval_adds_to_parent_projects_log(self):
         initial_project_logs = self.registration.registered_from.logs.count()
         self.registration.require_approval(
             self.user
@@ -132,7 +133,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         # adds initiated, approved, and registered logs
         assert self.registration.registered_from.logs.count() == initial_project_logs + 3
 
-    def test_one_approval_with_two_admins_stays_pending(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_one_approval_with_two_admins_stays_pending(self):
         admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=admin2)
         self.registration.add_permission(admin2, ADMIN, save=True)
@@ -257,7 +259,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         self.registration.save()
         assert self.registration.is_pending_registration
 
-    def test_should_suppress_emails(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_should_suppress_emails(self):
         self.registration = RegistrationFactory(project=self.project)
         self.registration.external_registration = True
         self.registration.save()
@@ -286,7 +289,8 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
             self.registration.sanction.ask(contributors)
         assert mock_notify_non_authorizer.call_count == 0
 
-    def test_on_complete_notify_initiator(self, mock_gravy_valet_get_links):
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    def test_on_complete_notify_initiator(self):
         self.registration.require_approval(
             self.user,
             notify_initiator_on_complete=True

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -38,12 +38,6 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         self.project = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(project=self.project)
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
     def test__require_approval_saves_approval(self):
         initial_count = RegistrationApproval.objects.all().count()
         self.registration._initiate_approval(
@@ -120,7 +114,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
             self.registration.registration_approval.approve(user=non_admin, token=approval_token)
         assert self.registration.is_pending_registration
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_approval_adds_to_parent_projects_log(self):
         initial_project_logs = self.registration.registered_from.logs.count()
         self.registration.require_approval(
@@ -133,7 +127,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         # adds initiated, approved, and registered logs
         assert self.registration.registered_from.logs.count() == initial_project_logs + 3
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_one_approval_with_two_admins_stays_pending(self):
         admin2 = UserFactory()
         Contributor.objects.create(node=self.registration, user=admin2)
@@ -259,7 +253,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         self.registration.save()
         assert self.registration.is_pending_registration
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_should_suppress_emails(self):
         self.registration = RegistrationFactory(project=self.project)
         self.registration.external_registration = True
@@ -289,7 +283,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
             self.registration.sanction.ask(contributors)
         assert mock_notify_non_authorizer.call_count == 0
 
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_on_complete_notify_initiator(self):
         self.registration.require_approval(
             self.user,

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -25,14 +25,10 @@ from osf.exceptions import (
 from osf.models import Contributor, Retraction
 from osf.utils import permissions
 
-@pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links():
-    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-        mock_get_links.return_value = []
-        yield mock_get_links
 
 
 @pytest.mark.enable_bookmark_creation
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class RegistrationRetractionModelsTestCase(OsfTestCase):
     def setUp(self):
         super().setUp()
@@ -406,6 +402,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
 
 
 @pytest.mark.enable_bookmark_creation
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
     def setUp(self):
         super().setUp()
@@ -763,6 +760,7 @@ class ComponentRegistrationRetractionViewsTestCase(OsfTestCase):
         assert res.status_code == http_status.HTTP_400_BAD_REQUEST
 
 @pytest.mark.enable_bookmark_creation
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class RegistrationRetractionViewsTestCase(OsfTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -26,7 +26,7 @@ from osf.models import Contributor, Retraction
 from osf.utils import permissions
 
 @pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links(self):
+def mock_gravy_valet_get_links():
     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
         mock_get_links.return_value = []
         yield mock_get_links

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -25,6 +25,12 @@ from osf.exceptions import (
 from osf.models import Contributor, Retraction
 from osf.utils import permissions
 
+@pytest.fixture(autouse=True)
+def mock_gravy_valet_get_links(self):
+    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+        mock_get_links.return_value = []
+        yield mock_get_links
+
 
 @pytest.mark.enable_bookmark_creation
 class RegistrationRetractionModelsTestCase(OsfTestCase):

--- a/tests/test_registrations/test_review_flows.py
+++ b/tests/test_registrations/test_review_flows.py
@@ -61,7 +61,7 @@ def retraction(provider=None):
     return sanction
 
 @pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links(self):
+def mock_gravy_valet_get_links():
     with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
         mock_get_links.return_value = []
         yield mock_get_links

--- a/tests/test_registrations/test_review_flows.py
+++ b/tests/test_registrations/test_review_flows.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from api.providers.workflows import Workflows
@@ -57,6 +59,12 @@ def retraction(provider=None):
     registration.update_moderation_state()
     registration.save()
     return sanction
+
+@pytest.fixture(autouse=True)
+def mock_gravy_valet_get_links(self):
+    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+        mock_get_links.return_value = []
+        yield mock_get_links
 
 
 @pytest.mark.enable_bookmark_creation

--- a/tests/test_registrations/test_review_flows.py
+++ b/tests/test_registrations/test_review_flows.py
@@ -60,15 +60,10 @@ def retraction(provider=None):
     registration.save()
     return sanction
 
-@pytest.fixture(autouse=True)
-def mock_gravy_valet_get_links():
-    with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-        mock_get_links.return_value = []
-        yield mock_get_links
-
 
 @pytest.mark.enable_bookmark_creation
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestUnmoderatedFlows():
 
     @pytest.mark.parametrize(
@@ -202,6 +197,7 @@ class TestUnmoderatedFlows():
 
 @pytest.mark.enable_bookmark_creation
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestModeratedFlows():
 
     @pytest.fixture
@@ -538,6 +534,7 @@ class TestModeratedFlows():
         assert sanction_object.approval_stage is ApprovalStates.MODERATOR_REJECTED
 
 @pytest.mark.enable_bookmark_creation
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestEmbargoTerminationFlows(OsfTestCase):
 
     def setUp(self):
@@ -648,6 +645,7 @@ class TestEmbargoTerminationFlows(OsfTestCase):
 
 @pytest.mark.enable_bookmark_creation
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestModerationActions:
 
     @pytest.fixture
@@ -762,6 +760,7 @@ class TestModerationActions:
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
 class TestNestedFlows():
 
     @pytest.fixture(params=[registration_approval, embargo, retraction])

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -88,13 +88,7 @@ class SanctionTokenHandlerBase(OsfTestCase):
         self.reg = AbstractNode.objects.get(Q(**{self.Model.SHORT_NAME: self.sanction}))
         self.user = self.reg.creator
 
-    @pytest.fixture
-    def mock_gravy_valet_get_links(self):
-        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
-            mock_get_links.return_value = []
-            yield mock_get_links
-
-    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
+    @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_sanction_handler(self):
         if not self.kind:
             return

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -88,6 +88,13 @@ class SanctionTokenHandlerBase(OsfTestCase):
         self.reg = AbstractNode.objects.get(Q(**{self.Model.SHORT_NAME: self.sanction}))
         self.user = self.reg.creator
 
+    @pytest.fixture
+    def mock_gravy_valet_get_links(self):
+        with mock.patch('osf.models.node.AbstractNode.get_verified_links') as mock_get_links:
+            mock_get_links.return_value = []
+            yield mock_get_links
+
+    @pytest.mark.usefixtures('mock_gravy_valet_get_links')
     def test_sanction_handler(self):
         if not self.kind:
             return

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -57,6 +57,9 @@ class DataCiteClient(AbstractIdentifierClient):
         doi_value = doi_value or self._get_doi_value(node)
         metadata_record_xml = self.build_metadata(node, doi_value, as_xml=True)
         if settings.DATACITE_ENABLED:
+            if isinstance(metadata_record_xml, bytes):
+                metadata_record_xml = metadata_record_xml.decode('utf-8')
+
             resp = self._client.metadata_post(metadata_record_xml)
             # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695
             doi = re.match(r'OK \((?P<doi>[a-zA-Z0-9 .\/]{0,})\)', resp).groupdict()['doi']

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -57,8 +57,6 @@ class DataCiteClient(AbstractIdentifierClient):
         doi_value = doi_value or self._get_doi_value(node)
         metadata_record_xml = self.build_metadata(node, doi_value, as_xml=True)
         if settings.DATACITE_ENABLED:
-            if isinstance(metadata_record_xml, bytes):
-                metadata_record_xml = metadata_record_xml.decode('utf-8')
 
             resp = self._client.metadata_post(metadata_record_xml)
             # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695

--- a/website/identifiers/clients/datacite.py
+++ b/website/identifiers/clients/datacite.py
@@ -57,7 +57,6 @@ class DataCiteClient(AbstractIdentifierClient):
         doi_value = doi_value or self._get_doi_value(node)
         metadata_record_xml = self.build_metadata(node, doi_value, as_xml=True)
         if settings.DATACITE_ENABLED:
-
             resp = self._client.metadata_post(metadata_record_xml)
             # Typical response: 'OK (10.70102/FK2osf.io/cq695)' to doi 10.70102/FK2osf.io/cq695
             doi = re.match(r'OK \((?P<doi>[a-zA-Z0-9 .\/]{0,})\)', resp).groupdict()['doi']

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -19,17 +19,14 @@ def update_doi_metadata_on_change(target_guid):
     task__update_doi_metadata_on_change(target_guid)
 
 @celery_app.task(bind=True, max_retries=5, acks_late=True)
-def task__update_doi_metadata_with_verified_links(self, target_guid, verified_links=None, link_resource_type='Text'):
+def task__update_doi_metadata_with_verified_links(self, target_guid):
     sentry.log_message('Updating DOI with verified links for guid',
-                      extra_data={'guid': target_guid, 'verified_links': verified_links, 'link_resource_type': link_resource_type},
+                      extra_data={'guid': target_guid},
                       level=logging.INFO)
 
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     try:
-        if verified_links is not None:
-            target_object.verified_links = verified_links
-            target_object.link_resource_type = link_resource_type
 
         target_object.request_identifier_update(category='doi')
 
@@ -44,5 +41,5 @@ def task__update_doi_metadata_with_verified_links(self, target_guid, verified_li
 
 @queued_task
 @celery_app.task(ignore_results=True)
-def update_doi_metadata_with_verified_links(target_guid, verified_links=None, resource_type='Text'):
-    task__update_doi_metadata_with_verified_links.apply_async((target_guid, verified_links, resource_type))
+def update_doi_metadata_with_verified_links(target_guid):
+    task__update_doi_metadata_with_verified_links(target_guid)

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -23,20 +23,20 @@ def update_doi_metadata_on_change(target_guid):
 
 @celery_app.task(bind=True, max_retries=5, acks_late=True)
 def task__update_doi_metadata_with_verified_links(self, target_guid):
-    logger.info(f'Updating DOI with verified links for guid - {target_guid}')
+    logger.debug(f'Updating DOI metadata for guid due to verified links configuration change in Gravy Valet: '
+                 f'[guid={target_guid}]')
 
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
     try:
-
         target_object.request_identifier_update(category='doi')
-
-        logger.info(f'DOI metadata with verified links updated for guid - {target_guid}')
+        logger.debug(f'DOI metadata for guid with verified links updated: [guid={target_guid}]')
     except GVException as e:
-        logger.info(f'Failed to update DOI metadata with verified links for guid - {target_guid}')
+        logger.error(f'DOI metadata for guid with verified links failed to update: [guid={target_guid}]')
         raise self.retry(exc=e)
 
 @queued_task
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_with_verified_links(target_guid):
+    # TODO: log sentry if fails after max retry
     task__update_doi_metadata_with_verified_links(target_guid)

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -1,9 +1,12 @@
 import logging
 from django.apps import apps
 
+from osf.external.gravy_valet.exceptions import GVException
 from framework.celery_tasks import app as celery_app
 from framework.celery_tasks.handlers import queued_task
 from framework import sentry
+
+logger = logging.getLogger(__name__)
 
 @celery_app.task(bind=True, max_retries=5, acks_late=True)
 def task__update_doi_metadata_on_change(self, target_guid):
@@ -20,9 +23,7 @@ def update_doi_metadata_on_change(target_guid):
 
 @celery_app.task(bind=True, max_retries=5, acks_late=True)
 def task__update_doi_metadata_with_verified_links(self, target_guid):
-    sentry.log_message('Updating DOI with verified links for guid',
-                      extra_data={'guid': target_guid},
-                      level=logging.INFO)
+    logger.info(f'Updating DOI with verified links for guid - {target_guid}')
 
     Guid = apps.get_model('osf.Guid')
     target_object = Guid.load(target_guid).referent
@@ -30,14 +31,10 @@ def task__update_doi_metadata_with_verified_links(self, target_guid):
 
         target_object.request_identifier_update(category='doi')
 
-        sentry.log_message('DOI metadata with verified links updated for guid',
-                         extra_data={'guid': target_guid},
-                         level=logging.INFO)
-    except Exception as exc:
-        sentry.log_message('Failed to update DOI metadata with verified links',
-                         extra_data={'guid': target_guid, 'error': str(exc)},
-                         level=logging.ERROR)
-        raise self.retry(exc=exc)
+        logger.info(f'DOI metadata with verified links updated for guid - {target_guid}')
+    except GVException as e:
+        logger.info(f'Failed to update DOI metadata with verified links for guid - {target_guid}')
+        raise self.retry(exc=e)
 
 @queued_task
 @celery_app.task(ignore_results=True)

--- a/website/identifiers/tasks.py
+++ b/website/identifiers/tasks.py
@@ -17,3 +17,32 @@ def task__update_doi_metadata_on_change(self, target_guid):
 @celery_app.task(ignore_results=True)
 def update_doi_metadata_on_change(target_guid):
     task__update_doi_metadata_on_change(target_guid)
+
+@celery_app.task(bind=True, max_retries=5, acks_late=True)
+def task__update_doi_metadata_with_verified_links(self, target_guid, verified_links=None, link_resource_type='Text'):
+    sentry.log_message('Updating DOI with verified links for guid',
+                      extra_data={'guid': target_guid, 'verified_links': verified_links, 'link_resource_type': link_resource_type},
+                      level=logging.INFO)
+
+    Guid = apps.get_model('osf.Guid')
+    target_object = Guid.load(target_guid).referent
+    try:
+        if verified_links is not None:
+            target_object.verified_links = verified_links
+            target_object.link_resource_type = link_resource_type
+
+        target_object.request_identifier_update(category='doi')
+
+        sentry.log_message('DOI metadata with verified links updated for guid',
+                         extra_data={'guid': target_guid},
+                         level=logging.INFO)
+    except Exception as exc:
+        sentry.log_message('Failed to update DOI metadata with verified links',
+                         extra_data={'guid': target_guid, 'error': str(exc)},
+                         level=logging.ERROR)
+        raise self.retry(exc=exc)
+
+@queued_task
+@celery_app.task(ignore_results=True)
+def update_doi_metadata_with_verified_links(target_guid, verified_links=None, resource_type='Text'):
+    task__update_doi_metadata_with_verified_links.apply_async((target_guid, verified_links, resource_type))


### PR DESCRIPTION
## Purpose

* Add celery task to update Datacite metadata
* Use new GV API endpoint to retrieve node's verified links
* Fix unit tests due to OSF making GV requests during identifier update

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-7839
https://openscience.atlassian.net/browse/ENG-7766
