### PR TITLE
fix: consistent shtrove record identifiers

### DIFF
--- a/api/share/utils.py
+++ b/api/share/utils.py
@@ -118,7 +118,7 @@ def share_update_cedar_metadata_record(self, referent_id, cedar_record_pk):
         shtrove_ingest_url(),
         params={
             'focus_iri': referent.get_semantic_iri(),
-            'record_identifier': _shtrove_cedar_record_identifier(cedar_record._id, cedar_record.template.cedar_id),
+            'record_identifier': _shtrove_cedar_record_identifier(referent._id, cedar_record.template.cedar_id),
             'is_supplementary': True,
         },
         headers={
@@ -142,7 +142,7 @@ def share_delete_cedar_metadata_record(
     response = requests.delete(
         shtrove_ingest_url(),
         params={
-            'record_identifier': _shtrove_cedar_record_identifier(cedar_record___id, cedar_template_cedar_id),
+            'record_identifier': _shtrove_cedar_record_identifier(cedar_referent___id, cedar_template_cedar_id),
         },
         headers=_shtrove_auth_headers(referent),
     )
@@ -300,8 +300,8 @@ def _shtrove_record_identifier(osf_item, osfmap_partition: OsfmapPartition):
     )
 
 
-def _shtrove_cedar_record_identifier(cedar_record___id, template_cedar_id) -> str:
-    return f'{cedar_record___id}/CedarMetadataRecord:{template_cedar_id}'
+def _shtrove_cedar_record_identifier(referent_osfid, template_cedar_id) -> str:
+    return f'{referent_osfid}/CedarMetadataRecord:{template_cedar_id}'
 
 
 def _shtrove_auth_headers(osf_item):

--- a/osf_tests/test_collection_submission.py
+++ b/osf_tests/test_collection_submission.py
@@ -874,12 +874,12 @@ class TestCollectionSubmissionWithCedarRecord:
             with mock.patch('api.share.utils._shtrove_cedar_record_identifier') as mock_identifier:
                 unmoderated_collection_submission_public.save()
                 mock_identifier.assert_called_with(
-                    to_create_record._id,
+                    to_create_record.guid._id,
                     to_create_record.template.cedar_id
                 )
                 assert (
-                    _shtrove_cedar_record_identifier(to_create_record._id, to_create_record.template.cedar_id) ==
-                    f'{to_create_record._id}/CedarMetadataRecord:http26'
+                    _shtrove_cedar_record_identifier(to_create_record.guid._id, to_create_record.template.cedar_id) ==
+                    f'{to_create_record.guid._id}/CedarMetadataRecord:http26'
                 )
 
     @mock.patch('api.share.utils.pls_send_trove_record')
@@ -897,10 +897,10 @@ class TestCollectionSubmissionWithCedarRecord:
         with mock.patch('api.share.utils.requests.delete'):
             with mock.patch('api.share.utils._shtrove_cedar_record_identifier') as mock_identifier:
                 unmoderated_collection_submission_public.save()
-                mock_identifier.assert_called_with(to_delete_record._id, to_delete_record.template.cedar_id)
+                mock_identifier.assert_called_with(to_delete_record.guid._id, to_delete_record.template.cedar_id)
                 assert (
-                    _shtrove_cedar_record_identifier(to_delete_record._id, to_delete_record.template.cedar_id) ==
-                    f'{to_delete_record._id}/CedarMetadataRecord:http25'
+                    _shtrove_cedar_record_identifier(to_delete_record.guid._id, to_delete_record.template.cedar_id) ==
+                    f'{to_delete_record.guid._id}/CedarMetadataRecord:http25'
                 )
 
     @mock.patch('api.share.utils.share_update_cedar_metadata_record')


### PR DESCRIPTION
when sending cedar records to shtrove as supplementary records about an item, use that item's osfid in the record_identifier instead of a database id, so the records are more clearly associated in shtrove admin

[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* [ENG-*****]()

## Purpose

[//]: # (Briefly describe the purpose of this PR.)

## Changes

[//]: # (Briefly describe or list your changes.)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
