### PR TITLE
[ENG-8261] Metadata download route

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -412,7 +412,12 @@ def make_url_map(app):
             website_views.dashboard,
             notemplate
         ),
-
+        Rule(
+            '/metadata/<guid>/',
+            'get',
+            website_views.metadata_download,
+            notemplate
+        ),
         Rule(
             '/myprojects/',
             'get',

--- a/website/views.py
+++ b/website/views.py
@@ -434,3 +434,9 @@ def guid_metadata_download(guid, resource, metadata_format):
                 'Content-Disposition': f'attachment; filename={result.filename}',
             },
         )
+
+
+def metadata_download(guid):
+    format_arg = request.args.get('format', 'datacite-json')
+    resource = Guid.load(guid)
+    return guid_metadata_download(guid, resource, format_arg)


### PR DESCRIPTION
## Purpose

So right now, our firewall rules aren't advanced enough to be able to let requests from /<guid>/metadata go through to osf on staging4. Instead, we have to start with a stable string, and do the dynamic part afterward, hence doing /metadata/<guid/  which we can match with /metadata/* in the firewall.

## Changes

Added a corresponding route

## Ticket

https://openscience.atlassian.net/browse/ENG-8261?atlOrigin=eyJpIjoiOWYxYTkwYjY0NDVmNGJjOWI0NzgxNDMzNzg5MmIzZmQiLCJwIjoiaiJ9