### PR TITLE
[ENG-7965] Add v2 email token confirmation endpoints

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -446,6 +446,7 @@ class ConfirmEmailTokenSerializer(BaseAPISerializer):
     uid = ser.CharField(write_only=True, required=True)
     destination = ser.CharField(write_only=True, required=True)
     token = ser.CharField(write_only=True, required=True)
+    redirect_url = ser.CharField(read_only=True, required=False)
 
     class Meta:
         type_ = 'email_token_serializer'

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -442,13 +442,37 @@ class UserResetPasswordSerializer(BaseAPISerializer):
         type_ = 'user_reset_password'
 
 
-class ConfirmEmailSerializer(BaseAPISerializer):
+class ConfirmEmailTokenSerializer(BaseAPISerializer):
     uid = ser.CharField(write_only=True, required=True)
     destination = ser.CharField(write_only=True, required=True)
     token = ser.CharField(write_only=True, required=True)
 
     class Meta:
-        type_ = 'external_login_confirm_email'
+        type_ = 'email_token_serializer'
+
+
+class SanctionTokenSerializer(ConfirmEmailTokenSerializer):
+    action = ser.ChoiceField(
+        write_only=True,
+        required=True,
+        choices=[
+            'approve',
+            'reject',
+        ],
+    )
+    sanction_type = ser.ChoiceField(
+        write_only=True,
+        required=False,
+        choices=[
+            'registration',
+            'embargo',
+            'embargo_termination_approval',
+            'retraction',
+        ],
+    )
+
+    class Meta:
+        type_ = 'sanction_token_serializer'
 
 
 class ExternalLoginSerialiser(BaseAPISerializer):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -442,7 +442,7 @@ class UserResetPasswordSerializer(BaseAPISerializer):
         type_ = 'user_reset_password'
 
 
