### PR TITLE
[ENG-5810] Switch to new UI when user views draft registration file

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1041,7 +1041,11 @@ class TargetField(ser.Field):
             'lookup_kwarg': 'preprint_id',
         },
         'draft-node': {
-            'view': 'draft_nodes:node-detail',
+            'view': 'draft_nodes:draft-node-detail',
+            'lookup_kwarg': 'node_id',
+        },
+        'draftnode': {
+            'view': 'draft_nodes:draft-node-detail',
             'lookup_kwarg': 'node_id',
         },
         'comment': {

--- a/website/views.py
+++ b/website/views.py
@@ -342,6 +342,9 @@ def resolve_guid(guid, suffix=None):
     elif isinstance(resource, Node) and clean_suffix and (clean_suffix.startswith('metadata') or clean_suffix.startswith('components')):
         return use_ember_app()
 
+    elif isinstance(resource, OsfStorageFile) and isinstance(resource.target, DraftNode):
+        return use_ember_app()
+
     elif isinstance(resource, BaseFileNode) and resource.is_file and not isinstance(resource.target, Preprint):
         if isinstance(resource.target, Registration) and flag_is_active(request, features.EMBER_FILE_REGISTRATION_DETAIL):
             return use_ember_app()


### PR DESCRIPTION
## Purpose

Throughout registration creation user can view attached files. However `resolve_guid` doesn't handle this case and renders the legacy UI that shows error because `get_rdf_type` raises `NotImplementedError`. So this case has no be handled by ember. However when we switch to the new UI, we get `draftnode is not a supported target type`. Also there will be some work for FE because for now ember relies on `node` relationship that draft node/registration don't have. Taking into account Futa's words, it's an unusual flow for ember

## Changes

Added redirect to ember, updated `view_map` that referenced to the non-existing view `draft_nodes:node-detail` to use `draft_nodes:draft-node-detail` view

## Notes
1. I'm not confident that `draft-node` key is still used in `view_map`. From the `resolve` method of `TargetField` I see that keys are either model name in lowercase or `referent._name` that I couldn't find how is created (maybe automatically). However if it existed, there would be some errors that this view does not exist. So I left both keys but with the correct view name. In case you know the answer, I can remove the original key and leave only the correct one

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?selectedIssue=ENG-5810