### PR TITLE
[ANG-1048] Make is_public and bookmarks field filterable for collections

### DIFF
--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -29,6 +29,8 @@ class CollectionSerializer(JSONAPISerializer):
         'title',
         'date_created',
         'date_modified',
+        'is_public',
+        'bookmarks',
     ])
 
     id = IDField(source='_id', read_only=True)


### PR DESCRIPTION
## Purpose

Make is_public and bookmarks field filterable for collections

## Changes

Make is_public and bookmarks field filterable for collections

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ANG-1048
