### PR TITLE
[hotfix/26.1.5] [ENG-10026] Enable admin/admin read-only access to include all four notification tables

### DIFF
--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -61,6 +61,10 @@ def get_admin_read_permissions():
         'view_registration',
         'view_registrationapproval',
         'view_registrationschema',
+        'view_notification',
+        'view_notificationtype',
+        'view_notificationsubscription',
+        'view_emailtask',
     ])
 
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-10026

## Purpose

Enable admin/admin read-only access to include all four notification tables (type, notification, subscription and task)

## Changes

See diff

## Side Effects

N/A

## QE Notes

N/A

## CE Notes

N/A

## Documentation

N/A
