### PR TITLE
[ENG-11012] Disable Preprint DELETE from API

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -299,7 +299,7 @@ class PreprintVersionsList(PreprintMetricsViewMixin, JSONAPIBaseView, generics.L
         return super().create(request, *args, **kwargs)
 
 
-class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin, JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, PreprintMixin, WaterButlerMixin):
+class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin, JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
     """See [documentation for this endpoint](https://developer.osf.io/#operation/preprints_read).
 
     Note: The resource now exposes a `versions` relationship pointing to
@@ -348,12 +348,6 @@ class PreprintDetail(PreprintOldVersionsImmutableMixin, PreprintMetricsViewMixin
         res = super().get_parser_context(http_request)
         res['legacy_type_allowed'] = True
         return res
-
-    def delete(self, request, *args, **kwargs):
-        if self.get_preprint().machine_state in ['initial', 'rejected']:
-            return super().delete(request, *args, **kwargs)
-
-        raise ValidationError('You cannot delete created preprint')
 
 class PreprintNodeRelationship(PreprintOldVersionsImmutableMixin, JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin):
     permission_classes = (

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -215,41 +215,13 @@ class TestPreprintDelete:
     def url(self, user):
         return f'/{API_BASE}preprints/{{}}/'
 
-    def test_can_delete_draft_preprints(
-        self, app, user, url, unpublished_preprint
-    ):
-
-        url = f'/{API_BASE}preprints/{unpublished_preprint._id}/'
-        res = app.delete(url, auth=user.auth)
-        assert res.status_code == 204
-
-        res = app.get(url, auth=user.auth, expect_errors=True)
-        assert res.status_code == 404
-
-    def test_cannot_delete_published_preprints(self, app, user, url, published_preprint):
-        url = f'/{API_BASE}preprints/{published_preprint._id}/'
-
-        res = app.delete(url, auth=user.auth, expect_errors=True)
-        assert res.json['errors'][0]['detail'] == 'You cannot delete created preprint'
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
-
-    def test_cannot_delete_in_moderation_preprints(self, app, user, url):
-        pre_moderation_preprint = PreprintFactory(creator=user, reviews_workflow='pre-moderation')
-        post_moderation_preprint = PreprintFactory(creator=user, reviews_workflow='post-moderation')
-
-        url = f'/{API_BASE}preprints/{pre_moderation_preprint._id}/'
-        res = app.delete(url, auth=user.auth, expect_errors=True)
-        assert res.json['errors'][0]['detail'] == 'You cannot delete created preprint'
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
-
-        url = f'/{API_BASE}preprints/{post_moderation_preprint._id}/'
-
-        res = app.delete(url, auth=user.auth, expect_errors=True)
-        assert res.json['errors'][0]['detail'] == 'You cannot delete created preprint'
-        res = app.get(url, auth=user.auth)
-        assert res.status_code == 200
+    def test_cannot_delete_preprints(self, app, user, url, unpublished_preprint, published_preprint):
+        res = app.delete(url.format(unpublished_preprint._id), auth=user.auth, expect_errors=True)
+        assert res.status_code == 405
+        assert unpublished_preprint.deleted is None
+        res = app.delete(url.format(published_preprint._id), auth=user.auth, expect_errors=True)
+        assert res.status_code == 405
+        assert published_preprint.deleted is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-11012

## Purpose

Disable Preprint DELETE from API

FE piece: https://github.com/CenterForOpenScience/angular-osf/pull/1009

## Changes

Revert changes from https://github.com/CenterForOpenScience/osf.io/pull/11191 and https://github.com/CenterForOpenScience/osf.io/pull/11693

## Side Effects

N/A

## QE Notes

N/A

## CE Notes

N/A

## Documentation

N/A