### PR TITLE
[ENG-8743] subscribe_osf_general_email settings is not updated

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -581,6 +581,7 @@ class UserSettingsUpdateSerializer(UserSettingsSerializer):
                     instance._id,
                     username=instance.username,
                 )
+            instance.reload()
         else:
             raise exceptions.ValidationError(detail='Invalid email preference.')
 
@@ -624,7 +625,6 @@ class UserSettingsUpdateSerializer(UserSettingsSerializer):
         return UserSettingsSerializer(instance=instance, context=context).data
 
     def update(self, instance, validated_data):
-
         for attr, value in validated_data.items():
             if 'two_factor_enabled' == attr:
                 two_factor_addon = instance.get_addon('twofactor')

--- a/api_tests/users/views/test_user_settings_detail.py
+++ b/api_tests/users/views/test_user_settings_detail.py
@@ -4,7 +4,7 @@ from api.base.settings.defaults import API_BASE
 from osf_tests.factories import (
     AuthUserFactory,
 )
-from website.settings import OSF_HELP_LIST
+from website.settings import OSF_HELP_LIST, MAILCHIMP_GENERAL_LIST
 
 
 @pytest.fixture()
@@ -208,6 +208,9 @@ class TestUserSettingsUpdateMailingList:
         user_one.refresh_from_db()
         assert res.json['data']['attributes']['subscribe_osf_help_email'] is False
         assert user_one.osf_mailing_lists[OSF_HELP_LIST] is False
+
+        assert res.json['data']['attributes']['subscribe_osf_general_email'] is True
+        assert user_one.mailchimp_mailing_lists[MAILCHIMP_GENERAL_LIST] is True
         mock_mailchimp_client.assert_called_with()
 
     def test_bad_payload_patch_400(self, app, user_one, bad_payload, url):


### PR DESCRIPTION
## Purpose

`subscribe_osf_general_email` setting is not updated

## Changes

Added user record reload in the serializer.

This attribute is indeed updated within `mailchimp_utils.subscribe_mailchimp` call but when we return back to the serializer, this update is lost. I assume it happens because `mailchimp_utils.subscribe_mailchimp` fetches user instance with `OSFUser.load()` that updates user but the serializer works with the old version of this user.

Moving `user.reload()` to `mailchimp_utils.subscribe_mailchimp` doesn't fix the issue, while adding
`instance.mailchimp_mailing_lists[MAILCHIMP_GENERAL_LIST] = True` in the serializer fixes it that confirms my assumption above.

## Ticket

https://openscience.atlassian.net/browse/ENG-8743
