### PR TITLE
[ENG-9913] Return mergerer page in case user was merged into another account

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -103,6 +103,7 @@ class UserSerializer(JSONAPISerializer):
             {
                 'html': 'absolute_url',
                 'profile_image': 'profile_image_url',
+                'merged_by': 'get_merged_by_absolute_url',
             },
         ),
     )
@@ -239,6 +240,10 @@ class UserSerializer(JSONAPISerializer):
 
     def get_accepted_terms_of_service(self, obj):
         return bool(obj.accepted_terms_of_service)
+
+    def get_merged_by_absolute_url(self, obj):
+        if obj.merged_by:
+            return obj.merged_by.absolute_url
 
     def profile_image_url(self, user):
         size = self.context['request'].query_params.get('profile_image_size')


### PR DESCRIPTION
## Purpose

Angular hasn't any info if user account was merged into another account that makes it impossible to notify users about it and redirect them to the new account

## Changes

Added a new field in a serializer

## Ticket

https://openscience.atlassian.net/browse/ENG-9913