### PR TITLE
[ENG-8247] Ability to delete draft preprints from database

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -279,7 +279,7 @@ class PreprintVersionsList(PreprintMetricsViewMixin, JSONAPIBaseView, generics.L
         return super().create(request, *args, **kwargs)
 
 
-class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin, JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
+class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin, JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, PreprintMixin, WaterButlerMixin):
     """The documentation for this endpoint can be found [here](https://developer.osf.io/#operation/preprints_read).
     """
     permission_classes = (
@@ -326,6 +326,11 @@ class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin
         res['legacy_type_allowed'] = True
         return res
 
+    def delete(self, request, *args, **kwargs):
+        if self.get_preprint().machine_state == 'initial':
+            return super().delete(request, *args, **kwargs)
+
+        raise ValidationError('You cannot delete created preprint')
 
 class PreprintNodeRelationship(PreprintOldVersionsImmutableMixin, JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin):
     permission_classes = (


### PR DESCRIPTION
## Purpose

User should be able to delete draft preprints, so that we don't save them in database

## Changes

Added `delete` method.
User can delete a preprint only if it's in initial state, so it means this preprint is a draft

## Ticket

https://openscience.atlassian.net/browse/ENG-8247?atlOrigin=eyJpIjoiYzdkN2MwNDU5N2NkNDk5ZmI5Y2FmYWE0MDFkNTVjYTciLCJwIjoiaiJ9