### PR TITLE
[ENG-8396] Enable filtering preprints by tags

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -605,6 +605,9 @@ class PreprintFilterMixin(ListFilterMixin):
         if field_name == 'subjects':
             self.postprocess_subject_query_param(operation)
 
+        if field_name == 'tags':
+            super().postprocess_query_param(key, field_name, operation)
+
     def preprints_queryset(self, base_queryset, auth_user, allow_contribs=True, public_only=False, latest_only=False):
         preprints = Preprint.objects.can_view(
             base_queryset=base_queryset,

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -102,6 +102,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
         'subjects',
         'reviews_state',
         'node_is_public',
+        'tags',
     ])
     available_metrics = frozenset([
         'downloads',


### PR DESCRIPTION
## Purpose

Angular team needs the ability to filter preprints by tags

## Changes

Make `tags` field filterable
Use `ListFilterMixin` behavior to process this field

## Ticket

https://openscience.atlassian.net/browse/ENG-8396?atlOrigin=eyJpIjoiNTQxYjM2MTA1MmY3NDE1M2I5ZDMxOTNhMzg0OTcyY2UiLCJwIjoiaiJ9