### PR TITLE
[ENG-9674] Fix password reset link

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -847,7 +847,7 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
                 user_obj.email_last_sent = timezone.now()
                 user_obj.save()
-                reset_link = f'{settings.RESET_PASSWORD_URL}{user_obj._id}/{user_obj.verification_key_v2['token']}/'
+                reset_link = f'{settings.DOMAIN}passwordreset/{user_obj._id}/{user_obj.verification_key_v2['token']}/'
                 if institutional:
                     notification_type = NotificationType.Type.USER_FORGOT_PASSWORD_INSTITUTION
                 else:


### PR DESCRIPTION
## Purpose

The `RESET_PASSWORD_URL` was not set correctly locally so it still displayed it's localhost value in the link.

## Changes

- Changes the password building url to one that's set properly locally. (`settings.DOMAIN`)

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9674