### PR TITLE
[ENG-9020] Custom html host for legacy OSF

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1183,6 +1183,13 @@ class LinksField(ser.Field):
             if hasattr(obj, 'get_absolute_info_url'):
                 ret['info'] = self._extend_url_with_vol_key(obj.get_absolute_info_url())
 
+        request = self.context['request']
+        referer = request.headers.get('Referer', '')
+        if 'html' in ret and 'legacy' in referer:
+            split_host = referer.split('://')
+            split_host[-1] = 'legacy.' + split_host[-1]
+            ret['html'] = '://'.join(split_host)
+
         return ret
 
 


### PR DESCRIPTION
## Purpose

Requests from the legacy OSF can be processed by any backend regardless of a host of the backend

## Changes

Added legacy host url for htmls of legacy OSF

## Ticket

https://openscience.atlassian.net/browse/ENG-9020?atlOrigin=eyJpIjoiYTMzN2QwOGNhYTFjNDQ0NmE0YjA5N2M1ZTBmZmM0ZjgiLCJwIjoiaiJ9
