### PR TITLE
[ENG-8016] Re-adding the same user to preprint providers as moderator/admin creates duplicate records.

### DIFF
--- a/admin/preprint_providers/forms.py
+++ b/admin/preprint_providers/forms.py
@@ -116,10 +116,10 @@ class PreprintProviderRegisterModeratorOrAdminForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         provider_groups = provider_groups or Group.objects.none()
-        self.fields['group_perms'] = forms.ModelMultipleChoiceField(
+        self.fields['group_perms'] = forms.ModelChoiceField(
             queryset=provider_groups,
             required=False,
-            widget=forms.CheckboxSelectMultiple
+            widget=forms.RadioSelect
         )
 
     user_id = forms.CharField(required=True, max_length=5, min_length=5)

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -481,10 +481,14 @@ class PreprintProviderRegisterModeratorOrAdmin(PermissionRequiredMixin, FormView
         if not osf_user:
             raise Http404(f'OSF user with id "{user_id}" not found. Please double check.')
 
-        for group in form.cleaned_data.get('group_perms'):
-            self.target_provider.add_to_group(osf_user, group)
+        if osf_user.has_groups(self.target_provider.group_names):
+            messages.error(self.request, f'User with guid: {user_id} is already a moderator or admin')
+            return super().form_invalid(form)
 
+        group = form.cleaned_data.get('group_perms')
+        self.target_provider.add_to_group(osf_user, group)
         osf_user.save()
+
         messages.success(self.request, f'Permissions update successful for OSF User {osf_user.username}!')
         return super().form_valid(form)
 

--- a/admin/providers/views.py
+++ b/admin/providers/views.py
@@ -29,8 +29,7 @@ class AddAdminOrModerator(TemplateView):
             messages.error(request, f'User for guid: {data["add-moderators-form"][0]} could not be found')
             return redirect(f'{self.url_namespace}:add_admin_or_moderator', provider_id=provider.id)
 
-        groups = [provider.format_group(name) for name in provider.groups.keys()]
-        if target_user.has_groups(groups):
+        if target_user.has_groups(provider.group_names):
             messages.error(request, f'User with guid: {data["add-moderators-form"][0]} is already a moderator or admin')
             return redirect(f'{self.url_namespace}:add_admin_or_moderator', provider_id=provider.id)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
don't add multiple group perms for preprint provider

## Changes
- check if user already belongs to some provider group
- change checkbox to radio select

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-8016
