### PR TITLE
[ENG-9064] When creating file guid through API, needs to work for people with read perms

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -30,7 +30,6 @@ from api.files.serializers import (
     FileDetailSerializer,
     FileVersionSerializer,
 )
-from osf.utils.permissions import ADMIN
 
 
 class FileMixin:
@@ -87,11 +86,11 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     # overrides RetrieveAPIView
     def get_object(self):
-        user = utils.get_user_auth(self.request).user
         file = self.get_file()
 
         if self.request.GET.get('create_guid', False):
-            if (self.get_target().has_permission(user, ADMIN) and utils.has_admin_scope(self.request)):
+            auth = utils.get_user_auth(self.request)
+            if self.get_target().can_view(auth):
                 file.get_guid(create=True)
 
         # We normally would pass this through `get_file` as an annotation, but the `select_for_update` feature prevents


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

allow READ users to create guid for files

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9064
