### PR TITLE
[ENG-8052] Fixed FilterMixin issue with multiple values of any filter

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -292,7 +292,8 @@ class FilterMixin:
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id', 'moderation_state']:
+                    # elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id', 'moderation_state']:
+                    elif not isinstance(value, int) and ',' in value:
                         query.get(key).update({
                             field_name: {
                                 'op': 'in',
@@ -505,7 +506,6 @@ class ListFilterMixin(FilterMixin):
                 if issubclass(self.model_class, GuidMixin)
                 else self.model_class.primary_identifier_name
             )
-            operation['op'] = 'in'
         if field_name == 'subjects':
             self.postprocess_subject_query_param(operation)
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -292,7 +292,6 @@ class FilterMixin:
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    # elif not isinstance(value, int) and source_field_name in ['_id', 'guid._id', 'journal_id', 'moderation_state']:
                     elif not isinstance(value, int) and ',' in value:
                         query.get(key).update({
                             field_name: {

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -160,6 +160,8 @@ class FilterMixin:
     LIST_FIELDS = (ser.ListField,)
     RELATIONSHIP_FIELDS = (RelationshipField, TargetField)
 
+    MULTIPLE_VALUES_FIELDS = ['_id', 'guid._id', 'journal_id', 'moderation_state', 'event_name']
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.serializer_class:
@@ -292,7 +294,7 @@ class FilterMixin:
                         query.get(key).update({
                             field_name: self._parse_date_param(field, source_field_name, op, value),
                         })
-                    elif not isinstance(value, int) and ',' in value:
+                    elif not isinstance(value, int) and source_field_name in self.MULTIPLE_VALUES_FIELDS:
                         query.get(key).update({
                             field_name: {
                                 'op': 'in',
@@ -505,6 +507,7 @@ class ListFilterMixin(FilterMixin):
                 if issubclass(self.model_class, GuidMixin)
                 else self.model_class.primary_identifier_name
             )
+            operation['op'] = 'in'
         if field_name == 'subjects':
             self.postprocess_subject_query_param(operation)
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -385,7 +385,6 @@ class TestListFilterMixin(ApiTestCase):
         assert parsed_field['value'] is False
         assert parsed_field['op'] == 'eq'
 
-
 @pytest.mark.django_db
 class TestOSFOrderingFilter(ApiTestCase):
     class query:

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -85,6 +85,7 @@ class FakeRecord:
 
 class FakeListView(ListFilterMixin, generics.GenericAPIView):
     serializer_class = FakeSerializer
+    model_class = FakeRecord
 
     def get_serializer_context(self):
         return {}
@@ -378,12 +379,71 @@ class TestListFilterMixin(ApiTestCase):
         query_params = {
             'filter[bool_field]': 'false',
         }
-
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
         assert parsed_field['source_field_name'] == 'foobar'
         assert parsed_field['value'] is False
         assert parsed_field['op'] == 'eq'
+
+    def test_multiple_values_filter(self):
+        user = AuthUserFactory()
+        node1 = NodeFactory(title='title1', creator=user)
+        node2 = NodeFactory(title='title2', creator=user)
+        node3 = NodeFactory(title='title3', creator=user)
+
+        url = f'/{API_BASE}users/{user._id}/nodes/'
+        res = self.app.get(url, auth=user.auth)
+        assert len(res.json['data']) == 3
+
+        # one filter, one value
+        res = self.app.get(url + '?filter[title]=title2', auth=user.auth)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['attributes']['title'] == 'title2'
+
+        # one filter, two values
+        res = self.app.get(url + '?filter[title]=title3,title2', auth=user.auth)
+        assert len(res.json['data']) == 2
+        for node in res.json['data']:
+            assert node['attributes']['title'] in ['title3', 'title2']
+
+        # one filter, all DB values
+        res = self.app.get(url + '?filter[title]=title1,title3,title2', auth=user.auth)
+        assert len(res.json['data']) == 3
+        for node in res.json['data']:
+            assert node['attributes']['title'] in ['title3', 'title2', 'title1']
+
+        # two filters, different number of values. Filters don't intersect by nodes
+        res = self.app.get(url + f'?filter[title]=title3,title2&filter[id]={node1._id}', auth=user.auth)
+        assert len(res.json['data']) == 0
+
+        # two filters, different filters ordering but intersect by node2
+        # node3 is not returned as filters use AND operator between themselves
+        res = self.app.get(url + f'?filter[id]={node2._id}&filter[title]=title3,title2', auth=user.auth)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == node2._id
+
+        # two filters, two values of the same entities
+        res = self.app.get(url + f'?filter[title]=title3,title1&filter[id]={node1._id},{node3._id}', auth=user.auth)
+        assert len(res.json['data']) == 2
+        for node in res.json['data']:
+            assert node['id'] in [node1._id, node3._id]
+            assert node['attributes']['title'] in ['title3', 'title1']
+
+        # two filters, one of them has an unexisting value, node1 in both filters, node3 is only in the second filter
+        # thus shouldn't be returned
+        res = self.app.get(url + f'?filter[title]=wrongtitle_____,title1&filter[id]={node1._id},{node3._id}', auth=user.auth)
+        assert len(res.json['data']) == 1
+        assert res.json['data'][0]['id'] == node1._id
+        assert res.json['data'][0]['attributes']['title'] == 'title1'
+
+        # two filters whose values refer to different entities, thus no intersection and no values returned
+        res = self.app.get(url + f'?filter[title]=title1,title4&filter[id]={node2._id},{node3._id}', auth=user.auth)
+        assert len(res.json['data']) == 0
+
+        # two filters, all values aren't present in DB
+        res = self.app.get(url + '?filter[title]=wrong1,wrong2&filter[id]=guid1,guid2,guid999', auth=user.auth)
+        assert len(res.json['data']) == 0
+
 
 @pytest.mark.django_db
 class TestOSFOrderingFilter(ApiTestCase):

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -378,6 +378,7 @@ class TestListFilterMixin(ApiTestCase):
         query_params = {
             'filter[bool_field]': 'false',
         }
+
         fields = self.view.parse_query_params(query_params)
         parsed_field = fields['filter[bool_field]']['bool_field']
         assert parsed_field['source_field_name'] == 'foobar'

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -85,7 +85,6 @@ class FakeRecord:
 
 class FakeListView(ListFilterMixin, generics.GenericAPIView):
     serializer_class = FakeSerializer
-    model_class = FakeRecord
 
     def get_serializer_context(self):
         return {}

--- a/api_tests/subscriptions/views/test_subscriptions_list.py
+++ b/api_tests/subscriptions/views/test_subscriptions_list.py
@@ -54,3 +54,9 @@ class TestSubscriptionList:
         assert patch_res.status_code == 405
         assert put_res.status_code == 405
         assert delete_res.status_code == 405
+
+    def test_multiple_values_filter(self, app, url, global_user_notification, user):
+        res = app.get(url + '?filter[event_name]=comments,global', auth=user.auth)
+        assert len(res.json['data']) == 2
+        for subscription in res.json['data']:
+            subscription['attributes']['event_name'] in ['global', 'comments']


### PR DESCRIPTION
## Purpose

Query params filters were limited to handle multiple values starting from this commit https://github.com/CenterForOpenScience/osf.io/commit/6fd196821736c71566b50545f8bf1d83ecdb211e for these fields only: `_id`, `guid._id`, `journal_id`, `moderation_state`. Over time this list have been updated to these four values. Now all filter classes that inherit from `FilterMixin` support this feature.
In order to filter by multiple values, FE should use the following syntax:
`?filter[title]=text1,text2`
Filter uses OR operator for its values while filters use AND operator between themselves

## Changes

1. Updated if statement to support multiple values for all fields
2. Also when one value was passed for any of the fields above, it was processed as a list. Now operator update was removed for `id` field in `ListFilterMixin.postprocess_query_param` so that `in` lookup is not used for one `id` that is actually string.
3. Added tests

## Concerns
1. Would be nice to test different endpoints that use different filters because the base filter mixin was updated, thus it may impact all filters.
2. Another concern is that now we use `__in` lookup for fields in these filters instead of `__icontains`(which was wrong as `title1,title2` was passed as one value). It doesn't impact any filtering that FE does using internal values they get from BE, so for the case in the ticket it'll work. But do we have filtering on the platform where user can enter text manually that will be passed as a query parameter together with some filter? If user enters "Dev" and FE filters like `?filter['title']=Dev` and it should find all records that contain this word, I assume it won't work. It'll actually require refactoring filters.

## Ticket

https://openscience.atlassian.net/jira/software/c/projects/ENG/boards/145?selectedIssue=ENG-8052