### PR TITLE
[ENG-7927] Improved logging for embargo termination

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1254,11 +1254,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     'This project has been marked as spam. Please contact the help desk if you think this is in error.')
             if self.is_registration:
                 if self.is_pending_embargo:
-                    raise NodeStateError('A registration with an unapproved embargo cannot be made public.')
+                    raise NodeStateError('An unapproved embargoed registration cannot be made public.')
                 elif self.is_pending_registration:
                     raise NodeStateError('An unapproved registration cannot be made public.')
-                elif self.is_pending_embargo:
-                    raise NodeStateError('An unapproved embargoed registration cannot be made public.')
                 elif self.is_embargoed:
                     # Embargoed registrations can be made public early
                     self.request_embargo_termination(auth.user)

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -94,7 +94,7 @@ def main(dry_run=True):
                         f'registration {parent_registration._id}. Continuing...'
                     )
                     logger.exception(err)
-                    sentry.log_message(str(err))
+                    sentry.log_message(f'Registration {parent_registration._id} could not be made public because {str(err)}')
                     transaction.savepoint_rollback(sid)
 
 

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -89,11 +89,7 @@ def main(dry_run=True):
                     parent_registration.terminate_embargo()
                     transaction.savepoint_commit(sid)
                 except Exception as err:
-                    logger.error(
-                        f'Unexpected error raised when completing embargo for '
-                        f'registration {parent_registration._id}. Continuing...',
-                        exc_info=err
-                    )
+                    logger.error(f'Registration {parent_registration._id} could not be made public because {str(err)}')
                     sentry.log_message(f'Registration {parent_registration._id} could not be made public because {str(err)}')
                     transaction.savepoint_rollback(sid)
 

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -89,7 +89,10 @@ def main(dry_run=True):
                     parent_registration.terminate_embargo()
                     transaction.savepoint_commit(sid)
                 except Exception as err:
-                    logger.error(f'Registration {parent_registration._id} could not be made public because {str(err)}')
+                    logger.error(
+                        f'Registration {parent_registration._id} could not be made public because {str(err)}',
+                        exc_info=err
+                    )
                     sentry.log_message(f'Registration {parent_registration._id} could not be made public because {str(err)}')
                     transaction.savepoint_rollback(sid)
 

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -91,9 +91,9 @@ def main(dry_run=True):
                 except Exception as err:
                     logger.error(
                         f'Unexpected error raised when completing embargo for '
-                        f'registration {parent_registration._id}. Continuing...'
+                        f'registration {parent_registration._id}. Continuing...',
+                        exc_info=err
                     )
-                    logger.exception(err)
                     sentry.log_message(f'Registration {parent_registration._id} could not be made public because {str(err)}')
                     transaction.savepoint_rollback(sid)
 


### PR DESCRIPTION
## Purpose

Embargo termination logging doesn't provide useful info regarding of what error was raised

## Changes

Improved logging, removed if statement duplicate

## Ticket

https://openscience.atlassian.net/browse/ENG-7927?atlOrigin=eyJpIjoiZDJkYTQ3MjdmN2UxNDBjYmIzMDg1YzVhNmI4ZjMzMWQiLCJwIjoiaiJ9