### PR TITLE
[ENG-8978] Stop creating subscriptions for `send_confirm_email`

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -847,7 +847,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         # Merge account confirmation
         merge_account_data = {
             'merge_target_fullname': merge_target.fullname or merge_target.username,
-            'user_username': user.fullname,
+            'user_username': user.username,
             'email': merge_target.email,
         }
         notification_type = NotificationType.Type.USER_CONFIRM_MERGE
@@ -862,8 +862,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         notification_type = NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
 
     notification_type.instance.emit(
-        user=user,
-        subscribed_object=user,
+        destination_address=merge_target.address or user.username,
         event_context={
             'user_fullname': user.fullname,
             'confirmation_url': confirmation_url,
@@ -873,6 +872,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
             'osf_support_email': settings.OSF_SUPPORT_EMAIL,
             **merge_account_data,
         },
+        save=False
     )
 
 def send_confirm_email_async(user, email, renew=False, external_id_provider=None, external_id=None, destination=None):


### PR DESCRIPTION
## Purpose

Send confirm email is not a digest and doesn't need a subscription, it also has issues tracking the merged user from per-subscribed account. There was also an issue with the template vars being wrong.

## Changes

- No longer save password confirmation as suscription.
- Fixx template fullname/username issue.=


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-8978