### PR TITLE
[ENG-8749] Implement SSO attributes de-duplication for email and names

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -226,11 +226,11 @@ class InstitutionAuthentication(BaseAuthentication):
 
         # Deduplicate full name first if it is provided
         if fullname:
-            fullname = deduplicate_sso_attributes(institution, sso_identity, 'fullname', fullname)
+            fullname = deduplicate_sso_attributes('fullname', fullname)
         # Use given name and family name to build full name if it is not provided
         if given_name and family_name and not fullname:
-            given_name = deduplicate_sso_attributes(institution, sso_identity, 'given_name', given_name)
-            family_name = deduplicate_sso_attributes(institution, sso_identity, 'family_name', family_name)
+            given_name = deduplicate_sso_attributes('given_name', given_name)
+            family_name = deduplicate_sso_attributes('family_name', family_name)
             fullname = given_name + ' ' + family_name
 
         # Non-empty full name is required. Fail the auth and inform sentry if not provided.
@@ -243,13 +243,7 @@ class InstitutionAuthentication(BaseAuthentication):
 
         # Deduplicate sso email, currently we only handle duplicate sso email instead of multiple sso email
         try:
-            sso_email = deduplicate_sso_attributes(
-                institution,
-                sso_identity,
-                'sso_email',
-                sso_email,
-                ignore_errors=False,
-            )
+            sso_email = deduplicate_sso_attributes('sso_email', sso_email)
         except MultipleSSOEmailError:
             message = f'Institution SSO Error: multiple SSO email [sso_email={sso_email}, sso_identity={sso_identity}, institution={institution._id}]'
             sentry.log_message(message)

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -224,15 +224,16 @@ class InstitutionAuthentication(BaseAuthentication):
                     f'sso_email={sso_email}, sso_identity={sso_identity}]',
                 )
 
-        # Deduplicate full name first if it is provided
+        # Deduplicate names first if it is provided
         if fullname:
             fullname = deduplicate_sso_attributes('fullname', fullname)
+        if given_name:
+            given_name = deduplicate_sso_attributes('given_name', given_name)
+        if family_name:
+            family_name = deduplicate_sso_attributes('family_name', family_name)
         # Use given name and family name to build full name if it is not provided
         if given_name and family_name and not fullname:
-            given_name = deduplicate_sso_attributes('given_name', given_name)
-            family_name = deduplicate_sso_attributes('family_name', family_name)
             fullname = given_name + ' ' + family_name
-
         # Non-empty full name is required. Fail the auth and inform sentry if not provided.
         if not fullname:
             message = f'Institution SSO Error: missing full name ' \

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -254,8 +254,7 @@ class InstitutionAuthentication(BaseAuthentication):
             message = f'Institution SSO Error: multiple SSO email [sso_email={sso_email}, sso_identity={sso_identity}, institution={institution._id}]'
             sentry.log_message(message)
             logger.error(message)
-            # TODO: this requires a CAS hotfix to handle `detail='InstitutionMultipleSSOEmails'`
-            raise PermissionDenied(detail='InstitutionMultipleSSOEmails')
+            raise PermissionDenied(detail='InstitutionSsoMultipleEmailsNotSupported')
         # Attempt to find an existing user that matches the email(s) provided via SSO. Create a new one if not found.
         # If a user is found, it is possible that the user is inactive (e.g. unclaimed, disabled, unconfirmed, etc.).
         # If a new user is created, the user object is confirmed but not registered (i.e. inactive until registered).

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -159,17 +159,16 @@ def get_or_create_institutional_user(fullname, sso_email, sso_identity, primary_
     return user, True, None, None, sso_identity
 
 
-def deduplicate_sso_attributes(institution, sso_identity, attr_name, attr_value, delimiter=';', ignore_errors=True):
+def deduplicate_sso_attributes(attr_name, attr_value, delimiter=';'):
     if delimiter not in attr_value:
         return attr_value
     value_set = set(attr_value.split(delimiter))
     if len(value_set) != 1:
-        message = (f'Multiple values {attr_value} found for SSO attribute {attr_name}: '
-                   f'[institution_id={institution._id}, sso_identity={sso_identity}]')
-        if ignore_errors:
-            sentry.log_message(message)
-            return attr_value
-        raise MultipleSSOEmailError(message)
+        message = f'Multiple values found for SSO attribute: [{attr_name}={attr_value}]'
+        sentry.log_message(message)
+        if attr_name == 'sso_email':
+            raise MultipleSSOEmailError(message)
+        return attr_value
     return value_set.pop()
 
 

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -154,8 +154,7 @@ def get_or_create_institutional_user(fullname, sso_email, sso_identity, primary_
     # CASE 5/5: If no user is found, create a confirmed user and return the user and sso identity.
     # Note: Institution users are created as confirmed with a strong and random password. Users don't need the
     # password since they sign in via SSO. They can reset their password to enable email/password login.
-    # user = OSFUser.create_confirmed(sso_email, str(uuid.uuid4()), fullname)
-    user = OSFUser.create_confirmed(sso_email, 'abCD12#$', fullname)
+    user = OSFUser.create_confirmed(sso_email, str(uuid.uuid4()), fullname)
     user.add_system_tag(institution_source_tag(primary_institution._id))
     return user, True, None, None, sso_identity
 

--- a/framework/auth/exceptions.py
+++ b/framework/auth/exceptions.py
@@ -65,3 +65,7 @@ class MergeConflictError(EmailConfirmTokenError):
     """Raised if a merge is not possible due to a conflict"""
     message_short = language.CANNOT_MERGE_ACCOUNTS_SHORT
     message_long = language.CANNOT_MERGE_ACCOUNTS_LONG
+
+
+class MultipleSSOEmailError(AuthError):
+    pass

--- a/framework/auth/exceptions.py
+++ b/framework/auth/exceptions.py
@@ -68,4 +68,5 @@ class MergeConflictError(EmailConfirmTokenError):
 
 
 class MultipleSSOEmailError(AuthError):
+    """Raised if institution SSO provides multiple emails which OSF cannot deduplicate."""
     pass


### PR DESCRIPTION
## Purpose

Implement SSO attributes de-duplication for email and names

- [x] Unit tests
- [x] Requires https://github.com/CenterForOpenScience/osf-cas/pull/86
- [x] Local Postman tests with CAS

## Changes

* Attempt to deduplicate emails and names
  * If successful, log sentry and let API return success to CAS
  * However, if found multiple different emails, raise error and inform CAS

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8749
