### PR TITLE
[ENG-8246] Fixed deletion of maintenance alerts in admin

### DIFF
--- a/admin/maintenance/views.py
+++ b/admin/maintenance/views.py
@@ -6,6 +6,7 @@ import website.maintenance as maintenance
 from admin.maintenance.forms import MaintenanceForm
 
 from django.shortcuts import redirect
+from django.urls import reverse_lazy
 from django.forms.models import model_to_dict
 from django.views.generic import DeleteView, TemplateView
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -15,11 +16,13 @@ class DeleteMaintenance(PermissionRequiredMixin, DeleteView):
     permission_required = 'osf.delete_maintenancestate'
     raise_exception = True
     template_name = 'maintenance/delete_maintenance.html'
+    success_url = reverse_lazy('maintenance:display')
 
     def get_object(self, queryset=None):
         return MaintenanceState.objects.first()
 
-    def delete(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
+        super().post(request, *args, **kwargs)
         maintenance.unset_maintenance()
         return redirect('maintenance:display')
 

--- a/admin_tests/maintenance/test_views.py
+++ b/admin_tests/maintenance/test_views.py
@@ -89,7 +89,7 @@ class TestDeleteMaintenance:
         return view
 
     def test_delete(self, view, req):
-        res = view.delete(req)
+        res = view.post(req)
         assert res.url == '/maintenance/'
         assert res.status_code == 302
         assert MaintenanceState.objects.all().count() == 0


### PR DESCRIPTION
## Purpose

Admins were not able to delete maintenance alerts because success_url was not set on backend. Also incorrect (`delete`) method was overridden as `BaseDeleteView` uses `post` method instead) so the deletion logic has never worked correctly

## Changes

Added success_url for a correct redirection that caused 502
Fixed overridden method

## Ticket

https://openscience.atlassian.net/browse/ENG-8246