### PR TITLE
[ENG-9622] Contributor claim link temporarily returns “Not Found” before becoming accessible and showing “User has already been claimed.”

### DIFF
--- a/tests/test_adding_contributor_views.py
+++ b/tests/test_adding_contributor_views.py
@@ -630,7 +630,7 @@ class TestClaimViews(OsfTestCase):
         res = self.app.get(claim_url)
 
         # should redirect to 'claim_user_registered' view
-        claim_registered_url = f'/user/{unregistered_user._id}/{self.project._id}/claim/verify/{token}/'
+        claim_registered_url = f'/legacy/user/{unregistered_user._id}/{self.project._id}/claim/verify/{token}/'
         assert res.status_code == 302
         assert claim_registered_url in res.headers.get('Location')
 
@@ -672,7 +672,7 @@ class TestClaimViews(OsfTestCase):
         res = self.app.get(claim_url)
 
         # should redirect to 'claim_user_registered' view
-        claim_registered_url = f'/user/{unregistered_user._id}/{self.project._id}/claim/verify/{token}/'
+        claim_registered_url = f'/legacy/user/{unregistered_user._id}/{self.project._id}/claim/verify/{token}/'
         assert res.status_code == 302
         assert claim_registered_url in res.headers.get('Location')
 
@@ -797,7 +797,7 @@ class TestClaimViews(OsfTestCase):
     def test_claim_user_when_user_is_registered_with_orcid(self, mock_response_from_ticket):
         # TODO: check in qa url encoding
         token = self.user.get_unclaimed_record(self.project._primary_key)['token']
-        url = f'/user/{self.user._id}/{self.project._id}/claim/verify/{token}/'
+        url = f'/legacy/user/{self.user._id}/{self.project._id}/claim/verify/{token}/'
         # logged out user gets redirected to cas login
         res1 = self.app.get(url)
         assert res1.status_code == 302

--- a/website/routes.py
+++ b/website/routes.py
@@ -867,7 +867,7 @@ def make_url_map(app):
         # user will be required to verify password
         # claim token must be present in query parameter
         Rule(
-            ['/user/<uid>/<pid>/claim/verify/<token>/'],
+            ['/legacy/user/<uid>/<pid>/claim/verify/<token>/'],
             ['get', 'post'],
             project_views.contributor.claim_user_registered,
             OsfWebRenderer('claim_account_registered.mako', trust=False)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
add legacy prefix to /claim/verify

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9622
