### PR TITLE
[ENG-7870] Crossref DOIs not minting with _v1, OSF is displaying DOI versions with _v1

### DIFF
--- a/osf/management/commands/check_crossref_dois.py
+++ b/osf/management/commands/check_crossref_dois.py
@@ -80,6 +80,9 @@ def check_crossref_dois(dry_run=True):
                 continue
             pending_dois.append(f'doi:{settings.DOI_FORMAT.format(prefix=doi_prefix, guid=preprint._id)}')
 
+        if not pending_dois:
+            continue
+
         url = '{}works?filter={}'.format(settings.CROSSREF_JSON_API_URL, ','.join(pending_dois))
 
         try:

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -767,11 +767,11 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
     def is_latest_version(self):
         return self.guids.exists()
 
-    def get_preprint_versions(self, include_rejected=True):
+    def get_preprint_versions(self, include_rejected=True, **version_filters):
         guids = self.versioned_guids.first().guid.versions.all()
         preprint_versions = (
             Preprint.objects
-            .filter(id__in=[vg.object_id for vg in guids])
+            .filter(id__in=[vg.object_id for vg in guids], **version_filters)
             .annotate(latest_version=Max('versioned_guids__version'))
             .order_by('-latest_version')
         )

--- a/tests/identifiers/test_crossref.py
+++ b/tests/identifiers/test_crossref.py
@@ -349,6 +349,15 @@ class TestCrossRefClient:
         assert contributors.find('.//{%s}institution_name' % crossref.CROSSREF_NAMESPACE).text == institution.name
         assert contributors.find('.//{%s}institution_id' % crossref.CROSSREF_NAMESPACE).text == institution.ror_uri
 
+    def test_metadata_uses_existing_identifier(self, crossref_client, preprint):
+        doi = settings.DOI_FORMAT.format(prefix=preprint.provider.doi_prefix, guid=preprint.id)
+        preprint.set_identifier_values(doi, save=True)
+
+        crossref_xml = crossref_client.build_metadata(preprint)
+        root = lxml.etree.fromstring(crossref_xml)
+
+        assert root.find('.//{%s}doi' % crossref.CROSSREF_NAMESPACE).text == preprint.get_identifier_value('doi')
+
     def test_public_preprint_title_is_composed_correctly(self, crossref_client, preprint):
         preprint.title = 'My Title'
         preprint.save()

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -8,7 +8,6 @@ import requests
 from django.db.models import QuerySet
 
 from .exceptions import CrossRefRateLimitError
-from framework import sentry
 from framework.auth.utils import impute_names
 from website.identifiers.utils import remove_control_characters
 from website.identifiers.clients.base import AbstractIdentifierClient
@@ -250,13 +249,6 @@ class CrossRefClient(AbstractIdentifierClient):
 
     def create_identifier(self, preprint, category, include_relation=True):
         if category == 'doi':
-            prefix = preprint.provider.doi_prefix
-            if prefix is None:
-                sentry.log_message(f'Preprint [_id={preprint._id}] has been skipped for CrossRef DOI Update '
-                                    f'since the provider [_id={preprint.provider._id}] has invalid DOI Prefix '
-                                    f'[doi_prefix={prefix}]')
-                return
-
             metadata = self.build_metadata(preprint, include_relation)
             doi = self.build_doi(preprint)
             username, password = self.get_credentials()

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -69,9 +69,11 @@ def update_or_enqueue_on_preprint_updated(preprint_id, saved_fields=None):
 def mint_doi_on_crossref_fail(self, preprint_id):
     from osf.models import Preprint
     preprint = Preprint.load(preprint_id)
+    vg = preprint.versioned_guids.first()
     existing_versions_without_minted_doi = Preprint.objects.filter(
-        versioned_guids__guid=preprint.versioned_guids.first().guid,
-        versioned_guids__version__lt=preprint.versioned_guids.first().version,
+        versioned_guids__guid=vg.guid,
+        versioned_guids__version__lt=vg.version,
+        date_published__isnull=False,
         preprint_doi_created__isnull=True
     ).exclude(id=preprint.id)
     if existing_versions_without_minted_doi:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
do not mint _v1 doi if legacy one exists

## Changes

- make sure that CrossrefClient works well with legacy DOIs
- don't send request to crossref when check_crossref_dois if no DOIs were selected
- check only published preprints when mint_doi_on_crossref_fail

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/ENG-7870
