### PR TITLE
avoid 502 on creating preprint version from rejected version

### DIFF
--- a/osf/models/preprint.py
+++ b/osf/models/preprint.py
@@ -407,7 +407,7 @@ class Preprint(DirtyFieldsMixin, VersionedGuidMixin, IdentifierMixin, Reviewable
         """Check and return the "initiated but unfinished version" and "unfinished or unpublished version".
         """
         last_not_rejected_version = self.get_last_not_rejected_version()
-        if last_not_rejected_version.date_published:
+        if not last_not_rejected_version or last_not_rejected_version.date_published:
             return None, None
         if last_not_rejected_version.machine_state == 'initial':
             return last_not_rejected_version, None


### PR DESCRIPTION
[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* https://openscience.atlassian.net/browse/ENG-11009

## Purpose

502 on creating preprint version from rejected version

## Changes

avoid `AttributeError: 'NoneType' object has no attribute 'date_published'`

https://github.com/user-attachments/assets/471e6881-c75c-4618-bd22-03064f9b58f7



## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
