### PR TITLE
[END-7969] Fixed children/parent relationships in admin templates

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -107,6 +107,7 @@ class NodeView(NodeMixin, GuidView):
             'SPAM_STATUS': SpamStatus,
             'STORAGE_LIMITS': settings.StorageLimits,
             'node': node,
+            'children': node.get_nodes(is_node_link=False),
             'duplicates': detailed_duplicates
         })
 

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -85,10 +85,10 @@
                     <tr>
                         <td>Parent</td>
                         <td>
-                            {% if not node.parent %}
+                            {% if not node.parent_node %}
                                 None
                             {% else %}
-                                <a href="{{ node.parent | reverse_node }}">{{ node.parent }}</a>
+                                <a href="{{ node.parent_node | reverse_node }}">{{ node.parent_node.title }}</a>
                             {% endif %}
                         </td>
                     </tr>
@@ -102,7 +102,7 @@
                     {% include "nodes/schema_responses.html" with schema_responses=node.schema_responses.all %}
                     {% include "nodes/retraction.html" with retraction=node.retraction %}
                     {% include "nodes/registrations.html" with registrations=node.registrations.all %}
-                    {% include "nodes/children.html" with children=node.children.all %}
+                    {% include "nodes/children.html" with children=children %}
                     {% include "nodes/embargo.html" with embargo=node.embargo is_registration=node.is_registration%}
                     {% include "nodes/embargo_termination_approval.html" with embargo_termination_approval=node.embargo_termination_approval %}
                     {% include "nodes/registration_approval.html" with registration_approval=node.registration_approval %}


### PR DESCRIPTION
## Purpose

Admin templates used nonexistent fields to display children and parent of a node (potentially new fields were added but the old fields weren't replaced by new ones). The templates used `parent` and `children` fields. However an endpoint that adds children and parent to a node uses fields `descendants` (or through `NodeRelation` using `get_nodes` method) and `parent_node` property through `_parents` field

## Changes

Use correct fields

## Notes

Deletion of children nodes that are displayed now is broken. Together with Mark decided to create a separate ticket for this issue

## Ticket

https://openscience.atlassian.net/browse/ENG-7969?atlOrigin=eyJpIjoiMGNhZWZhMWM4ZmM2NGNlM2E4ZDQ0OTg1ZjgyZmI1NGEiLCJwIjoiaiJ9