-class ExternalLoginConfirmEmailSerializer(BaseAPISerializer):
+class ConfirmEmailSerializer(BaseAPISerializer):
     uid = ser.CharField(write_only=True, required=True)
     destination = ser.CharField(write_only=True, required=True)
     token = ser.CharField(write_only=True, required=True)

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     re_path(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/accounts/(?P<account_id>\w+)/$', views.UserAddonAccountDetail.as_view(), name=views.UserAddonAccountDetail.view_name),
     re_path(r'^(?P<user_id>\w+)/claim/$', views.ClaimUser.as_view(), name=views.ClaimUser.view_name),
     re_path(r'^(?P<user_id>\w+)/confirm/$', views.ConfirmEmailView.as_view(), name=views.ConfirmEmailView.view_name),
+    re_path(r'^(?P<user_id>\w+)/sanction_response/$', views.SanctionResponseView.as_view(), name=views.SanctionResponseView.view_name),
     re_path(r'^(?P<user_id>\w+)/draft_registrations/$', views.UserDraftRegistrations.as_view(), name=views.UserDraftRegistrations.view_name),
     re_path(r'^(?P<user_id>\w+)/institutions/$', views.UserInstitutions.as_view(), name=views.UserInstitutions.view_name),
     re_path(r'^(?P<user_id>\w+)/nodes/$', views.UserNodes.as_view(), name=views.UserNodes.view_name),

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     re_path(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/accounts/$', views.UserAddonAccountList.as_view(), name=views.UserAddonAccountList.view_name),
     re_path(r'^(?P<user_id>\w+)/addons/(?P<provider>\w+)/accounts/(?P<account_id>\w+)/$', views.UserAddonAccountDetail.as_view(), name=views.UserAddonAccountDetail.view_name),
     re_path(r'^(?P<user_id>\w+)/claim/$', views.ClaimUser.as_view(), name=views.ClaimUser.view_name),
+    re_path(r'^(?P<user_id>\w+)/confirm/$', views.ConfirmEmailView.as_view(), name=views.ConfirmEmailView.view_name),
     re_path(r'^(?P<user_id>\w+)/draft_registrations/$', views.UserDraftRegistrations.as_view(), name=views.UserDraftRegistrations.view_name),
     re_path(r'^(?P<user_id>\w+)/institutions/$', views.UserInstitutions.as_view(), name=views.UserInstitutions.view_name),
     re_path(r'^(?P<user_id>\w+)/nodes/$', views.UserNodes.as_view(), name=views.UserNodes.view_name),

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -1076,8 +1076,8 @@ class ConfirmEmailView(generics.CreateAPIView):
         "destination": "<campaign-code or relative URL>"
     }
 
-    On success the endpoint redirects (HTTP 302) to CAS with a
-    one-time verification key, exactly like the original Flask view.
+    On success returns a response with a 201 status code with a JSONAPI payload that includes the `redirect_url`
+    attritbute.
     """
     permission_classes = (
         base_permissions.TokenHasScope,

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -17,7 +17,14 @@ from api.metrics.views import (
     CountedAuthUsageView,
     MetricsOpenapiView,
 )
-from api.users.views import ClaimUser, ResetPassword, ExternalLoginConfirmEmailView, ExternalLogin, ConfirmEmailView
+from api.users.views import (
+    ClaimUser,
+    ResetPassword,
+    ExternalLoginConfirmEmailView,
+    ExternalLogin,
+    ConfirmEmailView,
+    SanctionResponseView
+)
 from api.registrations.views import RegistrationCallbackView
 from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
@@ -66,6 +73,7 @@ class TestApiBaseViews(ApiTestCase):
             ConfirmEmailView,
             ExternalLogin,
             RegistrationCallbackView,
+            SanctionResponseView
         ]
 
     def test_root_returns_200(self):

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -17,7 +17,7 @@ from api.metrics.views import (
     CountedAuthUsageView,
     MetricsOpenapiView,
 )
-from api.users.views import ClaimUser, ResetPassword, ExternalLoginConfirmEmailView, ExternalLogin
+from api.users.views import ClaimUser, ResetPassword, ExternalLoginConfirmEmailView, ExternalLogin, ConfirmEmailView
 from api.registrations.views import RegistrationCallbackView
 from api.wb.views import MoveFileMetadataView, CopyFileMetadataView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
@@ -63,6 +63,7 @@ class TestApiBaseViews(ApiTestCase):
             MetricsOpenapiView,
             ResetPassword,
             ExternalLoginConfirmEmailView,
+            ConfirmEmailView,
             ExternalLogin,
             RegistrationCallbackView,
         ]

--- a/api_tests/users/views/sanction_response/test_user_sanction_response.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response.py
@@ -1,0 +1,150 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from framework.auth import Auth
+from osf_tests.factories import AuthUserFactory, RetractionFactory
+from osf.utils.tokens import encode
+
+
+@pytest.mark.django_db
+class TestSanctionResponse:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture
+    def sanction(self):
+        sanction = RetractionFactory()
+        registration = sanction.registrations.first()
+        sanction.add_authorizer(sanction.initiated_by, registration, save=True)
+        return sanction
+
+    @pytest.fixture
+    def registration(self, sanction):
+        return sanction.registrations.first()
+
+    @pytest.fixture
+    def url(self, sanction):
+        return f'/{API_BASE}users/{sanction.initiated_by._id}/sanction_response/'
+
+    @pytest.fixture
+    def approval_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['approval_token']
+
+    @pytest.fixture()
+    def sanction_url(self, user):
+        return f'/{API_BASE}users/{user._id}/sanction_response/'
+
+    @pytest.fixture()
+    def token(self, user):
+        return encode({'uid': user._id, 'email': user.username})
+
+    def test_get_not_allowed(self, app, sanction_url):
+        res = app.get(sanction_url, expect_errors=True)
+        assert res.status_code == 405
+
+    def test_post_missing_fields(self, app, sanction_url, user):
+        res = app.post_json_api(
+            sanction_url,
+            {'data': {'attributes': {}}},
+            auth=user.auth,
+            expect_errors=True
+        )
+        print(res.json)
+        assert res.json['errors'] == [
+            {
+                'source': {
+                    'pointer': '/data/attributes/uid'
+                },
+                'detail': 'This field is required.'
+            },
+            {
+                'source': {
+                    'pointer': '/data/attributes/destination'
+                },
+                'detail': 'This field is required.'
+            },
+            {
+                'source': {
+                    'pointer': '/data/attributes/token'
+                },
+                'detail': 'This field is required.'
+            },
+            {
+                'source': {
+                    'pointer': '/data/attributes/action'
+                },
+                'detail': 'This field is required.'
+            }
+        ]
+        assert res.status_code == 400
+
+    def test_post_user_not_found(self, app, token):
+        fake_uid = 'abc12'
+        url = f'/{API_BASE}users/{fake_uid}/sanction_response/'
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': fake_uid,
+                        'token': token,
+                        'action': 'approve',
+                        'sanction_type': 'retraction',
+                        'destination': 'foo'
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.json['errors'] == [{'detail': 'Not found.'}]
+
+    def test_missing_action(self, app, url, sanction, registration, approval_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': approval_token,
+                        'destination': 'notebook',
+                        'sanction_type': 'retraction',
+                    }
+                }
+            },
+            auth=Auth(user),
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'] == [
+            {
+                'source': {
+                    'pointer': '/data/attributes/action'
+                },
+                'detail': 'This field is required.'
+            }
+        ]
+
+        sanction.refresh_from_db()
+        registration.refresh_from_db()
+
+    def test_post_missing_sanction_type(self, app, sanction_url, user, token):
+        res = app.post_json_api(
+            sanction_url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': token,
+                        'action': 'reject',
+                        'destination': 'foo'
+                    }
+                }
+            },
+            auth=user.auth,
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'] == [{'detail': 'sanction_type not found.'}]

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_embargo.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_embargo.py
@@ -1,0 +1,85 @@
+import pytest
+
+from framework.auth import Auth
+from osf_tests.factories import EmbargoFactory
+from api.base.settings.defaults import API_BASE
+
+
+@pytest.mark.django_db
+class TestEmbargoApproval:
+
+    @pytest.fixture
+    def embargo(self):
+        embargo = EmbargoFactory()
+        registration = embargo.registrations.first()
+        embargo.add_authorizer(embargo.initiated_by, registration, save=True)
+        return embargo
+
+    @pytest.fixture
+    def registration(self, embargo):
+        return embargo.registrations.first()
+
+    @pytest.fixture
+    def url(self, embargo):
+        return f'/{API_BASE}users/{embargo.initiated_by._id}/sanction_response/'
+
+    @pytest.fixture
+    def approval_token(self, embargo):
+        return embargo.approval_state[embargo.initiated_by._id]['approval_token']
+
+    @pytest.fixture
+    def rejection_token(self, embargo):
+        return embargo.approval_state[embargo.initiated_by._id]['rejection_token']
+
+    def test_approve_embargo(self, app, url, embargo, registration, approval_token):
+        user = embargo.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': approval_token,
+                        'action': 'approve',
+                        'destination': 'tire',
+                        'sanction_type': 'embargo',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        embargo.refresh_from_db()
+        registration.refresh_from_db()
+
+        assert embargo.is_approved
+        assert embargo.approval_state[user._id]['has_approved'] is True
+        assert registration.is_embargoed
+        assert registration.embargo_end_date == embargo.embargo_end_date
+
+    def test_reject_embargo(self, app, url, embargo, registration, rejection_token):
+        user = embargo.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': rejection_token,
+                        'action': 'reject',
+                        'destination': 'tire',
+                        'sanction_type': 'embargo',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        embargo.refresh_from_db()
+        registration.refresh_from_db()
+
+        assert embargo.is_rejected
+        assert embargo.approval_state[user._id]['has_rejected'] is True
+        assert registration.registered_from is None or registration.is_deleted

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_embargo.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_embargo.py
@@ -48,7 +48,7 @@ class TestEmbargoApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         embargo.refresh_from_db()
         registration.refresh_from_db()
@@ -75,7 +75,7 @@ class TestEmbargoApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         embargo.refresh_from_db()
         registration.refresh_from_db()

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_embargo_termination.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_embargo_termination.py
@@ -49,7 +49,7 @@ class TestEmbargoTerminationApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
         registration.refresh_from_db()
         assert registration.embargo.state == 'approved'  # embargo still active because it needs unanimous approval
 
@@ -68,7 +68,7 @@ class TestEmbargoTerminationApproval:
             },
             auth=Auth(registration.creator)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
         registration.refresh_from_db()
         assert registration.embargo.state == 'completed'  # now all agree to terminate
 
@@ -89,7 +89,7 @@ class TestEmbargoTerminationApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         sanction.refresh_from_db()
 

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_embargo_termination.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_embargo_termination.py
@@ -1,0 +1,97 @@
+import pytest
+
+from framework.auth import Auth
+from osf_tests.factories import EmbargoTerminationApprovalFactory
+from api.base.settings.defaults import API_BASE
+
+
+@pytest.mark.django_db
+class TestEmbargoTerminationApproval:
+
+    @pytest.fixture
+    def sanction(self):
+        sanction = EmbargoTerminationApprovalFactory()
+        registration = sanction.embargoed_registration
+        sanction.add_authorizer(sanction.initiated_by, registration, save=True)
+        return sanction
+
+    @pytest.fixture
+    def registration(self, sanction):
+        return sanction.embargoed_registration
+
+    @pytest.fixture
+    def url(self, sanction):
+        return f'/{API_BASE}users/{sanction.initiated_by._id}/sanction_response/'
+
+    @pytest.fixture
+    def approval_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['approval_token']
+
+    @pytest.fixture
+    def rejection_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['rejection_token']
+
+    def test_approve_embargo_termination(self, app, url, sanction, registration, approval_token):
+        assert registration.embargo_termination_approval
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': approval_token,
+                        'action': 'approve',
+                        'destination': 'tire',
+                        'sanction_type': 'embargo_termination_approval',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+        registration.refresh_from_db()
+        assert registration.embargo.state == 'approved'  # embargo still active because it needs unanimous approval
+
+        res = app.post_json_api(
+            f'/{API_BASE}users/{registration.creator._id}/sanction_response/',
+            {
+                'data': {
+                    'attributes': {
+                        'uid': registration.creator._id,
+                        'token': sanction.approval_state[registration.creator._id]['approval_token'],
+                        'action': 'approve',
+                        'destination': 'tire',
+                        'sanction_type': 'embargo_termination_approval',
+                    }
+                }
+            },
+            auth=Auth(registration.creator)
+        )
+        assert res.status_code == 200
+        registration.refresh_from_db()
+        assert registration.embargo.state == 'completed'  # now all agree to terminate
+
+    def test_reject_embargo_termination(self, app, url, sanction, registration, rejection_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': rejection_token,
+                        'action': 'reject',
+                        'destination': 'tire',
+                        'sanction_type': 'embargo_termination_approval',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        sanction.refresh_from_db()
+
+        assert sanction.state == 'rejected'
+        assert registration.embargo.state == 'approved'  # embargo still active because it needs unanimous approval

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_registration_approval.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_registration_approval.py
@@ -52,7 +52,7 @@ class TestRegistrationApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         sanction.refresh_from_db()
         registration.refresh_from_db()
@@ -78,7 +78,7 @@ class TestRegistrationApproval:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         sanction.refresh_from_db()
 

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_registration_approval.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_registration_approval.py
@@ -1,0 +1,86 @@
+import pytest
+
+from framework.auth import Auth
+from osf.models import Registration
+from osf_tests.factories import RegistrationApprovalFactory
+from api.base.settings.defaults import API_BASE
+
+
+@pytest.mark.django_db
+class TestRegistrationApproval:
+
+    @pytest.fixture
+    def registration(self):
+        registration_approval = RegistrationApprovalFactory()
+        registration = Registration.objects.get(registration_approval=registration_approval)
+        assert registration_approval.is_pending_approval
+        assert registration.is_pending_registration
+        return registration
+
+    @pytest.fixture
+    def sanction(self, registration):
+        sanction = registration.registration_approval
+        sanction.add_authorizer(registration.creator, registration, save=True)
+        return sanction
+
+    @pytest.fixture
+    def url(self, registration):
+        return f'/{API_BASE}users/{registration.creator._id}/sanction_response/'
+
+    @pytest.fixture
+    def approval_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['approval_token']
+
+    @pytest.fixture
+    def rejection_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['rejection_token']
+
+    def test_approve(self, app, url, sanction, registration, approval_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': approval_token,
+                        'action': 'approve',
+                        'destination': 'tire',
+                        'sanction_type': 'registration',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        sanction.refresh_from_db()
+        registration.refresh_from_db()
+
+        assert sanction.is_approved
+        assert not registration.is_pending_registration
+        assert sanction.approval_state[user._id]['has_approved'] is True
+
+    def test_reject(self, app, url, sanction, registration, rejection_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': rejection_token,
+                        'action': 'reject',
+                        'destination': 'tire',
+                        'sanction_type': 'registration',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        sanction.refresh_from_db()
+
+        assert sanction.is_rejected
+        assert sanction.approval_state[user._id]['has_rejected'] is True

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_retraction.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_retraction.py
@@ -1,0 +1,82 @@
+import pytest
+
+from framework.auth import Auth
+from osf_tests.factories import RetractionFactory
+from api.base.settings.defaults import API_BASE
+
+
+@pytest.mark.django_db
+class TestRetractionApprovalAPI:
+
+    @pytest.fixture
+    def sanction(self):
+        sanction = RetractionFactory()
+        registration = sanction.registrations.first()
+        sanction.add_authorizer(sanction.initiated_by, registration, save=True)
+        return sanction
+
+    @pytest.fixture
+    def registration(self, sanction):
+        return sanction.registrations.first()
+
+    @pytest.fixture
+    def url(self, sanction):
+        return f'/{API_BASE}users/{sanction.initiated_by._id}/sanction_response/'
+
+    @pytest.fixture
+    def approval_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['approval_token']
+
+    @pytest.fixture
+    def rejection_token(self, sanction):
+        return sanction.approval_state[sanction.initiated_by._id]['rejection_token']
+
+    def test_approve_retraction(self, app, url, sanction, registration, approval_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': approval_token,
+                        'action': 'approve',
+                        'destination': 'notebook',
+                        'sanction_type': 'retraction',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        sanction.refresh_from_db()
+        registration.refresh_from_db()
+
+        assert sanction.is_approved
+        assert sanction.approval_state[user._id]['has_approved'] is True
+        assert registration.is_retracted
+
+    def test_reject_retraction(self, app, url, sanction, rejection_token):
+        user = sanction.initiated_by
+        res = app.post_json_api(
+            url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': rejection_token,
+                        'action': 'reject',
+                        'destination': 'notebook',
+                        'sanction_type': 'retraction',
+                    }
+                }
+            },
+            auth=Auth(user)
+        )
+        assert res.status_code == 200
+
+        sanction.refresh_from_db()
+
+        assert sanction.is_rejected
+        assert sanction.approval_state[user._id]['has_rejected'] is True

--- a/api_tests/users/views/sanction_response/test_user_sanction_response_retraction.py
+++ b/api_tests/users/views/sanction_response/test_user_sanction_response_retraction.py
@@ -48,7 +48,7 @@ class TestRetractionApprovalAPI:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         sanction.refresh_from_db()
         registration.refresh_from_db()
@@ -74,7 +74,7 @@ class TestRetractionApprovalAPI:
             },
             auth=Auth(user)
         )
-        assert res.status_code == 200
+        assert res.status_code == 201
 
         sanction.refresh_from_db()
 

--- a/api_tests/users/views/test_user_confirm.py
+++ b/api_tests/users/views/test_user_confirm.py
@@ -1,0 +1,200 @@
+import pytest
+from unittest import mock
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import AuthUserFactory
+
+
+@pytest.mark.django_db
+class TestConfirmEmail:
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def user_with_email_verification(self, user):
+        email = 'HurtsSoGood@eagles.burds.com'
+        external_identity = {
+            'ORCID': {
+                '0002-0001-0001-0001': 'CREATE',
+            }
+        }
+        token = user.add_unconfirmed_email(email, external_identity=external_identity)
+        user.external_identity.update(external_identity)
+        user.save()
+        return user, token, email
+
+    @pytest.fixture()
+    def confirm_url(self, user_with_email_verification):
+        user, _, _ = user_with_email_verification
+        return f'/{API_BASE}users/{user._id}/confirm/'
+
+    def test_get_not_allowed(self, app, confirm_url):
+        res = app.get(confirm_url, expect_errors=True)
+        assert res.status_code == 405
+
+    def test_post_missing_fields(self, app, confirm_url, user_with_email_verification):
+        user, _, _ = user_with_email_verification
+        res = app.post_json_api(
+            confirm_url,
+            {'data': {'attributes': {}}},
+            expect_errors=True,
+            auth=user.auth
+        )
+        assert res.status_code == 400
+        assert res.json['errors'] == [
+            {
+                'source': {
+                    'pointer': '/data/attributes/uid'
+                },
+                'detail': 'This field is required.'
+            },
+            {
+                'source': {
+                    'pointer': '/data/attributes/destination'
+                },
+                'detail': 'This field is required.'
+            },
+            {
+                'source': {
+                    'pointer': '/data/attributes/token'
+                },
+                'detail': 'This field is required.'
+            }
+        ]
+
+    def test_post_user_not_found(self, app, user_with_email_verification):
+        user, _, _ = user_with_email_verification
+        fake_user_id = 'abcd1'
+        res = app.post_json_api(
+            f'/{API_BASE}users/{fake_user_id}/confirm/',
+            {
+                'data': {
+                    'attributes': {
+                        'uid': fake_user_id,
+                        'token': 'doesnotmatter',
+                        'destination': 'doesnotmatter',
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert 'user not found' in res.json['errors'][0]['detail'].lower()
+
+    def test_post_invalid_token(self, app, confirm_url, user_with_email_verification):
+        user, _, _ = user_with_email_verification
+        res = app.post_json_api(
+            confirm_url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': 'badtoken',
+                        'destination': 'doesnotmatter',
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert res.json['errors'] == [{'detail': 'Invalid or expired token.'}]
+
+    def test_post_provider_mismatch(self, app, confirm_url, user_with_email_verification):
+        user, token, _ = user_with_email_verification
+        user.external_identity = {}  # clear the valid provider
+        user.save()
+
+        res = app.post_json_api(
+            confirm_url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': token,
+                        'destination': 'doesnotmatter',
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.status_code == 400
+        assert 'provider mismatch' in res.json['errors'][0]['detail'].lower()
+
+    @mock.patch('website.mails.send_mail')
+    def test_post_success_create(self, mock_send_mail, app, confirm_url, user_with_email_verification):
+        user, token, email = user_with_email_verification
+        user.is_registered = False
+        user.save()
+        res = app.post_json_api(
+            confirm_url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': token,
+                        'destination': 'doesnotmatter',
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.status_code == 302
+        import urllib.parse
+
+        # Extract and decode the service parameter
+        location = res.headers['Location']
+        parsed_url = urllib.parse.urlparse(location)
+        query = urllib.parse.parse_qs(parsed_url.query)
+        service = query.get('service', [None])[0]
+
+        assert service is not None
+        decoded_service = urllib.parse.unquote(service)
+        assert '&new=true' in decoded_service
+
+        assert not mock_send_mail.called
+
+        user.reload()
+        assert user.is_registered
+        assert token not in user.email_verifications
+        assert user.external_identity == {'ORCID': {'0002-0001-0001-0001': 'VERIFIED'}}
+        assert user.emails.filter(address=email.lower()).exists()
+
+    @mock.patch('website.mails.send_mail')
+    def test_post_success_link(self, mock_send_mail, app, confirm_url, user_with_email_verification):
+        import urllib.parse
+
+        user, token, email = user_with_email_verification
+        user.external_identity['ORCID']['0000-0000-0000-0000'] = 'LINK'
+        user.save()
+
+        res = app.post_json_api(
+            confirm_url,
+            {
+                'data': {
+                    'attributes': {
+                        'uid': user._id,
+                        'token': token,
+                        'destination': 'doesnotmatter'
+                    }
+                }
+            },
+            expect_errors=True
+        )
+        assert res.status_code == 302
+
+        # Decode the redirect URL and check that &new=true is NOT present
+        location = res.headers['Location']
+        parsed_url = urllib.parse.urlparse(location)
+        query = urllib.parse.parse_qs(parsed_url.query)
+        service = query.get('service', [None])[0]
+
+        assert service is not None
+        decoded_service = urllib.parse.unquote(service)
+        assert '&new=true' not in decoded_service
+
+        assert mock_send_mail.called
+
+        user.reload()
+        assert user.external_identity['ORCID']['0000-0000-0000-0000'] == 'VERIFIED'

--- a/api_tests/users/views/test_user_confirm.py
+++ b/api_tests/users/views/test_user_confirm.py
@@ -43,26 +43,8 @@ class TestConfirmEmail:
             auth=user.auth
         )
         assert res.status_code == 400
-        assert res.json['errors'] == [
-            {
-                'source': {
-                    'pointer': '/data/attributes/uid'
-                },
-                'detail': 'This field is required.'
-            },
-            {
-                'source': {
-                    'pointer': '/data/attributes/destination'
-                },
-                'detail': 'This field is required.'
-            },
-            {
-                'source': {
-                    'pointer': '/data/attributes/token'
-                },
-                'detail': 'This field is required.'
-            }
-        ]
+        print(res.json['errors'])
+        assert res.json['errors'] == [{'source': {'pointer': '/data/attributes/uid'}, 'detail': 'This field is required.'}, {'source': {'pointer': '/data/attributes/destination'}, 'detail': 'This field is required.'}, {'source': {'pointer': '/data/attributes/token'}, 'detail': 'This field is required.'}]
 
     def test_post_user_not_found(self, app, user_with_email_verification):
         user, _, _ = user_with_email_verification
@@ -81,7 +63,7 @@ class TestConfirmEmail:
             expect_errors=True
         )
         assert res.status_code == 400
-        assert 'user not found' in res.json['errors'][0]['detail'].lower()
+        assert res.json['errors'] == [{'detail': 'User not found.'}]
 
     def test_post_invalid_token(self, app, confirm_url, user_with_email_verification):
         user, _, _ = user_with_email_verification

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -41,6 +41,8 @@ class CoreScopes:
 
     USER_ADDON_READ = 'users.addon_read'
 
+    SANCTION_RESPONSE = 'sanction_response'
+
     SUBSCRIPTIONS_READ = 'subscriptions_read'
     SUBSCRIPTIONS_WRITE = 'subscriptions_write'
 
@@ -289,16 +291,26 @@ class ComposedScopes:
     # Privileges relating to editing content uploaded under that preprint
     PREPRINT_DATA_READ = (CoreScopes.PREPRINT_FILE_READ,)
     PREPRINT_DATA_WRITE = PREPRINT_DATA_READ + \
-                        (CoreScopes.PREPRINT_FILE_WRITE,)
+                        (
+                            CoreScopes.PREPRINT_FILE_WRITE,
+                            CoreScopes.SANCTION_RESPONSE,
+                        )
 
     # Privileges relating to who can access a node (via contributors or registrations)
     NODE_ACCESS_READ = (CoreScopes.NODE_CONTRIBUTORS_READ, CoreScopes.NODE_REGISTRATIONS_READ,
                         CoreScopes.NODE_VIEW_ONLY_LINKS_READ, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_READ,
                         CoreScopes.NODE_REQUESTS_READ, CoreScopes.NODE_SETTINGS_READ, CoreScopes.NODE_OSF_GROUPS_READ)
     NODE_ACCESS_WRITE = NODE_ACCESS_READ + \
-                            (CoreScopes.NODE_CONTRIBUTORS_WRITE, CoreScopes.NODE_REGISTRATIONS_WRITE,
-                             CoreScopes.NODE_VIEW_ONLY_LINKS_WRITE, CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_WRITE,
-                             CoreScopes.NODE_REQUESTS_WRITE, CoreScopes.NODE_SETTINGS_WRITE, CoreScopes.NODE_OSF_GROUPS_WRITE)
+                            (
+                                CoreScopes.NODE_CONTRIBUTORS_WRITE,
+                                CoreScopes.NODE_REGISTRATIONS_WRITE,
+                                CoreScopes.NODE_VIEW_ONLY_LINKS_WRITE,
+                                CoreScopes.REGISTRATION_VIEW_ONLY_LINKS_WRITE,
+                                CoreScopes.NODE_REQUESTS_WRITE,
+                                CoreScopes.NODE_SETTINGS_WRITE,
+                                CoreScopes.NODE_OSF_GROUPS_WRITE,
+                                CoreScopes.SANCTION_RESPONSE,
+                            )
 
     # Privileges relating to who can access a preprint via contributors
     PREPRINT_ACCESS_READ = (CoreScopes.PREPRINT_CONTRIBUTORS_READ,)

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -32,6 +32,7 @@ class CoreScopes:
     USERS_MESSAGE_READ_EMAIL = 'users_message_read_email'
     USERS_MESSAGE_WRITE_EMAIL = 'users_message_write_email'
     USERS_CREATE = 'users_create'
+    USERS_CONFIRM = 'users_confirm'
 
     USER_SETTINGS_READ = 'user.settings_read'
     USER_SETTINGS_WRITE = 'user.settings_write'
@@ -214,7 +215,13 @@ class ComposedScopes:
 
     # Users collection
     USERS_READ = (CoreScopes.USERS_READ, CoreScopes.SUBSCRIPTIONS_READ, CoreScopes.ALERTS_READ, CoreScopes.USER_SETTINGS_READ)
-    USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE, CoreScopes.SUBSCRIPTIONS_WRITE, CoreScopes.ALERTS_WRITE, CoreScopes.USER_SETTINGS_WRITE)
+    USERS_WRITE = USERS_READ + (
+        CoreScopes.USERS_WRITE,
+        CoreScopes.USERS_CONFIRM,
+        CoreScopes.SUBSCRIPTIONS_WRITE,
+        CoreScopes.ALERTS_WRITE,
+        CoreScopes.USER_SETTINGS_WRITE
+    )
     USERS_CREATE = USERS_READ + (CoreScopes.USERS_CREATE, )
 
     # User extensions

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -315,7 +315,6 @@ class TokenApprovableSanction(Sanction):
         if user is None and event_data.args:
             user = event_data.args[0]
         self.approval_state[user._id]['has_approved'] = True
-
         if self.mode == self.ANY or all(
                 authorizer['has_approved']
                 for authorizer in self.approval_state.values()):

--- a/osf/utils/tokens/__init__.py
+++ b/osf/utils/tokens/__init__.py
@@ -14,14 +14,14 @@ from osf.exceptions import TokenHandlerNotFound
 class TokenHandler:
 
     HANDLERS = {
-        'approve_registration_approval': functools.partial(handlers.sanction_handler, 'registration', 'approve'),
-        'reject_registration_approval': functools.partial(handlers.sanction_handler, 'registration', 'reject'),
-        'approve_embargo': functools.partial(handlers.sanction_handler, 'embargo', 'approve'),
-        'reject_embargo': functools.partial(handlers.sanction_handler, 'embargo', 'reject'),
-        'approve_embargo_termination_approval': functools.partial(handlers.sanction_handler, 'embargo_termination_approval', 'approve'),
-        'reject_embargo_termination_approval': functools.partial(handlers.sanction_handler, 'embargo_termination_approval', 'reject'),
-        'approve_retraction': functools.partial(handlers.sanction_handler, 'retraction', 'approve'),
-        'reject_retraction': functools.partial(handlers.sanction_handler, 'retraction', 'reject')
+        'approve_registration_approval': functools.partial(handlers.sanction_handler_flask, 'registration', 'approve'),
+        'reject_registration_approval': functools.partial(handlers.sanction_handler_flask, 'registration', 'reject'),
+        'approve_embargo': functools.partial(handlers.sanction_handler_flask, 'embargo', 'approve'),
+        'reject_embargo': functools.partial(handlers.sanction_handler_flask, 'embargo', 'reject'),
+        'approve_embargo_termination_approval': functools.partial(handlers.sanction_handler_flask, 'embargo_termination_approval', 'approve'),
+        'reject_embargo_termination_approval': functools.partial(handlers.sanction_handler_flask, 'embargo_termination_approval', 'reject'),
+        'approve_retraction': functools.partial(handlers.sanction_handler_flask, 'retraction', 'approve'),
+        'reject_retraction': functools.partial(handlers.sanction_handler_flask, 'retraction', 'reject')
     }
 
     def __init__(self, encoded_token=None, payload=None):

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -712,7 +712,7 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.registration.web_url_for('view_project', token=app_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test unauth user cannot reject
         res = self.app.get(
@@ -720,7 +720,7 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.project.web_url_for('view_project', token=rej_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Delete Node and try again
         self.project.is_deleted = True
@@ -731,14 +731,14 @@ class LegacyRegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.registration.web_url_for('view_project', token=app_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test unauth user cannot reject
         res = self.app.get(
             self.project.web_url_for('view_project', token=rej_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test auth user can approve registration with deleted parent
         res = self.app.get(
@@ -975,7 +975,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.registration.web_url_for('token_action', token=app_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test unauth user cannot reject
         res = self.app.get(
@@ -983,7 +983,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.project.web_url_for('token_action', token=rej_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Delete Node and try again
         self.project.is_deleted = True
@@ -994,14 +994,14 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
             self.registration.web_url_for('token_action', token=app_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test unauth user cannot reject
         res = self.app.get(
             self.project.web_url_for('token_action', token=rej_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == 401
+        assert res.status_code == 403
 
         # Test auth user can approve registration with deleted parent
         res = self.app.get(
@@ -1190,7 +1190,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
 
         res = self.app.get(approval_url, auth=non_contributor.auth)
         self.registration.reload()
-        assert http_status.HTTP_401_UNAUTHORIZED == res.status_code
+        assert http_status.HTTP_403_FORBIDDEN == res.status_code
         assert self.registration.is_pending_embargo
         assert self.registration.embargo.state == Embargo.UNAPPROVED
 
@@ -1207,6 +1207,6 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         approval_url = self.registration.web_url_for('token_action', token=rejection_token)
 
         res = self.app.get(approval_url, auth=non_contributor.auth)
-        assert http_status.HTTP_401_UNAUTHORIZED == res.status_code
+        assert http_status.HTTP_403_FORBIDDEN == res.status_code
         assert self.registration.is_pending_embargo
         assert self.registration.embargo.state == Embargo.UNAPPROVED

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -620,13 +620,13 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         })
 
     # node_registration_retraction_approve_tests
-    def test_GET_approve_from_unauthorized_user_returns_HTTPError_UNAUTHORIZED(self):
+    def test_GET_approve_from_unauthorized_user_returns_HTTPError_FORBIDDEN(self):
         unauthorized_user = AuthUserFactory()
         res = self.app.get(
             self.registration.web_url_for('token_action', token=self.approval_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
 
     def test_GET_approve_registration_without_retraction_returns_HTTPError_BAD_REQUEST(self):
         assert self.registration.is_pending_retraction
@@ -665,14 +665,14 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert res.status_code == http_status.HTTP_302_FOUND
 
     # node_registration_retraction_disapprove_tests
-    def test_GET_disapprove_from_unauthorized_user_returns_HTTPError_UNAUTHORIZED(self):
+    def test_GET_disapprove_from_unauthorized_user_returns_HTTPError_FORBIDDEN(self):
         unauthorized_user = AuthUserFactory()
 
         res = self.app.get(
             self.registration.web_url_for('token_action', token=self.rejection_token),
             auth=unauthorized_user.auth,
         )
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
 
     def test_GET_disapprove_registration_without_retraction_returns_HTTPError_BAD_REQUEST(self):
         assert self.registration.is_pending_retraction
@@ -915,32 +915,32 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         args, kwargs = mock_send.call_args
         assert self.user.username in args
 
-    def test_non_contributor_GET_approval_returns_HTTPError_UNAUTHORIZED(self):
+    def test_non_contributor_GET_approval_returns_HTTPError_FORBIDDEN(self):
         non_contributor = AuthUserFactory()
         self.registration.retract_registration(self.user)
         approval_token = self.registration.retraction.approval_state[self.user._id]['approval_token']
 
         approval_url = self.registration.web_url_for('token_action', token=approval_token)
         res = self.app.get(approval_url, auth=non_contributor.auth)
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
         assert self.registration.is_pending_retraction
         assert not self.registration.is_retracted
 
         # group admin on node fails disapproval GET
         res = self.app.get(approval_url, auth=self.group_mem.auth)
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
 
-    def test_non_contributor_GET_disapproval_returns_HTTPError_UNAUTHORIZED(self):
+    def test_non_contributor_GET_disapproval_returns_HTTPError_FORBIDDEN(self):
         non_contributor = AuthUserFactory()
         self.registration.retract_registration(self.user)
         rejection_token = self.registration.retraction.approval_state[self.user._id]['rejection_token']
 
         disapproval_url = self.registration.web_url_for('token_action', token=rejection_token)
         res = self.app.get(disapproval_url, auth=non_contributor.auth)
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN
         assert self.registration.is_pending_retraction
         assert not self.registration.is_retracted
 
         # group admin on node fails disapproval GET
         res = self.app.get(disapproval_url, auth=self.group_mem.auth)
-        assert res.status_code == http_status.HTTP_401_UNAUTHORIZED
+        assert res.status_code == http_status.HTTP_403_FORBIDDEN

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -88,16 +88,6 @@ class SanctionTokenHandlerBase(OsfTestCase):
         self.reg = AbstractNode.objects.get(Q(**{self.Model.SHORT_NAME: self.sanction}))
         self.user = self.reg.creator
 
-    def test_sanction_handler(self):
-        if not self.kind:
-            return
-        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
-        handler = TokenHandler.from_string(approval_token)
-        with mock_auth(self.user):
-            with mock.patch(f'osf.utils.tokens.handlers.{self.kind}_handler') as mock_handler:
-                handler.to_response()
-                mock_handler.assert_called_with('approve', self.reg, self.reg.registered_from)
-
     def test_sanction_handler_no_sanction(self):
         if not self.kind:
             return

--- a/website/language.py
+++ b/website/language.py
@@ -221,3 +221,22 @@ RESET_PASSWORD_SUCCESS_STATUS_MESSAGE = (
     'reset the OSF password has been sent to {email}. If you do not receive an email and believe '
     'you should have, please contact OSF Support. '
 )
+
+SANCTION_STATUS_MESSAGES = {
+    'registration': {
+        'approve': 'Your registration approval has been accepted.',
+        'reject': 'Your disapproval has been accepted and the registration has been cancelled.',
+    },
+    'embargo': {
+        'approve': 'Your embargo approval has been accepted.',
+        'reject': 'Your disapproval has been accepted and the embargo has been cancelled.',
+    },
+    'embargo_termination_approval': {
+        'approve': 'Your approval to make this embargo public has been accepted.',
+        'reject': 'Your disapproval has been accepted and this embargo will not be made public.',
+    },
+    'retraction': {
+        'approve': 'Your withdrawal approval has been accepted.',
+        'reject': 'Your disapproval has been accepted and the withdrawal has been cancelled.',
+    }
+}


### PR DESCRIPTION
## Purpose

Update the alternate email confirmation system to v2

## Changes

- adds `/users/<user_id>/confirm/` route with views
- adds tests
- adds `/users/<user_id>/sanction_response/` route with views
- adds tests
- cleans-up and simplifies sanction_handler code to work better in different request contexts



## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7965