### PR TITLE
[hotfix/26.1.5] [ENG-10026] Enable admin/admin write access to include all four notification tables

### DIFF
--- a/osf/migrations/__init__.py
+++ b/osf/migrations/__init__.py
@@ -107,7 +107,15 @@ def get_admin_write_permissions():
         'change_notabledomain',
         'delete_notabledomain',
         'change_cedarmetadatatemplate',
-        'change_registrationapproval'
+        'change_registrationapproval',
+        'change_notification',
+        'delete_notification',
+        'change_notificationtype',
+        'delete_notificationtype',
+        'change_notificationsubscription',
+        'delete_notificationsubscription',
+        'change_emailtask',
+        'delete_emailtask',
     ])
 
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-10026 follow-up

## Purpose

Enable admin/admin write access to include all four notification tables (type, notification, subscription and task)

## Changes

See diff

## Side Effects

N/A

## QE Notes

N/A

## CE Notes

N/A

## Documentation

N/A
