### PR TITLE
[ENG-8742] include ignored components when create a view-only link

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1697,12 +1697,15 @@ class NodeViewOnlyLinkSerializer(JSONAPISerializer):
         user = get_user_auth(self.context['request']).user
         anonymous = validated_data.pop('anonymous')
         node = self.context['view'].get_node()
+        children = self.context['request'].data.pop('target_type', [])
+        if children:
+            children = [AbstractNode.load(id) for id in children if id != 'nodes']
 
         try:
             view_only_link = new_private_link(
                 name=name,
                 user=user,
-                nodes=[node],
+                nodes=[node, *children],
                 anonymous=anonymous,
             )
         except ValidationError:

--- a/api_tests/nodes/views/test_node_view_only_links_list.py
+++ b/api_tests/nodes/views/test_node_view_only_links_list.py
@@ -55,6 +55,11 @@ def view_only_link(public_project):
     return view_only_link
 
 
+@pytest.fixture()
+def components_factory():
+    return ProjectFactory
+
+
 @pytest.mark.django_db
 class TestViewOnlyLinksList:
 
@@ -230,10 +235,10 @@ class TestViewOnlyLinksCreate:
         assert res.status_code == 401
 
     def test_create_vol_with_components(
-            self, app, user, url, public_project, view_only_link):
-        component1 = ProjectFactory(creator=user)
-        component2 = ProjectFactory(creator=user)
-        component3 = ProjectFactory(creator=user)
+            self, app, user, url, public_project, view_only_link, components_factory):
+        component1 = components_factory(creator=user)
+        component2 = components_factory(creator=user)
+        component3 = components_factory(creator=user)
         NodeRelationFactory(parent=public_project, child=component1)
         NodeRelationFactory(parent=public_project, child=component2)
         NodeRelationFactory(parent=public_project, child=component3)
@@ -269,8 +274,8 @@ class TestViewOnlyLinksCreate:
         assert len(data['embeds']['nodes']['data']) == 4
 
     def test_create_vol_no_duplicated_components(
-            self, app, user, url, public_project, view_only_link):
-        component1 = ProjectFactory(creator=user)
+            self, app, user, url, public_project, view_only_link, components_factory):
+        component1 = components_factory(creator=user)
         NodeRelationFactory(parent=public_project, child=component1)
 
         url = f'{url}?embed=creator&embed=nodes'

--- a/api_tests/registrations/views/test_registration_view_only_links_list.py
+++ b/api_tests/registrations/views/test_registration_view_only_links_list.py
@@ -58,6 +58,11 @@ def view_only_link(public_project):
     return view_only_link
 
 
+@pytest.fixture
+def components_factory():
+    return RegistrationFactory
+
+
 class TestRegistrationViewOnlyLinksList(TestViewOnlyLinksList):
     pass
 


### PR DESCRIPTION
## Purpose

Components are ignored when user creates a view-only link and includes components

## Ticket

https://openscience.atlassian.net/browse/ENG-8742?atlOrigin=eyJpIjoiYjg1ZGE2MzI3YjMyNGE2YWFiMDYyOGMyMjQyOTJhYmYiLCJwIjoiaiJ9
