### PR TITLE
[ENG-8321] Handle 500 error from crossref

### DIFF
--- a/osf/management/commands/sync_doi_metadata.py
+++ b/osf/management/commands/sync_doi_metadata.py
@@ -8,12 +8,13 @@ from django.core.management.base import BaseCommand
 from osf.models import GuidMetadataRecord, Identifier, Registration, Preprint
 from framework.celery_tasks import app
 from website.identifiers.clients.exceptions import CrossRefUnavailableError
+from website.settings import CROSSREF_UNAVAILABLE_DELAY
+
 
 logger = logging.getLogger(__name__)
 
 
 RATE_LIMIT_RETRY_DELAY = 60 * 5
-CROSSREF_UNAVAILABLE_DELAY = 24 * 60 * 60
 
 
 @app.task(name='osf.management.commands.sync_doi_metadata', bind=True, acks_late=True, max_retries=5, default_retry_delay=RATE_LIMIT_RETRY_DELAY)

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -267,7 +267,7 @@ class CrossRefClient(AbstractIdentifierClient):
             if response.status_code == 429:
                 raise CrossRefRateLimitError(response.text)
 
-            if response.status_code == 500:
+            if response.status_code >= 500:
                 raise CrossRefUnavailableError(response.text)
 
             return {'doi': doi}

--- a/website/identifiers/clients/crossref.py
+++ b/website/identifiers/clients/crossref.py
@@ -7,7 +7,7 @@ import logging
 import requests
 from django.db.models import QuerySet
 
-from .exceptions import CrossRefRateLimitError
+from .exceptions import CrossRefRateLimitError, CrossRefUnavailableError
 from framework.auth.utils import impute_names
 from website.identifiers.utils import remove_control_characters
 from website.identifiers.clients.base import AbstractIdentifierClient
@@ -266,6 +266,9 @@ class CrossRefClient(AbstractIdentifierClient):
             )
             if response.status_code == 429:
                 raise CrossRefRateLimitError(response.text)
+
+            if response.status_code == 500:
+                raise CrossRefUnavailableError(response.text)
 
             return {'doi': doi}
 

--- a/website/identifiers/clients/exceptions.py
+++ b/website/identifiers/clients/exceptions.py
@@ -16,3 +16,12 @@ class CrossRefRateLimitError(Exception):
 
     def __str__(self):
         return self.error
+
+
+class CrossRefUnavailableError(Exception):
+
+    def __init__(self, error):
+        self.error = error
+
+    def __str__(self):
+        return self.error

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -5,6 +5,7 @@ from framework.exceptions import HTTPError
 from framework.celery_tasks import app as celery_app
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task, get_task_from_postcommit_queue
 from website.identifiers.clients.exceptions import CrossRefUnavailableError
+from website.settings import CROSSREF_UNAVAILABLE_DELAY
 
 
 CROSSREF_FAIL_RETRY_DELAY = 12 * 60 * 60
@@ -69,7 +70,6 @@ def update_or_enqueue_on_preprint_updated(preprint_id, saved_fields=None):
 @celery_app.task(bind=True, acks_late=True, max_retries=5, default_retry_delay=CROSSREF_FAIL_RETRY_DELAY)
 def mint_doi_on_crossref_fail(self, preprint_id):
     from osf.models import Preprint
-    from osf.management.commands.sync_doi_metadata import CROSSREF_UNAVAILABLE_DELAY
 
     preprint = Preprint.load(preprint_id)
     vg = preprint.versioned_guids.first()

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -4,6 +4,7 @@ from framework import sentry
 from framework.exceptions import HTTPError
 from framework.celery_tasks import app as celery_app
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task, get_task_from_postcommit_queue
+from website.identifiers.clients.exceptions import CrossRefUnavailableError
 
 
 CROSSREF_FAIL_RETRY_DELAY = 12 * 60 * 60
@@ -68,6 +69,8 @@ def update_or_enqueue_on_preprint_updated(preprint_id, saved_fields=None):
 @celery_app.task(bind=True, acks_late=True, max_retries=5, default_retry_delay=CROSSREF_FAIL_RETRY_DELAY)
 def mint_doi_on_crossref_fail(self, preprint_id):
     from osf.models import Preprint
+    from osf.management.commands.sync_doi_metadata import CROSSREF_UNAVAILABLE_DELAY
+
     preprint = Preprint.load(preprint_id)
     vg = preprint.versioned_guids.first()
     existing_versions_without_minted_doi = Preprint.objects.filter(
@@ -84,5 +87,9 @@ def mint_doi_on_crossref_fail(self, preprint_id):
         self.retry()
     else:
         crossref_client = preprint.get_doi_client()
-        if crossref_client:
-            crossref_client.create_identifier(preprint, category='doi', include_relation=False)
+        try:
+            if crossref_client:
+                crossref_client.create_identifier(preprint, category='doi', include_relation=False)
+        except CrossRefUnavailableError as err:
+            logger.warning(f'CrossRef is unavailable during minting DOI on fail for preprint {preprint_id}. Error: {err.error}')
+            self.retry(countdown=CROSSREF_UNAVAILABLE_DELAY)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -341,6 +341,7 @@ CROSSREF_USERNAME = None
 CROSSREF_PASSWORD = None
 CROSSREF_URL = None  # Location to POST crossref data. In production, change this to the production CrossRef API endpoint
 CROSSREF_DEPOSITOR_EMAIL = 'None'  # This email will receive confirmation/error messages from CrossRef on submission
+CROSSREF_UNAVAILABLE_DELAY = 24 * 60 * 60
 
 ECSARXIV_CROSSREF_USERNAME = None
 ECSARXIV_CROSSREF_PASSWORD = None


### PR DESCRIPTION
## Purpose

CrossRef will be unavailable for 24 hours, so we handle it and do a few retries in 24 hours

## Changes

Handle 500 error

## Notes
So, in most cases we make a request to CrossRef via one of these methods:
`create_identifier`
`update_identifier`
`request_identifier_update`
`request_identifier`
Actually everything comes to `create_identifier` call
For now if crossref returns any status code besides `429` (rate limit), we don't show users any errors because crossref returns them via email.
Now we handle 500 error from crossref in celery tasks that already have retry in case of other errors. (all of them call `request_identifier_update`)

However what should we do with cases when `create_identifier` is called synchronously?
From one side we can make this method to call another celery task that will have retry.
On the other side some functions that use this synchronous call may depend on it and show users some error so that we can't make it asynchronous to use retry mechanism.
Should we worry about it?
 
## Ticket

https://openscience.atlassian.net/browse/ENG-8321?atlOrigin=eyJpIjoiMmI2NGU1NWFmNGI3NDgyZDg1NGYyOGE5ZGVlMGU4YzEiLCJwIjoiaiJ9