### PR TITLE
Revert "[ENG-8926][followup] fix: dataset metadata download with mononym creators"

### DIFF
--- a/osf/metadata/serializers/google_dataset_json_ld.py
+++ b/osf/metadata/serializers/google_dataset_json_ld.py
@@ -79,9 +79,9 @@ def format_creators(basket):
     for creator_iri in basket[DCTERMS.creator]:
         creator_data.append({
             '@type': 'Person',
-            'name': next(basket[creator_iri:FOAF.name], None),
-            'givenName': next(basket[creator_iri:FOAF.givenName], None),
-            'familyName': next(basket[creator_iri:FOAF.familyName], None),
+            'name': next(basket[creator_iri:FOAF.name]),
+            'givenName': next(basket[creator_iri:FOAF.givenName]),
+            'familyName': next(basket[creator_iri:FOAF.familyName]),
         })
     return creator_data
 

--- a/osf_tests/metadata/expected_metadata_files/file_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "PersonMcNamington",
+        "creatorName": "Person McNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/file_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="URL">http://localhost:5000/w3ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">PersonMcNamington</creatorName>
+      <creatorName nameType="Personal">Person McNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/file_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/file_basic.turtle
@@ -41,8 +41,9 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "PersonMcNamington" ;
-    foaf:name "PersonMcNamington" .
+    foaf:givenName "Person" ;
+    foaf:familyName "McNamington" ;
+    foaf:name "Person McNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "PersonMcNamington",
+        "creatorName": "Person McNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="DOI">11.pp/FK2osf.io/w4ibb_v1</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">PersonMcNamington</creatorName>
+      <creatorName nameType="Personal">Person McNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": null,
-      "givenName": "PersonMcNamington",
-      "name": "PersonMcNamington"
+      "familyName": "McNamington",
+      "givenName": "Person",
+      "name": "Person McNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/preprint_basic.turtle
@@ -75,8 +75,9 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "PersonMcNamington" ;
-    foaf:name "PersonMcNamington" .
+    foaf:givenName "Person" ;
+    foaf:familyName "McNamington" ;
+    foaf:name "Person McNamington" .
 
 <http://localhost:8000/v2/providers/preprints/preprovi/subjects/> a skos:ConceptScheme ;
     dcterms:title "preprovi" .

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "PersonMcNamington",
+        "creatorName": "Person McNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="DOI">10.70102/FK2osf.io/w2ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">PersonMcNamington</creatorName>
+      <creatorName nameType="Personal">Person McNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/project_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": null,
-      "givenName": "PersonMcNamington",
-      "name": "PersonMcNamington"
+      "familyName": "McNamington",
+      "givenName": "Person",
+      "name": "Person McNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/project_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/project_basic.turtle
@@ -94,8 +94,9 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "PersonMcNamington" ;
-    foaf:name "PersonMcNamington" .
+    foaf:givenName "Person" ;
+    foaf:familyName "McNamington" ;
+    foaf:name "Person McNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.json
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.json
@@ -21,7 +21,7 @@
   "creators": [
     {
       "creatorName": {
-        "creatorName": "PersonMcNamington",
+        "creatorName": "Person McNamington",
         "nameType": "Personal"
       },
       "nameIdentifier": {

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.xml
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.datacite.xml
@@ -3,7 +3,7 @@
   <identifier identifierType="URL">http://localhost:5000/w5ibb</identifier>
   <creators>
     <creator>
-      <creatorName nameType="Personal">PersonMcNamington</creatorName>
+      <creatorName nameType="Personal">Person McNamington</creatorName>
       <nameIdentifier nameIdentifierScheme="URL">http://localhost:5000/w1ibb</nameIdentifier>
     </creator>
   </creators>

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.google-dataset.json
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.google-dataset.json
@@ -4,9 +4,9 @@
   "creator": [
     {
       "@type": "Person",
-      "familyName": null,
-      "givenName": "PersonMcNamington",
-      "name": "PersonMcNamington"
+      "familyName": "McNamington",
+      "givenName": "Person",
+      "name": "Person McNamington"
     }
   ],
   "dateCreated": "2123-05-04",

--- a/osf_tests/metadata/expected_metadata_files/registration_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/registration_basic.turtle
@@ -77,8 +77,9 @@
 <http://localhost:5000/w1ibb> a dcterms:Agent,
         foaf:Person ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "PersonMcNamington" ;
-    foaf:name "PersonMcNamington" .
+    foaf:givenName "Person" ;
+    foaf:familyName "McNamington" ;
+    foaf:name "Person McNamington" .
 
 <http://localhost:5000> a dcterms:Agent,
         foaf:Organization ;

--- a/osf_tests/metadata/expected_metadata_files/user_basic.turtle
+++ b/osf_tests/metadata/expected_metadata_files/user_basic.turtle
@@ -6,5 +6,6 @@
         foaf:Person ;
     dcat:accessService <http://localhost:5000> ;
     dcterms:identifier "http://localhost:5000/w1ibb" ;
-    foaf:givenName "PersonMcNamington" ;
-    foaf:name "PersonMcNamington" .
+    foaf:givenName "Person" ;
+    foaf:familyName "McNamington" ;
+    foaf:name "Person McNamington" .

--- a/osf_tests/metadata/test_serialized_metadata.py
+++ b/osf_tests/metadata/test_serialized_metadata.py
@@ -194,7 +194,7 @@ class TestSerializers(OsfTestCase):
             self.enterContext(patcher)
         # build test objects
         self.user = factories.AuthUserFactory(
-            fullname='PersonMcNamington',  # note: will be copied to given_name, family_name left blank
+            fullname='Person McNamington',
         )
         self.project = factories.ProjectFactory(
             is_public=True,
@@ -305,10 +305,6 @@ class TestSerializers(OsfTestCase):
         }
 
     def _setUp_full(self):
-        self.user.fullname = 'Person McNamington'
-        self.user.given_name = 'Person'
-        self.user.family_name = 'McNamington'
-        self.user.save()
         self.metadata_record = osfdb.GuidMetadataRecord.objects.for_guid(self.project._id)
         self.metadata_record.update({
             'language': 'en',
@@ -393,8 +389,7 @@ class TestSerializers(OsfTestCase):
             # TODO: stable turtle serializer (or another primitive rdf serialization)
             self._assert_equivalent_turtle(actual_metadata, _expected_metadata, filename)
         else:
-            # note: ignore trailing spaces
-            self.assertEqual(actual_metadata.rstrip(), _expected_metadata.rstrip())
+            self.assertEqual(actual_metadata, _expected_metadata)
 
     def _assert_equivalent_turtle(self, actual_turtle, expected_turtle, filename):
         _actual = rdflib.Graph()


### PR DESCRIPTION
Reverts CenterForOpenScience/osf.io#11297