### PR TITLE
[ENG-8048_2] fixed None issue during iteration

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2497,7 +2497,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             if service.short_name == gv_pk:
                 break
         else:
-            return None
+            return []
 
         return self._get_addons_from_gv(requesting_user_id, service.type, auth=auth)
 


### PR DESCRIPTION
## Purpose

`_get_addon_from_gv` iterates through None when service is not found in `_get_addons_from_gv_without_caching`

## Changes

Replace None by an empty list
