### PR TITLE
[ENG-8325] Fixed displaying of privacy of child nodes in admin

### DIFF
--- a/admin/templates/nodes/children.html
+++ b/admin/templates/nodes/children.html
@@ -23,7 +23,7 @@
                         </a>
                     </td>
                     <td>{{ child.title }}</td>
-                    <td>{{ child.public }}</td>
+                    <td>{{ child.is_public }}</td>
                     <td>{{ child.contributors|length }}</td>
                     {%  if perms.osf.delete_node %}
                     <td>


### PR DESCRIPTION
## Purpose

Privacy of child nodes was not displayed.

## Changes

Use correct attribute to display privacy of child nodes

![image](https://github.com/user-attachments/assets/6b06752e-6a5f-4bb5-8076-5dcb9cef7655)
![image](https://github.com/user-attachments/assets/bf1f5d91-8cbf-4793-a61f-ee3b98379cf1)

## Ticket

https://openscience.atlassian.net/browse/ENG-8325?atlOrigin=eyJpIjoiNjBmODI2ZmRlYWNjNDJiNDgxYzk0MTZhMzQ4MjFmMDYiLCJwIjoiaiJ9