### PR TITLE
[ENG-9727] unable to create new version of a preprint when registration field has content

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -325,6 +325,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
 
         updated_has_prereg_links = validated_data.get('has_prereg_links', preprint.has_prereg_links)
         updated_why_no_prereg = validated_data.get('why_no_prereg', preprint.why_no_prereg)
+        prereg_links = validated_data.get('prereg_links', preprint.prereg_links)
 
         if updated_has_coi is False and updated_conflict_statement:
             raise exceptions.ValidationError(
@@ -341,7 +342,7 @@ class PreprintSerializer(TaxonomizableSerializerMixin, MetricsSerializerMixin, J
                 detail='Cannot provide data links when has_data_links is set to "no".',
             )
 
-        if updated_has_prereg_links != 'no' and updated_why_no_prereg:
+        if updated_has_prereg_links != 'no' and (updated_why_no_prereg and not prereg_links):
             raise exceptions.ValidationError(
                 detail='You cannot edit this statement while your prereg links availability is set to true or is unanswered.',
             )


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When attempting to create a new version of a preprint, user received the following error message:

"You cannot edit this statement while your prereg links availability is set to true or is unanswered."

Example:

https://osf.io/preprints/psyarxiv/jkfsx_v1 

User has https://osf.io/preprints/psyarxiv/jkfsx_v1 linked in the prereg section of the preprint

When user goes to either edit or create new version they receive the same error message. User is unable to adjust any settings leads me back to the same error message. User tried multiple browsers and logging in/out.

Support team was unable to reproduce on test.

## Changes


check prereg_links exists before raising exception (for current workflow it looks to be impossible 'why_no_prereg' be empty and 'prereg_links' exists simultaniously)


<img width="3454" height="1804" alt="image" src="https://github.com/user-attachments/assets/83346642-28de-48a2-95d0-b399b626acab" />

<img width="3428" height="1748" alt="image" src="https://github.com/user-attachments/assets/9e87952c-cbf7-40ac-9518-6e9bc5c160fe" />

<img width="3455" height="1846" alt="image" src="https://github.com/user-attachments/assets/acab2ded-d9cd-4c98-995e-8fb47eaf9078" />

for now
we can have either `why_no_prereg` or   `has_prereg_links` and `prereg_links` set simultaniously
and it is impossible to set all the records like it  for record https://osf.io/preprints/psyarxiv/jkfsx_v1 and maybe some other records

<img width="2489" height="1014" alt="image" src="https://github.com/user-attachments/assets/8a01bf82-0feb-4fac-b937-a3ac9a54fa53" />


## QA Notes

Not succeeed to reproduce the issue for staging

have tried to hardcode preprint antributes that is for https://osf.io/preprints/psyarxiv/jkfsx_v1  on local testing

https://github.com/user-attachments/assets/3bbd58f6-7e9f-46b2-8a2d-318e0b256e33


Any concerns/considerations/questions that development raised?


## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/ENG-9727