### PR TITLE
Fix/eng 8048 3

### DIFF
--- a/osf/models/archive.py
+++ b/osf/models/archive.py
@@ -146,7 +146,7 @@ class ArchiveJob(ObjectIDMixin, BaseModel):
 
     def set_targets(self):
         addons = []
-        for addon in [self.src_node.get_addon(name)
+        for addon in [self.src_node.get_addon(name, cached=False)
                       for name in settings.ADDONS_ARCHIVABLE
                       if settings.ADDONS_ARCHIVABLE[name] != 'none']:
             if not addon or not isinstance(addon, BaseStorageAddon) or not addon.complete:

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -554,12 +554,12 @@ class AddonModelMixin(models.Model):
             return addon
         return self.add_addon(name, *args, **kwargs)
 
-    def get_addon(self, name, is_deleted=False, auth=None):
+    def get_addon(self, name, is_deleted=False, auth=None, cached=True):
         # Avoid test-breakages by avoiding early access to the request context
         if name not in self.OSF_HOSTED_ADDONS:
             request, user_id = get_request_and_user_id()
             if flag_is_active(request, features.ENABLE_GV):
-                return self._get_addon_from_gv(gv_pk=name, requesting_user_id=user_id, auth=auth)
+                return self._get_addon_from_gv(gv_pk=name, requesting_user_id=user_id, auth=auth, cached=cached)
 
         try:
             settings_model = self._settings_model(name)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2495,21 +2495,28 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                     force=True
                 )
 
-    def _get_addon_from_gv(self, gv_pk, requesting_user_id, auth=None):
+    def _get_addons_from_gv_without_caching(self, gv_pk, requesting_user_id, auth=None):
+        requesting_user = OSFUser.load(requesting_user_id)
+        services = gv_translations.get_external_services(requesting_user)
+        for service in services:
+            if service.short_name == gv_pk:
+                break
+        else:
+            return None
+
+        return self._get_addons_from_gv(requesting_user_id, service.type, auth=auth)
+
+    def _get_addon_from_gv(self, gv_pk, requesting_user_id, auth=None, cached=True):
         request = get_current_request()
         # This is to avoid making multiple requests to GV
         # within the lifespan of one request on the OSF side
-        try:
-            gv_addons = request.gv_addons
-        except AttributeError:
-            requesting_user = OSFUser.load(requesting_user_id)
-            services = gv_translations.get_external_services(requesting_user)
-            for service in services:
-                if service.short_name == gv_pk:
-                    break
-            else:
-                return None
-            gv_addons = request.gv_addons = self._get_addons_from_gv(requesting_user_id, service.type, auth=auth)
+        if cached:
+            try:
+                gv_addons = request.gv_addons
+            except AttributeError:
+                gv_addons = request.gv_addons = self._get_addons_from_gv_without_caching(gv_pk, requesting_user_id, auth=auth)
+        else:
+            gv_addons = self._get_addons_from_gv_without_caching(gv_pk, requesting_user_id, auth=auth)
 
         for item in gv_addons:
             if item.short_name == gv_pk:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2502,7 +2502,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             if service.short_name == gv_pk:
                 break
         else:
-            return None
+            return []
 
         return self._get_addons_from_gv(requesting_user_id, service.type, auth=auth)
 


### PR DESCRIPTION
## Purpose

When user adds a component to a node that has addons with files and registers it, the node doesn't have any archived files. It happens because the child nodes are the first ones to be registered and if a child doesn't have any addons, this empty list would be saved in request.gv_addons attribute that is reused for all other parents and children to avoid making redundant requests to GV. However each child and parent may have its own collection of addons.

## Changes

<!-- Briefly describe or list your changes  -->

## Ticket

https://openscience.atlassian.net/browse/ENG-8048?atlOrigin=eyJpIjoiOGE5NDg4N2QzMjU3NGRmYjllNjIxY2I2ZTAwMWE5MDIiLCJwIjoiaiJ9