### PR TITLE
Hotfix/26.10.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 
 We follow the CalVer (https://calver.org/) versioning scheme: YY.MINOR.MICRO.
 
+26.10.1 (2026-05-22)
+====================
+
+- Hotfix to resume (rather than restart) a long task after connection error
+
 26.10.0 (2026-05-19)
 ===================
 

--- a/osf/management/commands/migrate_osfmetrics_6to8.py
+++ b/osf/management/commands/migrate_osfmetrics_6to8.py
@@ -18,6 +18,7 @@ from elasticsearch_metrics.imps import elastic8 as djel8me
 from psycopg2 import OperationalError as PostgresOperationalError
 
 from framework.celery_tasks import app as celery_app
+from framework.sentry import log_exception
 from osf.metadata.rdfutils import OSF
 from osf.metadata.osfmap_utils import is_osf_component
 from osf.metrics.preprint_metrics import (
@@ -72,13 +73,14 @@ _UNCHANGED_RECORDTYPES = {
     RegistriesModerationMetrics: es8_metrics.RegistriesModerationEventEs8,
 }
 
+_RETRY_ERRORS = (
+    DjangoOperationalError,
+    Elastic6ConnectionError,
+    Elastic8TransportError,
+    PostgresOperationalError,
+)
 _TASK_KWARGS = dict(
-    autoretry_for=(
-        DjangoOperationalError,
-        Elastic6ConnectionError,
-        Elastic8TransportError,
-        PostgresOperationalError,
-    ),
+    autoretry_for=_RETRY_ERRORS,
     retry_backoff=True,  # exponential backoff, with jitter
     max_retries=20,
 )
@@ -145,14 +147,31 @@ def migrate_preprint_downloads(from_when: str, until_when: str):
 
 
 @celery_app.task(**_TASK_KWARGS)
-def schedule_migrate_usage_reports(until_when: str):
-    for _osfid in _merge_sorted_osfids(
-        _each_usage_report_osfid(until_when=until_when),
-        _each_countedusage_osfid(until_when=until_when),
-        _each_preprintview_osfid(until_when=until_when),
-        _each_preprintdownload_osfid(until_when=until_when),
-    ):
-        migrate_usage_reports.delay(_osfid, until_when)
+def schedule_migrate_usage_reports(until_when: str, after_osfid: str | None = None):
+    _last_osfid = None
+    try:
+        for _osfid in _merge_sorted_osfids(
+            _each_usage_report_osfid(until_when, after_osfid),
+            _each_countedusage_osfid(until_when, after_osfid),
+            _each_preprintview_osfid(until_when, after_osfid),
+            _each_preprintdownload_osfid(until_when, after_osfid),
+        ):
+            migrate_usage_reports.delay(_osfid, until_when)
+            _last_osfid = _osfid
+    except _RETRY_ERRORS as _error:
+        if _last_osfid is None:
+            raise  # didn't even get started
+        # schedule another task to continue scheduling
+        schedule_migrate_usage_reports.delay(
+            until_when,
+            after_osfid=(  # avoid infinite loop from _merge_sorted_osfids removing "_v1"
+                f'{_last_osfid}_v1'
+                if '_' not in _last_osfid
+                else _last_osfid
+            ),
+        )
+        # let this task succeed but log the error
+        log_exception(_error)
 
 
 @celery_app.task(**_TASK_KWARGS)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OSF",
-  "version": "26.10.0",
+  "version": "26.10.1",
   "description": "Facilitating Open Science",
   "repository": "https://github.com/CenterForOpenScience/osf.io",
   "author": "Center for Open Science",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "osf-io"
-version = "26.10.0"
+version = "26.10.1"
 description = "The code for [https://osf.io](https://osf.io)."
 authors = ["Your Name <you@example.com>"]
 license = "Apache License 2.0"


### PR DESCRIPTION
[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* [ENG-*****]()

## Purpose
avoid repeating/wasting work in osfmetrics 6to8 data migration

[//]: # (Briefly describe the purpose of this PR.)

## Changes
update `schedule_migrate_usage_reports` to resume scheduling after its
last success when encountering a connection error, instead of restarting
from the beginning

(it should have been this way already, the logic was there, oops)

[//]: # (Briefly describe or list your changes.)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
