### PR TITLE
[ENG-8145] Update manual DOI assignment for Preprints

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -375,7 +375,9 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             guid=base_guid_obj
         )
         versioned_guid.save()
-        preprint.save(guid_ready=True, first_save=True, manual_doi=manual_doi)
+        preprint.save(guid_ready=True, first_save=True)
+        if manual_doi:
+            preprint.set_identifier_values(manual_doi, save=True)
 
         return preprint
 
@@ -985,7 +987,6 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             raise IntegrityError(err_msg)
 
         first_save = kwargs.pop('first_save', False)
-        manual_doi = kwargs.pop('manual_doi', None)
         set_creator_as_contributor = kwargs.pop('set_creator_as_contributor', True)
         saved_fields = self.get_dirty_fields() or []
 
@@ -1010,8 +1011,6 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
             # thus no need to set creator as the first contributor immediately
             if set_creator_as_contributor:
                 self._add_creator_as_contributor()
-            if manual_doi:
-                self.set_identifier_value('doi', manual_doi)
 
         if (not first_save and 'is_published' in saved_fields) or self.is_published:
             update_or_enqueue_on_preprint_updated(preprint_id=self._id, saved_fields=saved_fields)


### PR DESCRIPTION
## Purpose

* Manually set preprint DOI outside `Preprint.save()`
* Calls `Preprint.set_identifier_values()` instead of `IdentifierMixin.set_identifier_value()`. This removes this preprint from CrossRef DOI check task.

## Ticket

Follow-up for: https://openscience.atlassian.net/browse/ENG-8145