### PR TITLE
[hotfix/26.1.5] [ENG-10027] Fix links in registration moderator digest emails

### DIFF
--- a/notifications/listeners.py
+++ b/notifications/listeners.py
@@ -97,7 +97,7 @@ def reviews_withdraw_requests_notification_moderators(self, timestamp, context, 
     # Set message
     context['message'] = f'has requested withdrawal of "{resource.title}".'
     # Set submission url
-    context['reviews_submission_url'] = f'{DOMAIN}registries/{provider._id}/{resource._id}?mode=moderator'
+    context['reviews_submission_url'] = f'{DOMAIN}{resource._id}?mode=moderator'
     context['localized_timestamp'] = str(timestamp)
     NotificationType.Type.PROVIDER_NEW_PENDING_WITHDRAW_REQUESTS.instance.emit(
         subscribed_object=provider,

--- a/website/reviews/listeners.py
+++ b/website/reviews/listeners.py
@@ -32,7 +32,7 @@ def reviews_withdraw_requests_notification_moderators(self, timestamp, context, 
     from osf.models import NotificationType
 
     context['message'] = f'has requested withdrawal of "{resource.title}".'
-    context['reviews_submission_url'] = f'{DOMAIN}registries/{provider._id}/{resource._id}?mode=moderator'
+    context['reviews_submission_url'] = f'{DOMAIN}{resource._id}?mode=moderator'
 
     context['provider_id'] = provider.id
     for group_name in ['moderator', 'admin']:
@@ -91,7 +91,7 @@ def reviews_submit_notification_moderators(self, timestamp, resource, context):
     if provider.type == 'osf.preprintprovider':
         context['reviews_submission_url'] = f'{DOMAIN}preprints/{provider._id}/{resource._id}?mode=moderator'
     elif provider.type == 'osf.registrationprovider':
-        context['reviews_submission_url'] = f'{DOMAIN}registries/{provider._id}/{resource._id}?mode=moderator'
+        context['reviews_submission_url'] = f'{DOMAIN}/{resource._id}?mode=moderator'
     else:
         raise NotImplementedError(f'unsupported provider type {provider.type}')
 


### PR DESCRIPTION
## Ticket

* [ENG-10027](https://openscience.atlassian.net/browse/ENG-10027)

## Purpose

Fix link in moderator digest emails

## Changes

Follow-up fix for https://github.com/CenterForOpenScience/osf.io/pull/11537 which fix the preprints correctly but got the registrations wrong

## Side Effects

N/A

## QE Notes

* Test moderation digest emails to make sure it brings moderator/admin to the review page of a preprint or registration

## CE Notes

N/A

## Documentation

N/A


[ENG-10027]: https://openscience.atlassian.net/browse/ENG-10027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