### PR TITLE
[ENG-9857] Refactor notification type references to use NotificationTypeEnum

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -51,7 +51,7 @@ from osf.models import (
     DraftRegistration,
     Guid,
     FileVersionUserMetadata,
-    FileVersion, NotificationType
+    FileVersion, NotificationTypeEnum
 )
 from osf.metrics import PreprintView, PreprintDownload
 from osf.utils import permissions
@@ -575,9 +575,9 @@ def create_waterbutler_log(payload, **kwargs):
 
             if payload.get('email') or payload.get('errors'):
                 if payload.get('email'):
-                    notification_type = NotificationType.Type.USER_FILE_OPERATION_SUCCESS.instance
+                    notification_type = NotificationTypeEnum.USER_FILE_OPERATION_SUCCESS.instance
                 if payload.get('errors'):
-                    notification_type = NotificationType.Type.USER_FILE_OPERATION_FAILED.instance
+                    notification_type = NotificationTypeEnum.USER_FILE_OPERATION_FAILED.instance
                 notification_type.emit(
                     user=user,
                     subscribed_object=node,

--- a/addons/boa/tasks.py
+++ b/addons/boa/tasks.py
@@ -14,7 +14,7 @@ from addons.boa import settings as boa_settings
 from addons.boa.boa_error_code import BoaErrorCode
 from framework import sentry
 from framework.celery_tasks import app as celery_app
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationTypeEnum
 from osf.utils.fields import ensure_str, ensure_bytes
 from website import settings as osf_settings
 
@@ -183,7 +183,7 @@ async def submit_to_boa_async(host, username, password, user_guid, project_guid,
 
     logger.info('Successfully uploaded query output to OSF.')
     logger.debug('Task ends <<<<<<<<')
-    NotificationType.Type.ADDONS_BOA_JOB_COMPLETE.instance.emit(
+    NotificationTypeEnum.ADDONS_BOA_JOB_COMPLETE.instance.emit(
         user=user,
         event_context={
             'user_fullname': user.fullname,
@@ -209,7 +209,7 @@ def handle_boa_error(message, code, username, fullname, project_url, query_file_
         sentry.log_message(message, skip_session=True)
     except Exception:
         pass
-    NotificationType.Type.ADDONS_BOA_JOB_FAILURE.instance.emit(
+    NotificationTypeEnum.ADDONS_BOA_JOB_FAILURE.instance.emit(
         destination_address=username,
         event_context={
             'user_fullname': fullname,

--- a/addons/boa/tests/test_tasks.py
+++ b/addons/boa/tests/test_tasks.py
@@ -9,7 +9,7 @@ from urllib.error import HTTPError
 from addons.boa import settings as boa_settings
 from addons.boa.boa_error_code import BoaErrorCode
 from addons.boa.tasks import submit_to_boa, submit_to_boa_async, handle_boa_error
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import AuthUserFactory, ProjectFactory
 from tests.base import OsfTestCase
 from tests.utils import capture_notifications
@@ -66,7 +66,7 @@ class TestBoaErrorHandling(OsfTestCase):
                         job_id=self.job_id
                     )
                 assert len(notifications['emits']) == 1
-                assert notifications['emits'][0]['type'] == NotificationType.Type.ADDONS_BOA_JOB_FAILURE
+                assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDONS_BOA_JOB_FAILURE
                 mock_sentry_log_message.assert_called_with(self.error_message, skip_session=True)
                 mock_logger_error.assert_called_with(self.error_message)
                 assert return_value == BoaErrorCode.UNKNOWN

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -9,7 +9,7 @@ from django.conf import settings as django_conf_settings
 
 from framework.auth import Auth
 from addons.osfstorage.models import OsfStorageFile, OsfStorageFileNode, OsfStorageFolder
-from osf.models import BaseFileNode, NotificationType
+from osf.models import BaseFileNode, NotificationTypeEnum
 from osf.exceptions import ValidationError
 from osf.utils.permissions import WRITE, ADMIN
 
@@ -750,7 +750,7 @@ class TestNodeSettingsModel:
             fork = node.fork_node(auth_obj)
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
         fork_node_settings = fork.get_addon('osfstorage')
         fork_node_settings.reload()
 

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -20,7 +20,7 @@ from osf.exceptions import UserStateError
 from osf.models.base import Guid
 from osf.models.user import OSFUser
 from osf.models.spam import SpamStatus
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from framework.auth import get_user
 from framework.auth.core import generate_verification_key
 
@@ -183,7 +183,7 @@ class UserDisableView(UserMixin, View):
                 message=f'User account {user.pk} disabled',
                 action_flag=USER_REMOVED
             )
-            NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE.instance.emit(
+            NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE.instance.emit(
                 user=user,
                 event_context={
                     'user_fullname': user.fullname,

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import Permission, Group, AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 
 from tests.base import AdminTestCase
-from osf.models import Preprint, PreprintLog, PreprintRequest, NotificationType
+from osf.models import Preprint, PreprintLog, PreprintRequest, NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     PreprintFactory,
@@ -641,7 +641,7 @@ class TestPreprintWithdrawalRequests:
             machine_state=DefaultStates.INITIAL.value)
         withdrawal_request.run_submit(admin)
 
-        with assert_notification(type=NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_APPROVED):
+        with assert_notification(type=NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_APPROVED):
             withdrawal_request.run_accept(admin, withdrawal_request.comment)
 
         assert preprint.machine_state == 'withdrawn'

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -27,7 +27,7 @@ from admin.users import views
 from admin.users.forms import UserSearchForm, MergeUserForm
 from osf.models.admin_log_entry import AdminLogEntry
 from tests.utils import assert_notification, capture_notifications
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 
 pytestmark = pytest.mark.django_db
 
@@ -105,7 +105,7 @@ class TestResetPasswordView(AdminTestCase):
             response = views.ResetPasswordView.as_view()(request, guid=guid)
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORGOT_PASSWORD
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORGOT_PASSWORD
         self.assertEqual(response.status_code, 302)
 
 
@@ -168,7 +168,7 @@ class TestDisableUser(AdminTestCase):
     def test_disable_user(self):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
         count = AdminLogEntry.objects.count()
-        with assert_notification(type=NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE, user=self.user):
+        with assert_notification(type=NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE, user=self.user):
             self.view().post(self.request)
         self.user.reload()
         assert self.user.is_disabled
@@ -176,7 +176,7 @@ class TestDisableUser(AdminTestCase):
 
     def test_reactivate_user(self):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
-        with assert_notification(type=NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE, user=self.user):
+        with assert_notification(type=NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE, user=self.user):
             self.view().post(self.request)
         count = AdminLogEntry.objects.count()
         self.view().post(self.request)
@@ -206,7 +206,7 @@ class TestDisableUser(AdminTestCase):
         change_permission = Permission.objects.get(codename='change_osfuser')
         user.user_permissions.add(change_permission)
         user.save()
-        with assert_notification(type=NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE, user=user):
+        with assert_notification(type=NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE, user=user):
             request = RequestFactory().post(reverse('users:disable', kwargs={'guid': guid}))
             request.user = user
 

--- a/api/crossref/views.py
+++ b/api/crossref/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from rest_framework.views import APIView
 
 from api.crossref.permissions import RequestComesFromMailgun
-from osf.models import Preprint, NotificationType
+from osf.models import Preprint, NotificationTypeEnum
 from website import settings
 from website.preprints.tasks import mint_doi_on_crossref_fail
 
@@ -78,7 +78,7 @@ class ParseCrossRefConfirmation(APIView):
             if unexpected_errors:
                 batch_id = crossref_email_content.find('batch_id').text
                 email_error_text = request.POST['body-plain']
-                NotificationType.Type.DESK_CROSSREF_ERROR.instance.emit(
+                NotificationTypeEnum.DESK_CROSSREF_ERROR.instance.emit(
                     destination_address=settings.OSF_SUPPORT_EMAIL,
                     event_context={
                         'batch_id': batch_id,

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -21,7 +21,7 @@ from framework.auth.exceptions import MultipleSSOEmailError
 
 from osf import features
 from osf.exceptions import InstitutionAffiliationStateError
-from osf.models import Institution, NotificationType
+from osf.models import Institution, NotificationTypeEnum
 from osf.models.institution import SsoFilterCriteriaAction
 
 from website.settings import OSF_SUPPORT_EMAIL, DOMAIN
@@ -348,7 +348,7 @@ class InstitutionAuthentication(BaseAuthentication):
             user.save()
 
             # Send confirmation email for all three: created, confirmed and claimed
-            NotificationType.Type.USER_WELCOME_OSF4I.instance.emit(
+            NotificationTypeEnum.USER_WELCOME_OSF4I.instance.emit(
                 user=user,
                 event_context={
                     'domain': DOMAIN,
@@ -363,7 +363,7 @@ class InstitutionAuthentication(BaseAuthentication):
         if email_to_add:
             assert not is_created and email_to_add == sso_email
             user.emails.create(address=email_to_add)
-            NotificationType.Type.USER_WELCOME_OSF4I.instance.emit(
+            NotificationTypeEnum.USER_WELCOME_OSF4I.instance.emit(
                 user=user,
                 event_context={
                     'user_fullname': user.fullname,
@@ -383,7 +383,7 @@ class InstitutionAuthentication(BaseAuthentication):
             duplicate_user.remove_sso_identity_from_affiliation(institution)
             if secondary_institution:
                 duplicate_user.remove_sso_identity_from_affiliation(secondary_institution)
-            NotificationType.Type.USER_DUPLICATE_ACCOUNTS_OSF4I.instance.emit(
+            NotificationTypeEnum.USER_DUPLICATE_ACCOUNTS_OSF4I.instance.emit(
                 user=user,
                 subscribed_object=user,
                 event_context={

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -155,7 +155,7 @@ from osf.models import (
     CedarMetadataRecord,
     Preprint,
     Collection,
-    NotificationType,
+    NotificationTypeEnum,
 )
 from addons.osfstorage.models import Region
 from osf.utils.permissions import ADMIN, WRITE_NODE
@@ -1065,7 +1065,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
         try:
             fork = serializer.save(node=node)
         except Exception as exc:
-            NotificationType.Type.NODE_FORK_FAILED.instance.emit(
+            NotificationTypeEnum.NODE_FORK_FAILED.instance.emit(
                 user=user,
                 subscribed_object=node,
                 event_context={
@@ -1076,7 +1076,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
             )
             raise exc
 
-        NotificationType.Type.NODE_FORK_COMPLETED.instance.emit(
+        NotificationTypeEnum.NODE_FORK_COMPLETED.instance.emit(
             user=user,
             subscribed_object=node,
             event_context={

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -49,7 +49,7 @@ from osf.models import (
     PreprintProvider,
     Node,
     NodeLicense,
-    NotificationType,
+    NotificationTypeEnum,
 )
 from osf.utils import permissions as osf_permissions
 from osf.utils.workflows import DefaultStates
@@ -478,7 +478,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
                         preprint,
                         contributor=author,
                         auth=auth,
-                        notification_type=NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT,
+                        notification_type=NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT,
                     )
 
         return preprint

--- a/api/providers/serializers.py
+++ b/api/providers/serializers.py
@@ -10,7 +10,7 @@ from api.collections_providers.fields import CollectionProviderRelationshipField
 from api.preprints.serializers import PreprintProviderRelationshipField
 from api.providers.workflows import Workflows
 from api.base.metrics import MetricsSerializerMixin
-from osf.models import CitationStyle, NotificationType, RegistrationProvider, CollectionProvider
+from osf.models import CitationStyle, NotificationTypeEnum, RegistrationProvider, CollectionProvider
 from osf.models.user import Email, OSFUser
 from osf.models.validators import validate_email
 from osf.utils.permissions import REVIEW_GROUPS, ADMIN
@@ -385,9 +385,9 @@ class ModeratorSerializer(JSONAPISerializer):
         provider.add_to_group(user, perm_group)
         setattr(user, 'permission_group', perm_group)  # Allows reserialization
         if 'claim_url' in context:
-            notification_type = NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION
+            notification_type = NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION
         else:
-            notification_type = NotificationType.Type.PROVIDER_MODERATOR_ADDED
+            notification_type = NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
         notification_type.instance.emit(
             user=user,
             event_context=context,

--- a/api/providers/tasks.py
+++ b/api/providers/tasks.py
@@ -27,7 +27,7 @@ from osf.models import (
     RegistrationProvider,
     RegistrationSchema,
     Subject,
-    NotificationType,
+    NotificationTypeEnum,
 )
 from osf.models.licenses import NodeLicense
 from osf.models.registration_bulk_upload_job import JobState
@@ -137,7 +137,7 @@ def prepare_for_registration_bulk_creation(payload_hash, initiator_id, provider_
     # Cancel the preparation task if duplicates are found in the CSV and/or in DB
     if draft_error_list:
         upload.delete()
-        NotificationType.Type.REGISTRATION_BULK_UPLOAD_FAILURE_DUPLICATES.instance.emit(
+        NotificationTypeEnum.REGISTRATION_BULK_UPLOAD_FAILURE_DUPLICATES.instance.emit(
             user=initiator,
             event_context={
                 'user_fullname': initiator.fullname,
@@ -639,11 +639,11 @@ def bulk_upload_finish_job(upload, row_count, success_count, draft_errors, appro
     if not dry_run:
         upload.save()
         if upload.state == JobState.DONE_FULL:
-            notification_type = NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL
+            notification_type = NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL
         elif upload.state == JobState.DONE_PARTIAL:
-            notification_type = NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL
+            notification_type = NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL
         elif upload.state == JobState.DONE_ERROR:
-            notification_type = NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL
+            notification_type = NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL
         else:
             logger.error(f'Unexpected job state for upload [{upload.id}]: {upload.state.name}')
             sentry.log_message(f'Unexpected job state for upload [{upload.id}]: {upload.state.name}')
@@ -680,7 +680,7 @@ def handle_internal_error(initiator=None, provider=None, message=None, dry_run=T
 
     if not dry_run:
         if initiator:
-            NotificationType.Type.DESK_USER_REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE.instance.emit(
+            NotificationTypeEnum.DESK_USER_REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE.instance.emit(
                 user=initiator,
                 event_context={
                     'initiator_fullname': initiator.fullname,
@@ -700,7 +700,7 @@ def inform_product_of_errors(initiator=None, provider=None, message=None):
     user_info = f'{initiator._id}, {initiator.fullname}, {initiator.username}' if initiator else 'UNIDENTIFIED'
     provider_name = provider.name if provider else 'UNIDENTIFIED'
 
-    NotificationType.Type.DESK_REGISTRATION_BULK_UPLOAD_PRODUCT_OWNER.instance.emit(
+    NotificationTypeEnum.DESK_REGISTRATION_BULK_UPLOAD_PRODUCT_OWNER.instance.emit(
         destination_address=email,
         event_context={
             'user': user_info,

--- a/api/requests/serializers.py
+++ b/api/requests/serializers.py
@@ -15,7 +15,7 @@ from osf.models import (
     PreprintRequest,
     Institution,
     OSFUser,
-    NotificationType,
+    NotificationTypeEnum,
 )
 from osf.utils.workflows import DefaultStates, RequestTypes, NodeRequestTypes
 from osf.utils import permissions as osf_permissions
@@ -188,7 +188,7 @@ class NodeRequestCreateSerializer(NodeRequestSerializer):
 
             comment = validated_data.get('comment', '').strip() or language.EMPTY_REQUEST_INSTITUTIONAL_ACCESS_REQUEST_TEXT
 
-            NotificationType.Type.NODE_INSTITUTIONAL_ACCESS_REQUEST.instance.emit(
+            NotificationTypeEnum.NODE_INSTITUTIONAL_ACCESS_REQUEST.instance.emit(
                 user=recipient,
                 subscribed_object=node_request.target,
                 event_context={

--- a/api/subscriptions/views.py
+++ b/api/subscriptions/views.py
@@ -26,7 +26,7 @@ from osf.models import (
     AbstractNode,
     Guid,
 )
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf.models.notification_subscription import NotificationSubscription
 
 
@@ -51,38 +51,38 @@ class SubscriptionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
         ).values('guids___id')[:1]
 
         _global_file_updated = [
-            NotificationType.Type.USER_FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.USER_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
         _global_reviews = [
-            NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-            NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-            NotificationType.Type.REVIEWS_SUBMISSION_STATUS.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+            NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS.value,
         ]
         _node_file_updated = [
-            NotificationType.Type.NODE_FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.NODE_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
 
         qs = NotificationSubscription.objects.filter(
             notification_type__name__in=[
-                NotificationType.Type.USER_FILE_UPDATED.value,
-                NotificationType.Type.NODE_FILE_UPDATED.value,
-                NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+                NotificationTypeEnum.USER_FILE_UPDATED.value,
+                NotificationTypeEnum.NODE_FILE_UPDATED.value,
+                NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
             ] + _global_reviews + _global_file_updated + _node_file_updated,
             user=self.request.user,
         ).annotate(
@@ -167,16 +167,16 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
             annotated_obj_qs = NotificationSubscription.objects.filter(user=self.request.user).annotate(
                 legacy_id=Case(
                     When(
-                        notification_type__name=NotificationType.Type.NODE_FILE_UPDATED.value,
+                        notification_type__name=NotificationTypeEnum.NODE_FILE_UPDATED.value,
                         content_type=node_ct,
                         then=Concat(Subquery(node_subquery), Value('_files_updated')),
                     ),
                     When(
-                        notification_type__name=NotificationType.Type.USER_FILE_UPDATED.value,
+                        notification_type__name=NotificationTypeEnum.USER_FILE_UPDATED.value,
                         then=Value(f'{user_guid}_global_file_updated'),
                     ),
                     When(
-                        notification_type__name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+                        notification_type__name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
                         content_type=provider_ct,
                         then=Value(f'{user_guid}_global_reviews'),
                     ),
@@ -205,14 +205,14 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
             qs = NotificationSubscription.objects.filter(
                 user=self.request.user,
                 notification_type__name__in=[
-                    NotificationType.Type.USER_FILE_UPDATED.value,
-                    NotificationType.Type.FILE_ADDED.value,
-                    NotificationType.Type.FILE_REMOVED.value,
-                    NotificationType.Type.ADDON_FILE_COPIED.value,
-                    NotificationType.Type.ADDON_FILE_RENAMED.value,
-                    NotificationType.Type.ADDON_FILE_MOVED.value,
-                    NotificationType.Type.ADDON_FILE_REMOVED.value,
-                    NotificationType.Type.FOLDER_CREATED.value,
+                    NotificationTypeEnum.USER_FILE_UPDATED.value,
+                    NotificationTypeEnum.FILE_ADDED.value,
+                    NotificationTypeEnum.FILE_REMOVED.value,
+                    NotificationTypeEnum.ADDON_FILE_COPIED.value,
+                    NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+                    NotificationTypeEnum.ADDON_FILE_MOVED.value,
+                    NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+                    NotificationTypeEnum.FOLDER_CREATED.value,
                 ],
             ).exclude(content_type=ContentType.objects.get_for_model(AbstractNode))
             if not qs.exists():
@@ -228,11 +228,11 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
             qs = NotificationSubscription.objects.filter(
                 user=self.request.user,
                 notification_type__name__in=[
-                    NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-                    NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
-                    NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
-                    NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-                    NotificationType.Type.REVIEWS_SUBMISSION_STATUS.value,
+                    NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+                    NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
+                    NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
+                    NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+                    NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS.value,
                 ],
             )
             if not qs.exists():
@@ -252,14 +252,14 @@ class SubscriptionDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView):
                 content_type=ContentType.objects.get_for_model(AbstractNode),
                 object_id=node_id,
                 notification_type__name__in=[
-                    NotificationType.Type.NODE_FILE_UPDATED.value,
-                    NotificationType.Type.FILE_ADDED.value,
-                    NotificationType.Type.FILE_REMOVED.value,
-                    NotificationType.Type.ADDON_FILE_COPIED.value,
-                    NotificationType.Type.ADDON_FILE_RENAMED.value,
-                    NotificationType.Type.ADDON_FILE_MOVED.value,
-                    NotificationType.Type.ADDON_FILE_REMOVED.value,
-                    NotificationType.Type.FOLDER_CREATED.value,
+                    NotificationTypeEnum.NODE_FILE_UPDATED.value,
+                    NotificationTypeEnum.FILE_ADDED.value,
+                    NotificationTypeEnum.FILE_REMOVED.value,
+                    NotificationTypeEnum.ADDON_FILE_COPIED.value,
+                    NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+                    NotificationTypeEnum.ADDON_FILE_MOVED.value,
+                    NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+                    NotificationTypeEnum.FOLDER_CREATED.value,
                 ],
             )
             if not qs.exists():

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -34,7 +34,7 @@ from api.base.versioning import get_kebab_snake_case_field
 from api.nodes.serializers import NodeSerializer, RegionRelationshipField
 from framework.auth.views import send_confirm_email_async
 from osf.exceptions import ValidationValueError, ValidationError, BlockedEmailError
-from osf.models import Email, Node, OSFUser, Preprint, Registration, UserMessage, Institution, NotificationType
+from osf.models import Email, Node, OSFUser, Preprint, Registration, UserMessage, Institution, NotificationTypeEnum
 from osf.models.user_message import MessageTypes
 from osf.models.provider import AbstractProviderGroupObjectPermission
 from osf.utils.requests import string_type_request_headers
@@ -711,7 +711,7 @@ class UserEmailsSerializer(JSONAPISerializer):
         if primary and instance.confirmed:
             user.username = instance.address
             user.save()
-            notification_type = NotificationType.Type.USER_PRIMARY_EMAIL_CHANGED
+            notification_type = NotificationTypeEnum.USER_PRIMARY_EMAIL_CHANGED
             notification_type.instance.emit(
                 subscribed_object=user,
                 user=user,

--- a/api/users/services.py
+++ b/api/users/services.py
@@ -2,7 +2,7 @@ from furl import furl
 from django.utils import timezone
 
 from framework.auth.core import generate_verification_key
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from website import settings
 
 
@@ -15,8 +15,8 @@ def send_password_reset_email(user, email, verification_type='password', institu
     user.save()
 
     reset_link = furl(settings.DOMAIN).add(path=f'resetpassword/{user._id}/{user.verification_key_v2["token"]}').url
-    notification_type = NotificationType.Type.USER_FORGOT_PASSWORD_INSTITUTION if institutional \
-        else NotificationType.Type.USER_FORGOT_PASSWORD
+    notification_type = NotificationTypeEnum.USER_FORGOT_PASSWORD_INSTITUTION if institutional \
+        else NotificationTypeEnum.USER_FORGOT_PASSWORD
 
     notification_type.instance.emit(
         destination_address=email,

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -99,7 +99,7 @@ from osf.models import (
     OSFUser,
     Email,
     Tag,
-    NotificationType,
+    NotificationTypeEnum,
 )
 from osf.utils.tokens import TokenHandler
 from osf.utils.tokens.handlers import sanction_handler
@@ -639,7 +639,7 @@ class UserAccountExport(JSONAPIBaseView, generics.CreateAPIView, UserMixin):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = self.get_user()
-        NotificationType.Type.DESK_REQUEST_EXPORT.instance.emit(
+        NotificationTypeEnum.DESK_REQUEST_EXPORT.instance.emit(
             user=user,
             destination_address=settings.OSF_SUPPORT_EMAIL,
             event_context={
@@ -849,9 +849,9 @@ class ResetPassword(JSONAPIBaseView, generics.ListCreateAPIView):
                 user_obj.save()
                 reset_link = f'{settings.DOMAIN}passwordreset/{user_obj._id}/{user_obj.verification_key_v2['token']}/'
                 if institutional:
-                    notification_type = NotificationType.Type.USER_FORGOT_PASSWORD_INSTITUTION
+                    notification_type = NotificationTypeEnum.USER_FORGOT_PASSWORD_INSTITUTION
                 else:
-                    notification_type = NotificationType.Type.USER_FORGOT_PASSWORD
+                    notification_type = NotificationTypeEnum.USER_FORGOT_PASSWORD
 
                 notification_type.instance.emit(
                     user=user_obj,
@@ -1080,7 +1080,7 @@ class ConfirmEmailView(generics.CreateAPIView):
         if external_status == 'CREATE':
             service_url += '&' + urlencode({'new': 'true'})
         elif external_status == 'LINK':
-            NotificationType.Type.USER_EXTERNAL_LOGIN_LINK_SUCCESS.instance.emit(
+            NotificationTypeEnum.USER_EXTERNAL_LOGIN_LINK_SUCCESS.instance.emit(
                 user=user,
                 message_frequency='instantly',
                 event_context={
@@ -1402,7 +1402,7 @@ class ExternalLoginConfirmEmailView(generics.CreateAPIView):
         if external_status == 'CREATE':
             service_url += '&{}'.format(urlencode({'new': 'true'}))
         elif external_status == 'LINK':
-            NotificationType.Type.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK.instance.emit(
+            NotificationTypeEnum.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK.instance.emit(
                 user=user,
                 message_frequency='instantly',
                 event_context={

--- a/api_tests/actions/views/test_action_list.py
+++ b/api_tests/actions/views/test_action_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     PreprintFactory,
     AuthUserFactory,
@@ -193,8 +193,8 @@ class TestReviewActionCreateRoot:
         with capture_notifications() as notifications:
             res = app.post_json_api(url, accept_payload, auth=moderator.auth)
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.REVIEWS_SUBMISSION_STATUS
-        assert notifications['emits'][1]['type'] == NotificationType.Type.REVIEWS_SUBMISSION_STATUS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS
         assert res.status_code == 201
         preprint.refresh_from_db()
         assert preprint.machine_state == 'accepted'

--- a/api_tests/base/test_throttling.py
+++ b/api_tests/base/test_throttling.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 
 from tests.base import ApiTestCase
 from osf_tests.factories import AuthUserFactory, ProjectFactory
@@ -131,7 +131,7 @@ class TestAddContributorEmailThrottle(ApiTestCase):
                 auth=self.user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
         assert res.status_code == 201
         assert mock_allow.call_count == 1
 

--- a/api_tests/collection_submission_actions/views/test_collection_submissions_actions_list.py
+++ b/api_tests/collection_submission_actions/views/test_collection_submissions_actions_list.py
@@ -5,7 +5,7 @@ from osf_tests.factories import AuthUserFactory
 from django.utils import timezone
 from osf_tests.factories import NodeFactory, CollectionFactory, CollectionProviderFactory
 
-from osf.models import CollectionSubmission, NotificationType
+from osf.models import CollectionSubmission, NotificationTypeEnum
 from osf.utils.workflows import CollectionSubmissionsTriggers, CollectionSubmissionStates
 from tests.utils import capture_notifications
 
@@ -133,9 +133,9 @@ class TestCollectionSubmissionsActionsListPOSTPermissions:
             )
         assert len(notifications['emits']) == 1
         if moderator_trigger is CollectionSubmissionsTriggers.ACCEPT:
-            assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED
         if moderator_trigger is CollectionSubmissionsTriggers.REJECT:
-            assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REJECTED
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED
         assert resp.status_code == 201
 
     @pytest.mark.parametrize('moderator_trigger', [CollectionSubmissionsTriggers.ACCEPT, CollectionSubmissionsTriggers.REJECT])
@@ -181,13 +181,13 @@ class TestCollectionSubmissionsActionsListPOSTPermissions:
         assert resp.status_code == 201
         if user_role == UserRoles.MODERATOR:
             assert len(notifications['emits']) == 1
-            assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR
             assert notifications['emits'][0]['kwargs']['user'] == collection_submission.creator
         else:
             assert len(notifications['emits']) == 2
-            assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
             assert notifications['emits'][0]['kwargs']['user'] == collection_submission.creator
-            assert notifications['emits'][1]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
+            assert notifications['emits'][1]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
             assert notifications['emits'][1]['kwargs']['user'] == node.contributors.last()
 
 
@@ -211,7 +211,7 @@ class TestSubmissionsActionsListPOSTBehavior:
         with capture_notifications() as notifications:
             app.post_json_api(POST_URL, payload, auth=test_auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED
 
         user = collection_submission.collection.provider.get_group('moderator').user_set.first()
         collection_submission.refresh_from_db()
@@ -230,7 +230,7 @@ class TestSubmissionsActionsListPOSTBehavior:
         with capture_notifications() as notifications:
             app.post_json_api(POST_URL, payload, auth=test_auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REJECTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED
 
         user = collection_submission.collection.provider.get_group('moderator').user_set.first()
         collection_submission.refresh_from_db()
@@ -249,9 +249,9 @@ class TestSubmissionsActionsListPOSTBehavior:
         with capture_notifications() as notifications:
             app.post_json_api(POST_URL, payload, auth=test_auth)
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_CANCEL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_CANCEL
         assert notifications['emits'][0]['kwargs']['user'] == collection_submission.creator
-        assert notifications['emits'][1]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_CANCEL
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_CANCEL
         assert notifications['emits'][0]['kwargs']['user'] == node.creator
 
         collection_submission.refresh_from_db()
@@ -271,7 +271,7 @@ class TestSubmissionsActionsListPOSTBehavior:
         with capture_notifications() as notifications:
             app.post_json_api(POST_URL, payload, auth=test_auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR
         user = collection_submission.collection.provider.get_group('moderator').user_set.first()
         collection_submission.refresh_from_db()
         action = collection_submission.actions.last()
@@ -322,7 +322,7 @@ class TestSubmissionsActionsListPOSTBehavior:
                 expect_errors=True
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED
         assert resp.status_code == 201
 
 

--- a/api_tests/crossref/views/test_crossref_email_response.py
+++ b/api_tests/crossref/views/test_crossref_email_response.py
@@ -5,7 +5,7 @@ import lxml.etree
 
 from django.utils import timezone
 
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests import factories
 from tests.utils import capture_notifications
 from website import settings
@@ -163,7 +163,7 @@ class TestCrossRefEmailResponse:
         with capture_notifications() as notifications:
             app.post(url, context_data)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_CROSSREF_ERROR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_CROSSREF_ERROR
         assert not preprint.get_identifier_value('doi')
 
     def test_success_response_sets_doi(self, app, url, preprint, success_xml):

--- a/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_contributor_list.py
@@ -16,7 +16,7 @@ from api_tests.nodes.views.test_node_contributors_list import (
     TestNodeContributorFiltering,
 )
 from api_tests.nodes.views.utils import NodeCRUDTestCase
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf_tests.factories import (
     DraftRegistrationFactory,
     AuthUserFactory,
@@ -238,7 +238,7 @@ class TestDraftContributorCreateEmail(DraftRegistrationCRUDTestCase, TestNodeCon
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
 
     # Overrides TestNodeContributorCreateEmail
     def test_add_contributor_signal_if_default(
@@ -281,7 +281,7 @@ class TestDraftContributorCreateEmail(DraftRegistrationCRUDTestCase, TestNodeCon
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DRAFT_REGISTRATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DRAFT_REGISTRATION
 
     # Overrides TestNodeContributorCreateEmail
     def test_add_unregistered_contributor_signal_if_default(self, app, user, url_project_contribs):
@@ -300,7 +300,7 @@ class TestDraftContributorCreateEmail(DraftRegistrationCRUDTestCase, TestNodeCon
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DRAFT_REGISTRATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DRAFT_REGISTRATION
 
     # Overrides TestNodeContributorCreateEmail
     def test_add_unregistered_contributor_without_email_no_email(self, app, user, url_project_contribs):

--- a/api_tests/draft_registrations/views/test_draft_registration_list.py
+++ b/api_tests/draft_registrations/views/test_draft_registration_list.py
@@ -6,7 +6,7 @@ from api_tests.nodes.views.test_node_draft_registration_list import AbstractDraf
 from api.base.settings.defaults import API_BASE
 
 from osf.migrations import ensure_invisible_and_inactive_schema
-from osf.models import DraftRegistration, NodeLicense, RegistrationProvider, RegistrationSchema, NotificationType
+from osf.models import DraftRegistration, NodeLicense, RegistrationProvider, RegistrationSchema, NotificationTypeEnum
 from osf_tests.factories import (
     RegistrationFactory,
     CollectionFactory,
@@ -435,7 +435,7 @@ class TestDraftRegistrationCreateWithoutNode(AbstractDraftRegistrationTestCase):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
         assert notifications['emits'][0]['kwargs']['user'] == user
 
     def test_create_draft_with_provider(
@@ -515,7 +515,7 @@ class TestDraftRegistrationCreateWithoutNode(AbstractDraftRegistrationTestCase):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
         assert res.status_code == 201
         attributes = res.json['data']['attributes']
         assert attributes['title'] == ''

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     RegistrationFactory,
     InstitutionFactory,
@@ -409,7 +409,7 @@ class TestInstitutionRelationshipNodes:
 
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
     def test_email_sent_on_affiliation_removal(self, app, admin, institution, node_public, url_institution_nodes):
         current_institution = InstitutionFactory()
@@ -432,7 +432,7 @@ class TestInstitutionRelationshipNodes:
         assert res.status_code == 204
 
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert notifications['emits'][0]['kwargs']['user'] == node_public.creator
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert notifications['emits'][1]['kwargs']['user'] == admin

--- a/api_tests/mailhog/provider/test_collection_submission.py
+++ b/api_tests/mailhog/provider/test_collection_submission.py
@@ -7,7 +7,7 @@ from osf_tests.factories import (
     CollectionProviderFactory,
     CollectionFactory,
 )
-from osf.models import NotificationType, CollectionSubmission
+from osf.models import NotificationTypeEnum, CollectionSubmission
 from tests.utils import get_mailhog_messages, delete_mailhog_messages, capture_notifications
 from osf.utils.workflows import CollectionSubmissionStates
 
@@ -49,8 +49,8 @@ class TestModeratedCollectionSubmission:
             )
             collection_submission.save()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert collection_submission.state == CollectionSubmissionStates.PENDING
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
@@ -67,8 +67,8 @@ class TestModeratedCollectionSubmission:
             )
             collection_submission.save()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert collection_submission.state == CollectionSubmissionStates.PENDING
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])

--- a/api_tests/mailhog/provider/test_collections_provider_moderator_list.py
+++ b/api_tests/mailhog/provider/test_collections_provider_moderator_list.py
@@ -2,7 +2,7 @@ import pytest
 from waffle.testutils import override_switch
 from osf import features
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     CollectionProviderFactory,
@@ -69,7 +69,7 @@ class TestPOSTCollectionsModeratorList:
         with capture_notifications(passthrough=True) as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
         assert res.status_code == 201
         assert res.json['data']['id'] == nonmoderator._id
         assert res.json['data']['attributes']['permission_group'] == 'moderator'
@@ -97,7 +97,7 @@ class TestPOSTCollectionsModeratorList:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION
         assert notifications['emits'][0]['kwargs']['user'].username == unreg_user['email']
 
         massages = get_mailhog_messages()
@@ -113,7 +113,7 @@ class TestPOSTCollectionsModeratorList:
         with capture_notifications(passthrough=True) as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION
         assert res.status_code == 201
         assert len(res.json['data']['id']) == 5
         assert res.json['data']['attributes']['permission_group'] == 'moderator'

--- a/api_tests/mailhog/provider/test_preprints.py
+++ b/api_tests/mailhog/provider/test_preprints.py
@@ -2,7 +2,7 @@ from waffle.testutils import override_switch
 from osf import features
 
 from framework.auth.core import Auth
-from osf.models import NotificationType, Notification
+from osf.models import NotificationTypeEnum, Notification
 from osf_tests.factories import (
     ProjectFactory,
     AuthUserFactory,
@@ -33,7 +33,7 @@ class TestPreprintConfirmationEmails(OsfTestCase):
         with capture_notifications(passthrough=True) as notifications:
             self.preprint.set_published(True, auth=Auth(self.user), save=True)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         messages = get_mailhog_messages()
         assert not messages['items']
         assert Notification.objects.all()
@@ -47,7 +47,7 @@ class TestPreprintConfirmationEmails(OsfTestCase):
         with capture_notifications(passthrough=True) as notifications:
             self.preprint_branded.set_published(True, auth=Auth(self.user), save=True)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         messages = get_mailhog_messages()
         assert not messages['items']
         with capture_notifications(passthrough=True) as notifications:

--- a/api_tests/mailhog/provider/test_reviewable.py
+++ b/api_tests/mailhog/provider/test_reviewable.py
@@ -1,7 +1,7 @@
 import pytest
 from waffle.testutils import override_switch
 from osf import features
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import PreprintFactory, AuthUserFactory
 from tests.utils import get_mailhog_messages, delete_mailhog_messages, capture_notifications, assert_emails
@@ -20,7 +20,7 @@ class TestReviewable:
         with capture_notifications(passthrough=True) as notifications:
             preprint.run_submit(user)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         assert preprint.machine_state == DefaultStates.PENDING.value
         delete_mailhog_messages()
 
@@ -30,7 +30,7 @@ class TestReviewable:
             preprint.run_reject(user, 'comment')
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.REVIEWS_SUBMISSION_STATUS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS
         assert preprint.machine_state == DefaultStates.REJECTED.value
 
         massages = get_mailhog_messages()
@@ -41,7 +41,7 @@ class TestReviewable:
         with capture_notifications(passthrough=True) as notifications:
             preprint.run_submit(user)  # Resubmission alerts users and moderators
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
         assert preprint.machine_state == DefaultStates.PENDING.value
 
         messages = get_mailhog_messages()

--- a/api_tests/mailhog/provider/test_schema_responses.py
+++ b/api_tests/mailhog/provider/test_schema_responses.py
@@ -2,7 +2,7 @@ import pytest
 from waffle.testutils import override_switch
 from osf import features
 from api.providers.workflows import Workflows
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf.models import schema_response  # import module for mocking purposes
 from osf.utils.workflows import ApprovalStates
 from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory, RegistrationProviderFactory
@@ -125,9 +125,9 @@ class TestUnmoderatedSchemaResponseApprovalFlows:
         with capture_notifications(passthrough=True) as notifications:
             revised_response.submit(user=admin_user, required_approvers=[admin_user])
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
         assert_emails(massages, notifications)
@@ -145,9 +145,9 @@ class TestUnmoderatedSchemaResponseApprovalFlows:
         with capture_notifications(passthrough=True) as notifications:
             revised_response.approve(user=alternate_user)
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
         assert_emails(massages, notifications)
@@ -164,9 +164,9 @@ class TestUnmoderatedSchemaResponseApprovalFlows:
         with capture_notifications(passthrough=True) as notifications:
             revised_response.reject(user=admin_user)
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
         assert_emails(massages, notifications)
@@ -207,9 +207,9 @@ class TestModeratedSchemaResponseApprovalFlows:
             revised_response.approve(user=admin_user)
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == moderator
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert notifications['emits'][1]['kwargs']['user'] == admin_user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
         assert_emails(massages, notifications)
@@ -226,9 +226,9 @@ class TestModeratedSchemaResponseApprovalFlows:
             revised_response.approve(user=admin_user)
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == moderator
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert notifications['emits'][1]['kwargs']['user'] == admin_user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
         massages = get_mailhog_messages()
         assert massages['count'] == len(notifications['emails'])
         assert_emails(massages, notifications)

--- a/api_tests/mailhog/provider/test_submissions.py
+++ b/api_tests/mailhog/provider/test_submissions.py
@@ -18,7 +18,7 @@ from osf_tests.factories import (
 
 from tests.base import get_default_metaschema
 
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 
 from osf.migrations import update_provider_auth_groups
 from tests.utils import capture_notifications, get_mailhog_messages, delete_mailhog_messages
@@ -82,8 +82,8 @@ class TestRegistriesModerationSubmissions:
             resp = app.get(registration_actions_url, auth=moderator.auth)
 
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS
         messages = get_mailhog_messages()
         assert messages['count'] == 1
         assert messages['items'][0]['Content']['Headers']['To'][0] == registration.creator.username
@@ -116,8 +116,8 @@ class TestRegistriesModerationSubmissions:
             resp = app.get(provider_actions_url, auth=moderator.auth)
 
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         send_users_instant_digest_email.delay()
         messages = get_mailhog_messages()
         assert messages['count'] == 1

--- a/api_tests/mailhog/test_mailhog.py
+++ b/api_tests/mailhog/test_mailhog.py
@@ -12,7 +12,7 @@ from tests.base import (
     fake
 )
 from framework import auth
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationType, NotificationTypeEnum
 from tests.base import (
     OsfTestCase,
 )
@@ -28,7 +28,7 @@ class TestMailHog:
     def test_mailhog_received_mail(self):
         delete_mailhog_messages()
 
-        NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL.instance.emit(
+        NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL.instance.emit(
             message_frequency='instantly',
             destination_address='to_addr@mail.com',
             event_context={
@@ -44,7 +44,7 @@ class TestMailHog:
         assert res['count'] == 1
         assert res['items'][0]['Content']['Headers']['To'][0] == 'to_addr@mail.com'
         assert res['items'][0]['Content']['Headers']['Subject'][0] == NotificationType.objects.get(
-            name=NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL
+            name=NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL
         ).subject
         delete_mailhog_messages()
 

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -6,7 +6,7 @@ import random
 from api.base.settings.defaults import API_BASE
 from api.nodes.serializers import NodeContributorsCreateSerializer
 from framework.auth.core import Auth
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf_tests.factories import (
     fake_email,
     AuthUserFactory,
@@ -1273,7 +1273,7 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
         res = app.post_json_api(url, payload, auth=user.auth)
         args, kwargs = mock_send.call_args
         assert res.status_code == 201
-        assert NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT == kwargs['notification_type']
+        assert NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT == kwargs['notification_type']
 
     def test_add_contributor_signal_preprint_email_disallowed(
         self, app, user, user_two, url_project_contribs
@@ -1311,7 +1311,7 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
             )
             assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
 
     @mock.patch('website.project.signals.unreg_contributor_added.send')
     def test_add_unregistered_contributor_signal_if_default(
@@ -1333,7 +1333,7 @@ class TestNodeContributorCreateEmail(NodeCRUDTestCase):
             )
             assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
 
     def test_add_unregistered_contributor_signal_preprint_email_disallowed(
         self, app, user, url_project_contribs

--- a/api_tests/nodes/views/test_node_detail_update.py
+++ b/api_tests/nodes/views/test_node_detail_update.py
@@ -8,7 +8,7 @@ from api.caching.utils import storage_usage_cache
 from api_tests.nodes.views.utils import NodeCRUDTestCase
 from api_tests.subjects.mixins import UpdateSubjectsMixin
 from framework.auth.core import Auth
-from osf.models import NodeLog, NotificationType
+from osf.models import NodeLog, NotificationTypeEnum
 from osf.utils.sanitize import strip_html
 from osf.utils import permissions
 from osf_tests.factories import (
@@ -47,7 +47,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
                 ]
                 }
         }
-        with assert_notification(type=NotificationType.Type.NODE_AFFILIATION_CHANGED, user=user_two, times=2):
+        with assert_notification(type=NotificationTypeEnum.NODE_AFFILIATION_CHANGED, user=user_two, times=2):
             res = app.patch_json_api(
                 url_private,
                 make_node_payload(

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -8,7 +8,7 @@ from api.caching.utils import storage_usage_cache
 from api_tests.nodes.filters.test_filters import NodesListFilteringMixin, NodesListDateFilteringMixin
 from api_tests.subjects.mixins import SubjectsFilterMixin
 from framework.auth.core import Auth
-from osf.models import AbstractNode, Node, NodeLog, NotificationType
+from osf.models import AbstractNode, Node, NodeLog, NotificationTypeEnum
 from osf.models.licenses import NodeLicense
 from osf.utils.sanitize import strip_html
 from osf.utils import permissions
@@ -1428,7 +1428,7 @@ class TestNodeCreate:
 
     def test_creates_public_project_logged_in(
             self, app, user_one, public_project, url, institution_one):
-        with assert_notification(type=NotificationType.Type.NODE_AFFILIATION_CHANGED, user=user_one):
+        with assert_notification(type=NotificationTypeEnum.NODE_AFFILIATION_CHANGED, user=user_one):
             res = app.post_json_api(
                 url, public_project,
                 auth=user_one.auth
@@ -1531,7 +1531,7 @@ class TestNodeCreate:
                 auth=user_without_permissions.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         assert res.status_code == 201
 
     def test_non_contributor_create_project_from_private_template_no_permission_fails(self, app, user_one, category, url):
@@ -1576,7 +1576,7 @@ class TestNodeCreate:
                 auth=user_without_permissions.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         assert res.status_code == 201
         assert template_from.has_permission(user_without_permissions, permissions.READ)
 
@@ -1593,7 +1593,7 @@ class TestNodeCreate:
                 auth=user_without_permissions.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         assert res.status_code == 201
         assert template_from.has_permission(user_without_permissions, permissions.WRITE)
 
@@ -1610,7 +1610,7 @@ class TestNodeCreate:
                 auth=user_without_permissions.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         assert res.status_code == 201
         assert template_from.has_permission(user_without_permissions, permissions.ADMIN)
 
@@ -1759,7 +1759,7 @@ class TestNodeCreate:
                 }
             }
         }
-        with assert_notification(type=NotificationType.Type.NODE_AFFILIATION_CHANGED, user=user_one, times=2):
+        with assert_notification(type=NotificationTypeEnum.NODE_AFFILIATION_CHANGED, user=user_one, times=2):
             res = app.post_json_api(
                 url,
                 private_project,

--- a/api_tests/nodes/views/test_node_relationship_institutions.py
+++ b/api_tests/nodes/views/test_node_relationship_institutions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     InstitutionFactory,
     AuthUserFactory,
@@ -198,7 +198,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 201
         data = res.json['data']
@@ -228,9 +228,9 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
         assert len(notifications['emits']) == 2
 
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert notifications['emits'][1]['kwargs']['user'] == user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
     def test_remove_institutions_with_affiliated_user(
             self,
@@ -254,7 +254,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
 
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 200
         assert node.affiliated_institutions.count() == 0
@@ -287,7 +287,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 200
         assert institution_one in node.affiliated_institutions.all()
@@ -314,7 +314,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 200
         assert institution_one in node.affiliated_institutions.all()
@@ -342,10 +342,10 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert notifications['emits'][1]['kwargs']['user'] == user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 200
         assert institution_one not in node.affiliated_institutions.all()
@@ -373,7 +373,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 201
         assert institution_one in node.affiliated_institutions.all()
@@ -406,7 +406,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 204
         assert institution_one not in node.affiliated_institutions.all()
@@ -426,7 +426,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 204
         assert institution_one not in node.affiliated_institutions.all()
@@ -444,7 +444,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 204
 
@@ -488,7 +488,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=user_auth.auth,
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
 
         assert res.status_code == 204
         assert institution_one not in project.affiliated_institutions.all()
@@ -509,7 +509,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
             )
         assert len(notifications['emits']) == 1
         assert notifications['emits'][0]['kwargs']['user'] == user
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert res.status_code == 201
         assert institution_one in node.affiliated_institutions.all()
 
@@ -530,7 +530,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert res.status_code == 204
         assert institution_one not in node.affiliated_institutions.all()
 
@@ -552,7 +552,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert res.status_code == 204
         assert read_contrib_institution not in node.affiliated_institutions.all()
 
@@ -572,7 +572,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=write_contrib.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert res.status_code == 201
         assert write_contrib_institution in node.affiliated_institutions.all()
 
@@ -594,7 +594,7 @@ class TestNodeRelationshipInstitutions(RelationshipInstitutionsTestMixin):
                 auth=write_contrib.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_AFFILIATION_CHANGED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_AFFILIATION_CHANGED
         assert res.status_code == 204
         assert write_contrib_institution not in node.affiliated_institutions.all()
 

--- a/api_tests/notifications/test_notification_digest.py
+++ b/api_tests/notifications/test_notification_digest.py
@@ -1,7 +1,7 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
 
-from osf.models import Notification, NotificationType, EmailTask
+from osf.models import Notification, NotificationType, NotificationTypeEnum, EmailTask
 from notifications.tasks import (
     send_user_email_task,
     send_moderator_email_task,
@@ -41,14 +41,14 @@ class TestNotificationDigestTasks:
 
     def test_send_user_email_task_success(self):
         user = AuthUserFactory()
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         subscription_type = add_notification_subscription(
             user,
             notification_type,
             'daily',
             subscription=add_notification_subscription(
                 user,
-                NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED),
+                NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED),
                 'daily'
             )
         )
@@ -74,7 +74,7 @@ class TestNotificationDigestTasks:
         with capture_notifications() as notifications:
             send_user_email_task.apply(args=(user._id, notification_ids)).get()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_DIGEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_DIGEST
         assert notifications['emits'][0]['kwargs']['user'] == user
         email_task = EmailTask.objects.get(user_id=user.id)
         assert email_task.status == 'SUCCESS'
@@ -94,9 +94,9 @@ class TestNotificationDigestTasks:
         user = AuthUserFactory()
         user.deactivate_account()
         user.save()
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.USER_DIGEST)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.USER_DIGEST)
         notification = Notification.objects.create(
-            subscription=add_notification_subscription(user, NotificationType.Type.USER_FILE_UPDATED, notification_type),
+            subscription=add_notification_subscription(user, NotificationTypeEnum.USER_FILE_UPDATED, notification_type),
             sent=None,
             event_context={},
         )
@@ -120,7 +120,7 @@ class TestNotificationDigestTasks:
         RegistrationFactory(provider=reg_provider)
         moderator_group = reg_provider.get_group('moderator')
         moderator_group.user_set.add(user)
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS)
         notification = Notification.objects.create(
             subscription=add_notification_subscription(
                 user,
@@ -143,7 +143,7 @@ class TestNotificationDigestTasks:
         with capture_notifications() as notifications:
             send_moderator_email_task.apply(args=(user._id, notification_ids, reg_provider_content_type.id, reg_provider.id)).get()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DIGEST_REVIEWS_MODERATORS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DIGEST_REVIEWS_MODERATORS
         assert notifications['emits'][0]['kwargs']['user'] == user
 
         email_task = EmailTask.objects.filter(user_id=user.id).first()
@@ -158,7 +158,7 @@ class TestNotificationDigestTasks:
         RegistrationFactory(provider=provider)
 
         notification_ids = []
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS)
         add_notification_subscription(
             user,
             notification_type,
@@ -177,7 +177,7 @@ class TestNotificationDigestTasks:
 
     def test_get_users_emails(self):
         user = AuthUserFactory()
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         notification1 = Notification.objects.create(
             subscription=add_notification_subscription(user, notification_type, 'daily'),
             sent=None,
@@ -193,7 +193,7 @@ class TestNotificationDigestTasks:
         user = AuthUserFactory()
         provider = RegistrationProviderFactory()
         reg = RegistrationFactory(provider=provider)
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS)
         subscription = add_notification_subscription(user, notification_type, 'daily', subscribed_object=reg)
         Notification.objects.create(
             subscription=subscription,
@@ -209,14 +209,14 @@ class TestNotificationDigestTasks:
 
     def test_send_users_digest_email_end_to_end(self):
         user = AuthUserFactory()
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         subscription_type = add_notification_subscription(
             user,
             notification_type,
             'daily',
             subscription=add_notification_subscription(
                 user,
-                NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED),
+                NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED),
                 'daily'
             )
         )
@@ -246,7 +246,7 @@ class TestNotificationDigestTasks:
         with capture_notifications() as notifications:
             send_users_digest_email.delay()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_DIGEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_DIGEST
         email_task = EmailTask.objects.get(user_id=user.id)
         assert email_task.status == 'SUCCESS'
 
@@ -256,7 +256,7 @@ class TestNotificationDigestTasks:
         RegistrationFactory(provider=provider)
         moderator_group = provider.get_group('moderator')
         moderator_group.user_set.add(user)
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS)
         Notification.objects.create(
             subscription=add_notification_subscription(user, notification_type, 'daily', subscribed_object=provider),
             sent=None,
@@ -275,7 +275,7 @@ class TestNotificationDigestTasks:
         with capture_notifications() as notifications:
             send_moderators_digest_email.delay()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DIGEST_REVIEWS_MODERATORS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DIGEST_REVIEWS_MODERATORS
         email_task = EmailTask.objects.filter(user_id=user.id).first()
         assert email_task.status == 'SUCCESS'
 
@@ -288,7 +288,7 @@ class TestNotificationDigestTasks:
         RegistrationFactory(provider=provider)
 
         notification_ids = []
-        notification_type = NotificationType.objects.get(name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS)
+        notification_type = NotificationType.objects.get(name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS)
         add_notification_subscription(
             user,
             notification_type,

--- a/api_tests/notifications/test_notifications_db_transaction.py
+++ b/api_tests/notifications/test_notifications_db_transaction.py
@@ -3,7 +3,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     NotificationTypeFactory
 )
-from osf.models import Notification, NotificationType, NotificationSubscription
+from osf.models import Notification, NotificationTypeEnum, NotificationSubscription
 from tests.utils import capture_notifications
 from django.db import reset_queries, connection
 
@@ -24,9 +24,9 @@ class TestNotificationTypeDBTransaction:
         )
 
     def test_notification_type_cache(self):
-        NotificationType.Type.NODE_FILE_UPDATED.instance
+        NotificationTypeEnum.NODE_FILE_UPDATED.instance
         reset_queries()
-        NotificationType.Type.NODE_FILE_UPDATED.instance
+        NotificationTypeEnum.NODE_FILE_UPDATED.instance
         assert len(connection.queries) == 0
 
     def test_emit_without_saving(self, user_one, test_notification_type):

--- a/api_tests/preprints/views/test_preprint_contributors_list.py
+++ b/api_tests/preprints/views/test_preprint_contributors_list.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from api.base.settings.defaults import API_BASE
 from api.nodes.serializers import NodeContributorsCreateSerializer
 from framework.auth.core import Auth
-from osf.models import PreprintLog, NotificationType
+from osf.models import PreprintLog, NotificationTypeEnum
 from osf_tests.factories import (
     fake_email,
     AuthUserFactory,
@@ -1418,7 +1418,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
 
     def test_add_contributor_signal_no_query_param(
             self, app, user, user_two, url_preprint_contribs):
@@ -1444,7 +1444,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
 
     def test_add_unregistered_contributor_sends_email(
             self, app, user, url_preprint_contribs):
@@ -1463,7 +1463,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
                 auth=user.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_USER_INVITE_PREPRINT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_USER_INVITE_PREPRINT
         assert res.status_code == 201
 
     def test_add_unregistered_contributor_signal_if_preprint(self, app, user, url_preprint_contribs):
@@ -1483,7 +1483,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_USER_INVITE_PREPRINT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_USER_INVITE_PREPRINT
 
     def test_add_contributor_invalid_send_email_param(self, app, user, url_preprint_contribs):
         url = f'{url_preprint_contribs}?send_email=true'
@@ -1529,7 +1529,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
         user_two = AuthUserFactory()
         preprint_unpublished.add_contributor(user_two, permissions=permissions.WRITE, save=True)
         with capture_signals() as mock_signal:
-            with assert_notification(type=NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
+            with assert_notification(type=NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
                 res = app.patch_json_api(
                     url,
                     {
@@ -1564,7 +1564,7 @@ class TestPreprintContributorCreateEmail(NodeCRUDTestCase):
             )
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_USER_INVITE_PREPRINT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_USER_INVITE_PREPRINT
 
 @pytest.mark.django_db
 class TestPreprintContributorBulkCreate(NodeCRUDTestCase):

--- a/api_tests/preprints/views/test_preprint_detail_update.py
+++ b/api_tests/preprints/views/test_preprint_detail_update.py
@@ -11,7 +11,7 @@ from framework.auth.core import Auth
 from osf.models import (
     NodeLicense,
     PreprintContributor,
-    PreprintLog, NotificationType
+    PreprintLog, NotificationTypeEnum
 )
 from osf.utils import permissions as osf_permissions
 from osf.utils.permissions import WRITE
@@ -502,7 +502,7 @@ class TestPreprintUpdate:
             self, mock_update_doi_metadata, app, user, preprint, url
     ):
         new_user = AuthUserFactory()
-        with assert_notification(type=NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT, user=new_user):
+        with assert_notification(type=NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT, user=new_user):
             res = app.post_json_api(
                 url + 'contributors/',
                 {
@@ -602,7 +602,7 @@ class TestPreprintUpdate:
 
     def test_update_published(self, app, user):
         unpublished = PreprintFactory(creator=user, is_published=False)
-        with assert_notification(type=NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
+        with assert_notification(type=NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
             app.patch_json_api(
                 f'/{API_BASE}preprints/{unpublished._id}/',
                 build_preprint_update_payload(
@@ -622,7 +622,7 @@ class TestPreprintUpdate:
             project=project
         )
         assert not unpublished.node.is_public
-        with assert_notification(type=NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
+        with assert_notification(type=NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION, user=user):
             app.patch_json_api(
                 f'/{API_BASE}preprints/{unpublished._id}/',
                 build_preprint_update_payload(

--- a/api_tests/providers/collections/views/test_collections_provider_moderator_list.py
+++ b/api_tests/providers/collections/views/test_collections_provider_moderator_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     CollectionProviderFactory,
@@ -111,7 +111,7 @@ class TestPOSTCollectionsModeratorList:
         with capture_notifications() as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
         assert res.status_code == 201
         assert res.json['data']['id'] == nonmoderator._id
         assert res.json['data']['attributes']['permission_group'] == 'moderator'
@@ -136,7 +136,7 @@ class TestPOSTCollectionsModeratorList:
 
         assert res.status_code == 201
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION
         assert notifications['emits'][0]['kwargs']['user'].username == unreg_user['email']
 
     def test_POST_admin_failure_invalid_group(self, app, url, nonmoderator, moderator, admin, provider):
@@ -149,7 +149,7 @@ class TestPOSTCollectionsModeratorList:
         with capture_notifications() as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION
         assert res.status_code == 201
         assert len(res.json['data']['id']) == 5
         assert res.json['data']['attributes']['permission_group'] == 'moderator'

--- a/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
+++ b/api_tests/providers/preprints/views/test_preprint_provider_moderator_list.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     PreprintProviderFactory,
@@ -89,7 +89,7 @@ class ProviderModeratorListTestClass:
         assert res.json['data']['id'] == nonmoderator._id
         assert res.json['data']['attributes']['permission_group'] == 'moderator'
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
 
     def test_list_post_admin_failure_existing_moderator(self, app, url, moderator, admin):
         payload = self.create_payload(user_id=moderator._id, permission_group='moderator')

--- a/api_tests/providers/tasks/test_bulk_upload.py
+++ b/api_tests/providers/tasks/test_bulk_upload.py
@@ -5,7 +5,7 @@ from api.providers.tasks import bulk_create_registrations
 
 from osf.exceptions import RegistrationBulkCreationContributorError, RegistrationBulkCreationRowError
 from osf.models import RegistrationBulkUploadJob, RegistrationBulkUploadRow, RegistrationProvider, RegistrationSchema, \
-    NotificationType
+    NotificationTypeEnum
 from osf.models.registration_bulk_upload_job import JobState
 from osf.models.registration_bulk_upload_row import RegistrationBulkUploadContributors
 from osf.utils.permissions import ADMIN, READ, WRITE
@@ -331,7 +331,7 @@ class TestBulkUploadTasks:
         with capture_notifications() as notifications:
             bulk_create_registrations(upload_job_done_full.id, dry_run=False)
         notification_types = [notifications['type'] for notifications in notifications['emits']]
-        assert NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL in notification_types
+        assert NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL in notification_types
         upload_job_done_full.reload()
         assert upload_job_done_full.state == JobState.DONE_FULL
         assert upload_job_done_full.email_sent
@@ -359,7 +359,7 @@ class TestBulkUploadTasks:
         with capture_notifications() as notifications:
             bulk_create_registrations(upload_job_done_partial.id, dry_run=False)
         notification_types = [notifications['type'] for notifications in notifications['emits']]
-        assert NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL in notification_types
+        assert NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL in notification_types
         upload_job_done_partial.reload()
         assert upload_job_done_partial.state == JobState.DONE_PARTIAL
         assert upload_job_done_partial.email_sent
@@ -387,7 +387,7 @@ class TestBulkUploadTasks:
         with capture_notifications() as notifications:
             bulk_create_registrations(upload_job_done_error.id, dry_run=False)
         notification_types = [notifications['type'] for notifications in notifications['emits']]
-        assert NotificationType.Type.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL in notification_types
+        assert NotificationTypeEnum.USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL in notification_types
 
         upload_job_done_error.reload()
         assert upload_job_done_error.state == JobState.DONE_ERROR

--- a/api_tests/requests/views/test_node_request_institutional_access_logging.py
+++ b/api_tests/requests/views/test_node_request_institutional_access_logging.py
@@ -3,7 +3,7 @@ import pytest
 from api.base.settings.defaults import API_BASE
 
 from osf_tests.factories import NodeFactory, InstitutionFactory, AuthUserFactory
-from osf.models import NodeLog, NodeRequest, NotificationType
+from osf.models import NodeLog, NodeRequest, NotificationTypeEnum
 from osf.utils.workflows import NodeRequestTypes
 from tests.utils import assert_notification
 
@@ -70,7 +70,7 @@ class TestNodeRequestListInstitutionalAccessActionAccept:
         Test a successful POST request to create a node-request action and log it.
         """
         # Perform the POST request
-        with assert_notification(type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST, user=institutional_admin):
+        with assert_notification(type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST, user=institutional_admin):
             res = app.post_json_api(url, action_payload, auth=user_with_affiliation.auth)
         assert res.status_code == 201
         assert res.json['data']['attributes']['trigger'] == 'accept'
@@ -92,7 +92,7 @@ class TestNodeRequestListInstitutionalAccessActionAccept:
         """
         # Perform the POST request
         action_payload['data']['attributes']['trigger'] = 'reject'
-        with assert_notification(type=NotificationType.Type.NODE_REQUEST_ACCESS_DENIED, user=institutional_admin):
+        with assert_notification(type=NotificationTypeEnum.NODE_REQUEST_ACCESS_DENIED, user=institutional_admin):
             res = app.post_json_api(url, action_payload, auth=user_with_affiliation.auth)
         assert res.status_code == 201
         assert res.json['data']['attributes']['trigger'] == 'reject'

--- a/api_tests/requests/views/test_node_request_list.py
+++ b/api_tests/requests/views/test_node_request_list.py
@@ -2,7 +2,7 @@ import pytest
 
 from api.base.settings.defaults import API_BASE
 from api_tests.requests.mixins import NodeRequestTestMixin
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 
 from osf_tests.factories import NodeFactory, NodeRequestFactory, InstitutionFactory
 from osf.utils.workflows import DefaultStates, NodeRequestTypes
@@ -90,8 +90,8 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
             res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
 
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_REQUEST_ACCESS_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_REQUEST_ACCESS_SUBMITTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_REQUEST_ACCESS_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_REQUEST_ACCESS_SUBMITTED
         assert res.status_code == 201
 
     def test_email_not_sent_to_parent_admins_on_submit(self, app, project, noncontrib, url, create_payload, second_admin):
@@ -105,7 +105,7 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
                 auth=noncontrib.auth
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_REQUEST_ACCESS_SUBMITTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_REQUEST_ACCESS_SUBMITTED
         assert res.status_code == 201
         assert component.parent_admin_contributors.count() == 1
         assert component.contributors.count() == 1
@@ -156,7 +156,7 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
         # Create the first request a basic request_type == `institutional_request` request
         app.post_json_api(url, create_payload, auth=noncontrib.auth)
         node_request = project.requests.get()
-        with assert_notification(type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST, user=node_request.creator):
+        with assert_notification(type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST, user=node_request.creator):
             node_request.run_accept(project.creator, 'test comment2')
         node_request.refresh_from_db()
         assert node_request.machine_state == 'accepted'
@@ -166,7 +166,7 @@ class TestNodeRequestListCreate(NodeRequestTestMixin):
         create_payload['data']['attributes']['request_type'] = NodeRequestTypes.ACCESS.value
 
         # Attempt to create a second request, refresh and update as institutional
-        with assert_notification(type=NotificationType.Type.NODE_REQUEST_ACCESS_SUBMITTED, user=project.creator):
+        with assert_notification(type=NotificationTypeEnum.NODE_REQUEST_ACCESS_SUBMITTED, user=project.creator):
             res = app.post_json_api(url, create_payload, auth=noncontrib.auth)
         assert res.status_code == 201
         node_request.refresh_from_db()

--- a/api_tests/requests/views/test_request_actions_create.py
+++ b/api_tests/requests/views/test_request_actions_create.py
@@ -2,7 +2,7 @@ import pytest
 
 from api.base.settings.defaults import API_BASE
 from api_tests.requests.mixins import NodeRequestTestMixin, PreprintRequestTestMixin
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 
 from osf.utils import permissions
 from tests.utils import capture_notifications, assert_notification
@@ -201,7 +201,7 @@ class TestCreateNodeRequestAction(NodeRequestTestMixin):
         with capture_notifications() as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         assert res.status_code == 201
         node_request.reload()
         assert initial_state != node_request.machine_state
@@ -214,7 +214,7 @@ class TestCreateNodeRequestAction(NodeRequestTestMixin):
         with capture_notifications() as notifications:
             res = app.post_json_api(url, payload, auth=admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_REQUEST_ACCESS_DENIED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_REQUEST_ACCESS_DENIED
 
         assert res.status_code == 201
         node_request.reload()
@@ -326,7 +326,7 @@ class TestCreatePreprintRequestAction(PreprintRequestTestMixin):
             initial_state = request.machine_state
             assert not request.target.is_retracted
             payload = self.create_payload(request._id, trigger='accept')
-            with assert_notification(type=NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_APPROVED, user=request.target.creator):
+            with assert_notification(type=NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_APPROVED, user=request.target.creator):
                 res = app.post_json_api(url, payload, auth=moderator.auth)
             assert res.status_code == 201
             request.reload()
@@ -363,7 +363,7 @@ class TestCreatePreprintRequestAction(PreprintRequestTestMixin):
             initial_state = request.machine_state
             assert not request.target.is_retracted
             payload = self.create_payload(request._id, trigger='reject')
-            with assert_notification(type=NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_DECLINED, user=request.target.creator):
+            with assert_notification(type=NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_DECLINED, user=request.target.creator):
                 res = app.post_json_api(url, payload, auth=moderator.auth)
             assert res.status_code == 201
             request.reload()
@@ -402,8 +402,8 @@ class TestCreatePreprintRequestAction(PreprintRequestTestMixin):
             with capture_notifications() as notifications:
                 res = app.post_json_api(url, payload, auth=moderator.auth)
             assert len(notifications['emits']) == 2
-            assert notifications['emits'][0]['type'] == NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_APPROVED
-            assert notifications['emits'][1]['type'] == NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_APPROVED
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_APPROVED
+            assert notifications['emits'][1]['type'] == NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_APPROVED
             assert res.status_code == 201
             request.reload()
             request.target.reload()

--- a/api_tests/subscriptions/views/test_subscriptions_detail.py
+++ b/api_tests/subscriptions/views/test_subscriptions_detail.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     NotificationSubscriptionFactory
@@ -22,7 +22,7 @@ class TestSubscriptionDetail:
     @pytest.fixture()
     def notification(self, user):
         return NotificationSubscriptionFactory(
-            notification_type=NotificationType.Type.USER_FILE_UPDATED.instance,
+            notification_type=NotificationTypeEnum.USER_FILE_UPDATED.instance,
             object_id=user.id,
             content_type_id=ContentType.objects.get_for_model(user).id,
             user=user

--- a/api_tests/subscriptions/views/test_subscriptions_list.py
+++ b/api_tests/subscriptions/views/test_subscriptions_list.py
@@ -2,7 +2,7 @@ import pytest
 from django.contrib.contenttypes.models import ContentType
 
 from api.base.settings.defaults import API_BASE
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     PreprintProviderFactory,
@@ -31,7 +31,7 @@ class TestSubscriptionList:
     @pytest.fixture()
     def global_user_notification(self, user):
         return NotificationSubscriptionFactory(
-            notification_type=NotificationType.Type.USER_FILE_UPDATED.instance,
+            notification_type=NotificationTypeEnum.USER_FILE_UPDATED.instance,
             object_id=user.id,
             content_type_id=ContentType.objects.get_for_model(user).id,
             user=user,
@@ -40,7 +40,7 @@ class TestSubscriptionList:
     @pytest.fixture()
     def file_updated_notification(self, node, user):
         return NotificationSubscriptionFactory(
-            notification_type=NotificationType.Type.NODE_FILE_UPDATED.instance,
+            notification_type=NotificationTypeEnum.NODE_FILE_UPDATED.instance,
             object_id=node.id,
             content_type_id=ContentType.objects.get_for_model(node).id,
             user=user,
@@ -49,7 +49,7 @@ class TestSubscriptionList:
     @pytest.fixture()
     def provider_notification(self, provider, user):
         return NotificationSubscriptionFactory(
-            notification_type=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.instance,
+            notification_type=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.instance,
             object_id=provider.id,
             content_type_id=ContentType.objects.get_for_model(provider).id,
             subscribed_object=provider,

--- a/api_tests/users/views/test_user_claim.py
+++ b/api_tests/users/views/test_user_claim.py
@@ -6,7 +6,7 @@ from api.base.settings.defaults import API_BASE
 from api.users.views import ClaimUser
 from api_tests.utils import only_supports_methods
 from framework.auth.core import Auth
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     ProjectFactory,
@@ -126,7 +126,7 @@ class TestClaimUser:
                 self.payload(email='david@david.son', id=project._id),
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
         assert res.status_code == 204
 
     def test_claim_unauth_success_with_claimer_email(self, app, url, unreg_user, project, claimer):
@@ -137,8 +137,8 @@ class TestClaimUser:
             )
         assert res.status_code == 204
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORWARD_INVITE_REGISTERED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION_REGISTERED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION_REGISTERED
 
     def test_claim_unauth_success_with_unknown_email(self, app, url, project, unreg_user):
         with capture_notifications() as notifications:
@@ -148,8 +148,8 @@ class TestClaimUser:
             )
         assert res.status_code == 204
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_FORWARD_INVITE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE
 
     def test_claim_unauth_success_with_preprint_id(self, app, url, preprint, unreg_user):
         with capture_notifications() as notifications:
@@ -159,7 +159,7 @@ class TestClaimUser:
             )
         assert res.status_code == 204
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
 
     def test_claim_auth_failure(self, app, url, claimer, wrong_preprint, project, unreg_user, referrer):
         _url = url.format(unreg_user._id)
@@ -228,8 +228,8 @@ class TestClaimUser:
                     expect_errors=True
                 )
             assert len(notifications['emits']) == 2
-            assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORWARD_INVITE_REGISTERED
-            assert notifications['emits'][1]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION_REGISTERED
+            assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED
+            assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION_REGISTERED
         res = app.post_json_api(
             url.format(unreg_user._id),
             self.payload(id=project._id),
@@ -248,5 +248,5 @@ class TestClaimUser:
             )
         assert res.status_code == 204
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORWARD_INVITE_REGISTERED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION_REGISTERED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION_REGISTERED

--- a/api_tests/users/views/test_user_confirm.py
+++ b/api_tests/users/views/test_user_confirm.py
@@ -1,7 +1,7 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import AuthUserFactory
 from tests.utils import capture_notifications
 
@@ -168,7 +168,7 @@ class TestConfirmEmail:
             assert res.status_code == 201
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_EXTERNAL_LOGIN_LINK_SUCCESS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_EXTERNAL_LOGIN_LINK_SUCCESS
 
         user.reload()
         assert user.external_identity['ORCID']['0000-0000-0000-0000'] == 'VERIFIED'

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.cas import CasResponse
-from osf.models import OSFUser, ApiOAuth2PersonalToken, NotificationType
+from osf.models import OSFUser, ApiOAuth2PersonalToken, NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     UserFactory,
@@ -320,7 +320,7 @@ class TestUsersCreate:
                 data
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
         assert res.status_code == 201
         assert OSFUser.objects.filter(username=email_unconfirmed).count() == 1
 
@@ -359,7 +359,7 @@ class TestUsersCreate:
                 headers={'Authorization': f'Bearer {token.token_id}'}
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
 
         assert res.status_code == 201
         assert res.json['data']['attributes']['username'] == email_unconfirmed
@@ -519,7 +519,7 @@ class TestUsersCreate:
                 headers={'Authorization': f'Bearer {token.token_id}'}
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_MODERATOR_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_MODERATOR_ADDED
 
         assert res.status_code == 201
         assert res.json['data']['attributes']['username'] == email_unconfirmed

--- a/api_tests/users/views/test_user_message_institutional_access.py
+++ b/api_tests/users/views/test_user_message_institutional_access.py
@@ -1,6 +1,6 @@
 import pytest
 
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf.models.user_message import MessageTypes, UserMessage
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import (
@@ -221,7 +221,7 @@ class TestUserMessageInstitutionalAccess:
                 auth=institutional_admin.auth,
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INSTITUTIONAL_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INSTITUTIONAL_ACCESS_REQUEST
         assert notifications['emits'][0]['kwargs']['user'].username == user_with_affiliation.username
         assert res.status_code == 201
         user_message = UserMessage.objects.get()
@@ -235,7 +235,7 @@ class TestUserMessageInstitutionalAccess:
         with capture_notifications() as notifications:
             res = app.post_json_api(url_with_affiliation, payload, auth=institutional_admin.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INSTITUTIONAL_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INSTITUTIONAL_ACCESS_REQUEST
         assert notifications['emits'][0]['kwargs']['user'].username == user_with_affiliation.username
         assert res.status_code == 201
 

--- a/api_tests/users/views/test_user_settings.py
+++ b/api_tests/users/views/test_user_settings.py
@@ -7,7 +7,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     UserFactory,
 )
-from osf.models import Email, NotableDomain, NotificationType
+from osf.models import Email, NotableDomain, NotificationTypeEnum
 from framework.auth.views import auth_email_logout
 from tests.utils import capture_notifications
 
@@ -59,7 +59,7 @@ class TestUserRequestExport:
         with capture_notifications() as notifications:
             res = app.post_json_api(url, payload, auth=user_one.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_REQUEST_EXPORT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_REQUEST_EXPORT
         assert res.status_code == 204
         user_one.reload()
         assert user_one.email_last_sent is not None

--- a/api_tests/users/views/test_user_settings_reset_password.py
+++ b/api_tests/users/views/test_user_settings_reset_password.py
@@ -3,7 +3,7 @@ import urllib
 
 from api.base.settings.defaults import API_BASE
 from api.base.settings import CSRF_COOKIE_NAME
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import (
     UserFactory,
 )
@@ -49,7 +49,7 @@ class TestResetPassword:
         with capture_notifications() as notifications:
             res = app.get(url)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORGOT_PASSWORD
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORGOT_PASSWORD
         assert res.status_code == 200
         user_one.reload()
 

--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -4,7 +4,7 @@ import threading
 from django.utils import timezone
 
 from website import settings
-from osf.models import PreprintProvider, NotificationType
+from osf.models import PreprintProvider, NotificationTypeEnum
 from website.settings import DOMAIN, CAMPAIGN_REFRESH_THRESHOLD
 from website.util.metrics import OsfSourceTags, OsfClaimedTags, CampaignSourceTags, CampaignClaimedTags, provider_source_tag
 from framework.utils import throttle_period_expired
@@ -26,7 +26,7 @@ def get_campaigns():
                 'erpc': {
                     'system_tag': CampaignSourceTags.ErpChallenge.value,
                     'redirect_url': furl(DOMAIN).add(path='erpc/').url,
-                    'confirmation_email_template': NotificationType.Type.USER_CAMPAIGN_CONFIRM_EMAIL_ERPC,
+                    'confirmation_email_template': NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_EMAIL_ERPC,
                     'login_type': 'native',
                 },
             }
@@ -44,12 +44,12 @@ def get_campaigns():
             preprint_providers = PreprintProvider.objects.all()
             for provider in preprint_providers:
                 if provider._id == 'osf':
-                    confirmation_email_template = NotificationType.Type.USER_CAMPAIGN_CONFIRM_PREPRINTS_OSF
+                    confirmation_email_template = NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_PREPRINTS_OSF
                     name = 'OSF'
                     url_path = 'preprints/'
                     external_url = None
                 else:
-                    confirmation_email_template = NotificationType.Type.USER_CAMPAIGN_CONFIRM_PREPRINTS_BRANDED
+                    confirmation_email_template = NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_PREPRINTS_BRANDED
 
                     name = provider.name
                     url_path = f'preprints/{provider._id}'
@@ -85,7 +85,7 @@ def get_campaigns():
                 'osf-registered-reports': {
                     'system_tag': CampaignSourceTags.OsfRegisteredReports.value,
                     'redirect_url': furl(DOMAIN).add(path='rr/').url,
-                    'confirmation_email_template': NotificationType.Type.USER_CAMPAIGN_CONFIRM_EMAIL_REGISTRIES_OSF,
+                    'confirmation_email_template': NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_EMAIL_REGISTRIES_OSF,
                     'login_type': 'proxy',
                     'provider': 'osf',
                     'logo': settings.OSF_REGISTRIES_LOGO
@@ -96,7 +96,7 @@ def get_campaigns():
                 'agu_conference_2023': {
                     'system_tag': CampaignSourceTags.AguConference2023.value,
                     'redirect_url': furl(DOMAIN).add(path='dashboard/').url,
-                    'confirmation_email_template': NotificationType.Type.USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE_2023,
+                    'confirmation_email_template': NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE_2023,
                     'login_type': 'native',
                 }
             })
@@ -105,7 +105,7 @@ def get_campaigns():
                 'agu_conference': {
                     'system_tag': CampaignSourceTags.AguConference.value,
                     'redirect_url': furl(DOMAIN).add(path='dashboard/').url,
-                    'confirmation_email_template': NotificationType.Type.USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE,
+                    'confirmation_email_template': NotificationTypeEnum.USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE,
                     'login_type': 'native',
                 }
             })

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -26,7 +26,7 @@ from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from framework.sessions.utils import remove_sessions_for_user
 from framework.sessions import get_session
 from framework.utils import throttle_period_expired
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationTypeEnum
 from osf.utils.sanitize import strip_html
 from website import settings, language
 from website.util import web_url_for
@@ -208,7 +208,7 @@ def forgot_password_post():
     """Dispatches to ``_forgot_password_post`` passing non-institutional user mail template
     and reset action."""
     return _forgot_password_post(
-        notificaton_type=NotificationType.Type.USER_FORGOT_PASSWORD,
+        notificaton_type=NotificationTypeEnum.USER_FORGOT_PASSWORD,
         reset_route='reset_password_get'
     )
 
@@ -217,7 +217,7 @@ def forgot_password_institution_post():
     """Dispatches to `_forgot_password_post` passing institutional user mail template, reset
     action, and setting the ``institutional`` flag."""
     return _forgot_password_post(
-        notificaton_type=NotificationType.Type.USER_FORGOT_PASSWORD_INSTITUTION,
+        notificaton_type=NotificationTypeEnum.USER_FORGOT_PASSWORD_INSTITUTION,
         reset_route='reset_password_institution_get',
         institutional=True
     )
@@ -659,7 +659,7 @@ def external_login_confirm_email_get(auth, uid, token):
     if external_status == 'CREATE':
         service_url += '&{}'.format(urlencode({'new': 'true'}))
     elif external_status == 'LINK':
-        NotificationType.Type.USER_EXTERNAL_LOGIN_LINK_SUCCESS.instance.emit(
+        NotificationTypeEnum.USER_EXTERNAL_LOGIN_LINK_SUCCESS.instance.emit(
             user=user,
             event_context={
                 'user_fullname': user.fullname,
@@ -838,9 +838,9 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
     if external_id_provider and external_id:
         # First time login through external identity provider, link or create an OSF account confirmation
         if user.external_identity[external_id_provider][external_id] == 'CREATE':
-            notification_type = NotificationType.Type.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE
+            notification_type = NotificationTypeEnum.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE
         elif user.external_identity[external_id_provider][external_id] == 'LINK':
-            notification_type = NotificationType.Type.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK
+            notification_type = NotificationTypeEnum.USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK
         else:
             raise HTTPError(http_status.HTTP_400_BAD_REQUEST, data={})
     elif merge_target:
@@ -850,16 +850,16 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
             'user_username': user.username,
             'email': merge_target.email,
         }
-        notification_type = NotificationType.Type.USER_CONFIRM_MERGE
+        notification_type = NotificationTypeEnum.USER_CONFIRM_MERGE
     elif user.is_active:
         # Add email confirmation
-        notification_type = NotificationType.Type.USER_CONFIRM_EMAIL
+        notification_type = NotificationTypeEnum.USER_CONFIRM_EMAIL
     elif campaign:
         # Account creation confirmation: from campaign
         notification_type = campaigns.email_template_for_campaign(campaign)
     else:
         # Account creation confirmation: from OSF
-        notification_type = NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
+        notification_type = NotificationTypeEnum.USER_INITIAL_CONFIRM_EMAIL
 
     notification_type.instance.emit(
         destination_address=email,

--- a/notifications/file_event_notifications.py
+++ b/notifications/file_event_notifications.py
@@ -15,6 +15,7 @@ import markupsafe
 
 from osf.models import (
     NotificationType,
+    NotificationTypeEnum,
     AbstractNode,
     NodeLog,
     Preprint,
@@ -96,13 +97,13 @@ def file_updated(self, target=None, user=None, event_type=None, payload=None):
         return
 
     event = {
-        NodeLog.FILE_RENAMED: NotificationType.Type.ADDON_FILE_RENAMED,
-        NodeLog.FILE_COPIED: NotificationType.Type.ADDON_FILE_COPIED,
-        NodeLog.FILE_ADDED: NotificationType.Type.FILE_ADDED,
-        NodeLog.FILE_MOVED: NotificationType.Type.ADDON_FILE_MOVED,
-        NodeLog.FILE_REMOVED: NotificationType.Type.FILE_REMOVED,
-        NodeLog.FILE_UPDATED: NotificationType.Type.FILE_UPDATED,
-        NodeLog.FOLDER_CREATED: NotificationType.Type.FOLDER_CREATED,
+        NodeLog.FILE_RENAMED: NotificationTypeEnum.ADDON_FILE_RENAMED,
+        NodeLog.FILE_COPIED: NotificationTypeEnum.ADDON_FILE_COPIED,
+        NodeLog.FILE_ADDED: NotificationTypeEnum.FILE_ADDED,
+        NodeLog.FILE_MOVED: NotificationTypeEnum.ADDON_FILE_MOVED,
+        NodeLog.FILE_REMOVED: NotificationTypeEnum.FILE_REMOVED,
+        NodeLog.FILE_UPDATED: NotificationTypeEnum.FILE_UPDATED,
+        NodeLog.FOLDER_CREATED: NotificationTypeEnum.FOLDER_CREATED,
     }[event_type]
 
     if event not in event_registry:
@@ -268,7 +269,7 @@ class AddonFileRenamed(ComplexFileEvent):
             super().perform()
             return
 
-        NotificationType.Type.ADDON_FILE_RENAMED.instance.emit(
+        NotificationTypeEnum.ADDON_FILE_RENAMED.instance.emit(
             user=self.user,
             event_context={
                 'user_fullname': self.user.fullname,
@@ -305,7 +306,7 @@ class AddonFileMoved(ComplexFileEvent):
             super().perform()
             return
 
-        NotificationType.Type.ADDON_FILE_MOVED.instance.emit(
+        NotificationTypeEnum.ADDON_FILE_MOVED.instance.emit(
             user=self.user,
             event_context={
                 'user_fullname': self.user.fullname,
@@ -325,7 +326,7 @@ class AddonFileCopied(ComplexFileEvent):
             super().perform()
             return
 
-        NotificationType.Type.ADDON_FILE_COPIED.instance.emit(
+        NotificationTypeEnum.ADDON_FILE_COPIED.instance.emit(
             user=self.user,
             event_context={
                 'user_fullname': self.user.fullname,

--- a/notifications/listeners.py
+++ b/notifications/listeners.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 @project_created.connect
 def subscribe_creator(resource):
-    from osf.models import NotificationSubscription, NotificationType, Preprint
+    from osf.models import NotificationSubscription, NotificationTypeEnum, Preprint
 
     from django.contrib.contenttypes.models import ContentType
 
@@ -20,7 +20,7 @@ def subscribe_creator(resource):
         try:
             NotificationSubscription.objects.get_or_create(
                 user=user,
-                notification_type=NotificationType.Type.USER_FILE_UPDATED.instance,
+                notification_type=NotificationTypeEnum.USER_FILE_UPDATED.instance,
                 object_id=user.id,
                 content_type=ContentType.objects.get_for_model(user),
                 _is_digest=True,
@@ -34,7 +34,7 @@ def subscribe_creator(resource):
             try:
                 NotificationSubscription.objects.get_or_create(
                     user=user,
-                    notification_type=NotificationType.Type.NODE_FILE_UPDATED.instance,
+                    notification_type=NotificationTypeEnum.NODE_FILE_UPDATED.instance,
                     object_id=resource.id,
                     content_type=ContentType.objects.get_for_model(resource),
                     _is_digest=True,
@@ -48,7 +48,7 @@ def subscribe_creator(resource):
 @contributor_added.connect
 def subscribe_contributor(resource, contributor, auth=None, *args, **kwargs):
     from django.contrib.contenttypes.models import ContentType
-    from osf.models import NotificationSubscription, NotificationType, Preprint
+    from osf.models import NotificationSubscription, NotificationTypeEnum, Preprint
 
     from osf.models import Node
     if isinstance(resource, Node):
@@ -58,7 +58,7 @@ def subscribe_contributor(resource, contributor, auth=None, *args, **kwargs):
     try:
         NotificationSubscription.objects.get_or_create(
             user=contributor,
-            notification_type=NotificationType.Type.USER_FILE_UPDATED.instance,
+            notification_type=NotificationTypeEnum.USER_FILE_UPDATED.instance,
             object_id=contributor.id,
             content_type=ContentType.objects.get_for_model(contributor),
             _is_digest=True,
@@ -72,7 +72,7 @@ def subscribe_contributor(resource, contributor, auth=None, *args, **kwargs):
         try:
             NotificationSubscription.objects.get_or_create(
                 user=contributor,
-                notification_type=NotificationType.Type.NODE_FILE_UPDATED.instance,
+                notification_type=NotificationTypeEnum.NODE_FILE_UPDATED.instance,
                 object_id=resource.id,
                 content_type=ContentType.objects.get_for_model(resource),
                 _is_digest=True,
@@ -88,7 +88,7 @@ def subscribe_contributor(resource, contributor, auth=None, *args, **kwargs):
 @reviews_signals.reviews_withdraw_requests_notification_moderators.connect
 def reviews_withdraw_requests_notification_moderators(self, timestamp, context, user, resource):
     from website.settings import DOMAIN
-    from osf.models import NotificationType
+    from osf.models import NotificationTypeEnum
 
     provider = resource.provider
     context['provider_id'] = provider.id
@@ -97,7 +97,7 @@ def reviews_withdraw_requests_notification_moderators(self, timestamp, context, 
     # Set submission url
     context['reviews_submission_url'] = f'{DOMAIN}reviews/registries/{provider._id}/{resource._id}'
     context['localized_timestamp'] = str(timestamp)
-    NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
+    NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
         subscribed_object=provider,
         user=user,
         event_context=context

--- a/notifications/tasks.py
+++ b/notifications/tasks.py
@@ -11,7 +11,7 @@ from framework.celery_tasks import app as celery_app
 from celery.utils.log import get_task_logger
 
 from framework.postcommit_tasks.handlers import run_postcommit
-from osf.models import OSFUser, Notification, NotificationType, EmailTask, RegistrationProvider, \
+from osf.models import OSFUser, Notification, NotificationTypeEnum, EmailTask, RegistrationProvider, \
     CollectionProvider, AbstractProvider
 from framework.sentry import log_message
 from osf.registrations.utils import get_registration_provider_submissions_url
@@ -107,7 +107,7 @@ def send_user_email_task(self, user_id, notification_ids, **kwargs):
             'can_change_preferences': False
         }
 
-        NotificationType.Type.USER_DIGEST.instance.emit(
+        NotificationTypeEnum.USER_DIGEST.instance.emit(
             user=user,
             event_context=event_context,
             save=False
@@ -252,7 +252,7 @@ def send_moderator_email_task(self, user_id, notification_ids, provider_content_
             'logo': logo,
         }
 
-        NotificationType.Type.DIGEST_REVIEWS_MODERATORS.instance.emit(
+        NotificationTypeEnum.DIGEST_REVIEWS_MODERATORS.instance.emit(
             user=user,
             subscribed_object=user,
             event_context=event_context,
@@ -357,10 +357,10 @@ def get_moderators_emails(message_freq: str):
         cursor.execute(sql,
             [
                 message_freq,
-                NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-                NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-                NotificationType.Type.DIGEST_REVIEWS_MODERATORS.value,
-                NotificationType.Type.USER_DIGEST.value,
+                NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+                NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+                NotificationTypeEnum.DIGEST_REVIEWS_MODERATORS.value,
+                NotificationTypeEnum.USER_DIGEST.value,
             ]
         )
         return itertools.chain.from_iterable(cursor.fetchall())
@@ -398,10 +398,10 @@ def get_users_emails(message_freq):
         cursor.execute(sql,
             [
                 message_freq,
-                NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-                NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-                NotificationType.Type.DIGEST_REVIEWS_MODERATORS.value,
-                NotificationType.Type.USER_DIGEST.value,
+                NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+                NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+                NotificationTypeEnum.DIGEST_REVIEWS_MODERATORS.value,
+                NotificationTypeEnum.USER_DIGEST.value,
             ]
         )
         return itertools.chain.from_iterable(cursor.fetchall())

--- a/osf/management/commands/deactivate_requested_accounts.py
+++ b/osf/management/commands/deactivate_requested_accounts.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from framework.celery_tasks import app as celery_app
 from website.app import setup_django
 setup_django()
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationTypeEnum
 from django.core.management.base import BaseCommand
 from website.settings import OSF_SUPPORT_EMAIL
 
@@ -20,7 +20,7 @@ def deactivate_requested_accounts(dry_run=True):
         if user.has_resources:
             logger.info(f'OSF support is being emailed about deactivating the account of user {user._id}.')
             if not dry_run:
-                NotificationType.Type.DESK_REQUEST_DEACTIVATION.instance.emit(
+                NotificationTypeEnum.DESK_REQUEST_DEACTIVATION.instance.emit(
                     destination_address=OSF_SUPPORT_EMAIL,
                     user=user,
                     event_context={
@@ -35,7 +35,7 @@ def deactivate_requested_accounts(dry_run=True):
             if not dry_run:
                 user.deactivate_account()
                 user.is_registered = False
-                NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE.instance.emit(
+                NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE.instance.emit(
                     user=user,
                     event_context={
                         'user_fullname': user.fullname,

--- a/osf/management/commands/migrate_notifications.py
+++ b/osf/management/commands/migrate_notifications.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction, connection
 
-from osf.models import NotificationType, NotificationSubscription
+from osf.models import NotificationType, NotificationTypeEnum, NotificationSubscription
 from osf.models.notifications import NotificationSubscriptionLegacy
 from osf.management.commands.populate_notification_types import populate_notification_types
 from tqdm import tqdm
@@ -25,26 +25,26 @@ FREQ_MAP = {
 
 EVENT_NAME_TO_NOTIFICATION_TYPE = {
     # Provider notifications
-    'new_pending_withdraw_requests': NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS,
-    'contributor_added_preprint': NotificationType.Type.PROVIDER_CONTRIBUTOR_ADDED_PREPRINT,
-    'new_pending_submissions': NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS,
-    'moderator_added': NotificationType.Type.PROVIDER_MODERATOR_ADDED,
-    'reviews_submission_confirmation': NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION,
-    'reviews_resubmission_confirmation': NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION,
-    'confirm_email_moderation': NotificationType.Type.PROVIDER_CONFIRM_EMAIL_MODERATION,
-    'global_reviews': NotificationType.Type.REVIEWS_SUBMISSION_STATUS,
+    'new_pending_withdraw_requests': NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS,
+    'contributor_added_preprint': NotificationTypeEnum.PROVIDER_CONTRIBUTOR_ADDED_PREPRINT,
+    'new_pending_submissions': NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS,
+    'moderator_added': NotificationTypeEnum.PROVIDER_MODERATOR_ADDED,
+    'reviews_submission_confirmation': NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION,
+    'reviews_resubmission_confirmation': NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION,
+    'confirm_email_moderation': NotificationTypeEnum.PROVIDER_CONFIRM_EMAIL_MODERATION,
+    'global_reviews': NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS,
 
     # Node notifications
-    'file_updated': NotificationType.Type.NODE_FILE_UPDATED,
+    'file_updated': NotificationTypeEnum.NODE_FILE_UPDATED,
 
     # Collection submissions
-    'collection_submission_submitted': NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED,
-    'collection_submission_accepted': NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED,
-    'collection_submission_rejected': NotificationType.Type.COLLECTION_SUBMISSION_REJECTED,
-    'collection_submission_removed_admin': NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN,
-    'collection_submission_removed_moderator': NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR,
-    'collection_submission_removed_private': NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_PRIVATE,
-    'collection_submission_cancel': NotificationType.Type.COLLECTION_SUBMISSION_CANCEL,
+    'collection_submission_submitted': NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED,
+    'collection_submission_accepted': NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED,
+    'collection_submission_rejected': NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED,
+    'collection_submission_removed_admin': NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN,
+    'collection_submission_removed_moderator': NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR,
+    'collection_submission_removed_private': NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_PRIVATE,
+    'collection_submission_cancel': NotificationTypeEnum.COLLECTION_SUBMISSION_CANCEL,
 }
 
 
@@ -151,7 +151,7 @@ def migrate_legacy_notification_subscriptions(
 
             notif_enum = EVENT_NAME_TO_NOTIFICATION_TYPE.get(event_name)
             if subscribed_object == legacy.user and event_name == 'global_file_updated':
-                notif_enum = NotificationType.Type.USER_FILE_UPDATED
+                notif_enum = NotificationTypeEnum.USER_FILE_UPDATED
             if not notif_enum:
                 skipped += 1
                 continue

--- a/osf/management/commands/send_storage_exceeded_announcement.py
+++ b/osf/management/commands/send_storage_exceeded_announcement.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 
 from django.core.management.base import BaseCommand
 
-from osf.models import Node, OSFUser, NotificationType
+from osf.models import Node, OSFUser, NotificationType, NotificationTypeEnum
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -40,7 +40,7 @@ def main(json_file, dry=False):
             if not dry:
                 try:
                     NotificationType.objects.get(
-                        name=NotificationType.Type.USER_STORAGE_CAP_EXCEEDED_ANNOUNCEMENT
+                        name=NotificationTypeEnum.USER_STORAGE_CAP_EXCEEDED_ANNOUNCEMENT
                     ).emit(
                         user=user,
                         event_context={

--- a/osf/models/__init__.py
+++ b/osf/models/__init__.py
@@ -65,7 +65,7 @@ from .nodelog import NodeLog
 from .notable_domain import NotableDomain, DomainReference
 from .notifications import NotificationSubscriptionLegacy
 from .notification_subscription import NotificationSubscription
-from .notification_type import NotificationType
+from .notification_type import NotificationType, NotificationTypeEnum
 from .notification import Notification
 
 from .oauth import (

--- a/osf/models/collection_submission.py
+++ b/osf/models/collection_submission.py
@@ -16,7 +16,7 @@ from osf.utils.workflows import CollectionSubmissionsTriggers, CollectionSubmiss
 
 from website import settings
 from osf.utils.machines import CollectionSubmissionMachine
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -103,7 +103,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
                 assert str(e) == f'No unclaimed record for user {contributor._id} on node {self.guid.referent._id}'
                 claim_url = None
 
-            NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED.instance.emit(
+            NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED.instance.emit(
                 is_digest=True,
                 user=contributor,
                 subscribed_object=self,
@@ -135,7 +135,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
 
     def _notify_moderators_pending(self, event_data):
         user = event_data.kwargs.get('user', None)
-        NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.instance.emit(
+        NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.instance.emit(
             user=user,
             subscribed_object=self.collection.provider,
             event_context={
@@ -167,7 +167,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
     def _notify_accepted(self, event_data):
         if self.collection.provider:
             for contributor in self.guid.referent.contributors:
-                NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED.instance.emit(
+                NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED.instance.emit(
                     user=contributor,
                     subscribed_object=self,
                     event_context={
@@ -211,7 +211,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
 
     def _notify_moderated_rejected(self, event_data):
         for contributor in self.guid.referent.contributors:
-            NotificationType.Type.COLLECTION_SUBMISSION_REJECTED.instance.emit(
+            NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED.instance.emit(
                 user=contributor,
                 subscribed_object=self,
                 event_context={
@@ -284,7 +284,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
         if removed_due_to_privacy and self.collection.provider:
             if self.is_moderated:
                 for moderator in self.collection.moderators:
-                    NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_PRIVATE.instance.emit(
+                    NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_PRIVATE.instance.emit(
                         user=moderator,
                         event_context={
                             **event_context_base,
@@ -293,7 +293,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
                         },
                     )
             for contributor in node.contributors.all():
-                NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_PRIVATE.instance.emit(
+                NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_PRIVATE.instance.emit(
                     user=contributor,
                     event_context={
                         **event_context_base,
@@ -303,7 +303,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
                 )
         elif is_moderator and self.collection.provider:
             for contributor in node.contributors.all():
-                NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR.instance.emit(
+                NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR.instance.emit(
                     user=contributor,
                     event_context={
                         **event_context_base,
@@ -328,7 +328,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
                 )
         elif is_admin and self.collection.provider:
             for contributor in node.contributors.all():
-                NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN.instance.emit(
+                NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN.instance.emit(
                     user=contributor,
                     event_context={
                         **event_context_base,
@@ -388,7 +388,7 @@ class CollectionSubmission(TaxonomizableMixin, BaseModel):
             collection_provider_name = self.collection.title
 
         for contributor in node.contributors.all():
-            NotificationType.Type.COLLECTION_SUBMISSION_CANCEL.instance.emit(
+            NotificationTypeEnum.COLLECTION_SUBMISSION_CANCEL.instance.emit(
                 user=contributor,
                 subscribed_object=self.collection,
                 event_context={

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from framework import sentry
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .base import BaseModel, ObjectIDMixin
 from .contributor import InstitutionalContributor
 from .institution_affiliation import InstitutionAffiliation
@@ -220,7 +220,7 @@ class Institution(DirtyFieldsMixin, Loggable, ObjectIDMixin, BaseModel, Guardian
         success = 0
         for user in self.get_institution_users():
             attempts += 1
-            NotificationType.Type.USER_INSTITUTION_DEACTIVATION.instance.emit(
+            NotificationTypeEnum.USER_INSTITUTION_DEACTIVATION.instance.emit(
                 user=user,
                 event_context={
                     'user_fullname': user.fullname,

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -27,7 +27,7 @@ from osf.exceptions import (
     InvalidTagError,
     BlockedEmailError,
 )
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf.models.notification_subscription import NotificationSubscription
 from .node_relation import NodeRelation
 from .nodelog import NodeLog
@@ -312,7 +312,7 @@ class AffiliatedInstitutionMixin(models.Model):
 
             if notify and getattr(self, 'type', False) == 'osf.node':
                 for user, _ in self.get_admin_contributors_recursive(unique_users=True):
-                    NotificationType.Type.NODE_AFFILIATION_CHANGED.instance.emit(
+                    NotificationTypeEnum.NODE_AFFILIATION_CHANGED.instance.emit(
                         user=user,
                         subscribed_object=self,
                         event_context={
@@ -354,7 +354,7 @@ class AffiliatedInstitutionMixin(models.Model):
             self.update_search()
             if notify and getattr(self, 'type', False) == 'osf.node':
                 for user, _ in self.get_admin_contributors_recursive(unique_users=True):
-                    NotificationType.Type.NODE_AFFILIATION_CHANGED.instance.emit(
+                    NotificationTypeEnum.NODE_AFFILIATION_CHANGED.instance.emit(
                         user=user,
                         subscribed_object=self,
                         event_context={
@@ -1035,7 +1035,7 @@ class ReviewProviderMixin(GuardianMixin):
     reviews_comments_anonymous = models.BooleanField(null=True, blank=True)
 
     DEFAULT_SUBSCRIPTIONS = [
-        NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
     ]
 
     @property
@@ -1421,14 +1421,14 @@ class ContributorMixin(models.Model):
             from osf.models import AbstractNode, Preprint, DraftRegistration
 
             if isinstance(self, AbstractNode):
-                notification_type = NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+                notification_type = NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
             elif isinstance(self, Preprint):
                 if self.is_published:
-                    notification_type = NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
+                    notification_type = NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_DEFAULT
                 else:
                     notification_type = False
             elif isinstance(self, DraftRegistration):
-                notification_type = NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+                notification_type = NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
 
         if contrib_to_add.is_disabled:
             raise ValidationValueError('Deactivated users cannot be added as contributors.')
@@ -1596,14 +1596,14 @@ class ContributorMixin(models.Model):
             from osf.models import AbstractNode, Preprint, DraftRegistration
 
             if isinstance(self, AbstractNode):
-                notification_type = NotificationType.Type.USER_INVITE_DEFAULT
+                notification_type = NotificationTypeEnum.USER_INVITE_DEFAULT
             elif isinstance(self, Preprint):
                 if self.provider.is_default:
-                    notification_type = NotificationType.Type.USER_INVITE_OSF_PREPRINT
+                    notification_type = NotificationTypeEnum.USER_INVITE_OSF_PREPRINT
                 else:
-                    notification_type = NotificationType.Type.PROVIDER_USER_INVITE_PREPRINT
+                    notification_type = NotificationTypeEnum.PROVIDER_USER_INVITE_PREPRINT
             elif isinstance(self, DraftRegistration):
-                notification_type = NotificationType.Type.USER_INVITE_DRAFT_REGISTRATION
+                notification_type = NotificationTypeEnum.USER_INVITE_DRAFT_REGISTRATION
 
         self.add_contributor(
             contributor,
@@ -2321,7 +2321,7 @@ class SpamOverrideMixin(SpamMixin):
         user.flag_spam()
         if not user.is_disabled:
             user.deactivate_account()
-            NotificationType.Type.USER_SPAM_BANNED.instance.emit(
+            NotificationTypeEnum.USER_SPAM_BANNED.instance.emit(
                 user,
                 event_context={
                     'user_fullname': user.fullname,

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -35,7 +35,7 @@ from framework.celery_tasks.handlers import enqueue_task, get_task_from_queue
 from framework.exceptions import PermissionsError, HTTPError
 from framework.sentry import log_exception
 from osf.exceptions import InvalidTagError, NodeStateError, TagNotFoundError, ValidationError
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .contributor import Contributor
 from .collection_submission import CollectionSubmission
 
@@ -1250,7 +1250,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             self.save()
         if auth and permissions == 'public':
             for contributor in self.contributors:
-                NotificationType.Type.NODE_NEW_PUBLIC_PROJECT.instance.emit(
+                NotificationTypeEnum.NODE_NEW_PUBLIC_PROJECT.instance.emit(
                     user=contributor,
                     subscribed_object=self,
                     event_context={
@@ -1564,7 +1564,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         :return: Forked node
         """
         if notification_type is None:
-            notification_type = NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+            notification_type = NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
         Registration = apps.get_model('osf.Registration')
         PREFIX = 'Fork of '
         user = auth.user
@@ -1792,7 +1792,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             new,
             contributor=auth.user,
             auth=auth,
-            notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+            notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
         )
 
         # Log the creation

--- a/osf/models/notification_subscription.py
+++ b/osf/models/notification_subscription.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from osf.models.notification_type import get_default_frequency_choices, NotificationType
+from osf.models.notification_type import get_default_frequency_choices, NotificationTypeEnum
 from osf.models.notification import Notification
 from api.base import settings
 from api.base.utils import absolute_reverse
@@ -142,32 +142,32 @@ class NotificationSubscription(BaseModel):
         Legacy subscription id for API compatibility.
         """
         _global_file_updated = [
-            NotificationType.Type.USER_FILE_UPDATED.value,
-            NotificationType.Type.FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.USER_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
         _global_reviews = [
-            NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-            NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-            NotificationType.Type.REVIEWS_SUBMISSION_STATUS.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+            NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS.value,
         ]
         _node_file_updated = [
-            NotificationType.Type.NODE_FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.NODE_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
         if self.notification_type.name in _global_file_updated:
             return f'{self.user._id}_file_updated'

--- a/osf/models/notification_type.py
+++ b/osf/models/notification_type.py
@@ -10,153 +10,152 @@ def get_default_frequency_choices():
     DEFAULT_FREQUENCY_CHOICES = ['none', 'instantly', 'daily', 'weekly', 'monthly']
     return DEFAULT_FREQUENCY_CHOICES.copy()
 
+class NotificationTypeEnum(str, Enum):
+    # Desk notifications
+    REVIEWS_SUBMISSION_STATUS = 'reviews_submission_status'
+    ADDONS_BOA_JOB_FAILURE = 'addon_boa_job_failure'
+    ADDONS_BOA_JOB_COMPLETE = 'addon_boa_job_complete'
+
+    DESK_ARCHIVE_REGISTRATION_STUCK = 'desk_archive_registration_stuck'
+    DESK_REQUEST_EXPORT = 'desk_request_export'
+    DESK_REQUEST_DEACTIVATION = 'desk_request_deactivation'
+    DESK_OSF_SUPPORT_EMAIL = 'desk_osf_support_email'  # unused same as DESK_CROSSREF_ERROR
+    DESK_REGISTRATION_BULK_UPLOAD_PRODUCT_OWNER = 'desk_registration_bulk_upload_product_owner'
+    DESK_USER_REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE = 'desk_user_registration_bulk_upload_unexpected_failure'
+    DESK_ARCHIVE_JOB_EXCEEDED = 'desk_archive_job_exceeded'
+    DESK_ARCHIVE_JOB_COPY_ERROR = 'desk_archive_job_copy_error'
+    DESK_ARCHIVE_JOB_FILE_NOT_FOUND = 'desk_archive_job_file_not_found'
+    DESK_ARCHIVE_JOB_UNCAUGHT_ERROR = 'desk_archive_job_uncaught_error'
+    DESK_CROSSREF_ERROR = 'desk_crossref_error'
+
+    # User notifications
+    USER_PENDING_VERIFICATION = 'user_pending_verification'
+    USER_PENDING_VERIFICATION_REGISTERED = 'user_pending_verification_registered'
+    USER_STORAGE_CAP_EXCEEDED_ANNOUNCEMENT = 'user_storage_cap_exceeded_announcement'
+    USER_SPAM_BANNED = 'user_spam_banned'
+    USER_REQUEST_DEACTIVATION_COMPLETE = 'user_request_deactivation_complete'
+    USER_PRIMARY_EMAIL_CHANGED = 'user_primary_email_changed'
+    USER_INSTITUTION_DEACTIVATION = 'user_institution_deactivation'
+    USER_FORGOT_PASSWORD = 'user_forgot_password'
+    USER_FORGOT_PASSWORD_INSTITUTION = 'user_forgot_password_institution'
+    USER_REQUEST_EXPORT = 'user_request_export'  # unused no template
+    USER_DUPLICATE_ACCOUNTS_OSF4I = 'user_duplicate_accounts_osf4i'
+    USER_EXTERNAL_LOGIN_LINK_SUCCESS = 'user_external_login_link_success'
+    USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL = 'user_registration_bulk_upload_failure_all'
+    USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL = 'user_registration_bulk_upload_success_partial'
+    USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL = 'user_registration_bulk_upload_success_all'
+    USER_ADD_SSO_EMAIL_OSF4I = 'user_add_sso_email_osf4i'  # unused no template
+    USER_WELCOME_OSF4I = 'user_welcome_osf4i'
+    USER_ARCHIVE_JOB_EXCEEDED = 'user_archive_job_exceeded'
+    USER_ARCHIVE_JOB_COPY_ERROR = 'user_archive_job_copy_error'
+    USER_ARCHIVE_JOB_FILE_NOT_FOUND = 'user_archive_job_file_not_found'
+    # USER_COMMENT_REPLIES = 'user_comment_replies'  # unused
+    USER_FILE_UPDATED = 'user_file_updated'  # unused
+    USER_FILE_OPERATION_SUCCESS = 'user_file_operation_success'
+    USER_FILE_OPERATION_FAILED = 'user_file_operation_failed'
+    USER_PASSWORD_RESET = 'user_password_reset'
+    USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE = 'user_external_login_confirm_email_create'
+    USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK = 'user_external_login_email_confirm_link'
+    USER_CONFIRM_MERGE = 'user_confirm_merge'
+    USER_CONFIRM_EMAIL = 'user_confirm_email'
+    USER_INITIAL_CONFIRM_EMAIL = 'user_initial_confirm_email'
+    USER_INVITE_DEFAULT = 'user_invite_default'
+    USER_PENDING_INVITE = 'user_pending_invite'  # unused
+    USER_FORWARD_INVITE = 'user_forward_invite'
+    USER_FORWARD_INVITE_REGISTERED = 'user_forward_invite_registered'
+    USER_INVITE_DRAFT_REGISTRATION = 'user_invite_draft_registration'
+    USER_INVITE_OSF_PREPRINT = 'user_invite_osf_preprint'
+    USER_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = 'user_contributor_added_preprint_node_from_osf'  # unused
+    USER_CONTRIBUTOR_ADDED_ACCESS_REQUEST = 'user_contributor_added_access_request'  # unused
+    USER_ARCHIVE_JOB_UNCAUGHT_ERROR = 'user_archive_job_uncaught_error'
+    USER_INSTITUTIONAL_ACCESS_REQUEST = 'user_institutional_access_request'  # confirm behavior
+    USER_CAMPAIGN_CONFIRM_PREPRINTS_BRANDED = 'user_campaign_confirm_preprint_branded'
+    USER_CAMPAIGN_CONFIRM_PREPRINTS_OSF = 'user_campaign_confirm_preprint_osf'
+    USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE = 'user_campaign_confirm_email_agu_conference'
+    USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE_2023 = 'user_campaign_confirm_email_agu_conference_2023'
+    USER_CAMPAIGN_CONFIRM_EMAIL_REGISTRIES_OSF = 'user_campaign_confirm_email_registries_osf'
+    USER_CAMPAIGN_CONFIRM_EMAIL_ERPC = 'user_campaign_confirm_email_erpc'
+    USER_DIGEST = 'user_digest'
+    USER_NO_LOGIN = 'user_no_login'
+    DIGEST_REVIEWS_MODERATORS = 'digest_reviews_moderators'
+
+    # Node notifications
+    NODE_FILE_UPDATED = 'node_file_updated'  # unused
+    NODE_FILES_UPDATED = 'node_files_updated'  # unused
+    NODE_AFFILIATION_CHANGED = 'node_affiliation_changed'
+    NODE_REQUEST_ACCESS_SUBMITTED = 'node_request_access_submitted'
+    NODE_REQUEST_ACCESS_DENIED = 'node_request_access_denied'
+    NODE_FORK_COMPLETED = 'node_fork_completed'
+    NODE_FORK_FAILED = 'node_fork_failed'
+    NODE_INSTITUTIONAL_ACCESS_REQUEST = 'node_institutional_access_request'
+    NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST = 'node_contributor_added_access_request'
+    NODE_CONTRIBUTOR_ADDED_DEFAULT = 'node_contributor_added_default'
+    NODE_PENDING_EMBARGO_ADMIN = 'node_pending_embargo_admin'
+    NODE_PENDING_EMBARGO_NON_ADMIN = 'node_pending_embargo_non_admin'
+    NODE_PENDING_RETRACTION_NON_ADMIN = 'node_pending_retraction_non_admin'
+    NODE_PENDING_RETRACTION_ADMIN = 'node_pending_retraction_admin'
+    NODE_PENDING_REGISTRATION_NON_ADMIN = 'node_pending_registration_non_admin'
+    NODE_PENDING_REGISTRATION_ADMIN = 'node_pending_registration_admin'
+    NODE_PENDING_EMBARGO_TERMINATION_NON_ADMIN = 'node_pending_embargo_termination_non_admin'
+    NODE_PENDING_EMBARGO_TERMINATION_ADMIN = 'node_pending_embargo_termination_admin'
+    NODE_SCHEMA_RESPONSE_REJECTED = 'node_schema_response_rejected'
+    NODE_SCHEMA_RESPONSE_APPROVED = 'node_schema_response_approved'
+    NODE_SCHEMA_RESPONSE_SUBMITTED = 'node_schema_response_submitted'
+    NODE_SCHEMA_RESPONSE_INITIATED = 'node_schema_response_initiated'
+    NODE_WITHDRAWAl_REQUEST_APPROVED = 'node_withdrawal_request_approved'
+    NODE_WITHDRAWAl_REQUEST_REJECTED = 'node_withdrawal_request_rejected'
+    NODE_NEW_PUBLIC_PROJECT = 'node_new_public_project'
+
+    FILE_UPDATED = 'file_updated'
+    FILE_ADDED = 'file_added'
+    FILE_REMOVED = 'file_removed'
+    ADDON_FILE_COPIED = 'addon_file_copied'
+    ADDON_FILE_RENAMED = 'addon_file_renamed'
+    ADDON_FILE_MOVED = 'addon_file_moved'
+    ADDON_FILE_REMOVED = 'addon_file_removed'  # unused
+    FOLDER_CREATED = 'folder_created'
+
+    # Provider notifications
+    PROVIDER_NEW_PENDING_SUBMISSIONS = 'provider_new_pending_submissions'
+    PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS = 'provider_new_pending_withdraw_requests'
+    PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION = 'provider_reviews_submission_confirmation'
+    PROVIDER_REVIEWS_MODERATOR_SUBMISSION_CONFIRMATION = 'provider_reviews_moderator_submission_confirmation'  # unused
+    PROVIDER_REVIEWS_REJECT_CONFIRMATION = 'provider_reviews_reject_confirmation'  # unused
+    PROVIDER_REVIEWS_ACCEPT_CONFIRMATION = 'provider_reviews_accept_confirmation'  # unused
+    PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION = 'provider_reviews_resubmission_confirmation'
+    PROVIDER_REVIEWS_COMMENT_EDITED = 'provider_reviews_comment_edited'  # unused
+    PROVIDER_CONTRIBUTOR_ADDED_PREPRINT = 'provider_contributor_added_preprint'  # unused
+    PROVIDER_CONFIRM_EMAIL_MODERATION = 'provider_confirm_email_moderation'
+    PROVIDER_MODERATOR_ADDED = 'provider_moderator_added'
+    PROVIDER_CONFIRM_EMAIL_PREPRINTS = 'provider_confirm_email_preprints'  # unused
+    PROVIDER_USER_INVITE_PREPRINT = 'provider_user_invite_preprint'
+
+    # Preprint notifications
+    PREPRINT_REQUEST_WITHDRAWAL_APPROVED = 'preprint_request_withdrawal_approved'
+    PREPRINT_REQUEST_WITHDRAWAL_DECLINED = 'preprint_request_withdrawal_declined'
+    PREPRINT_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = 'preprint_contributor_added_preprint_node_from_osf'
+    PREPRINT_CONTRIBUTOR_ADDED_DEFAULT = 'preprint_contributor_added_default'
+    PREPRINT_PENDING_RETRACTION_ADMIN = 'preprint_pending_retraction_admin'  # unused
+
+    # Collections Submission notifications
+    COLLECTION_SUBMISSION_REMOVED_ADMIN = 'collection_submission_removed_admin'
+    COLLECTION_SUBMISSION_REMOVED_MODERATOR = 'collection_submission_removed_moderator'
+    COLLECTION_SUBMISSION_REMOVED_PRIVATE = 'collection_submission_removed_private'
+    COLLECTION_SUBMISSION_SUBMITTED = 'collection_submission_submitted'
+    COLLECTION_SUBMISSION_ACCEPTED = 'collection_submission_accepted'
+    COLLECTION_SUBMISSION_REJECTED = 'collection_submission_rejected'
+    COLLECTION_SUBMISSION_CANCEL = 'collection_submission_cancel'
+
+    REGISTRATION_BULK_UPLOAD_FAILURE_DUPLICATES = 'registration_bulk_upload_failure_duplicates'
+
+    DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT = 'draft_registration_contributor_added_default'
+
+    @ttl_cached_property(ttl=60 * 60 * 24)  # 24 hours
+    def instance(self):
+        obj, created = NotificationType.objects.get_or_create(name=self.value)
+        return obj
 
 class NotificationType(models.Model):
-
-    class Type(str, Enum):
-        # Desk notifications
-        REVIEWS_SUBMISSION_STATUS = 'reviews_submission_status'
-        ADDONS_BOA_JOB_FAILURE = 'addon_boa_job_failure'
-        ADDONS_BOA_JOB_COMPLETE = 'addon_boa_job_complete'
-
-        DESK_ARCHIVE_REGISTRATION_STUCK = 'desk_archive_registration_stuck'
-        DESK_REQUEST_EXPORT = 'desk_request_export'
-        DESK_REQUEST_DEACTIVATION = 'desk_request_deactivation'
-        DESK_OSF_SUPPORT_EMAIL = 'desk_osf_support_email'  # unused same as DESK_CROSSREF_ERROR
-        DESK_REGISTRATION_BULK_UPLOAD_PRODUCT_OWNER = 'desk_registration_bulk_upload_product_owner'
-        DESK_USER_REGISTRATION_BULK_UPLOAD_UNEXPECTED_FAILURE = 'desk_user_registration_bulk_upload_unexpected_failure'
-        DESK_ARCHIVE_JOB_EXCEEDED = 'desk_archive_job_exceeded'
-        DESK_ARCHIVE_JOB_COPY_ERROR = 'desk_archive_job_copy_error'
-        DESK_ARCHIVE_JOB_FILE_NOT_FOUND = 'desk_archive_job_file_not_found'
-        DESK_ARCHIVE_JOB_UNCAUGHT_ERROR = 'desk_archive_job_uncaught_error'
-        DESK_CROSSREF_ERROR = 'desk_crossref_error'
-
-        # User notifications
-        USER_PENDING_VERIFICATION = 'user_pending_verification'
-        USER_PENDING_VERIFICATION_REGISTERED = 'user_pending_verification_registered'
-        USER_STORAGE_CAP_EXCEEDED_ANNOUNCEMENT = 'user_storage_cap_exceeded_announcement'
-        USER_SPAM_BANNED = 'user_spam_banned'
-        USER_REQUEST_DEACTIVATION_COMPLETE = 'user_request_deactivation_complete'
-        USER_PRIMARY_EMAIL_CHANGED = 'user_primary_email_changed'
-        USER_INSTITUTION_DEACTIVATION = 'user_institution_deactivation'
-        USER_FORGOT_PASSWORD = 'user_forgot_password'
-        USER_FORGOT_PASSWORD_INSTITUTION = 'user_forgot_password_institution'
-        USER_REQUEST_EXPORT = 'user_request_export'  # unused no template
-        USER_DUPLICATE_ACCOUNTS_OSF4I = 'user_duplicate_accounts_osf4i'
-        USER_EXTERNAL_LOGIN_LINK_SUCCESS = 'user_external_login_link_success'
-        USER_REGISTRATION_BULK_UPLOAD_FAILURE_ALL = 'user_registration_bulk_upload_failure_all'
-        USER_REGISTRATION_BULK_UPLOAD_SUCCESS_PARTIAL = 'user_registration_bulk_upload_success_partial'
-        USER_REGISTRATION_BULK_UPLOAD_SUCCESS_ALL = 'user_registration_bulk_upload_success_all'
-        USER_ADD_SSO_EMAIL_OSF4I = 'user_add_sso_email_osf4i'  # unused no template
-        USER_WELCOME_OSF4I = 'user_welcome_osf4i'
-        USER_ARCHIVE_JOB_EXCEEDED = 'user_archive_job_exceeded'
-        USER_ARCHIVE_JOB_COPY_ERROR = 'user_archive_job_copy_error'
-        USER_ARCHIVE_JOB_FILE_NOT_FOUND = 'user_archive_job_file_not_found'
-        # USER_COMMENT_REPLIES = 'user_comment_replies'  # unused
-        USER_FILE_UPDATED = 'user_file_updated'  # unused
-        USER_FILE_OPERATION_SUCCESS = 'user_file_operation_success'
-        USER_FILE_OPERATION_FAILED = 'user_file_operation_failed'
-        USER_PASSWORD_RESET = 'user_password_reset'
-        USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE = 'user_external_login_confirm_email_create'
-        USER_EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK = 'user_external_login_email_confirm_link'
-        USER_CONFIRM_MERGE = 'user_confirm_merge'
-        USER_CONFIRM_EMAIL = 'user_confirm_email'
-        USER_INITIAL_CONFIRM_EMAIL = 'user_initial_confirm_email'
-        USER_INVITE_DEFAULT = 'user_invite_default'
-        USER_PENDING_INVITE = 'user_pending_invite'  # unused
-        USER_FORWARD_INVITE = 'user_forward_invite'
-        USER_FORWARD_INVITE_REGISTERED = 'user_forward_invite_registered'
-        USER_INVITE_DRAFT_REGISTRATION = 'user_invite_draft_registration'
-        USER_INVITE_OSF_PREPRINT = 'user_invite_osf_preprint'
-        USER_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = 'user_contributor_added_preprint_node_from_osf'  # unused
-        USER_CONTRIBUTOR_ADDED_ACCESS_REQUEST = 'user_contributor_added_access_request'  # unused
-        USER_ARCHIVE_JOB_UNCAUGHT_ERROR = 'user_archive_job_uncaught_error'
-        USER_INSTITUTIONAL_ACCESS_REQUEST = 'user_institutional_access_request'  # confirm behavior
-        USER_CAMPAIGN_CONFIRM_PREPRINTS_BRANDED = 'user_campaign_confirm_preprint_branded'
-        USER_CAMPAIGN_CONFIRM_PREPRINTS_OSF = 'user_campaign_confirm_preprint_osf'
-        USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE = 'user_campaign_confirm_email_agu_conference'
-        USER_CAMPAIGN_CONFIRM_EMAIL_AGU_CONFERENCE_2023 = 'user_campaign_confirm_email_agu_conference_2023'
-        USER_CAMPAIGN_CONFIRM_EMAIL_REGISTRIES_OSF = 'user_campaign_confirm_email_registries_osf'
-        USER_CAMPAIGN_CONFIRM_EMAIL_ERPC = 'user_campaign_confirm_email_erpc'
-        USER_DIGEST = 'user_digest'
-        USER_NO_LOGIN = 'user_no_login'
-        DIGEST_REVIEWS_MODERATORS = 'digest_reviews_moderators'
-
-        # Node notifications
-        NODE_FILE_UPDATED = 'node_file_updated'  # unused
-        NODE_FILES_UPDATED = 'node_files_updated'  # unused
-        NODE_AFFILIATION_CHANGED = 'node_affiliation_changed'
-        NODE_REQUEST_ACCESS_SUBMITTED = 'node_request_access_submitted'
-        NODE_REQUEST_ACCESS_DENIED = 'node_request_access_denied'
-        NODE_FORK_COMPLETED = 'node_fork_completed'
-        NODE_FORK_FAILED = 'node_fork_failed'
-        NODE_INSTITUTIONAL_ACCESS_REQUEST = 'node_institutional_access_request'
-        NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST = 'node_contributor_added_access_request'
-        NODE_CONTRIBUTOR_ADDED_DEFAULT = 'node_contributor_added_default'
-        NODE_PENDING_EMBARGO_ADMIN = 'node_pending_embargo_admin'
-        NODE_PENDING_EMBARGO_NON_ADMIN = 'node_pending_embargo_non_admin'
-        NODE_PENDING_RETRACTION_NON_ADMIN = 'node_pending_retraction_non_admin'
-        NODE_PENDING_RETRACTION_ADMIN = 'node_pending_retraction_admin'
-        NODE_PENDING_REGISTRATION_NON_ADMIN = 'node_pending_registration_non_admin'
-        NODE_PENDING_REGISTRATION_ADMIN = 'node_pending_registration_admin'
-        NODE_PENDING_EMBARGO_TERMINATION_NON_ADMIN = 'node_pending_embargo_termination_non_admin'
-        NODE_PENDING_EMBARGO_TERMINATION_ADMIN = 'node_pending_embargo_termination_admin'
-        NODE_SCHEMA_RESPONSE_REJECTED = 'node_schema_response_rejected'
-        NODE_SCHEMA_RESPONSE_APPROVED = 'node_schema_response_approved'
-        NODE_SCHEMA_RESPONSE_SUBMITTED = 'node_schema_response_submitted'
-        NODE_SCHEMA_RESPONSE_INITIATED = 'node_schema_response_initiated'
-        NODE_WITHDRAWAl_REQUEST_APPROVED = 'node_withdrawal_request_approved'
-        NODE_WITHDRAWAl_REQUEST_REJECTED = 'node_withdrawal_request_rejected'
-        NODE_NEW_PUBLIC_PROJECT = 'node_new_public_project'
-
-        FILE_UPDATED = 'file_updated'
-        FILE_ADDED = 'file_added'
-        FILE_REMOVED = 'file_removed'
-        ADDON_FILE_COPIED = 'addon_file_copied'
-        ADDON_FILE_RENAMED = 'addon_file_renamed'
-        ADDON_FILE_MOVED = 'addon_file_moved'
-        ADDON_FILE_REMOVED = 'addon_file_removed'  # unused
-        FOLDER_CREATED = 'folder_created'
-
-        # Provider notifications
-        PROVIDER_NEW_PENDING_SUBMISSIONS = 'provider_new_pending_submissions'
-        PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS = 'provider_new_pending_withdraw_requests'
-        PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION = 'provider_reviews_submission_confirmation'
-        PROVIDER_REVIEWS_MODERATOR_SUBMISSION_CONFIRMATION = 'provider_reviews_moderator_submission_confirmation'  # unused
-        PROVIDER_REVIEWS_REJECT_CONFIRMATION = 'provider_reviews_reject_confirmation'  # unused
-        PROVIDER_REVIEWS_ACCEPT_CONFIRMATION = 'provider_reviews_accept_confirmation'  # unused
-        PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION = 'provider_reviews_resubmission_confirmation'
-        PROVIDER_REVIEWS_COMMENT_EDITED = 'provider_reviews_comment_edited'  # unused
-        PROVIDER_CONTRIBUTOR_ADDED_PREPRINT = 'provider_contributor_added_preprint'  # unused
-        PROVIDER_CONFIRM_EMAIL_MODERATION = 'provider_confirm_email_moderation'
-        PROVIDER_MODERATOR_ADDED = 'provider_moderator_added'
-        PROVIDER_CONFIRM_EMAIL_PREPRINTS = 'provider_confirm_email_preprints'  # unused
-        PROVIDER_USER_INVITE_PREPRINT = 'provider_user_invite_preprint'
-
-        # Preprint notifications
-        PREPRINT_REQUEST_WITHDRAWAL_APPROVED = 'preprint_request_withdrawal_approved'
-        PREPRINT_REQUEST_WITHDRAWAL_DECLINED = 'preprint_request_withdrawal_declined'
-        PREPRINT_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = 'preprint_contributor_added_preprint_node_from_osf'
-        PREPRINT_CONTRIBUTOR_ADDED_DEFAULT = 'preprint_contributor_added_default'
-        PREPRINT_PENDING_RETRACTION_ADMIN = 'preprint_pending_retraction_admin'  # unused
-
-        # Collections Submission notifications
-        COLLECTION_SUBMISSION_REMOVED_ADMIN = 'collection_submission_removed_admin'
-        COLLECTION_SUBMISSION_REMOVED_MODERATOR = 'collection_submission_removed_moderator'
-        COLLECTION_SUBMISSION_REMOVED_PRIVATE = 'collection_submission_removed_private'
-        COLLECTION_SUBMISSION_SUBMITTED = 'collection_submission_submitted'
-        COLLECTION_SUBMISSION_ACCEPTED = 'collection_submission_accepted'
-        COLLECTION_SUBMISSION_REJECTED = 'collection_submission_rejected'
-        COLLECTION_SUBMISSION_CANCEL = 'collection_submission_cancel'
-
-        REGISTRATION_BULK_UPLOAD_FAILURE_DUPLICATES = 'registration_bulk_upload_failure_duplicates'
-
-        DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT = 'draft_registration_contributor_added_default'
-
-        @ttl_cached_property(ttl=60 * 60 * 24)  # 24 hours
-        def instance(self):
-            obj, created = NotificationType.objects.get_or_create(name=self.value)
-            return obj
 
     notification_interval_choices = ArrayField(
         base_field=models.CharField(max_length=32),
@@ -256,32 +255,32 @@ class NotificationType(models.Model):
         from osf.models.notification_subscription import NotificationSubscription
 
         _global_file_updated = [
-            NotificationType.Type.USER_FILE_UPDATED.value,
-            NotificationType.Type.FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.USER_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
         _global_reviews = [
-            NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
-            NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
-            NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
-            NotificationType.Type.REVIEWS_SUBMISSION_STATUS.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION.value,
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.value,
+            NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS.value,
         ]
         _node_file_updated = [
-            NotificationType.Type.NODE_FILE_UPDATED.value,
-            NotificationType.Type.FILE_ADDED.value,
-            NotificationType.Type.FILE_REMOVED.value,
-            NotificationType.Type.ADDON_FILE_COPIED.value,
-            NotificationType.Type.ADDON_FILE_RENAMED.value,
-            NotificationType.Type.ADDON_FILE_MOVED.value,
-            NotificationType.Type.ADDON_FILE_REMOVED.value,
-            NotificationType.Type.FOLDER_CREATED.value,
+            NotificationTypeEnum.NODE_FILE_UPDATED.value,
+            NotificationTypeEnum.FILE_ADDED.value,
+            NotificationTypeEnum.FILE_REMOVED.value,
+            NotificationTypeEnum.ADDON_FILE_COPIED.value,
+            NotificationTypeEnum.ADDON_FILE_RENAMED.value,
+            NotificationTypeEnum.ADDON_FILE_MOVED.value,
+            NotificationTypeEnum.ADDON_FILE_REMOVED.value,
+            NotificationTypeEnum.FOLDER_CREATED.value,
         ]
 
         if self.name in _global_file_updated:

--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -20,7 +20,7 @@ from framework import sentry
 from framework.auth import Auth
 from framework.exceptions import PermissionsError, UnpublishedPendingPreprintVersionExists
 from framework.auth import oauth_scopes
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 
 from .subject import Subject
 from .tag import Tag
@@ -1026,7 +1026,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
     def _send_preprint_confirmation(self, auth):
         # Send creator confirmation email
         recipient = self.creator
-        NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.instance.emit(
+        NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION.instance.emit(
             subscribed_object=self.provider,
             user=recipient,
             event_context={

--- a/osf/models/provider.py
+++ b/osf/models/provider.py
@@ -14,7 +14,7 @@ from dirtyfields import DirtyFieldsMixin
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 
 from framework import sentry
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .base import BaseModel, TypedObjectIDMixin
 from .mixins import ReviewProviderMixin
 from .brand import Brand
@@ -253,7 +253,7 @@ class AbstractProvider(TypedModel, TypedObjectIDMixin, ReviewProviderMixin, Dirt
 
 class CollectionProvider(AbstractProvider):
     DEFAULT_SUBSCRIPTIONS = [
-        NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
     ]
 
     class Meta:
@@ -295,8 +295,8 @@ class RegistrationProvider(AbstractProvider):
     STATE_FIELD_NAME = 'moderation_state'
 
     DEFAULT_SUBSCRIPTIONS = [
-        NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS,
-        NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS,
+        NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS,
+        NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS,
 
     ]
 

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -23,7 +23,7 @@ from osf.utils.permissions import ADMIN, READ, WRITE
 from osf.exceptions import NodeStateError, DraftRegistrationStateError
 from osf.external.internet_archive.tasks import archive_to_ia, update_ia_metadata
 from osf.metrics import RegistriesModerationMetrics
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .action import RegistrationAction
 from .archive import ArchiveJob
 from .contributor import DraftRegistrationContributor
@@ -1332,7 +1332,7 @@ class DraftRegistration(ObjectIDMixin, RegistrationResponseMixin, DirtyFieldsMix
             node=None,
             data=None,
             provider=None,
-            notification_type=NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+            notification_type=NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
     ):
         if not provider:
             provider = RegistrationProvider.get_default()

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -19,7 +19,7 @@ from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils import tokens
 from osf.utils.machines import ApprovalsMachine
 from osf.utils.workflows import ApprovalStates, SanctionTypes
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 
 VIEW_PROJECT_URL_TEMPLATE = osf_settings.DOMAIN + '{node_id}/'
 
@@ -462,8 +462,8 @@ class Embargo(SanctionCallbackMixin, EmailApprovableSanction):
     DISPLAY_NAME = 'Embargo'
     SHORT_NAME = 'embargo'
 
-    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_EMBARGO_ADMIN
-    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_EMBARGO_NON_ADMIN
+    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_EMBARGO_ADMIN
+    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_EMBARGO_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
     APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
@@ -662,8 +662,8 @@ class Retraction(EmailApprovableSanction):
     DISPLAY_NAME = 'Retraction'
     SHORT_NAME = 'retraction'
 
-    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_RETRACTION_ADMIN
-    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_RETRACTION_NON_ADMIN
+    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_RETRACTION_ADMIN
+    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_RETRACTION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
     APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
@@ -800,8 +800,8 @@ class RegistrationApproval(SanctionCallbackMixin, EmailApprovableSanction):
     DISPLAY_NAME = 'Approval'
     SHORT_NAME = 'registration_approval'
 
-    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_REGISTRATION_ADMIN
-    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_REGISTRATION_NON_ADMIN
+    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_REGISTRATION_ADMIN
+    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_REGISTRATION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
     APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'
@@ -980,8 +980,8 @@ class EmbargoTerminationApproval(EmailApprovableSanction):
     DISPLAY_NAME = 'Embargo Termination Request'
     SHORT_NAME = 'embargo_termination_approval'
 
-    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_EMBARGO_TERMINATION_ADMIN
-    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationType.Type.NODE_PENDING_EMBARGO_TERMINATION_NON_ADMIN
+    AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_EMBARGO_TERMINATION_ADMIN
+    NON_AUTHORIZER_NOTIFY_EMAIL_TYPE = NotificationTypeEnum.NODE_PENDING_EMBARGO_TERMINATION_NON_ADMIN
 
     VIEW_URL_TEMPLATE = VIEW_PROJECT_URL_TEMPLATE
     APPROVE_URL_TEMPLATE = osf_settings.DOMAIN + 'token_action/{node_id}/?token={token}'

--- a/osf/models/schema_response.py
+++ b/osf/models/schema_response.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from framework.exceptions import PermissionsError
 
 from osf.exceptions import PreviousSchemaResponseError, SchemaResponseStateError, SchemaResponseUpdateError
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .base import BaseModel, ObjectIDMixin
 from .metaschema import RegistrationSchemaBlock
 from .schema_response_block import SchemaResponseBlock
@@ -488,10 +488,10 @@ class SchemaResponse(ObjectIDMixin, BaseModel):
             )
 
         notification_type = {
-            'create': NotificationType.Type.NODE_SCHEMA_RESPONSE_INITIATED.instance,
-            'submit': NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED.instance,
-            'accept': NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED.instance,
-            'reject': NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED.instance,
+            'create': NotificationTypeEnum.NODE_SCHEMA_RESPONSE_INITIATED.instance,
+            'submit': NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED.instance,
+            'accept': NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED.instance,
+            'reject': NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED.instance,
         }.get(event)
         if not notification_type:
             return

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -61,7 +61,7 @@ from website import filters
 from website.project import new_bookmark_collection
 from website.util.metrics import OsfSourceTags, unregistered_created_source_tag
 from importlib import import_module
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf.utils.requests import string_type_request_headers
 
 
@@ -1059,7 +1059,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             raise ChangePasswordError(['Password cannot be the same as your email address'])
         super().set_password(raw_password)
         if had_existing_password and notify:
-            NotificationType.Type.USER_PASSWORD_RESET.instance.emit(
+            NotificationTypeEnum.USER_PASSWORD_RESET.instance.emit(
                 subscribed_object=self,
                 user=self,
                 message_frequency='instantly',

--- a/osf/models/user_message.py
+++ b/osf/models/user_message.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from .base import BaseModel, ObjectIDMixin
 from website import settings
 
@@ -32,7 +32,7 @@ class MessageTypes(models.TextChoices):
             str: The email template string for the specified message type.
         """
         return {
-            cls.INSTITUTIONAL_REQUEST: NotificationType.Type.USER_INSTITUTIONAL_ACCESS_REQUEST
+            cls.INSTITUTIONAL_REQUEST: NotificationTypeEnum.USER_INSTITUTIONAL_ACCESS_REQUEST
         }[message_type]
 
 

--- a/osf/utils/machines.py
+++ b/osf/utils/machines.py
@@ -6,7 +6,7 @@ from api.providers.workflows import Workflows
 from framework.auth import Auth
 
 from osf.exceptions import InvalidTransitionError
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from osf.models.preprintlog import PreprintLog
 from osf.models.action import ReviewAction, NodeRequestAction, PreprintRequestAction
 from osf.utils import permissions
@@ -192,7 +192,7 @@ class ReviewsMachine(BaseMachine):
             if context.get('requester_fullname', None):
                 context['is_requester'] = requester == contributor
 
-            NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_APPROVED.instance.emit(
+            NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_APPROVED.instance.emit(
                 user=contributor,
                 subscribed_object=self.machineable,
                 event_context={
@@ -234,7 +234,7 @@ class NodeRequestMachine(BaseMachine):
                 make_curator = self.machineable.request_type == NodeRequestTypes.INSTITUTIONAL_REQUEST.value
                 visible = False if make_curator else ev.kwargs.get('visible', True)
                 if self.machineable.request_type in (NodeRequestTypes.ACCESS.value, NodeRequestTypes.INSTITUTIONAL_REQUEST.value):
-                    notification_type = NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+                    notification_type = NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
                 else:
                     notification_type = None
 
@@ -265,7 +265,7 @@ class NodeRequestMachine(BaseMachine):
 
         if not self.machineable.request_type == NodeRequestTypes.INSTITUTIONAL_REQUEST.value:
             for admin in self.machineable.target.get_users_with_perm(permissions.ADMIN):
-                NotificationType.Type.NODE_REQUEST_ACCESS_SUBMITTED.instance.emit(
+                NotificationTypeEnum.NODE_REQUEST_ACCESS_SUBMITTED.instance.emit(
                     user=admin,
                     subscribed_object=self.machineable,
                     event_context={
@@ -286,7 +286,7 @@ class NodeRequestMachine(BaseMachine):
         if ev.event.name == DefaultTriggers.REJECT.value:
             context = self.get_context()
 
-            NotificationType.Type.NODE_REQUEST_ACCESS_DENIED.instance.emit(
+            NotificationTypeEnum.NODE_REQUEST_ACCESS_DENIED.instance.emit(
                 user=self.machineable.creator,
                 subscribed_object=self.machineable,
                 event_context=context
@@ -344,7 +344,7 @@ class PreprintRequestMachine(BaseMachine):
             context['comment'] = self.action.comment
             context['contributor_fullname'] = self.machineable.creator.fullname
 
-            NotificationType.Type.PREPRINT_REQUEST_WITHDRAWAL_DECLINED.instance.emit(
+            NotificationTypeEnum.PREPRINT_REQUEST_WITHDRAWAL_DECLINED.instance.emit(
                 user=self.machineable.creator,
                 subscribed_object=self.machineable,
                 event_context=context

--- a/osf/utils/notifications.py
+++ b/osf/utils/notifications.py
@@ -1,6 +1,6 @@
 from django.utils import timezone
 
-from osf.models.notification_type import NotificationType
+from osf.models.notification_type import NotificationTypeEnum
 from website.reviews import signals as reviews_signals
 from website.settings import DOMAIN, OSF_SUPPORT_EMAIL, OSF_CONTACT_EMAIL
 from osf.utils.workflows import RegistrationModerationTriggers
@@ -50,7 +50,7 @@ def notify_submit(resource, user, *args, **kwargs):
         context=context,
         recipients=recipients,
         resource=resource,
-        notification_type=NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        notification_type=NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
     )
     reviews_signals.reviews_email_submit_moderators_notifications.send(
         timestamp=timezone.now(),
@@ -71,7 +71,7 @@ def notify_resubmit(resource, user, *args, **kwargs):
     reviews_signals.reviews_email_submit.send(
         recipients=recipients,
         context=context,
-        notification_type=NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION,
+        notification_type=NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION,
         resource=resource,
     )
     reviews_signals.reviews_email_submit_moderators_notifications.send(
@@ -94,7 +94,7 @@ def notify_accept_reject(resource, user, action, states, *args, **kwargs):
     reviews_signals.reviews_email.send(
         creator=user,
         context=context,
-        template=NotificationType.Type.REVIEWS_SUBMISSION_STATUS,
+        template=NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS,
         action=action
     )
 
@@ -110,7 +110,7 @@ def notify_edit_comment(resource, user, action, states, *args, **kwargs):
         reviews_signals.reviews_email.send(
             creator=user,
             context=context,
-            template=NotificationType.Type.REVIEWS_SUBMISSION_STATUS,
+            template=NotificationTypeEnum.REVIEWS_SUBMISSION_STATUS,
             action=action
         )
 
@@ -128,7 +128,7 @@ def notify_reject_withdraw_request(resource, action, *args, **kwargs):
         context['contributor_fullname'] = contributor.fullname
         context['is_requester'] = action.creator == contributor
         context['comment'] = action.comment
-        NotificationType.Type.NODE_WITHDRAWAl_REQUEST_REJECTED.instance.emit(
+        NotificationTypeEnum.NODE_WITHDRAWAl_REQUEST_REJECTED.instance.emit(
             user=contributor,
             event_context={
                 'is_requester': contributor == action.creator,
@@ -163,7 +163,7 @@ def notify_withdraw_registration(resource, action, *args, **kwargs):
         context['user_fullname'] = contributor.fullname
         context['is_requester'] = resource.retraction.initiated_by == contributor
 
-        NotificationType.Type.NODE_WITHDRAWAl_REQUEST_APPROVED.instance.emit(
+        NotificationTypeEnum.NODE_WITHDRAWAl_REQUEST_APPROVED.instance.emit(
             user=contributor,
             event_context=context
         )

--- a/osf_tests/management_commands/test_migrate_notifications.py
+++ b/osf_tests/management_commands/test_migrate_notifications.py
@@ -11,6 +11,7 @@ from osf_tests.factories import (
 )
 from osf.models import (
     NotificationType,
+    NotificationTypeEnum,
     NotificationSubscription,
 )
 from osf.management.commands.migrate_notifications import (
@@ -123,7 +124,7 @@ class TestNotificationSubscriptionMigration:
         self.create_legacy_sub(event_name='new_pending_submissions', users=users, provider=RegistrationProvider.get_default())
         migrate_legacy_notification_subscriptions()
         subs = NotificationSubscription.objects.filter(
-            notification_type__name=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+            notification_type__name=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         )
         assert subs.count() == 9
         for obj in [provider, provider2, RegistrationProvider.get_default()]:
@@ -132,7 +133,7 @@ class TestNotificationSubscriptionMigration:
 
     def test_migrate_node_subscription(self, users, user, node):
         migrate_legacy_notification_subscriptions()
-        nt = NotificationType.objects.get(name=NotificationType.Type.NODE_FILE_UPDATED)
+        nt = NotificationType.objects.get(name=NotificationTypeEnum.NODE_FILE_UPDATED)
         assert nt.object_content_type == ContentType.objects.get_for_model(Node)
         subs = NotificationSubscription.objects.filter(notification_type=nt)
         assert subs.count() == 1
@@ -154,7 +155,7 @@ class TestNotificationSubscriptionMigration:
                 user=user,
                 object_id=node.id,
                 content_type=ContentType.objects.get_for_model(node.__class__),
-                notification_type__name=NotificationType.Type.NODE_FILE_UPDATED
+                notification_type__name=NotificationTypeEnum.NODE_FILE_UPDATED
             )
 
     def test_migrate_all_subscription_types(self, users, user, provider, provider2, node):
@@ -189,13 +190,13 @@ class TestNotificationSubscriptionMigration:
         for provider in providers:
             content_type = ContentType.objects.get_for_model(provider.__class__)
             assert NotificationSubscription.objects.filter(
-                notification_type=NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.instance,
+                notification_type=NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.instance,
                 content_type=content_type,
                 object_id=provider.id
             ).exists()
         node_ct = ContentType.objects.get_for_model(node.__class__)
         assert NotificationSubscription.objects.filter(
-            notification_type=NotificationType.Type.NODE_FILE_UPDATED.instance,
+            notification_type=NotificationTypeEnum.NODE_FILE_UPDATED.instance,
             content_type=node_ct,
             object_id=node.id
         ).exists()
@@ -238,7 +239,7 @@ class TestNotificationSubscriptionMigration:
         )
         migrate_legacy_notification_subscriptions()
         assert NotificationSubscription.objects.filter(
-            notification_type__name=NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
+            notification_type__name=NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
         ).count() == 3
 
     def test_migrate_subscription_frequencies_none(self, user, django_db_blocker):
@@ -251,7 +252,7 @@ class TestNotificationSubscriptionMigration:
 
         migrate_legacy_notification_subscriptions()
 
-        nt = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        nt = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         subs = NotificationSubscription.objects.filter(notification_type=nt)
         assert subs.count() == 1
         assert subs.get().message_frequency == 'none'
@@ -265,7 +266,7 @@ class TestNotificationSubscriptionMigration:
 
         migrate_legacy_notification_subscriptions()
 
-        nt = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        nt = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         subs = NotificationSubscription.objects.filter(
             notification_type=nt,
             content_type=ContentType.objects.get_for_model(user.__class__),
@@ -283,7 +284,7 @@ class TestNotificationSubscriptionMigration:
 
         migrate_legacy_notification_subscriptions()
 
-        nt = NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+        nt = NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         subs = NotificationSubscription.objects.filter(
             notification_type=nt,
             content_type=ContentType.objects.get_for_model(user.__class__),
@@ -301,7 +302,7 @@ class TestNotificationSubscriptionMigration:
 
         migrate_legacy_notification_subscriptions()
 
-        nt = NotificationType.objects.get(name=NotificationType.Type.NODE_FILE_UPDATED)
+        nt = NotificationType.objects.get(name=NotificationTypeEnum.NODE_FILE_UPDATED)
         subs = NotificationSubscription.objects.filter(
             user=user,
             notification_type=nt,

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -20,7 +20,7 @@ from website.app import *  # noqa: F403
 from website.archiver import listeners
 from website.archiver.tasks import *   # noqa: F403
 
-from osf.models import Guid, RegistrationSchema, Registration, NotificationType
+from osf.models import Guid, RegistrationSchema, Registration, NotificationTypeEnum
 from osf.models.archive import ArchiveTarget, ArchiveJob
 from osf.models.base import generate_object_id
 from osf.utils.migrations import map_schema_to_schemablocks
@@ -735,8 +735,8 @@ class TestArchiverUtils(ArchiverTestCase):
                 {}
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_ARCHIVE_JOB_COPY_ERROR
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_ARCHIVE_JOB_COPY_ERROR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_ARCHIVE_JOB_COPY_ERROR
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_ARCHIVE_JOB_COPY_ERROR
         assert notifications['emits'][0]['kwargs']['destination_address'] == settings.OSF_SUPPORT_EMAIL
         assert notifications['emits'][1]['kwargs']['user'] == self.user
         self.dst.reload()
@@ -752,8 +752,8 @@ class TestArchiverUtils(ArchiverTestCase):
                 {}
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_ARCHIVE_JOB_COPY_ERROR
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_ARCHIVE_JOB_COPY_ERROR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_ARCHIVE_JOB_COPY_ERROR
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_ARCHIVE_JOB_COPY_ERROR
         assert notifications['emits'][0]['kwargs']['destination_address'] == settings.OSF_SUPPORT_EMAIL
         assert notifications['emits'][1]['kwargs']['user'] == self.user
 
@@ -767,8 +767,8 @@ class TestArchiverUtils(ArchiverTestCase):
                 {}
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_ARCHIVE_JOB_EXCEEDED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_ARCHIVE_JOB_EXCEEDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_ARCHIVE_JOB_EXCEEDED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_ARCHIVE_JOB_EXCEEDED
         assert notifications['emits'][0]['kwargs']['destination_address'] == settings.OSF_SUPPORT_EMAIL
         assert notifications['emits'][1]['kwargs']['user'] == self.user
 
@@ -782,8 +782,8 @@ class TestArchiverUtils(ArchiverTestCase):
                 {}
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_ARCHIVE_JOB_UNCAUGHT_ERROR
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_ARCHIVE_JOB_UNCAUGHT_ERROR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_ARCHIVE_JOB_UNCAUGHT_ERROR
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_ARCHIVE_JOB_UNCAUGHT_ERROR
         assert notifications['emits'][0]['kwargs']['destination_address'] == settings.OSF_SUPPORT_EMAIL
         assert notifications['emits'][1]['kwargs']['user'] == self.user
 

--- a/osf_tests/test_collection.py
+++ b/osf_tests/test_collection.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 
 from framework.auth import Auth
 
-from osf.models import Collection, NotificationType
+from osf.models import Collection, NotificationTypeEnum
 from osf.exceptions import NodeStateError
 from tests.utils import capture_notifications
 from website.views import find_bookmark_collection
@@ -134,7 +134,7 @@ class TestImplicitRemoval:
         with capture_notifications() as notifications:
             provider_collected_node.set_privacy('private', auth=auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_PRIVATE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_PRIVATE
 
     @mock.patch('osf.models.node.Node.check_privacy_change_viability', mock.Mock())  # mocks the storage usage limits
     def test_node_removed_from_collection_on_privacy_change_no_provider(self, auth, collected_node, bookmark_collection):

--- a/osf_tests/test_collection_submission.py
+++ b/osf_tests/test_collection_submission.py
@@ -8,7 +8,7 @@ from transitions import MachineError
 
 from osf_tests.factories import NodeFactory, CollectionFactory, CollectionProviderFactory
 
-from osf.models import CollectionSubmission, NotificationType
+from osf.models import CollectionSubmission, NotificationTypeEnum
 from osf.utils.workflows import CollectionSubmissionStates
 from framework.exceptions import PermissionsError
 from api_tests.utils import UserRoles
@@ -165,8 +165,8 @@ class TestModeratedCollectionSubmission:
             )
             collection_submission.save()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert collection_submission.state == CollectionSubmissionStates.PENDING
 
     def test_notify_moderators_pending(self, node, moderated_collection):
@@ -179,8 +179,8 @@ class TestModeratedCollectionSubmission:
             )
             collection_submission.save()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert collection_submission.state == CollectionSubmissionStates.PENDING
 
     @pytest.mark.parametrize('user_role', [UserRoles.UNAUTHENTICATED, UserRoles.NONCONTRIB])
@@ -201,7 +201,7 @@ class TestModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             moderated_collection_submission.accept(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED
 
         assert moderated_collection_submission.state == CollectionSubmissionStates.ACCEPTED
 
@@ -224,7 +224,7 @@ class TestModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             moderated_collection_submission.reject(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REJECTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED
 
         assert moderated_collection_submission.state == CollectionSubmissionStates.REJECTED
 
@@ -253,7 +253,7 @@ class TestModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             moderated_collection_submission.remove(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR
 
         assert moderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 
@@ -264,8 +264,8 @@ class TestModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             moderated_collection_submission.remove(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][1]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
 
         assert moderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 
@@ -350,8 +350,8 @@ class TestUnmoderatedCollectionSubmission:
         with capture_notifications() as notifications:
             unmoderated_collection_submission.remove(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
-        assert notifications['emits'][1]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
         assert unmoderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 
     def test_resubmit_success(self, node, unmoderated_collection_submission):
@@ -454,7 +454,7 @@ class TestHybridModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             hybrid_moderated_collection_submission.accept(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_ACCEPTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_ACCEPTED
         assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.ACCEPTED
 
     @pytest.mark.parametrize('user_role', [UserRoles.UNAUTHENTICATED, UserRoles.NONCONTRIB])
@@ -476,7 +476,7 @@ class TestHybridModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             hybrid_moderated_collection_submission.reject(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REJECTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REJECTED
         assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.REJECTED
 
     @pytest.mark.parametrize('user_role', UserRoles.excluding(*[UserRoles.ADMIN_USER, UserRoles.MODERATOR]))
@@ -504,7 +504,7 @@ class TestHybridModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             hybrid_moderated_collection_submission.remove(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_MODERATOR
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_MODERATOR
         assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 
     def test_notify_moderated_removed_admin(self, node, hybrid_moderated_collection_submission):
@@ -514,8 +514,8 @@ class TestHybridModeratedCollectionSubmission:
         with capture_notifications() as notifications:
             hybrid_moderated_collection_submission.remove(user=moderator, comment='Test Comment')
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
-        assert notifications['emits'][1]['type'] == NotificationType.Type.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.COLLECTION_SUBMISSION_REMOVED_ADMIN
 
         assert hybrid_moderated_collection_submission.state == CollectionSubmissionStates.REMOVED
 

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from addons.osfstorage.models import Region
-from osf.models import Institution, InstitutionStorageRegion, NotificationType
+from osf.models import Institution, InstitutionStorageRegion, NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     InstitutionFactory,
@@ -157,8 +157,8 @@ class TestInstitutionManager:
         with capture_notifications() as notifications:
             institution._send_deactivation_email()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INSTITUTION_DEACTIVATION
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_INSTITUTION_DEACTIVATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INSTITUTION_DEACTIVATION
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_INSTITUTION_DEACTIVATION
 
     def test_send_deactivation_email_call_args(self):
         institution = InstitutionFactory()
@@ -168,7 +168,7 @@ class TestInstitutionManager:
         with capture_notifications() as notifications:
             institution._send_deactivation_email()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INSTITUTION_DEACTIVATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INSTITUTION_DEACTIVATION
 
     def test_deactivate_inactive_institution_noop(self):
         institution = InstitutionFactory()

--- a/osf_tests/test_institutional_admin_contributors.py
+++ b/osf_tests/test_institutional_admin_contributors.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import mock
 
 
-from osf.models import Contributor, NotificationType
+from osf.models import Contributor, NotificationTypeEnum
 from osf_tests.factories import (
     AuthUserFactory,
     ProjectFactory,
@@ -142,7 +142,7 @@ class TestContributorModel:
                 auth=mock.ANY,
                 permissions=permissions.ADMIN,  # `requested_permissions` should take precedence
                 visible=True,
-                notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
+                notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
                 make_curator=False,
             )
 
@@ -168,7 +168,7 @@ class TestContributorModel:
                 auth=mock.ANY,
                 permissions=permissions.ADMIN,  # `requested_permissions` should take precedence
                 visible=True,
-                notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
+                notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
                 make_curator=False,
             )
 
@@ -194,6 +194,6 @@ class TestContributorModel:
                 auth=mock.ANY,
                 permissions=permissions.ADMIN,  # `requested_permissions` should take precedence
                 visible=True,
-                notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
+                notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST,
                 make_curator=False,
             )

--- a/osf_tests/test_merging_users.py
+++ b/osf_tests/test_merging_users.py
@@ -19,7 +19,7 @@ from osf_tests.factories import (
 )
 from importlib import import_module
 from django.conf import settings as django_conf_settings
-from osf.models import UserSessionMap, NotificationType
+from osf.models import UserSessionMap, NotificationTypeEnum
 from tests.utils import run_celery_tasks, capture_notifications
 from waffle.testutils import override_flag
 from osf.features import ENABLE_GV
@@ -300,5 +300,5 @@ class TestUserMerging(OsfTestCase):
         with capture_notifications() as notifications:
             send_confirm_email(merger, target_email)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_CONFIRM_MERGE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_CONFIRM_MERGE
         assert notifications['emits'][0]['kwargs']['destination_address'] == target_email

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -34,7 +34,7 @@ from osf.models import (
     NodeRelation,
     Registration,
     DraftRegistration,
-    CollectionSubmission, NotificationType
+    CollectionSubmission, NotificationTypeEnum
 )
 
 from addons.wiki.models import WikiPage, WikiVersion
@@ -2150,7 +2150,7 @@ class TestSetPrivacy:
         with capture_notifications() as notifications:
             node.set_privacy('public', auth=auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_NEW_PUBLIC_PROJECT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_NEW_PUBLIC_PROJECT
         assert node.logs.first().action == NodeLog.MADE_PUBLIC
         assert last_logged_before_method_call != node.last_logged
         node.save()
@@ -2171,7 +2171,7 @@ class TestSetPrivacy:
             node.set_privacy('private', auth=auth)
             node.set_privacy('public', auth=auth, meeting_creation=False)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_NEW_PUBLIC_PROJECT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_NEW_PUBLIC_PROJECT
 
     def test_set_privacy_can_not_cancel_pending_embargo_for_registration(self, node, user, auth):
         registration = RegistrationFactory(project=node)

--- a/osf_tests/test_registration_moderation_notifications.py
+++ b/osf_tests/test_registration_moderation_notifications.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from notifications.tasks import send_users_digest_email
 from osf.management.commands.populate_notification_types import populate_notification_types
 from osf.migrations import update_provider_auth_groups
-from osf.models import Brand, NotificationSubscription, NotificationType
+from osf.models import Brand, NotificationSubscription, NotificationTypeEnum
 from osf.models.action import RegistrationAction
 from osf.utils.notifications import (
     notify_submit,
@@ -135,11 +135,11 @@ class TestRegistrationMachineNotification:
             notify_submit(registration, admin)
 
         assert len(notification['emits']) == 3
-        assert notification['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notification['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         assert notification['emits'][0]['kwargs']['user'] == admin
-        assert notification['emits'][1]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notification['emits'][1]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         assert notification['emits'][1]['kwargs']['user'] == contrib
-        assert notification['emits'][2]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notification['emits'][2]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert NotificationSubscription.objects.count() == 6
         digest = NotificationSubscription.objects.last()
         assert digest.user == moderator

--- a/osf_tests/test_reviewable.py
+++ b/osf_tests/test_reviewable.py
@@ -1,7 +1,7 @@
 from unittest import mock
 import pytest
 
-from osf.models import Preprint, NotificationType
+from osf.models import Preprint, NotificationTypeEnum
 from osf.utils.workflows import DefaultStates
 from osf_tests.factories import PreprintFactory, AuthUserFactory
 from tests.utils import capture_notifications
@@ -48,7 +48,7 @@ class TestReviewable:
         with capture_notifications() as notifications:
             preprint.run_submit(user)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
         assert preprint.machine_state == DefaultStates.PENDING.value
 
         assert not user.notification_subscriptions.exists()
@@ -59,5 +59,5 @@ class TestReviewable:
         with capture_notifications() as notifications:
             preprint.run_submit(user)  # Resubmission alerts users and moderators
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_RESUBMISSION_CONFIRMATION
         assert preprint.machine_state == DefaultStates.PENDING.value

--- a/osf_tests/test_schema_responses.py
+++ b/osf_tests/test_schema_responses.py
@@ -3,7 +3,7 @@ import pytest
 from api.providers.workflows import Workflows
 from framework.exceptions import PermissionsError
 from osf.exceptions import PreviousSchemaResponseError, SchemaResponseStateError, SchemaResponseUpdateError
-from osf.models import RegistrationSchema, RegistrationSchemaBlock, SchemaResponseBlock, NotificationType
+from osf.models import RegistrationSchema, RegistrationSchemaBlock, SchemaResponseBlock, NotificationTypeEnum
 from osf.models import schema_response  # import module for mocking purposes
 from osf.utils.workflows import ApprovalStates, SchemaResponseTriggers
 from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory, RegistrationProviderFactory
@@ -259,7 +259,7 @@ class TestCreateSchemaResponse():
                 initiator=admin_user
             )
         assert len(notifications['emits']) == len(notification_recipients)
-        assert all(notification['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_INITIATED
+        assert all(notification['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_INITIATED
                    for notification in notifications['emits'])
         assert all(notification['kwargs']['user'].username in notification_recipients for notification in notifications['emits'])
 
@@ -588,9 +588,9 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         with capture_notifications() as notifications:
             revised_response.submit(user=admin_user, required_approvers=[admin_user])
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_SUBMITTED
 
     def test_no_submit_notification_on_initial_response(self, initial_response, admin_user):
         initial_response.approvals_state_machine.set_state(ApprovalStates.IN_PROGRESS)
@@ -752,7 +752,7 @@ class TestUnmoderatedSchemaResponseApprovalFlows():
         with capture_notifications() as notifications:
             revised_response.reject(user=admin_user)
         assert len(notifications['emits']) == 3
-        assert all(notification['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
+        assert all(notification['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
                    for notification in notifications['emits'])
 
     def test_no_reject_notification_on_initial_response(self, initial_response, admin_user):
@@ -861,9 +861,9 @@ class TestModeratedSchemaResponseApprovalFlows():
             revised_response.approve(user=admin_user)
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == moderator
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert notifications['emits'][1]['kwargs']['user'] == admin_user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
 
     def test_moderators_notified_on_admin_approval(self, revised_response, admin_user, moderator):
         revised_response.approvals_state_machine.set_state(ApprovalStates.UNAPPROVED)
@@ -874,9 +874,9 @@ class TestModeratedSchemaResponseApprovalFlows():
             revised_response.approve(user=admin_user)
         assert len(notifications['emits']) == 2
         assert notifications['emits'][0]['kwargs']['user'] == moderator
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS
         assert notifications['emits'][1]['kwargs']['user'] == admin_user
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
 
     def test_no_moderator_notification_on_admin_approval_of_initial_response(
             self, initial_response, admin_user):
@@ -914,9 +914,9 @@ class TestModeratedSchemaResponseApprovalFlows():
         with capture_notifications() as notifications:
             revised_response.accept(user=moderator)
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_APPROVED
 
     def test_no_moderator_accept_notification_on_initial_response(
             self, initial_response, moderator):
@@ -954,9 +954,9 @@ class TestModeratedSchemaResponseApprovalFlows():
         with capture_notifications() as notifications:
             revised_response.reject(user=moderator)
         assert len(notifications['emits']) == 3
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
-        assert notifications['emits'][1]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
-        assert notifications['emits'][2]['type'] == NotificationType.Type.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
+        assert notifications['emits'][2]['type'] == NotificationTypeEnum.NODE_SCHEMA_RESPONSE_REJECTED
 
     def test_no_moderator_reject_notification_on_initial_response(
             self, initial_response, moderator):

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -33,7 +33,7 @@ from osf.models import (
     DraftRegistrationContributor,
     DraftRegistration,
     DraftNode,
-    UserSessionMap, NotificationType,
+    UserSessionMap, NotificationTypeEnum,
 )
 from osf.models.institution_affiliation import get_user_by_institution_identity
 from addons.github.tests.factories import GitHubAccountFactory
@@ -912,7 +912,7 @@ class TestChangePassword:
             user.save()
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PASSWORD_RESET
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PASSWORD_RESET
 
     def test_set_password_no_notify(self, user):
         old_password = 'password'

--- a/scripts/stuck_registration_audit.py
+++ b/scripts/stuck_registration_audit.py
@@ -14,7 +14,7 @@ from website import settings
 from framework.auth import Auth
 from framework.celery_tasks import app as celery_app
 from osf.management.commands import force_archive as fa
-from osf.models import Registration, NotificationType
+from osf.models import Registration, NotificationTypeEnum
 from website.settings import ADDONS_REQUESTED
 
 from scripts import utils as scripts_utils
@@ -95,7 +95,7 @@ def main():
         dict_writer.writeheader()
         dict_writer.writerows(broken_registrations)
 
-        NotificationType.Type.DESK_ARCHIVE_REGISTRATION_STUCK.instance.emit(
+        NotificationTypeEnum.DESK_ARCHIVE_REGISTRATION_STUCK.instance.emit(
             destination_address=settings.OSF_SUPPORT_EMAIL,
             event_context={
                 'broken_registrations_count': len(broken_registrations),

--- a/scripts/tests/test_deactivate_requested_accounts.py
+++ b/scripts/tests/test_deactivate_requested_accounts.py
@@ -1,6 +1,6 @@
 import pytest
 
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from osf_tests.factories import ProjectFactory, AuthUserFactory
 
 from osf.management.commands.deactivate_requested_accounts import deactivate_requested_accounts
@@ -30,7 +30,7 @@ class TestDeactivateRequestedAccount:
         with capture_notifications() as notifications:
             deactivate_requested_accounts(dry_run=False)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_REQUEST_DEACTIVATION_COMPLETE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_REQUEST_DEACTIVATION_COMPLETE
         user_requested_deactivation.reload()
 
         assert user_requested_deactivation.requested_deactivation
@@ -42,7 +42,7 @@ class TestDeactivateRequestedAccount:
         with capture_notifications() as notifications:
             deactivate_requested_accounts(dry_run=False)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_REQUEST_DEACTIVATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_REQUEST_DEACTIVATION
         user_requested_deactivation_with_node.reload()
 
         assert user_requested_deactivation_with_node.requested_deactivation

--- a/scripts/triggered_mails.py
+++ b/scripts/triggered_mails.py
@@ -6,7 +6,7 @@ from django.db.models import Q, Exists, OuterRef
 from django.utils import timezone
 
 from framework.celery_tasks import app as celery_app
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationTypeEnum
 from website.app import init_app
 from website import settings
 
@@ -112,7 +112,7 @@ def send_no_login_email(email_task_id: int):
             email_task.save()
             logger.warning(f'EmailTask {email_task.id}: user {user.id} is not active')
             return
-        NotificationType.Type.USER_NO_LOGIN.instance.emit(
+        NotificationTypeEnum.USER_NO_LOGIN.instance.emit(
             user=user,
             event_context={
                 'user_fullname': user.fullname,

--- a/tests/test_add_contributiors_subscriptions.py
+++ b/tests/test_add_contributiors_subscriptions.py
@@ -1,6 +1,6 @@
 import pytest
 from framework.auth import Auth
-from osf.models import NotificationType, NotificationSubscription
+from osf.models import NotificationTypeEnum, NotificationSubscription
 from osf_tests.factories import ProjectFactory, UserFactory
 from tests.utils import capture_notifications
 from framework.auth import register_unconfirmed
@@ -39,7 +39,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.NODE_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.NODE_FILE_UPDATED
 
         subs = NotificationSubscription.objects.filter(
             user=user,
@@ -51,7 +51,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.USER_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.USER_FILE_UPDATED
 
     def test_only_one_subscription_for_unregistered_user(self):
         """Adding the same unregistered contributor multiple times creates only one subscription."""
@@ -91,7 +91,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.NODE_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.NODE_FILE_UPDATED
 
         subs = NotificationSubscription.objects.filter(
             user=unreg_user,
@@ -103,7 +103,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.USER_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.USER_FILE_UPDATED
 
     def test_only_one_subscription_for_creator(self):
         """Ensure the project creator only has one NotificationSubscription for their own node."""
@@ -134,7 +134,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.NODE_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.NODE_FILE_UPDATED
 
         subs = NotificationSubscription.objects.filter(
             user=creator,
@@ -146,7 +146,7 @@ class TestNodeContributorNotificationUniqueness:
             f"found {subs.count()}"
         )
         sub = subs.first()
-        assert sub.notification_type.name == NotificationType.Type.USER_FILE_UPDATED
+        assert sub.notification_type.name == NotificationTypeEnum.USER_FILE_UPDATED
 
     def test_unregistered_contributor_then_registered_user_only_one_subscription(self):
         """When an unregistered contributor later registers, their subscriptions merge correctly."""
@@ -178,7 +178,7 @@ class TestNodeContributorNotificationUniqueness:
         assert subs_node.count() == 1, (
             f"Expected one NODE_FILE_UPDATED subscription after registration, found {subs_node.count()}"
         )
-        assert subs_node.first().notification_type.name == NotificationType.Type.NODE_FILE_UPDATED
+        assert subs_node.first().notification_type.name == NotificationTypeEnum.NODE_FILE_UPDATED
 
         subs_user = NotificationSubscription.objects.filter(
             user=registered_user,
@@ -188,7 +188,7 @@ class TestNodeContributorNotificationUniqueness:
         assert subs_user.count() == 1, (
             f"Expected one USER_FILE_UPDATED subscription after registration, found {subs_user.count()}"
         )
-        assert subs_user.first().notification_type.name == NotificationType.Type.USER_FILE_UPDATED
+        assert subs_user.first().notification_type.name == NotificationTypeEnum.USER_FILE_UPDATED
 
     def test_contributor_removed_then_readded_only_one_subscription(self):
         """Removing a contributor and re-adding them should not duplicate subscriptions."""
@@ -216,7 +216,7 @@ class TestNodeContributorNotificationUniqueness:
         assert subs_node.count() == 1, (
             f"Expected one NODE_FILE_UPDATED subscription after re-adding, found {subs_node.count()}"
         )
-        assert subs_node.first().notification_type.name == NotificationType.Type.NODE_FILE_UPDATED
+        assert subs_node.first().notification_type.name == NotificationTypeEnum.NODE_FILE_UPDATED
 
         subs_user = NotificationSubscription.objects.filter(
             user=user,
@@ -226,4 +226,4 @@ class TestNodeContributorNotificationUniqueness:
         assert subs_user.count() == 1, (
             f"Expected one USER_FILE_UPDATED subscription after re-adding, found {subs_user.count()}"
         )
-        assert subs_user.first().notification_type.name == NotificationType.Type.USER_FILE_UPDATED
+        assert subs_user.first().notification_type.name == NotificationTypeEnum.USER_FILE_UPDATED

--- a/tests/test_adding_contributor_views.py
+++ b/tests/test_adding_contributor_views.py
@@ -8,7 +8,7 @@ from rest_framework import status as http_status
 from framework import auth
 from framework.auth import Auth
 from framework.exceptions import HTTPError
-from osf.models import NodeRelation, NotificationType
+from osf.models import NodeRelation, NotificationTypeEnum
 from osf.utils import permissions
 from osf_tests.factories import (
     fake_email,
@@ -266,7 +266,7 @@ class TestAddingContributorViews(OsfTestCase):
             project.add_contributors(contributors, auth=self.auth, notification_type=None)
             project.save()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 
     def test_contributor_added_email_sent_to_unreg_user(self):
         unreg_user = UnregUserFactory()
@@ -305,17 +305,17 @@ class TestAddingContributorViews(OsfTestCase):
                 notify_added_contributor(
                     project,
                     contributor,
-                    notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT,
+                    notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT,
                     auth=auth
                 )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 
         # 2nd call does not send email because throttle period has not expired
         notify_added_contributor(
             project,
             contributor,
-            notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT,
+            notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT,
             auth=auth
         )
 
@@ -327,23 +327,23 @@ class TestAddingContributorViews(OsfTestCase):
             notify_added_contributor(
                 project,
                 contributor,
-                NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT,
+                NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT,
                 auth,
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 
         time.sleep(2)  # throttle period expires
         with capture_notifications() as notifications:
             notify_added_contributor(
                 project,
                 contributor,
-                NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT,
+                NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT,
                 auth,
                 throttle=1
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 
     def test_add_contributor_to_fork_sends_email(self):
         contributor = UserFactory()
@@ -352,7 +352,7 @@ class TestAddingContributorViews(OsfTestCase):
             fork.add_contributor(contributor, auth=Auth(self.creator))
             fork.save()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 
     def test_add_contributor_to_template_sends_email(self):
         contributor = UserFactory()
@@ -361,11 +361,11 @@ class TestAddingContributorViews(OsfTestCase):
             template.add_contributor(
                 contributor,
                 auth=Auth(self.creator),
-                notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+                notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
             )
             template.save()
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_ACCESS_REQUEST
 
     def test_creating_fork_does_not_email_creator(self):
         with capture_notifications():
@@ -512,7 +512,7 @@ class TestUserInviteViews(OsfTestCase):
         with capture_notifications() as notifications:
             send_claim_email(email=given_email, unclaimed_user=unreg_user, node=project)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
 
     def test_send_claim_email_to_referrer(self):
         project = ProjectFactory()
@@ -528,8 +528,8 @@ class TestUserInviteViews(OsfTestCase):
             send_claim_email(email=real_email, unclaimed_user=unreg_user, node=project)
 
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION
-        assert notifications['emits'][1]['type'] ==  NotificationType.Type.USER_FORWARD_INVITE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION
+        assert notifications['emits'][1]['type'] ==  NotificationTypeEnum.USER_FORWARD_INVITE
 
     def test_send_claim_email_before_throttle_expires(self):
         project = ProjectFactory()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -24,7 +24,7 @@ from osf_tests.factories import (
 from framework.auth import Auth
 from framework.auth.decorators import must_be_logged_in
 from framework.sessions import get_session
-from osf.models import OSFUser, NotificationType
+from osf.models import OSFUser, NotificationTypeEnum
 from osf.utils import permissions
 from tests.utils import capture_notifications
 from website import settings
@@ -165,7 +165,7 @@ class TestAuthUtils(OsfTestCase):
             user.set_password('killerqueen')
             user.save()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PASSWORD_RESET
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PASSWORD_RESET
 
     @mock.patch('framework.auth.utils.requests.post')
     def test_validate_recaptcha_success(self, req_post):
@@ -210,12 +210,12 @@ class TestAuthUtils(OsfTestCase):
         with capture_notifications() as notifications:
             self.app.post(url, json=sign_up_data)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INITIAL_CONFIRM_EMAIL
 
         with capture_notifications() as notifications:
             self.app.post(url, json=sign_up_data)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INITIAL_CONFIRM_EMAIL
 
 
 class TestAuthObject(OsfTestCase):

--- a/tests/test_auth_views.py
+++ b/tests/test_auth_views.py
@@ -25,7 +25,7 @@ from framework.auth.campaigns import (
 )
 from framework.auth.exceptions import InvalidTokenError
 from framework.auth.views import login_and_register_handler
-from osf.models import OSFUser, NotableDomain, NotificationType
+from osf.models import OSFUser, NotableDomain, NotificationTypeEnum
 from osf_tests.factories import (
     fake_email,
     AuthUserFactory,
@@ -326,7 +326,7 @@ class TestAuthViews(OsfTestCase):
             self.app.put(url, json={'id': self.user._id, 'email': header}, auth=self.user.auth)
 
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_CONFIRM_EMAIL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_CONFIRM_EMAIL
 
         self.user.reload()
         assert token != self.user.get_confirmation_token(email)
@@ -505,7 +505,7 @@ class TestAuthViews(OsfTestCase):
         with capture_notifications() as notifications:
             self.app.put(url, json={'id': self.user._id, 'email': header}, auth=self.user.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_CONFIRM_EMAIL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_CONFIRM_EMAIL
         # 2nd call does not send email because throttle period has not expired
         res = self.app.put(url, json={'id': self.user._id, 'email': header}, auth=self.user.auth)
         assert res.status_code == 400

--- a/tests/test_claim_views.py
+++ b/tests/test_claim_views.py
@@ -10,7 +10,7 @@ from framework.exceptions import HTTPError
 from framework.flask import redirect
 from osf.models import (
     OSFUser,
-    Tag, NotificationType,
+    Tag, NotificationTypeEnum,
 )
 from osf_tests.factories import (
     fake_email,
@@ -98,8 +98,8 @@ class TestClaimViews(OsfTestCase):
                 }
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_FORWARD_INVITE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE
 
         # set unregistered record email since we are mocking send_claim_email()
         unclaimed_record = unregistered_user.get_unclaimed_record(self.project._primary_key)
@@ -147,8 +147,8 @@ class TestClaimViews(OsfTestCase):
                 }
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_FORWARD_INVITE
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE
 
         # set unregistered record email since we are mocking send_claim_email()
         unclaimed_record = unregistered_user.get_unclaimed_record(self.project._primary_key)
@@ -236,8 +236,8 @@ class TestClaimViews(OsfTestCase):
                     node=self.project,
                 )
                 assert len(notifications['emits']) == 2
-                assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORWARD_INVITE_REGISTERED
-                assert notifications['emits'][1]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION_REGISTERED
+                assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED
+                assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION_REGISTERED
         # second call raises error because it was called before throttle period
         with pytest.raises(HTTPError):
                 send_claim_registered_email(
@@ -433,7 +433,7 @@ class TestClaimViews(OsfTestCase):
             )
         assert res.json['fullname'] == self.given_name
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INVITE_DEFAULT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INVITE_DEFAULT
 
     def test_claim_user_post_if_email_is_different_from_given_email(self):
         email = fake_email()  # email that is different from the one the referrer gave
@@ -446,9 +446,9 @@ class TestClaimViews(OsfTestCase):
                 }
             )
         assert len(notifications['emits']) == 2
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_PENDING_VERIFICATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_PENDING_VERIFICATION
         assert notifications['emits'][0]['kwargs']['user'].username == self.given_email
-        assert notifications['emits'][1]['type'] == NotificationType.Type.USER_FORWARD_INVITE
+        assert notifications['emits'][1]['type'] == NotificationTypeEnum.USER_FORWARD_INVITE
         assert notifications['emits'][1]['kwargs']['destination_address'] == email
 
     def test_claim_url_with_bad_token_returns_400(self):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from django.contrib.contenttypes.models import ContentType
 
-from osf.models import NotificationType
+from osf.models import NotificationType, NotificationTypeEnum
 from tests.utils import capture_notifications
 from notifications.file_event_notifications import  (
     event_registry,
@@ -121,7 +121,7 @@ class TestFileUpdated(OsfTestCase):
         self.sub = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.sub.save()
         self.event = event_registry['file_updated'](self.user_2, self.project, 'file_updated', payload=file_payload)
@@ -135,7 +135,7 @@ class TestFileUpdated(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.FILE_UPDATED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.FILE_UPDATED
 
 
 class TestFileAdded(OsfTestCase):
@@ -147,7 +147,7 @@ class TestFileAdded(OsfTestCase):
         self.project_subscription = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.project_subscription.save()
         self.user2 = factories.UserFactory()
@@ -162,7 +162,7 @@ class TestFileAdded(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.FILE_ADDED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.FILE_ADDED
 
 
 class TestFileRemoved(OsfTestCase):
@@ -174,7 +174,7 @@ class TestFileRemoved(OsfTestCase):
         self.project_subscription = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_REMOVED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_REMOVED)
         )
         self.project_subscription.object_id = self.project.id
         self.project_subscription.content_type = ContentType.objects.get_for_model(self.project)
@@ -185,12 +185,12 @@ class TestFileRemoved(OsfTestCase):
         )
 
     def test_info_formed_correct_file(self):
-        assert NotificationType.Type.FILE_UPDATED == self.event.event_type
+        assert NotificationTypeEnum.FILE_UPDATED == self.event.event_type
         assert f'removed file "<b>{materialized.lstrip("/")}</b>".' == self.event.html_message
         assert f'removed file "{materialized.lstrip("/")}".' == self.event.text_message
 
     def test_info_formed_correct_folder(self):
-        assert NotificationType.Type.FILE_UPDATED == self.event.event_type
+        assert NotificationTypeEnum.FILE_UPDATED == self.event.event_type
         self.event.payload['metadata']['materialized'] += '/'
         assert f'removed folder "<b>{materialized.lstrip("/")}/</b>".' == self.event.html_message
         assert f'removed folder "{materialized.lstrip("/")}/".' == self.event.text_message
@@ -199,7 +199,7 @@ class TestFileRemoved(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.FILE_REMOVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.FILE_REMOVED
 
 
 class TestFolderCreated(OsfTestCase):
@@ -210,7 +210,7 @@ class TestFolderCreated(OsfTestCase):
         self.project = factories.ProjectFactory()
         self.project_subscription = factories.NotificationSubscriptionFactory(
             user=self.user,
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED),
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED),
         )
         self.project_subscription.save()
         self.user2 = factories.UserFactory()
@@ -219,7 +219,7 @@ class TestFolderCreated(OsfTestCase):
         )
 
     def test_info_formed_correct(self):
-        assert NotificationType.Type.FILE_UPDATED == self.event.event_type
+        assert NotificationTypeEnum.FILE_UPDATED == self.event.event_type
         assert 'created folder "<b>Three/</b>".' == self.event.html_message
         assert 'created folder "Three/".' == self.event.text_message
 
@@ -227,7 +227,7 @@ class TestFolderCreated(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.FOLDER_CREATED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.FOLDER_CREATED
 
 
 class TestFolderFileRenamed(OsfTestCase):
@@ -242,7 +242,7 @@ class TestFolderFileRenamed(OsfTestCase):
             user=self.user_2,
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.USER_FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.USER_FILE_UPDATED)
         )
         self.sub.save()
 
@@ -295,21 +295,21 @@ class TestFileMoved(OsfTestCase):
         self.sub = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.sub.save()
         # for private node
         self.private_sub = factories.NotificationSubscriptionFactory(
             object_id=self.private_node.id,
             content_type=ContentType.objects.get_for_model(self.private_node),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.private_sub.save()
         # for file subscription
         self.file_sub = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.NODE_FILES_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.NODE_FILES_UPDATED)
         )
         self.file_sub.save()
 
@@ -327,7 +327,7 @@ class TestFileMoved(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_MOVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_MOVED
         assert notifications['emits'][0]['kwargs']['user'] == self.user_2
 
     def test_perform_store_called_once(self):
@@ -336,7 +336,7 @@ class TestFileMoved(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_MOVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_MOVED
 
     def test_perform_store_one_of_each(self):
         # Move Event: Tests that store_emails is called 3 times, one in
@@ -357,7 +357,7 @@ class TestFileMoved(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_MOVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_MOVED
 
     def test_remove_user_sent_once(self):
         # Move Event: Tests removed user is removed once. Regression
@@ -368,7 +368,7 @@ class TestFileMoved(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_MOVED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_MOVED
 
 
 class TestFileCopied(OsfTestCase):
@@ -393,21 +393,21 @@ class TestFileCopied(OsfTestCase):
         self.sub = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.sub.save()
         # for private node
         self.private_sub = factories.NotificationSubscriptionFactory(
             object_id=self.private_node.id,
             content_type=ContentType.objects.get_for_model(self.private_node),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.FILE_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.FILE_UPDATED)
         )
         self.private_sub.save()
         # for file subscription
         self.file_sub = factories.NotificationSubscriptionFactory(
             object_id=self.project.id,
             content_type=ContentType.objects.get_for_model(self.project),
-            notification_type=NotificationType.objects.get(name=NotificationType.Type.NODE_FILES_UPDATED)
+            notification_type=NotificationType.objects.get(name=NotificationTypeEnum.NODE_FILES_UPDATED)
         )
         self.file_sub.save()
 
@@ -439,7 +439,7 @@ class TestFileCopied(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_COPIED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_COPIED
 
     def test_user_performing_action_no_email(self):
         # Move Event: Makes sure user who performed the action is not
@@ -449,7 +449,7 @@ class TestFileCopied(OsfTestCase):
         with capture_notifications() as notifications:
             self.event.perform()
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.ADDON_FILE_COPIED
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.ADDON_FILE_COPIED
 
 
 class TestSubscriptionManipulations(OsfTestCase):

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote_plus
 
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from tests.base import OsfTestCase
 from osf_tests.factories import (
     AuthUserFactory,
@@ -50,7 +50,7 @@ class TestForgotPassword(OsfTestCase):
             res = form.submit(self.app)
         # check mail was sent
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORGOT_PASSWORD
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORGOT_PASSWORD
         # check http 200 response
         assert res.status_code == 200
         # check request URL is /forgotpassword
@@ -152,7 +152,7 @@ class TestForgotPasswordInstitution(OsfTestCase):
 
         # check mail was sent
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_FORGOT_PASSWORD_INSTITUTION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_FORGOT_PASSWORD_INSTITUTION
         # check http 200 response
         assert res.status_code == 200
         # check request URL is /forgotpassword

--- a/tests/test_misc_views.py
+++ b/tests/test_misc_views.py
@@ -21,7 +21,7 @@ from osf.models import (
     Comment,
     OSFUser,
     SpamStatus,
-    NodeRelation, NotificationType,
+    NodeRelation, NotificationTypeEnum,
 )
 from osf.utils import permissions
 from osf_tests.factories import (
@@ -423,7 +423,7 @@ class TestExternalAuthViews(OsfTestCase):
         with capture_notifications() as notifications:
             res = self.app.get(url)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_EXTERNAL_LOGIN_LINK_SUCCESS
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_EXTERNAL_LOGIN_LINK_SUCCESS
         assert res.status_code == 302, 'redirects to cas login'
         assert 'You should be redirected automatically' in str(res.html)
         assert '/login?service=' in res.location

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -26,7 +26,7 @@ from addons.osfstorage.models import OsfStorageFile
 from addons.base import views
 from admin_tests.utilities import setup_view
 from api.preprints.views import PreprintContributorDetail
-from osf.models import Tag, Preprint, PreprintLog, PreprintContributor, NotificationType
+from osf.models import Tag, Preprint, PreprintLog, PreprintContributor, NotificationTypeEnum
 from osf.exceptions import PreprintStateError, ValidationError, ValidationValueError
 from osf_tests.factories import (
     ProjectFactory,
@@ -2014,12 +2014,12 @@ class TestPreprintConfirmationEmails(OsfTestCase):
         with capture_notifications() as notifications:
             self.preprint.set_published(True, auth=Auth(self.user), save=True)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
 
         with capture_notifications() as notifications:
             self.preprint_branded.set_published(True, auth=Auth(self.user), save=True)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.PROVIDER_REVIEWS_SUBMISSION_CONFIRMATION
 
 class TestPreprintOsfStorage(OsfTestCase):
     def setUp(self):

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -22,7 +22,7 @@ from osf.exceptions import (
     InvalidSanctionApprovalToken, InvalidSanctionRejectionToken,
     NodeStateError,
 )
-from osf.models import Contributor, Retraction, NotificationType
+from osf.models import Contributor, Retraction, NotificationTypeEnum
 from osf.utils import permissions
 from tests.utils import capture_notifications
 
@@ -804,7 +804,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
                 auth=self.user.auth,
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_PENDING_RETRACTION_ADMIN
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_PENDING_RETRACTION_ADMIN
 
     def test_POST_pending_embargo_returns_HTTPError_HTTPOK(self):
         self.registration.embargo_registration(
@@ -900,7 +900,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
                 auth=self.user.auth,
             )
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.NODE_PENDING_RETRACTION_ADMIN
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.NODE_PENDING_RETRACTION_ADMIN
 
     def test_non_contributor_GET_approval_returns_HTTPError_FORBIDDEN(self):
         non_contributor = AuthUserFactory()

--- a/tests/test_resend_confirmation.py
+++ b/tests/test_resend_confirmation.py
@@ -1,4 +1,4 @@
-from osf.models import NotificationType
+from osf.models import NotificationTypeEnum
 from tests.base import OsfTestCase
 from osf_tests.factories import (
     UserFactory,
@@ -34,7 +34,7 @@ class TestResendConfirmation(OsfTestCase):
             res = form.submit(self.app)
         # check email, request and response
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.USER_INITIAL_CONFIRM_EMAIL
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_INITIAL_CONFIRM_EMAIL
         assert res.status_code == 200
         assert res.request.path == self.post_url
 

--- a/tests/test_spam_mixin.py
+++ b/tests/test_spam_mixin.py
@@ -10,7 +10,7 @@ from framework.auth import Auth
 
 from tests.base import DbTestCase
 from osf_tests.factories import UserFactory, CommentFactory, ProjectFactory, PreprintFactory, RegistrationFactory, AuthUserFactory
-from osf.models import NotableDomain, SpamStatus, NotificationType
+from osf.models import NotableDomain, SpamStatus, NotificationTypeEnum
 from tests.utils import capture_notifications
 from website import settings
 
@@ -27,7 +27,7 @@ def test_throttled_autoban():
             proj.save()
             projects.append(proj)
     assert len(notifications['emits']) == 1
-    assert notifications['emits'][0]['type'] == NotificationType.Type.USER_SPAM_BANNED
+    assert notifications['emits'][0]['type'] == NotificationTypeEnum.USER_SPAM_BANNED
     user.reload()
     assert user.is_disabled
     for project in projects:

--- a/tests/test_triggered_mails.py
+++ b/tests/test_triggered_mails.py
@@ -8,7 +8,7 @@ from tests.base import OsfTestCase
 from tests.utils import run_celery_tasks, capture_notifications
 
 from osf_tests.factories import UserFactory
-from osf.models import EmailTask, NotificationType
+from osf.models import EmailTask, NotificationTypeEnum
 
 from scripts.triggered_mails import (
     find_inactive_users_without_enqueued_or_sent_no_login,
@@ -84,7 +84,7 @@ class TestTriggeredMails(OsfTestCase):
 
         # Force the emit call to raise to exercise failure branch
         with mock.patch.object(
-            NotificationType.Type.USER_NO_LOGIN.instance,
+            NotificationTypeEnum.USER_NO_LOGIN.instance,
             'emit',
             side_effect=RuntimeError('kaboom'),
         ), run_celery_tasks():

--- a/tests/test_user_profile_view.py
+++ b/tests/test_user_profile_view.py
@@ -9,7 +9,7 @@ from rest_framework import status as http_status
 from addons.github.tests.factories import GitHubAccountFactory
 from framework.celery_tasks import handlers
 from osf.external.spam import tasks as spam_tasks
-from osf.models import NotableDomain, NotificationType
+from osf.models import NotableDomain, NotificationTypeEnum
 from osf_tests.factories import (
     fake_email,
     ApiOAuth2ApplicationFactory,
@@ -728,7 +728,7 @@ class TestUserAccount(OsfTestCase):
         with capture_notifications() as notifications:
             self.app.post(url, auth=self.user.auth)
         assert len(notifications['emits']) == 1
-        assert notifications['emits'][0]['type'] == NotificationType.Type.DESK_REQUEST_EXPORT
+        assert notifications['emits'][0]['type'] == NotificationTypeEnum.DESK_REQUEST_EXPORT
 
         res = self.app.post(url, auth=self.user.auth)
         assert res.status_code == 400

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -539,7 +539,7 @@ def _safe_obj_id(obj: Any) -> Optional[str]:
 @contextlib.contextmanager
 def assert_notification(
     *,
-    type,                       # NotificationType, NotificationType.Type, or str
+    type,                       # NotificationType, NotificationTypeEnum, or str
     user: Any = None,           # optional user object to match
     subscribed_object: Any = None,  # optional object (e.g., node) to match
     times: int = 1,             # exact number of emits expected
@@ -549,7 +549,7 @@ def assert_notification(
 ):
     """
     Usage:
-        with assert_notification(type=NotificationType.Type.NODE_FORK_COMPLETED, user=self.user):
+        with assert_notification(type=NotificationTypeEnum.NODE_FORK_COMPLETED, user=self.user):
             <code that emits>
     """
     expected_type = _notif_type_name(type)

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -27,9 +27,9 @@ def normalize_unicode_filenames(filename):
 
 
 def send_archiver_size_exceeded_mails(src, user, stat_result, url):
-    from osf.models.notification_type import NotificationType
+    from osf.models.notification_type import NotificationTypeEnum
 
-    NotificationType.Type.DESK_ARCHIVE_JOB_EXCEEDED.instance.emit(
+    NotificationTypeEnum.DESK_ARCHIVE_JOB_EXCEEDED.instance.emit(
         destination_address=settings.OSF_SUPPORT_EMAIL,
         subscribed_object=src,
         event_context={
@@ -44,7 +44,7 @@ def send_archiver_size_exceeded_mails(src, user, stat_result, url):
             'can_change_preferences': False,
         }
     )
-    NotificationType.Type.USER_ARCHIVE_JOB_EXCEEDED.instance.emit(
+    NotificationTypeEnum.USER_ARCHIVE_JOB_EXCEEDED.instance.emit(
         user=user,
         subscribed_object=user,
         event_context={
@@ -59,9 +59,9 @@ def send_archiver_size_exceeded_mails(src, user, stat_result, url):
 
 
 def send_archiver_copy_error_mails(src, user, results, url):
-    from osf.models.notification_type import NotificationType
+    from osf.models.notification_type import NotificationTypeEnum
 
-    NotificationType.Type.DESK_ARCHIVE_JOB_COPY_ERROR.instance.emit(
+    NotificationTypeEnum.DESK_ARCHIVE_JOB_COPY_ERROR.instance.emit(
         destination_address=settings.OSF_SUPPORT_EMAIL,
         event_context={
             'domain': settings.DOMAIN,
@@ -75,7 +75,7 @@ def send_archiver_copy_error_mails(src, user, results, url):
             'can_change_preferences': False,
         }
     )
-    NotificationType.Type.USER_ARCHIVE_JOB_COPY_ERROR.instance.emit(
+    NotificationTypeEnum.USER_ARCHIVE_JOB_COPY_ERROR.instance.emit(
         user=user,
         event_context={
             'domain': settings.DOMAIN,
@@ -90,9 +90,9 @@ def send_archiver_copy_error_mails(src, user, results, url):
     )
 
 def send_archiver_file_not_found_mails(src, user, results, url):
-    from osf.models.notification_type import NotificationType
+    from osf.models.notification_type import NotificationTypeEnum
 
-    NotificationType.Type.DESK_ARCHIVE_JOB_FILE_NOT_FOUND.instance.emit(
+    NotificationTypeEnum.DESK_ARCHIVE_JOB_FILE_NOT_FOUND.instance.emit(
         destination_address=settings.OSF_SUPPORT_EMAIL,
         event_context={
             'user': user.id,
@@ -102,7 +102,7 @@ def send_archiver_file_not_found_mails(src, user, results, url):
             'can_change_preferences': False,
         }
     )
-    NotificationType.Type.USER_ARCHIVE_JOB_FILE_NOT_FOUND.instance.emit(
+    NotificationTypeEnum.USER_ARCHIVE_JOB_FILE_NOT_FOUND.instance.emit(
         user=user,
         event_context={
             'user': user.id,
@@ -115,9 +115,9 @@ def send_archiver_file_not_found_mails(src, user, results, url):
     )
 
 def send_archiver_uncaught_error_mails(src, user, results, url):
-    from osf.models.notification_type import NotificationType
+    from osf.models.notification_type import NotificationTypeEnum
 
-    NotificationType.Type.DESK_ARCHIVE_JOB_UNCAUGHT_ERROR.instance.emit(
+    NotificationTypeEnum.DESK_ARCHIVE_JOB_UNCAUGHT_ERROR.instance.emit(
         destination_address=settings.OSF_SUPPORT_EMAIL,
         event_context={
             'user_fullname': user.fullname,
@@ -132,7 +132,7 @@ def send_archiver_uncaught_error_mails(src, user, results, url):
             'can_change_preferences': False,
         }
     )
-    NotificationType.Type.USER_ARCHIVE_JOB_UNCAUGHT_ERROR.instance.emit(
+    NotificationTypeEnum.USER_ARCHIVE_JOB_UNCAUGHT_ERROR.instance.emit(
         user=user,
         event_context={
             'user_fullname': user.fullname,

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -5,7 +5,6 @@ from django.db.models import Q
 
 from osf.utils.permissions import READ
 from website.notifications import constants
-from website.notifications.exceptions import InvalidSubscriptionError
 from website.project import signals
 
 class NotificationsDict(dict):
@@ -401,56 +400,6 @@ def subscribe_user_to_global_notifications(user):
         subscription, created = NotificationSubscription.objects.get_or_create(_id=user_event_id, user=user, event_name=user_event)
         subscription.add_user_to_subscription(user, notification_type)
         subscription.save()
-
-
-def subscribe_user_to_notifications(node, user):
-    """ Update the notification settings for the creator or contributors
-    :param user: User to subscribe to notifications
-    """
-    NotificationSubscription = apps.get_model('osf.NotificationSubscription')
-    Preprint = apps.get_model('osf.Preprint')
-    DraftRegistration = apps.get_model('osf.DraftRegistration')
-    if isinstance(node, Preprint):
-        raise InvalidSubscriptionError('Preprints are invalid targets for subscriptions at this time.')
-
-    if isinstance(node, DraftRegistration):
-        raise InvalidSubscriptionError('DraftRegistrations are invalid targets for subscriptions at this time.')
-
-    if node.is_collection:
-        raise InvalidSubscriptionError('Collections are invalid targets for subscriptions')
-
-    if node.is_deleted:
-        raise InvalidSubscriptionError('Deleted Nodes are invalid targets for subscriptions')
-
-    if getattr(node, 'is_registration', False):
-        raise InvalidSubscriptionError('Registrations are invalid targets for subscriptions')
-
-    events = constants.NODE_SUBSCRIPTIONS_AVAILABLE
-    notification_type = 'email_transactional'
-    target_id = node._id
-
-    if user.is_registered:
-        for event in events:
-            event_id = to_subscription_key(target_id, event)
-            global_event_id = to_subscription_key(user._id, 'global_' + event)
-            global_subscription = NotificationSubscription.load(global_event_id)
-
-            subscription = NotificationSubscription.load(event_id)
-
-            # If no subscription for component and creator is the user, do not create subscription
-            # If no subscription exists for the component, this means that it should adopt its
-            # parent's settings
-            if not (node and node.parent_node and not subscription and node.creator == user):
-                if not subscription:
-                    subscription = NotificationSubscription(_id=event_id, owner=node, event_name=event)
-                    # Need to save here in order to access m2m fields
-                    subscription.save()
-                if global_subscription:
-                    global_notification_type = get_global_notification_type(global_subscription, user)
-                    subscription.add_user_to_subscription(user, global_notification_type)
-                else:
-                    subscription.add_user_to_subscription(user, notification_type)
-                subscription.save()
 
 
 def format_user_and_project_subscriptions(user):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -26,7 +26,7 @@ from framework.status import push_status_message
 from framework.utils import throttle_period_expired
 
 from osf import features
-from osf.models import ApiOAuth2Application, ApiOAuth2PersonalToken, OSFUser, NotificationType
+from osf.models import ApiOAuth2Application, ApiOAuth2PersonalToken, OSFUser, NotificationTypeEnum
 from osf.exceptions import BlockedEmailError, OSFError
 from osf.utils.requests import string_type_request_headers
 from website import mailchimp_utils
@@ -187,7 +187,7 @@ def update_user(auth):
 
         # make sure the new username has already been confirmed
         if username and username != user.username and user.emails.filter(address=username).exists():
-            NotificationType.Type.USER_PRIMARY_EMAIL_CHANGED.instance.emit(
+            NotificationTypeEnum.USER_PRIMARY_EMAIL_CHANGED.instance.emit(
                 subscribed_object=user,
                 user=user,
                 event_context={
@@ -798,7 +798,7 @@ def request_export(auth):
                         data={'message_long': 'Too many requests. Please wait a while before sending another account export request.',
                               'error_type': 'throttle_error'})
 
-    NotificationType.Type.DESK_REQUEST_EXPORT.instance.emit(
+    NotificationTypeEnum.DESK_REQUEST_EXPORT.instance.emit(
         user=user,
         event_context={
             'user_username': user.username,

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -26,7 +26,7 @@ from osf.models import (
     Preprint,
     PreprintProvider,
     RecentlyAddedContributor,
-    NotificationType
+    NotificationTypeEnum
 )
 from osf.utils import sanitize
 from osf.utils.permissions import ADMIN
@@ -214,7 +214,7 @@ def finalize_invitation(
         node,
         contributor,
         auth,
-        notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+        notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 ):
     try:
         record = contributor.get_unclaimed_record(node._primary_key)
@@ -436,7 +436,7 @@ def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 360
     )
     if check_email_throttle(
             referrer,
-            notification_type=NotificationType.Type.USER_FORWARD_INVITE_REGISTERED,
+            notification_type=NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED,
             throttle=throttle
     ):
         raise HTTPError(
@@ -447,7 +447,7 @@ def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 360
         )
 
     # Send mail to referrer, telling them to forward verification link to claimer
-    NotificationType.Type.USER_FORWARD_INVITE_REGISTERED.instance.emit(
+    NotificationTypeEnum.USER_FORWARD_INVITE_REGISTERED.instance.emit(
         user=referrer,
         event_context={
             'claim_url': claim_url,
@@ -459,7 +459,7 @@ def send_claim_registered_email(claimer, unclaimed_user, node, throttle=24 * 360
         }
     )
     # Send mail to claimer, telling them to wait for referrer
-    NotificationType.Type.USER_PENDING_VERIFICATION_REGISTERED.instance.emit(
+    NotificationTypeEnum.USER_PENDING_VERIFICATION_REGISTERED.instance.emit(
         subscribed_object=claimer,
         user=claimer,
         event_context={
@@ -479,7 +479,7 @@ def send_claim_email(
     node,
     notify=True,
     throttle=24 * 3600,
-    notification_type=NotificationType.Type.NODE_CONTRIBUTOR_ADDED_DEFAULT
+    notification_type=NotificationTypeEnum.NODE_CONTRIBUTOR_ADDED_DEFAULT
 ):
     """
     Send a claim email to an unregistered contributor or the referrer, depending on the scenario.
@@ -508,15 +508,15 @@ def send_claim_email(
         match notification_type:
             case 'preprint':
                 if getattr(node.provider, 'is_default', False):
-                    notification_type = NotificationType.Type.USER_INVITE_OSF_PREPRINT
+                    notification_type = NotificationTypeEnum.USER_INVITE_OSF_PREPRINT
                     logo = settings.OSF_PREPRINTS_LOGO
                 else:
-                    notification_type = NotificationType.Type.PROVIDER_USER_INVITE_PREPRINT
+                    notification_type = NotificationTypeEnum.PROVIDER_USER_INVITE_PREPRINT
                     logo = getattr(node.provider, '_id', None)
             case 'draft_registration':
-                notification_type = NotificationType.Type.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
+                notification_type = NotificationTypeEnum.DRAFT_REGISTRATION_CONTRIBUTOR_ADDED_DEFAULT
             case _:
-                notification_type = NotificationType.Type.USER_INVITE_DEFAULT
+                notification_type = NotificationTypeEnum.USER_INVITE_DEFAULT
 
         unclaimed_record['claimer_email'] = claimer_email
         unclaimed_user.save()
@@ -539,7 +539,7 @@ def send_claim_email(
         unclaimed_user.save()
 
         if notify:
-            NotificationType.Type.USER_PENDING_VERIFICATION.instance.emit(
+            NotificationTypeEnum.USER_PENDING_VERIFICATION.instance.emit(
                 subscribed_object=unclaimed_user,
                 user=unclaimed_user,
                 event_context={
@@ -552,7 +552,7 @@ def send_claim_email(
                 }
             )
 
-        notification_type = NotificationType.Type.USER_FORWARD_INVITE
+        notification_type = NotificationTypeEnum.USER_FORWARD_INVITE
     claim_url = unclaimed_user.get_claim_url(node._primary_key, external=True)
 
     notification_type.instance.emit(
@@ -626,7 +626,7 @@ def notify_added_contributor(resource, contributor, notification_type, auth=None
 
     logo = settings.OSF_LOGO
     if getattr(resource, 'has_linked_published_preprints', None):
-        notification_type = NotificationType.Type.PREPRINT_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF
+        notification_type = NotificationTypeEnum.PREPRINT_CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF
         logo = settings.OSF_PREPRINTS_LOGO
 
     throttle = kwargs.get('throttle', settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE)

--- a/website/reviews/listeners.py
+++ b/website/reviews/listeners.py
@@ -27,7 +27,7 @@ def reviews_notification(self, creator, template, context, action):
 def reviews_withdraw_requests_notification_moderators(self, timestamp, context, user, resource):
     context['referrer_fullname'] = user.fullname
     provider = resource.provider
-    from osf.models import NotificationType
+    from osf.models import NotificationTypeEnum
 
     context['message'] = f'has requested withdrawal of "{resource.title}".'
     context['reviews_submission_url'] = f'{DOMAIN}reviews/registries/{provider._id}/{resource._id}'
@@ -38,7 +38,7 @@ def reviews_withdraw_requests_notification_moderators(self, timestamp, context, 
             context['user_fullname'] = recipient.fullname
             context['recipient_fullname'] = recipient.fullname
 
-            NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
                 user=recipient,
                 subscribed_object=provider,
                 event_context=context,
@@ -51,7 +51,7 @@ def reviews_withdrawal_requests_notification(self, timestamp, context):
     context['reviewable_absolute_url'] = preprint.absolute_url
     context['reviewable_title'] = preprint.title
     context['reviewable__id'] = preprint._id
-    from osf.models import NotificationType
+    from osf.models import NotificationTypeEnum
 
     preprint_word = preprint.provider.preprint_word
     context['message'] = f'has requested withdrawal of the {preprint_word} "{preprint.title}".'
@@ -63,7 +63,7 @@ def reviews_withdrawal_requests_notification(self, timestamp, context):
             context['user_fullname'] = recipient.fullname
             context['recipient_fullname'] = recipient.fullname
 
-            NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
                 user=recipient,
                 event_context=context,
                 subscribed_object=preprint.provider,
@@ -103,7 +103,7 @@ def reviews_submit_notification_moderators(self, timestamp, resource, context):
         else:
             context['message'] = f'submitted "{resource.title}".'
 
-    from osf.models import NotificationType
+    from osf.models import NotificationTypeEnum
     context['requester_contributor_names'] = ''.join(resource.contributors.values_list('fullname', flat=True))
     context['localized_timestamp'] = str(timezone.now())
 
@@ -114,7 +114,7 @@ def reviews_submit_notification_moderators(self, timestamp, resource, context):
             context['requester_fullname'] = recipient.fullname
             context['is_request_email'] = False
 
-            NotificationType.Type.PROVIDER_NEW_PENDING_SUBMISSIONS.instance.emit(
+            NotificationTypeEnum.PROVIDER_NEW_PENDING_SUBMISSIONS.instance.emit(
                 user=recipient,
                 subscribed_object=provider,
                 event_context=context,


### PR DESCRIPTION
## Purpose

Refactor notification type references to use NotificationTypeEnum

- Updated all instances of NotificationType.Type to NotificationTypeEnum in test files and application code.
- Ensured consistency in notification type usage.
- This change improves clarity and maintainability by standardizing the notification type references.

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9857
