### PR TITLE
[ENG-8926][followup] fix: dataset metadata download with mononym creators

### DIFF
--- a/osf/metadata/serializers/google_dataset_json_ld.py
+++ b/osf/metadata/serializers/google_dataset_json_ld.py
@@ -79,9 +79,9 @@ def format_creators(basket):
     for creator_iri in basket[DCTERMS.creator]:
         creator_data.append({
             '@type': 'Person',
-            'name': next(basket[creator_iri:FOAF.name]),
-            'givenName': next(basket[creator_iri:FOAF.givenName]),
-            'familyName': next(basket[creator_iri:FOAF.familyName]),
+            'name': next(basket[creator_iri:FOAF.name], None),
+            'givenName': next(basket[creator_iri:FOAF.givenName], None),
+            'familyName': next(basket[creator_iri:FOAF.familyName], None),
         })
     return creator_data
 

--- a/osf_tests/metadata/expected_metadata_files/file_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "Person McNamington",
+        "creatorName": "PersonMcNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/file_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="URL">http://localhost:5000/w3ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">Person McNamington</creatorName>
+      <creatorName nameType="Personal">PersonMcNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/file_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.turtle
@@ -41,9 +41,8 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "Person" ;
-    foaf:familyName "McNamington" ;
-    foaf:name "Person McNamington" .
+    foaf:givenName "PersonMcNamington" ;
+    foaf:name "PersonMcNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "Person McNamington",
+        "creatorName": "PersonMcNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">Person McNamington</creatorName>
+      <creatorName nameType="Personal">PersonMcNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": "McNamington",
-      "givenName": "Person",
-      "name": "Person McNamington"
+      "familyName": null,
+      "givenName": "PersonMcNamington",
+      "name": "PersonMcNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
@@ -75,9 +75,8 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "Person" ;
-    foaf:familyName "McNamington" ;
-    foaf:name "Person McNamington" .
+    foaf:givenName "PersonMcNamington" ;
+    foaf:name "PersonMcNamington" .
 
 <http://localhost:8000/v2/providers/preprints/preprovi/subjects/> a skos:ConceptScheme ;
     dcterms:title "preprovi" .

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "Person McNamington",
+        "creatorName": "PersonMcNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="DOI">10.70102/FK2osf.io/w2ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">Person McNamington</creatorName>
+      <creatorName nameType="Personal">PersonMcNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/project_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": "McNamington",
-      "givenName": "Person",
-      "name": "Person McNamington"
+      "familyName": null,
+      "givenName": "PersonMcNamington",
+      "name": "PersonMcNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/project_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.turtle
@@ -94,9 +94,8 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "Person" ;
-    foaf:familyName "McNamington" ;
-    foaf:name "Person McNamington" .
+    foaf:givenName "PersonMcNamington" ;
+    foaf:name "PersonMcNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "Person McNamington",
+        "creatorName": "PersonMcNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="URL">http://localhost:5000/w5ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">Person McNamington</creatorName>
+      <creatorName nameType="Personal">PersonMcNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": "McNamington",
-      "givenName": "Person",
-      "name": "Person McNamington"
+      "familyName": null,
+      "givenName": "PersonMcNamington",
+      "name": "PersonMcNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.turtle
@@ -77,9 +77,8 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "Person" ;
-    foaf:familyName "McNamington" ;
-    foaf:name "Person McNamington" .
+    foaf:givenName "PersonMcNamington" ;
+    foaf:name "PersonMcNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/user_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/user_basic.turtle
@@ -6,6 +6,5 @@
         foaf:Person ;
     dcat:accessService <http://localhost:5000> ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "Person" ;
-    foaf:familyName "McNamington" ;
-    foaf:name "Person McNamington" .
+    foaf:givenName "PersonMcNamington" ;
+    foaf:name "PersonMcNamington" .

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -194,7 +194,7 @@ class TestSerializers(OsfTestCase):
             self.enterContext(patcher)
         # build test objects
         self.user = factories.AuthUserFactory(
-            fullname='Person McNamington',
+            fullname='PersonMcNamington',  # note: will be copied to given_name, family_name left blank
         )
         self.project = factories.ProjectFactory(
             is_public=True,
@@ -305,6 +305,10 @@ class TestSerializers(OsfTestCase):
         }
 
     def _setUp_full(self):
+        self.user.fullname = 'Person McNamington'
+        self.user.given_name = 'Person'
+        self.user.family_name = 'McNamington'
+        self.user.save()
         self.metadata_record = osfdb.GuidMetadataRecord.objects.for_guid(self.project._id)
         self.metadata_record.update({
             'language': 'en',
@@ -389,7 +393,8 @@ class TestSerializers(OsfTestCase):
             # TODO: stable turtle serializer (or another primitive rdf serialization)
             self._assert_equivalent_turtle(actual_metadata, _expected_metadata, filename)
         else:
-            self.assertEqual(actual_metadata, _expected_metadata)
+            # note: ignore trailing spaces
+            self.assertEqual(actual_metadata.rstrip(), _expected_metadata.rstrip())
 
     def _assert_equivalent_turtle(self, actual_turtle, expected_turtle, filename):
         _actual = rdflib.Graph()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
fix regression introduced in #11296 -- error at `osf.example/metadata/<osfid>?format=google-dataset-json-ld` when a creator has only a single name (blank family name)
<!-- Describe the purpose of your changes -->

## Changes
- update `GoogleDatasetJsonLdSerializer` to default null for missing name parts instead of raising an error
- update `osf_tests.metadata.test_serialized_metadata` (and expected output files):
  - single-named creator in "basic" scenario
  - multi-named creator in "full" scenario
  - (for convenience) ignore trailing spaces when comparing output
<!-- Briefly describe or list your changes  -->

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify `osf.example/metadata/<osfid>?format=google-dataset-json-ld` when the id'd item has a creator with a one-word name

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
[ENG-8926]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


[ENG-8926]: https://openscience.atlassian.net/browse/ENG-8926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