### PR TITLE
[ENG-9758] Make notification preferences use proper values

### DIFF
--- a/api/subscriptions/views.py
+++ b/api/subscriptions/views.py
@@ -73,6 +73,11 @@ class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
                     notification_type=NotificationType.Type.USER_FILE_UPDATED.instance,
                     then=Value(f'{user_guid}_global_file_updated'),
                 ),
+                When(
+                    Q(notification_type=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.instance) &
+                    Q(content_type=provider_ct),
+                    then=Value('new_pending_submissions'),
+                ),
             ),
             legacy_id=Case(
                 When(
@@ -143,7 +148,7 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
 
         if event != 'global':
             if subscription_obj is None:
-                subscription_obj = AbstractProvider.objects.get(_id=guid_id)
+                subscription_obj = PreprintProvider.objects.get(_id=guid_id)
             obj_filter = Q(
                 object_id=getattr(subscription_obj, 'id', None),
                 content_type=ContentType.objects.get_for_model(subscription_obj.__class__),


### PR DESCRIPTION
…ly model

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Works with https://github.com/CenterForOpenScience/angular-osf/pull/760 to restore notification value picking

## Changes

- give preprint moderation preference proper event name
- use preprintprovider model to avoid conflicts with registies

## QA Notes

Please make verification statements inspired by your code and what your code touches.
- Verify
- Verify

What are the areas of risk?

Any concerns/considerations/questions that development raised?

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9758