### PR TITLE
[ENG-9020] Custom html host for legacy OSF

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1183,6 +1183,13 @@ class LinksField(ser.Field):
             if hasattr(obj, 'get_absolute_info_url'):
                 ret['info'] = self._extend_url_with_vol_key(obj.get_absolute_info_url())
 
+        request = self.context['request']
+        referer = request.headers.get('Referer', '')
+        if 'html' in ret and 'legacy' in referer:
+            split_host = referer.split('://')
+            split_host[-1] = 'legacy.' + split_host[-1]
+            ret['html'] = '://'.join(split_host)
+
         return ret
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1186,9 +1186,9 @@ class LinksField(ser.Field):
         request = self.context['request']
         referer = request.headers.get('Referer', '')
         if 'html' in ret and 'legacy' in referer:
-            split_host = referer.split('://')
-            split_host[-1] = 'legacy.' + split_host[-1]
-            ret['html'] = '://'.join(split_host)
+            parsed_html_url = urlparse(ret['html'])
+            legacy_url = urlparse(referer)
+            ret['html'] = parsed_html_url._replace(scheme=legacy_url.scheme, netloc=legacy_url.netloc).geturl()
 
         return ret
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -259,6 +259,16 @@ class TestNodeList:
         res = app.get(url_public, auth=superuser.auth)
         assert permissions.READ not in res.json['data'][0]['attributes']['current_user_permissions']
 
+    def test_legacy_host_for_htmls(self, app, url, public_project):
+        settings.DOMAIN = 'https://staging3.osf.io'
+        current_domain_response = app.get(url).json['data']
+        assert current_domain_response[-1]['links']['html'].startswith(settings.DOMAIN)
+
+        # mock request from legacy OSF domain to staging3 backend
+        # so that backend uses it to generate html links instead of current domain
+        legacy_domain_response = app.get(url, headers={'Referer': 'http://legacy.osf.io'}).json['data']
+        assert legacy_domain_response[-1]['links']['html'].startswith('http://legacy.osf.io')
+
 
 @pytest.mark.django_db
 @pytest.mark.enable_bookmark_creation


### PR DESCRIPTION
## Purpose ##
Requests from the legacy OSF can be processed by any backend regardless of a host of the backend

## Changes ##
Added legacy host url for htmls of legacy OSF

## Ticket ##
https://openscience.atlassian.net/browse/ENG-9020?atlOrigin=eyJpIjoiYTMzN2QwOGNhYTFjNDQ0NmE0YjA5N2M1ZTBmZmM0ZjgiLCJwIjoiaiJ9