### PR TITLE
[ENG-10365] Make waterbutled callback after addons archiving is finished

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -6,7 +6,7 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from addons.base.views import DOWNLOAD_ACTIONS
 from website.archiver import signals, ARCHIVER_NETWORK_ERROR, ARCHIVER_SUCCESS, ARCHIVER_FAILURE
-from website.project import signals as project_signals
+from website.archiver.tasks import archive_callback
 
 from osf.models import Registration, OSFUser, RegistrationProvider, OutcomeArtifact, CedarMetadataRecord
 from osf.models.spam import SpamStatus
@@ -1114,7 +1114,7 @@ class RegistrationCallbackView(JSONAPIBaseView, generics.UpdateAPIView, Registra
                     src_provider,
                     ARCHIVER_SUCCESS,
                 )
-            project_signals.archive_callback.send(registration)
+            archive_callback(registration)
             return Response(status=status.HTTP_200_OK)
         except HTTPError as e:
             registration.archive_status = ARCHIVER_NETWORK_ERROR

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -1114,7 +1114,7 @@ class RegistrationCallbackView(JSONAPIBaseView, generics.UpdateAPIView, Registra
                     src_provider,
                     ARCHIVER_SUCCESS,
                 )
-            archive_callback(registration)
+            archive_callback(registration._id)
             return Response(status=status.HTTP_200_OK)
         except HTTPError as e:
             registration.archive_status = ARCHIVER_NETWORK_ERROR

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -580,23 +580,64 @@ class TestArchiverTasks(ArchiverTestCase):
             job_pk=self.archive_job._id,
         )
 
-    @mock.patch('website.archiver.tasks.make_copy_request.delay')
-    def test_archive_addon(self, mock_make_copy_request):
-        archive_addon('osfstorage', self.archive_job._id)
+    def test_archive_addon(self):
+        params = archive_addon('osfstorage', self.archive_job._id)
         assert self.archive_job.get_target('osfstorage').status == ARCHIVER_INITIATED
         cookie = self.user.get_or_create_cookie()
 
-        mock_make_copy_request.assert_called_with(
+        assert params['addon_short_name'] == 'osfstorage'
+        assert params['url'] == f'{settings.WATERBUTLER_URL}/v1/resources/{self.src._id}/providers/osfstorage/?cookie={cookie.decode()}'
+        assert params['data'] == {
+            'action': 'copy',
+            'path': '/',
+            'rename': 'Archive of OSF Storage',
+            'resource': self.archive_job.info()[1]._id,
+            'provider': 'osfstorage',
+        }
+
+    @mock.patch('website.archiver.tasks.archive_callback.delay')
+    def test_archive_addon_does_not_trigger_callback_immediately(self, mock_archive_callback):
+        archive_addon('osfstorage', self.archive_job._id)
+
+        mock_archive_callback.assert_not_called()
+
+    @mock.patch('website.archiver.tasks.handlers.enqueue_task')
+    @mock.patch('website.archiver.tasks.archive_callback.si')
+    @mock.patch('website.archiver.tasks.make_copy_request.s')
+    @mock.patch('website.archiver.tasks.celery.chain')
+    @mock.patch('website.archiver.tasks.celery.group')
+    @mock.patch('website.archiver.tasks.archive_addon.si')
+    def test_archive_node_only_enqueues_addon_work_before_callback(
+        self,
+        mock_archive_addon,
+        mock_group,
+        mock_chain,
+        mock_make_copy_request_s,
+        mock_archive_callback,
+        mock_enqueue_task,
+    ):
+        settings.MAX_ARCHIVE_SIZE = 1024 ** 3
+        with mock.patch.object(BaseStorageAddon, '_get_file_tree') as mock_file_tree:
+            mock_file_tree.return_value = FILE_TREE
+            results = [stat_addon(addon, self.archive_job._id) for addon in ['osfstorage']]
+
+        archive_node(results, self.archive_job._id)
+
+        mock_archive_addon.assert_called_once_with(
+            addon_short_name='osfstorage',
             job_pk=self.archive_job._id,
-            url=f'{settings.WATERBUTLER_URL}/v1/resources/{self.src._id}/providers/osfstorage/?cookie={cookie.decode()}',
-            data={
-                'action': 'copy',
-                'path': '/',
-                'rename': 'Archive of OSF Storage',
-                'resource': self.archive_job.info()[1]._id,
-                'provider': 'osfstorage',
-            }
         )
+        self.assertEqual(mock_chain.call_count, 2)
+        mock_chain.assert_any_call([
+            mock_archive_addon.return_value,
+            mock_make_copy_request_s.return_value,
+        ])
+        mock_group.assert_called_once_with([mock_chain.return_value])
+        mock_chain.assert_any_call([
+            mock_group.return_value,
+            mock_archive_callback.return_value,
+        ])
+        mock_enqueue_task.assert_called_once_with(mock_chain.return_value)
 
     @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success(self):
@@ -993,7 +1034,7 @@ class TestArchiverListeners(ArchiverTestCase):
         )
         self.dst.archive_job.save()
         with mock.patch('website.archiver.utils.handle_archive_fail') as mock_fail:
