### PR TITLE
[ENG-8239] Fix regex for parsing node URL when logging GV add-ons

### DIFF
--- a/osf/tasks.py
+++ b/osf/tasks.py
@@ -7,7 +7,7 @@ from framework.celery_tasks import app
 from framework.sentry import log_message
 
 logger = logging.getLogger(__name__)
-iri_regex = re.compile(r'http://[^/]+/(?P<id>\w{5})/?')
+iri_regex = re.compile(r'https?://[^/]+/(?P<id>\w{5})/?')
 
 def get_object_by_url[T: Model](url: str, model: type[T]) -> T | None:
     if not (match := iri_regex.match(url)):


### PR DESCRIPTION
## Purpose

Fix regex for parsing node URL when logging GV add-ons

## Changes

Fix regex for parsing node URL when logging GV add-ons

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8239
