### PR TITLE
[ENG-9678] Fix no login email status

### DIFF
--- a/scripts/triggered_mails.py
+++ b/scripts/triggered_mails.py
@@ -116,6 +116,8 @@ def send_no_login_email(email_task_id: int):
                 'domain': settings.DOMAIN,
             }
         )
+        email_task.status = 'SUCCESS'
+        email_task.save()
 
     except Exception as exc:  # noqa: BLE001
         logger.exception(f'EmailTask {email_task.id}: error while sending')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix EmailTask status only are stuck with `PENDING` status.

<img width="2560" height="1440" alt="Screenshot 2025-10-31 at 12 36 55 PM (2)" src="https://github.com/user-attachments/assets/5fc103aa-c7b9-496e-9917-54db3966e979" />

No login in” email tasks aren’t getting set correctly, but are remaining in PENDING status, though they have been sent. I should use the NoficiationSubscribtion to check if the message has been sent before.

## Changes

- save status as `success`
- ensure emails are only sent once.

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9678