### PR TITLE
[ENG-8709] fix issue with `script.approve_registrations`

### DIFF
--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -72,6 +72,10 @@ def main(dry_run=True):
     approvals_past_pending = models.RegistrationApproval.objects.filter(
         state=models.RegistrationApproval.UNAPPROVED,
         initiation_date__lt=timezone.now() - settings.REGISTRATION_APPROVAL_TIME
+    ).exclude(
+        registrations__spam_status__in=[
+            models.SpamStatus.FLAGGED, models.SpamStatus.SPAM
+        ]
     )
     approve_past_pendings(approvals_past_pending, dry_run)
 


### PR DESCRIPTION
## Purpose

Exclude spammy registrations from approval in the approve_registrations script and add corresponding test case

## Changes

See diff

## QA Notes

N/A

What are the areas of risk?

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8709
