### PR TITLE
[ENG-8239] Add external_high and external_low to celery task router

### DIFF
--- a/framework/celery_tasks/routers.py
+++ b/framework/celery_tasks/routers.py
@@ -15,6 +15,10 @@ def match_by_module(task_path):
             return CeleryConfig.task_remote_computing_queue
         if task_subpath in CeleryConfig.task_account_status_changes_queue:
             return CeleryConfig.task_account_status_changes_queue
+        if task_subpath in CeleryConfig.task_external_low_queue:
+            return CeleryConfig.task_external_low_queue
+        if task_subpath in CeleryConfig.task_external_high_queue:
+            return CeleryConfig.task_external_high_queue
     return CeleryConfig.task_default_queue
 
 


### PR DESCRIPTION
## Purpose

Add `external_high` and `external_low` to celery task router

## Changes

N/A

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8264
