### PR TITLE
[ANG-1044] Fix sitemap for preprint files download

### DIFF
--- a/osf_tests/test_generate_sitemap.py
+++ b/osf_tests/test_generate_sitemap.py
@@ -141,9 +141,9 @@ class TestGenerateSitemap:
             f'/preprints/{provider_osf._id}/{preprint_osf_version._id}',
             f'/preprints/{provider_other._id}/{preprint_other._id}',
             f'/preprints/{provider_osf._id}/{preprint_withdrawn._id}',
-            f'/{preprint_osf._id}/download/?format=pdf',
-            f'/{preprint_osf_version._id}/download/?format=pdf',
-            f'/{preprint_other._id}/download/?format=pdf'
+            f'/download/{preprint_osf._id}/?format=pdf',
+            f'/download/{preprint_osf_version._id}/?format=pdf',
+            f'/download/{preprint_other._id}/?format=pdf'
         ])
         urls_to_include = [urljoin(settings.DOMAIN, item) for item in urls_to_include]
 

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -229,8 +229,8 @@ class Sitemap:
                         file_config['loc'] = urljoin(
                             settings.DOMAIN,
                             os.path.join(
-                                obj._id,
                                 'download',
+                                obj._id,
                                 '?format=pdf'
                             )
                         )


### PR DESCRIPTION
## Purpose

Fix sitemap for preprint files download

This is a follow-up for https://github.com/CenterForOpenScience/osf.io/pull/11355

## Changes

Fix sitemap for preprint files download

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ANG-1044
