### PR TITLE
Security: Missing Input Validation in Dropbox Serializer credentials_are_valid

### DIFF
--- a/addons/dropbox/serializer.py
+++ b/addons/dropbox/serializer.py
@@ -10,7 +10,7 @@ class DropboxSerializer(StorageAddonSerializer):
     addon_short_name = 'dropbox'
 
     def credentials_are_valid(self, user_settings, client):
-        if user_settings:
+        if user_settings and user_settings.external_accounts:
             client = client or Dropbox(user_settings.external_accounts[0].oauth_key)
             try:
                 client.users_get_current_account()


### PR DESCRIPTION
## Summary

Security: Missing Input Validation in Dropbox Serializer credentials_are_valid

## Problem

**Severity**: `Medium` | **File**: `addons/dropbox/serializer.py:L14`

The DropboxSerializer.credentials_are_valid method accesses user_settings.external_accounts[0] without checking if the list is empty. This could cause an IndexError exception. Additionally, the method creates a Dropbox client with an OAuth key without proper validation of the key format or source.

## Solution

Add explicit bounds checking before accessing external_accounts[0]. Validate the OAuth key format before creating the Dropbox client. Consider using a try-except block specifically for IndexError.

## Changes

- `addons/dropbox/serializer.py` (modified)