-            archive_callback(self.dst)
+            archive_callback(self.dst._id)
         assert not mock_fail.called
         assert mock_delay.called
 
@@ -1001,7 +1042,7 @@ class TestArchiverListeners(ArchiverTestCase):
     def test_archive_callback_done_success(self, mock_archive_success):
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         self.dst.archive_job.save()
-        archive_callback(self.dst)
+        archive_callback(self.dst._id)
 
     @mock.patch('website.archiver.tasks.archive_success.delay')
     def test_archive_callback_done_embargoed(self, mock_archive_success):
@@ -1015,13 +1056,13 @@ class TestArchiverListeners(ArchiverTestCase):
         self.dst.embargo_registration(self.user, end_date)
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         self.dst.save()
-        archive_callback(self.dst)
+        archive_callback(self.dst._id)
 
     def test_archive_callback_done_errors(self):
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_FAILURE)
         self.dst.archive_job.save()
         with mock.patch('website.archiver.utils.handle_archive_fail') as mock_fail:
-            archive_callback(self.dst)
+            archive_callback(self.dst._id)
         call_args = mock_fail.call_args[0]
         assert call_args[0] == ARCHIVER_UNCAUGHT_ERROR
         assert call_args[1] == self.src
@@ -1037,7 +1078,7 @@ class TestArchiverListeners(ArchiverTestCase):
         child = reg.nodes[0]
         child.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         child.save()
-        archive_callback(child)
+        archive_callback(child._id)
         assert not child.archiving
 
     def test_archive_tree_finished_d1(self):
@@ -1105,13 +1146,13 @@ class TestArchiverListeners(ArchiverTestCase):
             node.archive_job.update_target('osfstorage', ARCHIVER_INITIATED)
         rchild.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         rchild.save()
-        archive_callback(rchild)
+        archive_callback(rchild._id)
         reg.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         reg.save()
-        archive_callback(reg)
+        archive_callback(reg._id)
         rchild2.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         rchild2.save()
-        archive_callback(rchild2)
+        archive_callback(rchild2._id)
 
 class TestArchiverScripts(ArchiverTestCase):
 
@@ -1178,7 +1219,7 @@ class TestArchiverBehavior(OsfTestCase):
             mock.patch('osf.models.ArchiveJob.archive_tree_finished', mock.Mock(return_value=True)),
             mock.patch('osf.models.ArchiveJob.success', mock.PropertyMock(return_value=True))
         ) as (mock_finished, mock_success):
-            archive_callback(reg)
+            archive_callback(reg._id)
         assert mock_update_search.call_count == 1
 
     @pytest.mark.enable_search
@@ -1192,7 +1233,7 @@ class TestArchiverBehavior(OsfTestCase):
                 mock.patch('osf.models.archive.ArchiveJob.archive_tree_finished', mock.Mock(return_value=True)),
                 mock.patch('osf.models.archive.ArchiveJob.success', mock.PropertyMock(return_value=False))
             ) as (mock_finished, mock_success):
-                archive_callback(reg)
+                archive_callback(reg._id)
 
     @mock.patch('osf.models.AbstractNode.update_search')
     def test_archiving_nodes_not_added_to_search_on_archive_incomplete(self, mock_update_search):
@@ -1200,7 +1241,7 @@ class TestArchiverBehavior(OsfTestCase):
         reg = factories.RegistrationFactory(project=proj)
         reg.save()
         with mock.patch('osf.models.ArchiveJob.archive_tree_finished', mock.Mock(return_value=False)):
