### PR TITLE
[ENG-9909] validate user email addresses in notification tasks and subscriptions

### DIFF
--- a/osf/models/notification.py
+++ b/osf/models/notification.py
@@ -29,7 +29,7 @@ class Notification(models.Model):
         """
 
         """
-        recipient_address = destination_address or self.subscription.user.username
+        recipient_address = destination_address or self.subscription.user.email or self.subscription.user.emails.first().address
         if not api_settings.CI_ENV:
             logging.info(
                 f"Attempting to send Notification:"


### PR DESCRIPTION
## Purpose

Validate the user's email address before sending an email.

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9909
