### PR TITLE
[ANG-963] Fix double slashes in institution access request email

### DIFF
--- a/website/templates/emails/node_request_institutional_access_request.html.mako
+++ b/website/templates/emails/node_request_institutional_access_request.html.mako
@@ -14,12 +14,12 @@
         </p>
         % endif
         <p>
-            To review the request, click <a href="${node.absolute_url}/contributors/">here</a> to allow or deny access and configure permissions.
+            To review the request, click <a href="${node.absolute_url}contributors/">here</a> to allow or deny access and configure permissions.
         </p>
         <p>
             This request is being sent to you because your project has the “Request Access” feature enabled.
             This allows potential collaborators to request to be added to your project or to disable this feature, click
-            <a href="${node.absolute_url}/settings/">here</a>
+            <a href="${node.absolute_url}settings/">here</a>
         </p>
 
         <p>


### PR DESCRIPTION
 * We have two templates to notify admins that a user wants access to a project. One is for regular admins, another is for institutional admins. They are encoded differently, so the insitutional one ends up with two slashes in the url. Remove the additional  slash from the url  for now. A  better fix would be  to `urljoin` this  in the python code the same as the regular version, but this'll do, pig.

https://openscience.atlassian.net/browse/ANG-963
