### PR TITLE
[ENG-9985] Only the creator admin receives approval/deny email for registrations

### DIFF
--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -412,7 +412,7 @@ class EmailApprovableSanction(TokenApprovableSanction):
             return
         for contrib, node in group:
             if contrib._id in self.approval_state:
-                return self.AUTHORIZER_NOTIFY_EMAIL_TYPE.instance.emit(
+                self.AUTHORIZER_NOTIFY_EMAIL_TYPE.instance.emit(
                     user=contrib,
                     subscribed_object=node,
                     event_context=self._email_template_context(
@@ -422,7 +422,7 @@ class EmailApprovableSanction(TokenApprovableSanction):
                     )
                 )
             else:
-                return self.NON_AUTHORIZER_NOTIFY_EMAIL_TYPE.instance.emit(
+                self.NON_AUTHORIZER_NOTIFY_EMAIL_TYPE.instance.emit(
                     user=contrib,
                     subscribed_object=node,
                     event_context=self._email_template_context(contrib, node)


### PR DESCRIPTION
## Purpose

Only the creator admin receives approval/deny email for registrations

## Changes

See diff 

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9985
