### PR TITLE
[ENG-8516] OSF admins can update contributor permissions of any object

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -265,7 +265,8 @@ class NodeUpdatePermissionsView(NodeMixin, View):
                 permission,
                 resource.get_visible(user),
                 request,
-                save=True
+                save=True,
+                skip_permission=True
             )
 
         return redirect(self.get_success_url())

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -1644,7 +1644,7 @@ class ContributorMixin(models.Model):
                 contributor.save()
 
     # TODO: optimize me
-    def update_contributor(self, user, permission, visible, auth, save=False):
+    def update_contributor(self, user, permission, visible, auth, save=False, skip_permission=False):
         """ TODO: this method should be updated as a replacement for the main loop of
         Node#manage_contributors. Right now there are redundancies, but to avoid major
         feature creep this will not be included as this time.
@@ -1653,7 +1653,7 @@ class ContributorMixin(models.Model):
         """
         OSFUser = apps.get_model('osf.OSFUser')
 
-        if not self.has_permission(auth.user, ADMIN):
+        if not skip_permission and not self.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can modify contributor permissions')
 
         if permission:


### PR DESCRIPTION
## Purpose

OSF admins cannot update contributor permissions for nodes/preprints where they aren't admin contributor

## Changes

Skip permission validation for osf admins

## Ticket

https://openscience.atlassian.net/browse/ENG-8516?atlOrigin=eyJpIjoiYmY0MzdlZjhlZTRlNGIyMmI4MmM3ODI4MmUwNWI1ODQiLCJwIjoiaiJ9