-            archive_callback(reg)
+            archive_callback(reg._id)
         assert not mock_update_search.called
 
 

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -526,7 +526,7 @@ class TestArchiverTasks(ArchiverTestCase):
         )
         mock_log_exception.assert_called_once()
 
-    @mock.patch('website.archiver.tasks.archive_addon.delay')
+    @mock.patch('website.archiver.tasks.archive_addon.si')
     def test_archive_node_pass(self, mock_archive_addon):
         settings.MAX_ARCHIVE_SIZE = 1024 ** 3
         with mock.patch.object(BaseStorageAddon, '_get_file_tree') as mock_file_tree:
@@ -545,8 +545,8 @@ class TestArchiverTasks(ArchiverTestCase):
         with pytest.raises(ArchiverSizeExceeded):  # Note: Requires task_eager_propagates = True in celery
             archive_node.apply(args=(results, self.archive_job._id))
 
-    @mock.patch('website.project.signals.archive_callback.send')
-    @mock.patch('website.archiver.tasks.archive_addon.delay')
+    @mock.patch('website.archiver.tasks.archive_callback.si')
+    @mock.patch('website.archiver.tasks.archive_addon.si')
     def test_archive_node_does_not_archive_empty_addons(self, mock_archive_addon, mock_send):
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon') as mock_get_addon:
             mock_addon = MockAddon()
@@ -566,7 +566,7 @@ class TestArchiverTasks(ArchiverTestCase):
         assert mock_send.called
 
     @use_fake_addons
-    @mock.patch('website.archiver.tasks.archive_addon.delay')
+    @mock.patch('website.archiver.tasks.archive_addon.si')
     def test_archive_node_no_archive_size_limit(self, mock_archive_addon):
         settings.MAX_ARCHIVE_SIZE = 100
         self.archive_job.initiator.add_system_tag(NO_ARCHIVE_LIMIT)
@@ -993,7 +993,7 @@ class TestArchiverListeners(ArchiverTestCase):
         )
         self.dst.archive_job.save()
         with mock.patch('website.archiver.utils.handle_archive_fail') as mock_fail:
-            listeners.archive_callback(self.dst)
+            archive_callback(self.dst)
         assert not mock_fail.called
         assert mock_delay.called
 
@@ -1001,7 +1001,7 @@ class TestArchiverListeners(ArchiverTestCase):
     def test_archive_callback_done_success(self, mock_archive_success):
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         self.dst.archive_job.save()
-        listeners.archive_callback(self.dst)
+        archive_callback(self.dst)
 
     @mock.patch('website.archiver.tasks.archive_success.delay')
     def test_archive_callback_done_embargoed(self, mock_archive_success):
@@ -1015,13 +1015,13 @@ class TestArchiverListeners(ArchiverTestCase):
         self.dst.embargo_registration(self.user, end_date)
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         self.dst.save()
-        listeners.archive_callback(self.dst)
+        archive_callback(self.dst)
 
     def test_archive_callback_done_errors(self):
         self.dst.archive_job.update_target('osfstorage', ARCHIVER_FAILURE)
         self.dst.archive_job.save()
         with mock.patch('website.archiver.utils.handle_archive_fail') as mock_fail:
-            listeners.archive_callback(self.dst)
+            archive_callback(self.dst)
         call_args = mock_fail.call_args[0]
         assert call_args[0] == ARCHIVER_UNCAUGHT_ERROR
         assert call_args[1] == self.src
@@ -1037,7 +1037,7 @@ class TestArchiverListeners(ArchiverTestCase):
         child = reg.nodes[0]
         child.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         child.save()
-        listeners.archive_callback(child)
+        archive_callback(child)
         assert not child.archiving
 
     def test_archive_tree_finished_d1(self):
@@ -1105,13 +1105,13 @@ class TestArchiverListeners(ArchiverTestCase):
             node.archive_job.update_target('osfstorage', ARCHIVER_INITIATED)
         rchild.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         rchild.save()
-        listeners.archive_callback(rchild)
+        archive_callback(rchild)
         reg.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         reg.save()
-        listeners.archive_callback(reg)
+        archive_callback(reg)
         rchild2.archive_job.update_target('osfstorage', ARCHIVER_SUCCESS)
         rchild2.save()
