### PR TITLE
[ENG-11297] Only remove OSF cookie and redirect to the request URL if cookie/session is invalid

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -164,7 +164,7 @@ def create_session(response, data=None):
 def before_request():
     # TODO: Fix circular import
     from framework.auth.core import get_user
-    from framework.auth import cas, utils
+    from framework.auth import cas
     UserSessionMap = apps.get_model('osf.UserSessionMap')
 
     # Request Type 1: Service ticket validation during CAS login.
@@ -215,8 +215,15 @@ def before_request():
         try:
             user_session = flask_get_session_from_cookie(cookie)
         except InvalidCookieOrSessionError:
-            # If invalid session/cookie happens, perform a full logout to clear both CAS and OSF Sessions
-            response = redirect(utils.get_default_osf_logout_url())
+            # If invalid session/cookie happens, only remove the invalid cookie and redirect to the same request.
+            # This ensures users landing on the page/link they previously clicked.
+            # Case 1: If it's a public page, they land on the correct page.
+            # Case 2: If it's a private page and if they already have a CAS cookie, they will be automatically logged
+            #         back in and land on the correct page.
+            # Case 3: If it's a private page and if they don't have a CAS cookie, they will need to manually log in.
+            #         After successful login, they will land on the correct page.
+            redirect_url = request.url
+            response = redirect(redirect_url)
             response.delete_cookie(settings.COOKIE_NAME, domain=settings.OSF_COOKIE_DOMAIN)
             return response
         # Case 1: anonymous session that is used for first time external (e.g. ORCiD) login only

--- a/tests/test_auth_basic_auth.py
+++ b/tests/test_auth_basic_auth.py
@@ -29,6 +29,7 @@ class TestAuthBasicAuthentication(OsfTestCase):
         self.reachable_project = ProjectFactory(title='Private Project User 1', is_public=False, creator=self.user1)
         self.unreachable_project = ProjectFactory(title='Private Project User 2', is_public=False, creator=self.user2)
         self.reachable_url = self.reachable_project.web_url_for('view_project')
+        self.reachable_absolute_url = self.reachable_project.web_url_for('view_project', _absolute=True)
         self.unreachable_url = self.unreachable_project.web_url_for('view_project')
 
     def test_missing_credential_fails(self):
@@ -97,6 +98,14 @@ class TestAuthBasicAuthentication(OsfTestCase):
         session = SessionStore(session_key=session_key)
         session.delete()
         self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
-        res = self.app.get(self.reachable_url)
+        res = self.app.get(self.reachable_absolute_url)
         assert res.status_code == 302
-        assert 'http://localhost:5000/logout/?next=http://localhost:4200/' == res.location
+        assert f'{settings.COOKIE_NAME}=;' in res.headers.get('Set-Cookie')
+        assert self.reachable_absolute_url == res.location
+
+    def test_invalid_cookie(self):
+        self.app.set_cookie(settings.COOKIE_NAME, str('INVALID_COOKIE'))
+        res = self.app.get(self.reachable_absolute_url)
+        assert res.status_code == 302
+        assert f'{settings.COOKIE_NAME}=;' in res.headers.get('Set-Cookie')
+        assert self.reachable_absolute_url == res.location


### PR DESCRIPTION
## Ticket

* [ENG-11297](https://openscience.atlassian.net/browse/ENG-11297)

## Purpose

Only remove OSF cookie and redirect to the request URL if cookie/session is invalid

## Changes

See diff

## Side Effects

N/A

## QE Notes

N/A

## CE Notes

N/A

## Documentation

N/A


[ENG-11297]: https://openscience.atlassian.net/browse/ENG-11297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