### PR TITLE
[ENG-7979] Registrations pending moderation that have components also pending moderation do not display the children

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -481,7 +481,7 @@ class BaseChildrenList(JSONAPIBaseView, NodesFilterMixin):
         return self.default_ordering
 
     # overrides GenericAPIView
-    def get_queryset(self):
+    def get_queryset(self, *args, **kwargs):
         """
         Returns non-deleted children of the current resource that the user has permission to view -
         Children could be public, viewable through a view-only link (if provided), or the user
@@ -494,8 +494,8 @@ class BaseChildrenList(JSONAPIBaseView, NodesFilterMixin):
         if self.request.query_params.get('sort', None) == '_order':
             # Order by the order of the node_relations
             order = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(node_pks)])
-            return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user, auth.private_link).order_by(order)
-        return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user, auth.private_link)
+            return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user, auth.private_link, *args, **kwargs).order_by(order)
+        return self.get_queryset_from_request().filter(pk__in=node_pks).can_view(auth.user, auth.private_link, *args, **kwargs)
 
 
 class BaseContributorDetail(JSONAPIBaseView, generics.RetrieveAPIView):

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -351,6 +351,12 @@ class RegistrationProvider(AbstractProvider):
         if not self.schemas.filter(id=schema.id).exists():
             raise ValidationError('Invalid schema for provider.')
 
+    def is_moderator(self, user):
+        """Return True if the user is a moderator for this provider"""
+        if user and user.is_authenticated:
+            return user.has_perm('osf.view_submissions', self)
+        return False
+
 
 class PreprintProvider(AbstractProvider):
     """

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -452,14 +452,7 @@ class Registration(AbstractNode):
         if not auth or not auth.user or not self.is_moderated:
             return False
 
-        moderator_viewable_states = {
-            RegistrationModerationStates.PENDING.db_name,
-            RegistrationModerationStates.PENDING_WITHDRAW.db_name,
-            RegistrationModerationStates.EMBARGO.db_name,
-            RegistrationModerationStates.PENDING_EMBARGO_TERMINATION.db_name,
-        }
-        user_is_moderator = auth.user.has_perm('view_submissions', self.provider)
-        if self.moderation_state in moderator_viewable_states and user_is_moderator:
+        if self.moderation_state in RegistrationModerationStates.in_moderation_states() and self.provider.is_moderator(auth.user):
             return True
 
         return False

--- a/osf/utils/workflows.py
+++ b/osf/utils/workflows.py
@@ -121,6 +121,15 @@ class RegistrationModerationStates(ModerationEnum):
 
         return new_state
 
+    @classmethod
+    def in_moderation_states(cls):
+        return [
+            cls.PENDING.db_name,
+            cls.EMBARGO.db_name,
+            cls.PENDING_EMBARGO_TERMINATION.db_name,
+            cls.PENDING_WITHDRAW.db_name,
+        ]
+
 
 class RegistrationModerationTriggers(ModerationEnum):
     '''The acceptable 'triggers' to describe a moderated action on a Registration.'''


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fix registration children visibility and count for non-contributor moderators

## Changes

- extend get_node_count() sql to include pending registrations if user is moderator
- add custom_filters to AbstractNode.can_view() method to include not only public nodes

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-7979
