### PR TITLE
[ENG-8224] Fixed force archive template with registration addons

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -761,7 +761,7 @@ class ForceArchiveRegistrationsView(NodeMixin, View):
 
         allow_unconfigured = force_archive_params.get('allow_unconfigured', False)
 
-        addons = set(force_archive_params.getlist('addons', []))
+        addons = set(registration.registered_from.get_addon_names())
         addons.update(DEFAULT_PERMISSIBLE_ADDONS)
 
         try:
@@ -780,8 +780,8 @@ class ForceArchiveRegistrationsView(NodeMixin, View):
                     registration,
                     permissible_addons=addons,
                     allow_unconfigured=allow_unconfigured,
-                    skip_collision=skip_collision,
-                    delete_collision=delete_collision,
+                    skip_collisions=skip_collision,
+                    delete_collisions=delete_collision,
                 )
                 messages.success(request, 'Registration archive process has finished.')
             except Exception as exc:

--- a/admin/templates/nodes/registration_force_archive_form.html
+++ b/admin/templates/nodes/registration_force_archive_form.html
@@ -19,7 +19,7 @@
             <h4>Permissible Addons (Optional):</h4>
             <div>
                 <div>
-                    {% for addon_name in node.get_addon_names %}
+                    {% for addon_name in node.registered_from.get_addon_names %}
                     <input class="form-check-input" type="checkbox" name="addons" id="permissibleAddon" value="{{ addon_name }}">
                     <label class="form-check-label" for="permissibleAddon">{{ addon_name }}</label>
                     {% endfor %}

--- a/admin/templates/nodes/registration_force_archive_form.html
+++ b/admin/templates/nodes/registration_force_archive_form.html
@@ -16,17 +16,6 @@
             </div>
         </div>
         <div>
-            <h4>Permissible Addons (Optional):</h4>
-            <div>
-                <div>
-                    {% for addon_name in node.registered_from.get_addon_names %}
-                    <input class="form-check-input" type="checkbox" name="addons" id="permissibleAddon" value="{{ addon_name }}">
-                    <label class="form-check-label" for="permissibleAddon">{{ addon_name }}</label>
-                    {% endfor %}
-                </div>
-            </div>
-        </div>
-        <div>
             <h4>Other:</h4>
             <div>
                 <div class="form-check">


### PR DESCRIPTION
## Purpose

Product team reported that they cannot force archive registration because of this error:
`["7t6qj: Original node zts5b has addons: ['osfstorage', 'wiki', 'github', 'zotero']`
It happens due to not all configured addons are displayed and selected in the template that is required to archive a registration

For example this registration has zotero and github addons that aren't displayed because we fetch addons from registration, not from it's parent node
![image](https://github.com/user-attachments/assets/6e2bb72d-6491-4c2e-858f-47f97647c691)

## Changes

Implicitly fetch addons so that admins shouldn't select them.
Fixed passed params issue
Hide addons from the template (agreed with Blaine)
![image](https://github.com/user-attachments/assets/4ca6cf90-59d1-4f5f-a13b-71ce41cf13f8)

# QA Notes
Nothing was changed in force archive logic, but I encountered one bug related to function params that was fixed as well (as configurable addons have never been displayed, this flow couldn't be really tested by QA, thus force archiver has to be retested with addons)

## Ticket

https://openscience.atlassian.net/browse/ENG-8224?atlOrigin=eyJpIjoiZWExYjFiNWJiYzViNGNlMmFhOWQwNDU3NDFmMmJhYjEiLCJwIjoiaiJ9