### PR TITLE
[ENG-8978] Fix issue with user confirmation/merger creating subscription

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -847,7 +847,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         # Merge account confirmation
         merge_account_data = {
             'merge_target_fullname': merge_target.fullname or merge_target.username,
-            'user_username': user.fullname,
+            'user_username': user.username,
             'email': merge_target.email,
         }
         notification_type = NotificationType.Type.USER_CONFIRM_MERGE
@@ -862,8 +862,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         notification_type = NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
 
     notification_type.instance.emit(
-        user=user,
-        subscribed_object=user,
+        destination_address=email,
         event_context={
             'user_fullname': user.fullname,
             'confirmation_url': confirmation_url,
@@ -873,6 +872,7 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
             'osf_support_email': settings.OSF_SUPPORT_EMAIL,
             **merge_account_data,
         },
+        save=False
     )
 
 def send_confirm_email_async(user, email, renew=False, external_id_provider=None, external_id=None, destination=None):

--- a/osf/models/notification_subscription.py
+++ b/osf/models/notification_subscription.py
@@ -71,6 +71,9 @@ class NotificationSubscription(BaseModel):
             destination_address (optional): overides the user's email address for the notification. Good for sending
             to a test address or OSF desk support'
             email_context (dict, optional): Context for sending the email bcc, reply_to header etc
+            save (bool, optional): save the notification and creates a subscription object if true, otherwise just
+            send the notification with no db transaction, therefore message_frequency should always be 'instantly' when
+            used.
         """
         if not settings.CI_ENV:
             logging.info(

--- a/osf/models/notification_type.py
+++ b/osf/models/notification_type.py
@@ -202,6 +202,10 @@ class NotificationType(models.Model):
             message_frequency (optional): Initializing message frequency.
             event_context (dict, optional): Context for rendering the notification template.
             email_context (dict, optional): Context for additional email notification information, so as blind cc etc
+            is_digest (bool, optional): is this email part of a larger digest notification?
+            save (bool, optional): save the notification and creates a subscription object if true, otherwise just
+            send the notification with no db transaction, therefore message_frequency should always be 'instantly' when
+            used.
         """
         from osf.models.notification_subscription import NotificationSubscription
         if not save:

--- a/osf_tests/test_merging_users.py
+++ b/osf_tests/test_merging_users.py
@@ -301,3 +301,4 @@ class TestUserMerging(OsfTestCase):
             send_confirm_email(merger, target_email)
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['type'] == NotificationType.Type.USER_CONFIRM_MERGE
+        assert notifications['emits'][0]['kwargs']['destination_address'] == target_email


### PR DESCRIPTION
## Purpose

Stops issue with merged and confirmed users getting subscriptions which pointed to old users.

## Changes

- Doesn't create a subscription for confirming accounts
- fix template typo


## QA Notes

TBD

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-8978