-        listeners.archive_callback(rchild2)
+        archive_callback(rchild2)
 
 class TestArchiverScripts(ArchiverTestCase):
 
@@ -1178,7 +1178,7 @@ class TestArchiverBehavior(OsfTestCase):
             mock.patch('osf.models.ArchiveJob.archive_tree_finished', mock.Mock(return_value=True)),
             mock.patch('osf.models.ArchiveJob.success', mock.PropertyMock(return_value=True))
         ) as (mock_finished, mock_success):
-            listeners.archive_callback(reg)
+            archive_callback(reg)
         assert mock_update_search.call_count == 1
 
     @pytest.mark.enable_search
@@ -1192,7 +1192,7 @@ class TestArchiverBehavior(OsfTestCase):
                 mock.patch('osf.models.archive.ArchiveJob.archive_tree_finished', mock.Mock(return_value=True)),
                 mock.patch('osf.models.archive.ArchiveJob.success', mock.PropertyMock(return_value=False))
             ) as (mock_finished, mock_success):
-                listeners.archive_callback(reg)
+                archive_callback(reg)
 
     @mock.patch('osf.models.AbstractNode.update_search')
     def test_archiving_nodes_not_added_to_search_on_archive_incomplete(self, mock_update_search):
@@ -1200,7 +1200,7 @@ class TestArchiverBehavior(OsfTestCase):
         reg = factories.RegistrationFactory(project=proj)
         reg.save()
         with mock.patch('osf.models.ArchiveJob.archive_tree_finished', mock.Mock(return_value=False)):
-            listeners.archive_callback(reg)
+            archive_callback(reg)
         assert not mock_update_search.called
 
 

