### PR TITLE
[ENG-9968] Fix beat_schedule key name for send_no_addon_email

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -620,7 +620,7 @@ class CeleryConfig:
             'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m
             'kwargs': {'dry_run': False},
         },
-        'no_login_mails': {
+        'no_addon_emails': {
             'task': 'notifications.tasks.send_no_addon_email',
             'schedule': crontab(minute=0, hour=17),  # Daily 12 p.m
             'kwargs': {'dry_run': False},


### PR DESCRIPTION
## Purpose

Fix beat_schedule key name for send_no_addon_email

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9968
