### PR TITLE
[ENG-8514] Remove CSRF protection from reset password api v2 POST

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -897,7 +897,6 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 )
         return Response(status=status.HTTP_200_OK, data={'message': status_message, 'kind': kind, 'institutional': institutional})
 
-    @method_decorator(csrf_protect)
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -211,8 +211,7 @@ class TestResetPassword:
             assert res.status_code == 200
             assert not mock_send_mail.called
 
-    def test_post(self, app, url, user_one, csrf_token):
-        app.set_cookie(CSRF_COOKIE_NAME, csrf_token)
+    def test_post(self, app, url, user_one):
         encoded_email = urllib.parse.quote(user_one.email)
         url = f'{url}?email={encoded_email}'
         res = app.get(url)
@@ -227,7 +226,7 @@ class TestResetPassword:
             }
         }
 
-        res = app.post_json_api(url, payload, headers={'X-CSRFToken': csrf_token})
+        res = app.post_json_api(url, payload)
         user_one.reload()
         assert res.status_code == 200
         assert user_one.check_password('password2')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

remove csrf protection from reset password endpoint

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-8514