--- a/osf_tests/utils.py
+++ b/osf_tests/utils.py
@@ -155,7 +155,7 @@ def mock_archive(project, schema=None, auth=None, data=None, parent=None,
         sanction = registration.sanction
         mock.patch.object(root_job, 'archive_tree_finished', mock.Mock(return_value=True)),
         mock.patch('website.archiver.tasks.archive_success.delay', mock.Mock())
-        archive_callback(registration)
+        archive_callback(registration._id)
 
     if autoapprove:
         sanction = registration.sanction

--- a/osf_tests/utils.py
+++ b/osf_tests/utils.py
@@ -10,7 +10,8 @@ from google.cloud.storage import Client, Bucket, Blob
 import blinker
 from website.signals import ALL_SIGNALS
 from website.archiver import ARCHIVER_SUCCESS
-from website.archiver import listeners as archiver_listeners
+from website.archiver.tasks import archive_callback
+
 
 from osf.models import (
     Sanction,
@@ -154,7 +155,7 @@ def mock_archive(project, schema=None, auth=None, data=None, parent=None,
         sanction = registration.sanction
         mock.patch.object(root_job, 'archive_tree_finished', mock.Mock(return_value=True)),
         mock.patch('website.archiver.tasks.archive_success.delay', mock.Mock())
-        archiver_listeners.archive_callback(registration)
+        archive_callback(registration)
 
     if autoapprove:
         sanction = registration.sanction

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,7 +20,7 @@ from osf_tests.factories import DraftRegistrationFactory
 from osf.models import Sanction, NotificationType, Notification
 from tests.base import get_default_metaschema
 from website.archiver import ARCHIVER_SUCCESS
-from website.archiver import listeners as archiver_listeners
+from website.archiver.tasks import archive_callback
 from website import settings as website_settings
 from osf import features
 
@@ -155,7 +155,7 @@ def mock_archive(project, schema=None, auth=None, draft_registration=None, paren
         # Ensure patches actually apply:
         with mock.patch.object(root_job, 'archive_tree_finished', mock.Mock(return_value=True)), \
              mock.patch('website.archiver.tasks.archive_success.delay', mock.Mock()):
-            archiver_listeners.archive_callback(registration)
+            archive_callback(registration)
 
     if autoapprove:
         sanction = registration.root.sanction

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -155,7 +155,7 @@ def mock_archive(project, schema=None, auth=None, draft_registration=None, paren
         # Ensure patches actually apply:
         with mock.patch.object(root_job, 'archive_tree_finished', mock.Mock(return_value=True)), \
              mock.patch('website.archiver.tasks.archive_success.delay', mock.Mock()):
-            archive_callback(registration)
+            archive_callback(registration._id)
 
     if autoapprove:
         sanction = registration.root.sanction

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -3,9 +3,6 @@ import celery
 from framework.celery_tasks import handlers
 
 from website.archiver import utils as archiver_utils
-from website.archiver import (
-    ARCHIVER_UNCAUGHT_ERROR,
-)
 from website.archiver import signals as archiver_signals
 
 from website.project import signals as project_signals
@@ -28,33 +25,6 @@ def after_register(src, dst, user):
     handlers.enqueue_task(
         celery.chain(archive_tasks)
     )
-
-
-@project_signals.archive_callback.connect
-def archive_callback(dst):
-    """Blinker listener for updates to the archive task. When the tree of ArchiveJob
-    instances is complete, proceed to send success or failure mails
-
-    :param dst: registration Node
-    """
-    root = dst.root
-    root_job = root.archive_job
-    if not root_job.archive_tree_finished():
-        return
-    if root_job.sent:
-        return
-    if root_job.success:
-        # Prevent circular import with app.py
-        from website.archiver import tasks
-        tasks.archive_success.delay(dst_pk=root._id, job_pk=root_job._id)
-    else:
-        archiver_utils.handle_archive_fail(
-            ARCHIVER_UNCAUGHT_ERROR,
-            root.registered_from,
-            root,
-            root.registered_user,
-            dst.archive_job.target_info(),
-        )
 
 
 @archiver_signals.archive_fail.connect

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -10,7 +10,7 @@ from celery.utils.log import get_task_logger
 from django.utils import timezone
 from datetime import timedelta
 
-from framework.celery_tasks import app as celery_app
+from framework.celery_tasks import app as celery_app, handlers
 from framework.celery_tasks.utils import logged
 from framework.exceptions import HTTPError
 from framework import sentry
@@ -30,11 +30,11 @@ from website.archiver import (
 )
 from website.archiver import utils
 from website.archiver.utils import normalize_unicode_filenames
+from website.archiver import utils as archiver_utils
 from website.archiver import signals as archiver_signals
 
 from scripts.check_manual_restart_approval import delayed_manual_restart_approval
 
-from website.project import signals as project_signals
 from website import settings
 from website.app import init_addons
 
@@ -361,15 +361,27 @@ def archive_node(self, stat_results, job_pk):
         if not stat_result.targets:
             job.status = ARCHIVER_SUCCESS
             job.save()
+
+        addon_tasks = []
         for result in stat_result.targets:
             if not result['num_files']:
                 job.update_target(result['target_name'], ARCHIVER_SUCCESS)
             else:
-                archive_addon.delay(
+                addon_tasks.append(archive_addon.si(
                     addon_short_name=result['target_name'],
                     job_pk=job_pk
-                )
-        project_signals.archive_callback.send(dst)
+                ))
+
+        handlers.enqueue_task(
+            celery.chain(
+                [
+                    celery.group(addon_tasks),
+                    archive_callback.si(
+                        dst=dst
+                    )
+                ]
+            )
+        )
 
 
 def archive(job_pk):
@@ -488,3 +500,29 @@ def force_archive(self, registration_id, permissible_addons, allow_unconfigured=
         sentry.log_message(f'Archive task failed for {registration_id}: {exc}')
         sentry.log_exception(exc)
         return f'{exc.__class__.__name__}: {str(exc)}'
+
+
+@celery_app.task
+@logged('archive_callback')
+def archive_callback(dst):
+    """Blinker task for updates to the archive task. When the tree of ArchiveJob
+    instances is complete, proceed to send success or failure mails
+
+    :param dst: registration Node
+    """
+    root = dst.root
+    root_job = root.archive_job
+    if not root_job.archive_tree_finished():
+        return
+    if root_job.sent:
+        return
+    if root_job.success:
+        archive_success.delay(dst_pk=root._id, job_pk=root_job._id)
+    else:
+        archiver_utils.handle_archive_fail(
+            ARCHIVER_UNCAUGHT_ERROR,
+            root.registered_from,
+            root,
+            root.registered_user,
+            dst.archive_job.target_info(),
+        )

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -254,22 +254,35 @@ def stat_addon(self, addon_short_name, job_pk):
     default_retry_delay=60,
 )
 @logged('make_copy_request')
-def make_copy_request(self, job_pk, url, data):
+def make_copy_request(self, params, job_pk):
     """Make the copy request to the WaterButler API and handle
     successful and failed responses
 
+    :param params: dict returned by archive_addon containing addon_short_name, url, and data
     :param job_pk: primary key of ArchiveJob
-    :param url: URL to send request to
-    :param data: <dict> of setting to send in POST to WaterButler API
     :return: None
     """
     create_app_context()
     job = self.load_archive_job(job_pk)
     src, dst, user = job.info()
+    addon_short_name = params['addon_short_name']
+    url = params['url']
+    data = params['data']
     logger.info(f"Sending copy request for addon: {data['provider']} on node: {dst._id}")
     cookie = furl(url).query.params.get('cookie')
-    res = requests.post(url, data=json.dumps(data), cookies={settings.COOKIE_NAME: cookie}, timeout=settings.EXTERNAL_REQUEST_TIMEOUT)
+    try:
+        res = requests.post(
+            url,
+            data=json.dumps(data),
+            cookies={settings.COOKIE_NAME: cookie},
+            timeout=settings.EXTERNAL_REQUEST_TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        job.update_target(addon_short_name, ARCHIVER_FAILURE, errors=[str(exc)])
+        raise
+
     if res.status_code not in (http_status.HTTP_200_OK, http_status.HTTP_201_CREATED, http_status.HTTP_202_ACCEPTED):
+        job.update_target(addon_short_name, ARCHIVER_FAILURE, errors=[res.text or f'WaterButler request failed with status {res.status_code}'])
         raise HTTPError(res.status_code)
 
 def make_waterbutler_payload(dst_id, rename):
@@ -324,7 +337,11 @@ def archive_addon(self, addon_short_name, job_pk):
     rename = f'{folder_name_nfd}{rename_suffix}'
     url = waterbutler_api_url_for(src._id, addon_short_name, _internal=True, base_url=src.osfstorage_region.waterbutler_url, **params)
     data = make_waterbutler_payload(dst._id, rename)
-    make_copy_request.delay(job_pk=job_pk, url=url, data=data)
+    return {
+        'addon_short_name': addon_short_name,
+        'url': url,
+        'data': data,
+    }
 
 @celery_app.task(
     bind=True,
@@ -367,18 +384,29 @@ def archive_node(self, stat_results, job_pk):
             if not result['num_files']:
                 job.update_target(result['target_name'], ARCHIVER_SUCCESS)
             else:
-                addon_tasks.append(archive_addon.si(
-                    addon_short_name=result['target_name'],
-                    job_pk=job_pk
-                ))
+                addon_tasks.append(
+                    celery.chain(
+                        [
+                            archive_addon.si(
+                                addon_short_name=result['target_name'],
+                                job_pk=job_pk,
+                            ),
+                            make_copy_request.s(
+                                job_pk=job_pk,
+                            ),
+                        ]
+                    )
+                )
+
+        if not addon_tasks:
+            handlers.enqueue_task(archive_callback.si(dst_id=dst._id))
+            return
 
         handlers.enqueue_task(
             celery.chain(
                 [
                     celery.group(addon_tasks),
-                    archive_callback.si(
-                        dst=dst
-                    )
+                    archive_callback.si(dst_id=dst._id),
                 ]
             )
         )
@@ -504,12 +532,13 @@ def force_archive(self, registration_id, permissible_addons, allow_unconfigured=
 
 @celery_app.task
 @logged('archive_callback')
-def archive_callback(dst):
+def archive_callback(dst_id):
     """Blinker task for updates to the archive task. When the tree of ArchiveJob
     instances is complete, proceed to send success or failure mails
 
     :param dst: registration Node
     """
+    dst = Registration.load(dst_id)
     root = dst.root
     root_job = root.archive_job
     if not root_job.archive_tree_finished():

--- a/website/project/signals.py
+++ b/website/project/signals.py
@@ -9,5 +9,3 @@ write_permissions_revoked = signals.signal('write-permissions-revoked')
 node_deleted = signals.signal('node-deleted')
 
 after_create_registration = signals.signal('post-create-registration')
-
-archive_callback = signals.signal('archive-callback')


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-10365

## Changes

Implement solution from analysis ticket. Here is the issue description and proposed solution:
https://openscience.atlassian.net/browse/ENG-10851?focusedCommentId=121306

Call `archive_callback` only after all addons are archived