### PR TITLE
[ENG-9050] Only admins and moderators and access moderation-related endpoints

### DIFF
--- a/api/providers/permissions.py
+++ b/api/providers/permissions.py
@@ -1,4 +1,3 @@
-from guardian.shortcuts import get_perms
 from rest_framework import permissions as drf_permissions
 
 from api.base.utils import get_user_auth
@@ -36,4 +35,7 @@ class CanUpdateModerator(drf_permissions.BasePermission):
 class MustBeModerator(drf_permissions.BasePermission):
     def has_permission(self, request, view):
         auth = get_user_auth(request)
-        return bool(get_perms(auth.user, view.get_provider()))
+        provider = view.get_provider()
+        is_admin = provider.get_group('admin').user_set.filter(id=auth.user.id).exists()
+        is_moderator = provider.get_group('moderator').user_set.filter(id=auth.user.id).exists()
+        return is_moderator or is_admin

--- a/api/registrations/permissions.py
+++ b/api/registrations/permissions.py
@@ -7,10 +7,10 @@ class ContributorOrModerator(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         auth = get_user_auth(request)
+        is_admin = obj.provider.get_group('admin').user_set.filter(id=auth.user.id).exists()
+        is_moderator = obj.provider.get_group('moderator').user_set.filter(id=auth.user.id).exists()
 
-        # If a user has perms on the provider, they must be a moderator or admin
-        is_moderator = bool(get_perms(auth.user, obj.provider))
-        return obj.is_admin_contributor(auth.user) or is_moderator
+        return obj.is_admin_contributor(auth.user) or is_moderator or is_admin
 
 
 class ContributorOrModeratorOrPublic(permissions.BasePermission):

--- a/api_tests/providers/collections/views/test_permissions.py
+++ b/api_tests/providers/collections/views/test_permissions.py
@@ -1,0 +1,22 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.providers.mixins import OnlyModeratorOrAdminPermissionsMixin
+
+from osf_tests.factories import CollectionProviderFactory
+
+
+@pytest.mark.django_db
+class TestOnlyModeratorOrAdmin(OnlyModeratorOrAdminPermissionsMixin):
+
+    @pytest.fixture()
+    def urls(self, provider, moderator, admin):
+        return [
+            f'/{API_BASE}providers/collections/{provider._id}/moderators/',
+            f'/{API_BASE}providers/collections/{provider._id}/moderators/{moderator._id}/',
+            f'/{API_BASE}providers/collections/{provider._id}/moderators/{admin._id}/',
+        ]
+
+    @pytest.fixture()
+    def provider(self):
+        return CollectionProviderFactory()

--- a/api_tests/providers/preprints/views/test_permissions.py
+++ b/api_tests/providers/preprints/views/test_permissions.py
@@ -1,0 +1,23 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.providers.mixins import OnlyModeratorOrAdminPermissionsMixin
+
+from osf_tests.factories import PreprintProviderFactory
+
+
+@pytest.mark.django_db
+class TestOnlyModeratorOrAdmin(OnlyModeratorOrAdminPermissionsMixin):
+
+    @pytest.fixture()
+    def urls(self, provider, moderator, admin):
+        return [
+            f'/{API_BASE}providers/preprints/{provider._id}/withdraw_requests/',
+            f'/{API_BASE}providers/preprints/{provider._id}/moderators/',
+            f'/{API_BASE}providers/preprints/{provider._id}/moderators/{moderator._id}/',
+            f'/{API_BASE}providers/preprints/{provider._id}/moderators/{admin._id}/',
+        ]
+
+    @pytest.fixture()
+    def provider(self):
+        return PreprintProviderFactory()

--- a/api_tests/providers/registrations/views/test_permissions.py
+++ b/api_tests/providers/registrations/views/test_permissions.py
@@ -1,0 +1,25 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from api_tests.providers.mixins import OnlyModeratorOrAdminPermissionsMixin
+
+from osf_tests.factories import RegistrationProviderFactory
+
+
+@pytest.mark.django_db
+class TestOnlyModeratorOrAdmin(OnlyModeratorOrAdminPermissionsMixin):
+
+    @pytest.fixture()
+    def urls(self, provider, moderator, admin):
+        return [
+            f'/{API_BASE}providers/registrations/{provider._id}/requests/',
+            f'/{API_BASE}providers/registrations/{provider._id}/registrations/',
+            f'/{API_BASE}providers/registrations/{provider._id}/actions/',
+            f'/{API_BASE}providers/registrations/{provider._id}/moderators/',
+            f'/{API_BASE}providers/registrations/{provider._id}/moderators/{moderator._id}/',
+            f'/{API_BASE}providers/registrations/{provider._id}/moderators/{admin._id}/',
+        ]
+
+    @pytest.fixture()
+    def provider(self):
+        return RegistrationProviderFactory()


### PR DESCRIPTION
## Purpose

Any user can access moderation pages regardless of his permission, however only moderators and admins should be able to do it

## Changes

Adjusted `MustBeModerator` permission that controls access to moderation pages (collections, preprints, registrations)
Adjusted `ContributorOrModerator` permission that controls viewing registration actions (only moderators and admins can do that)

## QA Notes

Would be nice if QA team tests all endpoints manually and separately. The reason is that I manually opened appropriate pages to check what requests are made on these pages. All of them had `MustBeModerator` permission.

## Notes
1. `CollectionProviderActionList` view is not used anywhere, so can be removed in the future
2. `CollectionProviderSubmissionList`, `PreprintProviderPreprintList`, `RegistrationProviderSubmissionList` - have custom permissions where usual user has access to specific data (like you are either admin or object is public/published). I assume this kind of data is displayed somewhere else for ordinary users, so they weren't covered with tests

## Ticket

https://openscience.atlassian.net/browse/ENG-9050?atlOrigin=eyJpIjoiYmVhNDBlOTA2OTBmNDE4MWFhNTgzN2I5ZTc3ZmExYWIiLCJwIjoiaiJ9