### PR TITLE
[ENG-9675] Fix collection template link

### DIFF
--- a/osf/models/collection_submission.py
+++ b/osf/models/collection_submission.py
@@ -185,7 +185,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
                         'collection_provider_name': self.collection.provider.name,
                         'collection_provider__id': self.collection.provider._id,
                         'node_title': self.guid.referent.title,
-                        'node_absolute_url': self.guid.referent.get_absolute_url(),
+                        'node_absolute_url': self.guid.referent.absolute_url,
                         'domain': settings.DOMAIN,
                         'osf_contact_email': settings.OSF_CONTACT_EMAIL,
                         'is_initiator': self.creator == contributor,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The collection accepted template uses the `get_absolute_url` instead of the property `absolute_url` though these have similar names one points to the api and the other points to the web link.

## Changes

- change url from api link to web link,


## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9675