### PR TITLE
[ENG-8455] Added academiaInstitution in social-schema, fixed True value for ongoing

### DIFF
--- a/api/base/schemas/education-schema.json
+++ b/api/base/schemas/education-schema.json
@@ -25,18 +25,6 @@
 				"minimum": 1900
 			},
 			"ongoing": {
-				"oneOf": [{
-						"enum": [false],
-						"required": ["startYear", "endYear"]
-					},
-					{
-						"enum": [true],
-						"required": ["startYear"],
-						"not": {
-							"required": ["endYear"]
-						}
-					}
-				],
 				"type": "boolean"
 			},
 			"department": {
@@ -56,7 +44,25 @@
 			"startMonth": ["startYear"],
 			"startYear": ["ongoing"],
 			"endYear": ["ongoing"],
-			"endYear": ["startYear"]
+			"endYear": ["startYear"],
+			"ongoing": {
+				"if": {
+					"properties": {
+						"ongoing": {
+							"const": false
+						}
+					}
+				},
+				"then": {
+					"required": ["startYear", "endYear"]
+				},
+				"else": {
+					"required": ["startYear"],
+					"not": {
+						"required": ["endYear"]
+					}
+				}
+			}
 		}
 	}
 }

--- a/api/base/schemas/employment-schema.json
+++ b/api/base/schemas/employment-schema.json
@@ -25,18 +25,6 @@
 				"minimum": 1900
 			},
 			"ongoing": {
-				"oneOf": [{
-						"enum": [false],
-						"required": ["startYear", "endYear"]
-					},
-					{
-						"enum": [true],
-						"required": ["startYear"],
-						"not": {
-							"required": ["endYear"]
-						}
-					}
-				],
 				"type": "boolean"
 			},
 			"department": {
@@ -56,7 +44,25 @@
 			"startMonth": ["startYear"],
 			"startYear": ["ongoing"],
 			"endYear": ["ongoing"],
-			"endYear": ["startYear"]
+			"endYear": ["startYear"],
+			"ongoing": {
+				"if": {
+					"properties": {
+						"ongoing": {
+							"const": false
+						}
+					}
+				},
+				"then": {
+					"required": ["startYear", "endYear"]
+				},
+				"else": {
+					"required": ["startYear"],
+					"not": {
+						"required": ["endYear"]
+					}
+				}
+			}
 		}
 	}
 }

--- a/api/base/schemas/social-schema.json
+++ b/api/base/schemas/social-schema.json
@@ -64,6 +64,10 @@
       "description": "The academiaProfileID for the given user",
       "type": "string"
     },
+    "academiaInstitution": {
+      "description": "The academiaInstitution for the given user",
+      "type": "string"
+    },
     "orcid": {
       "description": "The orcid for the given user",
       "type": "string"


### PR DESCRIPTION
## Purpose

V2 API doesn't allow setting `True` value for `ongoing` property for employment/education tabs and set `academiaInstitution` property for social tab

## Changes

Added academiaInstitution field in social-schema
Fixed ignored required properties for `ongoing` property in employment/education-schema files
Added new tests and fixed the old ones

## QA Notes

Can be tested only via API
Updates can be viewed in user settings

## Ticket

https://openscience.atlassian.net/browse/ENG-8455?atlOrigin=eyJpIjoiMTNmYWQzZTE0YTRmNDNkNGFjNjRhNDA3MzZhZmUzMWQiLCJwIjoiaiJ9