### PR TITLE
[ENG-8846] Project status notifications: Subject not matching when project is made public

### DIFF
--- a/notifications.yaml
+++ b/notifications.yaml
@@ -320,7 +320,7 @@ notification_types:
     tests: []
 
   - name: user_new_public_project
-    subject: 'Problem Registering'
+    subject: 'Now, public. Next, impact.'
     __docs__: ...
     object_content_type_model_name: osfuser
     template: 'website/templates/new_public_project.html.mako'


### PR DESCRIPTION
## Purpose

Update Project status notifications subject

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8846
