### PR TITLE
[ENG-9970] Check for the POPULATE_NOTIFICATION_TYPES switch only during the post-migration process

### DIFF
--- a/osf/management/commands/populate_notification_types.py
+++ b/osf/management/commands/populate_notification_types.py
@@ -20,10 +20,11 @@ FREQ_MAP = {
 }
 
 def populate_notification_types(*args, **kwargs):
-    if not switch_is_active(features.POPULATE_NOTIFICATION_TYPES):
-        if 'pytest' not in sys.modules:
-            logger.info('POPULATE_NOTIFICATION_TYPES switch is off; skipping population of notification types.')
-            return
+    if kwargs.get('sender'):  # exists when called as a post_migrate signal
+        if not switch_is_active(features.POPULATE_NOTIFICATION_TYPES):
+            if 'pytest' not in sys.modules:
+                logger.info('POPULATE_NOTIFICATION_TYPES switch is off; skipping population of notification types.')
+                return
     logger.info('Populating notification types...')
     from django.contrib.contenttypes.models import ContentType
     from osf.models.notification_type import NotificationType


### PR DESCRIPTION
## Purpose

Check for the POPULATE_NOTIFICATION_TYPES switch only during the post-migration process

## Changes

See diff

## QA Notes

N/A

## Documentation

N/A

## Side Effects

N/A

## Ticket

https://openscience.atlassian.net/browse/ENG-9970
