### PR TITLE
[ENG-9895] add manual filtering for event_name in subscription list

### DIFF
--- a/api/subscriptions/views.py
+++ b/api/subscriptions/views.py
@@ -99,6 +99,7 @@ class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
                     notification_type__name__in=_global_reviews,
                     then=Value('global_reviews'),
                 ),
+                default=Value('notification_type__name'),
             ),
             legacy_id=Case(
                 When(
@@ -113,6 +114,7 @@ class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
                     notification_type__name__in=_global_reviews,
                     then=Value(f'{user_guid}_global_reviews'),
                 ),
+                default=Value('notification_type__name'),
             ),
         ).distinct('legacy_id')
 

--- a/api_tests/subscriptions/views/test_subscriptions_list.py
+++ b/api_tests/subscriptions/views/test_subscriptions_list.py
@@ -91,7 +91,7 @@ class TestSubscriptionList:
         assert delete_res.status_code == 405
 
     def test_multiple_values_filter(self, app, url, user):
-        res = app.get(url + '?filter[event_name]=comments,file_updated', auth=user.auth)
+        res = app.get(url + '?filter[event_name]=global_file_updated,files_updated', auth=user.auth)
         assert len(res.json['data']) == 2
         for subscription in res.json['data']:
             subscription['attributes']['event_name'] in ['global', 'comments']


### PR DESCRIPTION
## Purpose

add manual filtering for event_name in subscription list

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9895
