### PR TITLE
[ENG-11171] Add admin tool to update ROR names 

### DIFF
--- a/admin/management/urls.py
+++ b/admin/management/urls.py
@@ -23,4 +23,6 @@ urlpatterns = [
     re_path(r'^remove_orcid_from_user_social', views.RemoveOrcidFromUserSocial.as_view(),
             name='remove_orcid_from_user_social'),
     path('migrate_osfmetrics_fix_6to8', views.MigrateOsfmetricsFix6to8.as_view(), name='migrate_osfmetrics_fix_6to8'),
+    re_path(r'^migrate_funder_names_to_ror', views.MigrateFunderNamesToRor.as_view(),
+            name='migrate_funder_names_to_ror'),
 ]

--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -220,3 +220,15 @@ class MigrateOsfmetricsFix6to8(ManagementCommandPermissionView):
         for _line in _out_io.getvalue().split('\n'):
             messages.info(request, _line)
         return redirect(reverse('management:commands'))
+
+
+class MigrateFunderNamesToRor(ManagementCommandPermissionView):
+
+    def post(self, request):
+        _command_kwargs = {}
+        _out_io = StringIO()
+        call_command('migrate_funder_names_to_ror', **_command_kwargs, stdout=_out_io)
+        messages.success(request, 'ROR funder names have been successfully updated and made consistent.')
+        for _line in _out_io.getvalue().split('\n'):
+            messages.info(request, _line)
+        return redirect(reverse('management:commands'))

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -207,6 +207,22 @@
                     </nav>
                 </form>
             </section>
+            <section>
+                <h4><u>Update ROR funder names to be consistent and proper.</u></h4>
+                <p>
+                    Take a csv file of <code>ROR ID</code>, <code>ROR
+                    Name</code> (without column headers) and update
+                    all ROR funder entries to use the same name for a
+                    given id.
+                </p>
+                <form method="post"
+                      action="{% url 'management:migrate_funder_names_to_ror'%}">
+                    {% csrf_token %}
+                    <nav>
+                        <input class="btn btn-success" type="submit" value="Run" />
+                    </nav>
+                </form>
+            </section>
         </div>
     </section>
 {% endblock %}

--- a/osf/management/commands/funder_mapping.csv
+++ b/osf/management/commands/funder_mapping.csv
@@ -1,0 +1,1138 @@
+https://ror.org/000025p04,Thailand Science Research and Innovation
+https://ror.org/00013q465,Pontifical Catholic University of Peru
+https://ror.org/00097mb19,Japan Science and Technology Agency
+https://ror.org/000az4664,Canada Foundation for Innovation
+https://ror.org/000e0be47,Northwestern University
+https://ror.org/000xsnr85,University of the Basque Country
+https://ror.org/0015x1k58,National Center for Injury Prevention and Control
+https://ror.org/00190t495,National Center for Complementary and Integrative Health
+https://ror.org/001ajjs72,Cambridge Philosophical Society
+https://ror.org/001aqnf71,UK Research and Innovation
+https://ror.org/001d55x84,NIH Common Fund
+https://ror.org/001rdaz60,Bavarian Academy of Sciences and Humanities
+https://ror.org/001tw8739,Canadian Association of Research Libraries
+https://ror.org/001w7jn25,Charité - Universitätsmedizin Berlin
+https://ror.org/001xhss06,Directorate for Biological Sciences
+https://ror.org/0020x6414,Hunter Medical Research Institute
+https://ror.org/00240q980,University of Padua
+https://ror.org/0029jxk29,Tula Foundation
+https://ror.org/002h8g185,University of Bath
+https://ror.org/002skex07,Mohamed Bin Zayed Species Conservation Fund
+https://ror.org/00300j256,Fulbright Association
+https://ror.org/0030zas98,Hong Kong Polytechnic University
+https://ror.org/0034k2773,Louisiana Cancer Research Consortium
+https://ror.org/003bxzv61,Data Science Research Center
+https://ror.org/003h57f17,Diabetesfonden
+https://ror.org/003hb2249,Health Research Board
+https://ror.org/003vg9w96,"Institut National de Recherche pour l'Agriculture, l'Alimentation et l'Environnement"
+https://ror.org/003x0zc53,Agencia Estatal de Investigación
+https://ror.org/003xyzq10,Henan University
+https://ror.org/0044e2g62,Minzu University of China
+https://ror.org/00490n048,American Institutes for Research
+https://ror.org/004a2wv92,National Institute of Dental and Craniofacial Research
+https://ror.org/004d1k391,Open Philanthropy Project
+https://ror.org/004hzzk67,Knut and Alice Wallenberg Foundation
+https://ror.org/0057ax056,King Mongkut's University of Technology Thonburi
+https://ror.org/005mpbw70,Universidade Nove de Julho
+https://ror.org/005rpmt10,Korea Institute of Oriental Medicine
+https://ror.org/0060t0j89,United States National Library of Medicine
+https://ror.org/0064zg438,Izaak Walton Killam Health Centre
+https://ror.org/00675rp98,Centre National pour la Recherche Scientifique et Technique (CNRST)
+https://ror.org/006b2g567,Government of Alberta
+https://ror.org/006e5kg04,Vrije Universiteit Brussel
+https://ror.org/006hf6230,University of Twente
+https://ror.org/006w34k90,Howard Hughes Medical Institute
+https://ror.org/006wxqw41,Gordon and Betty Moore Foundation
+https://ror.org/006zn3t30,National Institute of Arthritis and Musculoskeletal and Skin Diseases
+https://ror.org/00789fa95,Ministero della Salute
+https://ror.org/007pgtp80,Fundação Cearense de Apoio ao Desenvolvimento Científico e Tecnológico
+https://ror.org/007s7nj58,Land Nordrhein-Westfalen
+https://ror.org/0081fs513,Universidad de Buenos Aires
+https://ror.org/008c2qm47,Gemeinsamer Bundesausschuss
+https://ror.org/008kev776,World Health Organization Regional Office for the Americas
+https://ror.org/008n7pv89,University of Plymouth
+https://ror.org/008stv805,University of the South Pacific
+https://ror.org/008xxew50,Vrije Universiteit Amsterdam
+https://ror.org/008zkt807,Bpifrance
+https://ror.org/008zsd307,National Institute for Social Care and Health Research
+https://ror.org/0090zs177,London School of Economics and Political Science
+https://ror.org/0093a8w51,Blekinge Institute of Technology
+https://ror.org/0097mvx21,Generalitat Valenciana
+https://ror.org/009axkg17,Indian Council of Social Science Research
+https://ror.org/009byq155,Centro de Investigación Biomédica en Red de Salud Mental
+https://ror.org/00a2xv884,Zhejiang University
+https://ror.org/00adh9b73,National Institute of Diabetes and Digestive and Kidney Diseases
+https://ror.org/00aejfc65,Consejo Nacional de Ciencia y Tecnología
+https://ror.org/00afp2z80,University of Liège
+https://ror.org/00afsp483,United States Army
+https://ror.org/00apj8t60,Bandung Institute of Technology
+https://ror.org/00aps1a34,NIHR Oxford Musculoskeletal Biomedical Research Centre
+https://ror.org/00ayhx656,University of Sussex
+https://ror.org/00b30xv10,University of Pennsylvania
+https://ror.org/00b9f9778,Fonds de Recherche du Québec – Nature et Technologies
+https://ror.org/00baak391,National Human Genome Research Institute
+https://ror.org/00bhv3b03,Institute of Circulatory and Respiratory Health
+https://ror.org/00by1q217,Roche (Switzerland)
+https://ror.org/00c7kvd80,"Christian Medical College, Vellore"
+https://ror.org/00ca2c886,Instituto de Salud Carlos III
+https://ror.org/00cjrc276,Mitacs
+https://ror.org/00cv9y106,Ghent University
+https://ror.org/00cwqg982,Biotechnology and Biological Sciences Research Council
+https://ror.org/00d9ah105,"University of California, Merced"
+https://ror.org/00da1gf19,Hasanuddin University
+https://ror.org/00daj4111,Innovation Fund Denmark
+https://ror.org/00davry38,Tecnológico Nacional de México
+https://ror.org/00djwmt25,University Grants Committee
+https://ror.org/00dmfq477,University of California Office of the President
+https://ror.org/00dqsq280,Pipeline and Hazardous Materials Safety Administration
+https://ror.org/00dr28g20,University of Crete
+https://ror.org/00dvgej48,The Australasian Institute of Judicial Administration
+https://ror.org/00dw1q752,Experimental Psychology Society
+https://ror.org/00dxj9a45,Universidad Santiago de Cali
+https://ror.org/00e0ttj68,Federal Ministry of Economic Cooperation and Development
+https://ror.org/00eae9z71,University of Newcastle Australia
+https://ror.org/00epmv149,The Research Council of Norway
+https://ror.org/00ew61678,Strategic Environmental Research and Development Program
+https://ror.org/00ey0ed83,Odense University Hospital
+https://ror.org/00f3sc705,Fritz Thyssen Foundation
+https://ror.org/00f7hpc57,Friedrich-Alexander-Universität Erlangen-Nürnberg
+https://ror.org/00f8man71,Indiana State University
+https://ror.org/00f93gc02,Vehicle Technologies Office
+https://ror.org/00fb4ms10,Promobilia Foundation
+https://ror.org/00fn7gb05,Wilfrid Laurier University
+https://ror.org/00fpwd955,Bundesministerium des Innern
+https://ror.org/00fq5cm18,National Institute on Drug Abuse
+https://ror.org/00fszdj92,Organization for Women in Science for the Developing World
+https://ror.org/00fvyjk73,Colby College
+https://ror.org/00g01fs73,Ebnet Stiftung
+https://ror.org/00g5sqv46,Universitat Rovira i Virgili
+https://ror.org/00g8hms52,Administration for Children and Families
+https://ror.org/00ghka958,National Centre of Competence in Research Evolving Language
+https://ror.org/00gz9xf10,Society for the Study of School Psychology
+https://ror.org/00hasdx88,Washington Research Foundation
+https://ror.org/00her7k05,Whitehall Foundation
+https://ror.org/00hhkn466,Japan Society for the Promotion of Science
+https://ror.org/00hj8s172,Columbia University
+https://ror.org/00ht2ab73,Association Nationale de la Recherche et de la Technologie
+https://ror.org/00hwxbz16,Wisconsin Alumni Research Foundation
+https://ror.org/00j4k1h63,National Institute of Environmental Health Sciences
+https://ror.org/00j8z2m73,United States-Israel Binational Science Foundation
+https://ror.org/00jga9g46,Mi̇lli̇ Eği̇ti̇m Bakanliği
+https://ror.org/00jjeja18,Estonian Research Council
+https://ror.org/00jmfr291,University of Michigan
+https://ror.org/00jv65847,Walloon Government
+https://ror.org/00k0a6x92,Craig H Neilsen Foundation
+https://ror.org/00k4n6c32,European Commission
+https://ror.org/00k86s890,Foundation for the National Institutes of Health
+https://ror.org/00kaqnj29,Karen Elise Jensens Fond
+https://ror.org/00kgf1c95,Velux Stiftung
+https://ror.org/00kpeqx67,AccessLex Institute
+https://ror.org/00ks66431,University of Surrey
+https://ror.org/00kwnh405,Guizhou Provincial Science and Technology Department
+https://ror.org/00kybxq39,Université de Sherbrooke
+https://ror.org/00kztt736,The Kavli Foundation
+https://ror.org/00m3wrz48,United States Institute of Peace
+https://ror.org/00mt8k932,"State Secretariat for Education, Research and Innovation"
+https://ror.org/00n0s9w57,Federal Government of Brazil
+https://ror.org/00n2qrv22,Magistrat der Stadt Wien
+https://ror.org/00n3w3b69,University of Strathclyde
+https://ror.org/00n7m6g17,Politécnico Grancolombiano
+https://ror.org/00n9f0r32,"Thüringer Ministerium für Wirtschaft, Wissenschaft und Digitale Gesellschaft"
+https://ror.org/00nc55f03,Fundação de Amparo à Pesquisa do Estado de Minas Gerais
+https://ror.org/00ne6sr39,Universidad de Deusto
+https://ror.org/00njsd438,Google (United States)
+https://ror.org/00nkcmy90,National Bank of Austria
+https://ror.org/00p9jf779,Medicines for Malaria Venture
+https://ror.org/00p9vpz11,Universidade Federal da Paraíba
+https://ror.org/00pd74e08,University of Münster
+https://ror.org/00pjede26,Friede Springer Stiftung
+https://ror.org/00pmt4r91,American Educational Research Association
+https://ror.org/00pptgy96,"Consejería de Economía, Conocimiento, Empresas y Universidad"
+https://ror.org/00pz2fp31,Basque Government
+https://ror.org/00q08t645,Deutsche Gesellschaft für Internationale Zusammenarbeit
+https://ror.org/00q1y5994,Worldwide Universities Network
+https://ror.org/00qnfvz68,Open Society Foundations
+https://ror.org/00r66pz14,Natural England
+https://ror.org/00rbzpz17,Agence Nationale de la Recherche
+https://ror.org/00rdpwj76,Spencer Foundation
+https://ror.org/00rk2pe57,Office of Naval Research
+https://ror.org/00rqy9422,The University of Queensland
+https://ror.org/00rs28409,Duke Endowment
+https://ror.org/00rs6vg23,The Ohio State University
+https://ror.org/00rt1d436,American Psychological Association
+https://ror.org/00rzspn62,University of Malaya
+https://ror.org/00shpc021,Fonds de Recherche du Québec - Société et culture
+https://ror.org/00snfqn58,Fundação para a Ciência e Tecnologia
+https://ror.org/00t3pr326,British Council
+https://ror.org/00tbe9875,Stiftung Mercator Schweiz
+https://ror.org/00te3t702,University of Georgia
+https://ror.org/00tjpb250,Ministry of Health and Long Term Care
+https://ror.org/00twb6c09,Riga Technical University
+https://ror.org/00v349e63,Hungarian Scientific Research Fund
+https://ror.org/00v8fdc16,Autonomous University of Queretaro
+https://ror.org/00v8p7w89,National Institute of Justice
+https://ror.org/00va36f15,Zhejiang Provincial Health Commission
+https://ror.org/00vp82b55,15. Juni Fonden
+https://ror.org/00vr49948,Universidad Nacional Agraria La Molina
+https://ror.org/00vtgdb53,University of Glasgow
+https://ror.org/00vxae445,Canadian Egg Marketing Agency
+https://ror.org/00vxgjw72,Ministry of Health and Welfare
+https://ror.org/00w8cq239,Fundação de Apoio a Pesquisa do Estado de Goiás
+https://ror.org/00wge5k78,UiT The Arctic University of Norway
+https://ror.org/00whkrf32,Division of Graduate Education
+https://ror.org/00wnb9798,National Science and Technology Council
+https://ror.org/00wqdbc63,Government of Western Australia
+https://ror.org/00x0ma614,Coordenação de Aperfeicoamento de Pessoal de Nível Superior
+https://ror.org/00x0z1472,Templeton World Charity Foundation
+https://ror.org/00x194q47,Rikkyo University
+https://ror.org/00x9ewr78,National Council for Scientific Research
+https://ror.org/00xhj8c72,Loyola Marymount University
+https://ror.org/00xqf8t64,Padjadjaran University
+https://ror.org/00y6khe77,Ministry of Health
+https://ror.org/00y6q9n79,Ministry of Health
+https://ror.org/00yae6e25,University of Wrocław
+https://ror.org/00yew9b22,International Fund for Agricultural Development
+https://ror.org/00yhnba62,Qatar University
+https://ror.org/00yjd3n13,Swiss National Science Foundation
+https://ror.org/00yjgag34,International Psychoanalytical Association
+https://ror.org/00ypgyy34,State University of Malang
+https://ror.org/00yq55g44,Witten/Herdecke University
+https://ror.org/00yqqb480,National Initiative for Education Research
+https://ror.org/00ysfqy60,Oregon State University
+https://ror.org/00z72fs19,Department of Health Research
+https://ror.org/00zbf3d93,Health Research Council of New Zealand
+https://ror.org/00zd5gr55,Hessian Ministry for Science and the Arts
+https://ror.org/00zdnkx70,National Tsing Hua University
+https://ror.org/00zn8rh30,National Association for the Self-Employed
+https://ror.org/00zpmdm60,American Otological Society
+https://ror.org/0101xrq71,Department of Science and Technology
+https://ror.org/0103gnm60,Stiftung Lindenhof Bern
+https://ror.org/0108mwc04,Universidad del Rosario
+https://ror.org/0116zj450,University of Indonesia
+https://ror.org/011cav305,Swiss Academy of Medical Sciences
+https://ror.org/011e9bt93,United States Air Force Office of Scientific Research
+https://ror.org/011hc8f90,DEVCOM Army Research Laboratory
+https://ror.org/011kf5r70,National Health and Medical Research Council
+https://ror.org/011q66e29,Instituto Nacional de Investigación y Tecnología Agraria y Alimentaria
+https://ror.org/011s40y19,Fondation OCP
+https://ror.org/011wdec52,Centre of Excellence for Biosecurity Risk Analysis
+https://ror.org/0120w5678,European Observatory on Health Systems and Policies
+https://ror.org/01226dv09,University Hospital Regensburg
+https://ror.org/012jp3q29,Department of Higher Education and Training
+https://ror.org/012kf4317,Alexander von Humboldt Foundation
+https://ror.org/012kqkf58,Robert Bosch Stiftung
+https://ror.org/012mzw131,Leverhulme Trust
+https://ror.org/012pb6c26,National Heart Lung and Blood Institute
+https://ror.org/013314927,University of Surabaya
+https://ror.org/0134qgb15,West African Science Service Centre on Climate Change and Adapted Land Use
+https://ror.org/013aysd81,National Research Foundation of Korea
+https://ror.org/013fsnh78,University of Waikato
+https://ror.org/013kjyp64,American Heart Association
+https://ror.org/013meh722,University of Cambridge
+https://ror.org/013tf3c58,FWF Austrian Science Fund
+https://ror.org/013w1n936,Velux Fonden
+https://ror.org/013w98a82,University of Ha'il
+https://ror.org/0141yg674,Gavi
+https://ror.org/01462r250,University Hospital of Zurich
+https://ror.org/014837179,Iscte – Instituto Universitário de Lisboa
+https://ror.org/014bj5w56,Directorate for STEM Education (EDU)
+https://ror.org/014q65q44,Patient-Centered Outcomes Research Institute
+https://ror.org/0151bmh98,University of Hyogo
+https://ror.org/01526pb12,Federal Office for Food and Agriculture
+https://ror.org/015803449,South London and Maudsley NHS Foundation Trust
+https://ror.org/01585b035,Universidade Estadual de Londrina
+https://ror.org/015h0qg34,Maria Curie-Skłodowska University
+https://ror.org/015j3sb07,Sustainable Energy Authority of Ireland
+https://ror.org/015kngk22,Stiftelsen Clas Groschinskys Minnesfond
+https://ror.org/015m7wh34,Université de Rennes
+https://ror.org/015pzp858,Government of Ontario
+https://ror.org/015wb9p75,Foundation for Physical Therapy Research
+https://ror.org/015y1mx47,United Nations University World Institute for Development Economics Research
+https://ror.org/01613vh25,Chief Scientist Office
+https://ror.org/0161w0r98,Department for the Economy
+https://ror.org/0166hxq48,"Ministry of Education, Universities and Research"
+https://ror.org/0168r3w48,University of California San Diego
+https://ror.org/016bysn57,University of Northern Colorado
+https://ror.org/016gd3115,Metro South Health
+https://ror.org/016ks4x90,Swedish Society of Medicine
+https://ror.org/016xsfp80,Radboud University Nijmegen
+https://ror.org/0171mag52,Goddard Space Flight Center
+https://ror.org/017d1hs72,Banco Santander (Spain)
+https://ror.org/017ehfh78,"Ministry of Economy, Science and Digitalisation"
+https://ror.org/0181ptd26,National Headache Foundation
+https://ror.org/0181xnw06,Xunta de Galicia
+https://ror.org/0187kwz08,National Institute for Health Research
+https://ror.org/0189raq88,German Sport University Cologne
+https://ror.org/018etvh69,The Kavli Trust
+https://ror.org/018kdpd27,Leakey Foundation
+https://ror.org/018mejw64,Deutsche Forschungsgemeinschaft
+https://ror.org/018wfhg78,National Research Council of Thailand
+https://ror.org/018zj6955,Trond Mohn stiftelse
+https://ror.org/019af4n30,Innovative Medicines Initiative
+https://ror.org/019tgvf94,Université Côte d'Azur
+https://ror.org/019wt1929,Sheffield Hallam University
+https://ror.org/01a44gd51,Bavarian State Ministry for Science and Art
+https://ror.org/01a4es322,Tiny Blue Dot Foundation
+https://ror.org/01a77tt86,University of Warwick
+https://ror.org/01aetvt06,Woolworths Group (Australia)
+https://ror.org/01aj84f44,Aarhus University
+https://ror.org/01an7q238,"University of California, Berkeley"
+https://ror.org/01arysc35,Santa Fe Institute
+https://ror.org/01bcmwk98,Brain Canada Foundation
+https://ror.org/01bg62x04,Generalitat de Catalunya
+https://ror.org/01bstzn19,European Cooperation in Science and Technology
+https://ror.org/01c5g1b56,UK Aid Direct
+https://ror.org/01cc9yk21,ViiV Healthcare (United Kingdom)
+https://ror.org/01cmst727,Simons Foundation
+https://ror.org/01cvsyf94,Labex (Sweden)
+https://ror.org/01cwc0f90,The Waterloo Foundation
+https://ror.org/01cwqze88,National Institutes of Health
+https://ror.org/01d2cn965,Norwegian Directorate of Health
+https://ror.org/01d35cw23,Burroughs Wellcome Fund
+https://ror.org/01dtyv127,Region Zealand
+https://ror.org/01e6qks80,Dalhousie University
+https://ror.org/01ee9ar58,University of Nottingham
+https://ror.org/01ej9dk98,The University of Melbourne
+https://ror.org/01ek73717,Intel (United States)
+https://ror.org/01evzkn27,Fundação Getulio Vargas
+https://ror.org/01f5wp925,Universitat Oberta de Catalunya
+https://ror.org/01f5ytq51,Texas A&M University
+https://ror.org/01f6dz702,Overdeck Family Foundation
+https://ror.org/01f7dp456,Ministry of Food and Drug Safety
+https://ror.org/01f80g185,World Health Organization
+https://ror.org/01f9mc681,Vienna Science and Technology Fund
+https://ror.org/01fapfv42,Belgian Federal Science Policy Office
+https://ror.org/01ftvnv05,Royal Brisbane and Women's Hospital Foundation
+https://ror.org/01g9ty582,Semmelweis University
+https://ror.org/01gavpb45,Canadian Institutes of Health Research
+https://ror.org/01gb99w41,National Polytechnic School
+https://ror.org/01gdbf303,Royal College of General Practitioners
+https://ror.org/01gm5f004,"Biomedical Research Networking Center in Bioengineering, Biomaterials and Nanomedicine"
+https://ror.org/01gpaz870,Ministry of Justice and Public Security
+https://ror.org/01h0zpd94,National Natural Science Foundation of China
+https://ror.org/01h531d29,Natural Sciences and Engineering Research Council of Canada
+https://ror.org/01hc18p32,"Ministerium für Wissenschaft, Forschung und Kunst Baden-Württemberg"
+https://ror.org/01hewbk46,Universidade Estadual de Montes Claros
+https://ror.org/01hhn8329,Max Planck Society
+https://ror.org/01hx92781,Children's Tumor Foundation
+https://ror.org/01j1rma10,Ajman University
+https://ror.org/01j8qgg43,Joachim Herz Stiftung
+https://ror.org/01j9p1r26,University of L'Aquila
+https://ror.org/01jem9c82,Junta de Andalucía
+https://ror.org/01jzs3b90,Fundación BBVA
+https://ror.org/01kcva023,Ministry of Education
+https://ror.org/01kj2bm70,Newcastle University
+https://ror.org/01km6p862,United Arab Emirates University
+https://ror.org/01kpjmx04,Carlsberg Foundation
+https://ror.org/01kpzv902,Flinders University
+https://ror.org/01ktx4s83,Canada First Research Excellence Fund
+https://ror.org/01m2yw646,Horticultural Research Institute
+https://ror.org/01m3qaz74,Polish Grid Infrastructure
+https://ror.org/01mar7r17,D’Or Institute for Research and Education
+https://ror.org/01mdyhz69,Pan African Thoracic Society
+https://ror.org/01mg9t146,Hasso Plattner Foundation
+https://ror.org/01mng8331,Division of Computing and Communication Foundations
+https://ror.org/01mp52y34,Heising-Simons Foundation
+https://ror.org/01mv9t934,Ministry of Education of the People's Republic of China
+https://ror.org/01n4pqe45,Agència de Gestió d'Ajuts Universitaris i de Recerca
+https://ror.org/01n6e6j62,United States Agency for International Development
+https://ror.org/01n6r0e97,Leibniz Association
+https://ror.org/01nfmeh72,University of Tasmania
+https://ror.org/01nrxwf90,University of Edinburgh
+https://ror.org/01nxc2t48,Montclair State University
+https://ror.org/01p7jjy08,Saint Louis University
+https://ror.org/01p93h210,University of South Australia
+https://ror.org/01pg81m90,Robert and Janice McNair Foundation
+https://ror.org/01pnej532,University of Szeged
+https://ror.org/01pv73b02,Czech Science Foundation
+https://ror.org/01px84952,Unitec Institute of Technology
+https://ror.org/01q70bz83,NOAA Weather Program Office
+https://ror.org/01q7jq182,Unitatea Executiva Pentru Finantarea Invatamantului Superior a Cercetarii Dezvoltarii si Inovarii
+https://ror.org/01qanyf14,"Directorate-General for Employment, Social Affairs and Inclusion"
+https://ror.org/01qwawt17,William Penn Foundation
+https://ror.org/01r0c1p88,University System of Maryland
+https://ror.org/01r7sqp31,Melbourne Water
+https://ror.org/01rq3ht76,Institute of International Studies
+https://ror.org/01rxfrp27,La Trobe University
+https://ror.org/01ryk1543,University of Southampton
+https://ror.org/01s5gyw91,Department of Education of Guangdong Province
+https://ror.org/01s5ya894,National Institute of Neurological Disorders and Stroke
+https://ror.org/01s6y4r94,Horizons Foundation
+https://ror.org/01sf06y89,Macquarie University
+https://ror.org/01svaqq28,Qatar National Research Fund
+https://ror.org/01syxq867,William Thomas Grant Foundation
+https://ror.org/01t264m74,Istituto Nazionale per l'Assicurazione Contro gli Infortuni sul Lavoro
+https://ror.org/01t9r8c86,Prince Albert II of Monaco Foundation
+https://ror.org/01tevnk56,University of Siena
+https://ror.org/01tmp8f25,Universidad Nacional Autónoma de México
+https://ror.org/01txfgz53,Center for Statistics and Applications in Forensic Evidence
+https://ror.org/01v29qb04,Durham University
+https://ror.org/01v2m4n16,Erasmus+
+https://ror.org/01v376g59,Fresenius (Germany)
+https://ror.org/01v3fsc55,Office of the Director of National Intelligence
+https://ror.org/01vv00d67,Taiwan Foundation for Democracy
+https://ror.org/01vx35703,East Carolina University
+https://ror.org/01w8z9742,L V Prasad Eye Institute
+https://ror.org/01wjejq96,Yonsei University
+https://ror.org/01wspv808,Norfolk and Norwich University Hospitals NHS Foundation Trust
+https://ror.org/01wxdd722,German Cancer Aid
+https://ror.org/01x80kz37,Consejo Veracruzano de Investigación Científica y Desarrollo Tecnológico
+https://ror.org/01xdqrp08,Pfizer (United States)
+https://ror.org/01xsqw823,GlaxoSmithKline (United Kingdom)
+https://ror.org/01xtthb56,University of Oslo
+https://ror.org/01y2jtd41,University of Wisconsin‚ÄìMadison
+https://ror.org/01y3zfr79,National Institute of Nursing Research
+https://ror.org/01y9bpm73,University of Göttingen
+https://ror.org/01yaj9a77,"ZonMw, The Dutch Organisation for knowledge and innovation in health, healthcare and well-being"
+https://ror.org/01yc7t268,Washington University in St. Louis
+https://ror.org/01yj5ad85,"Bundesministerium für Umwelt, Naturschutz, nukleare Sicherheit und Verbraucherschutz"
+https://ror.org/01ykfnp55,Gates Family Foundation
+https://ror.org/01yp9g959,University of Ulster
+https://ror.org/01zbnvs85,Meta (United States)
+https://ror.org/01zd45k33,Centre for Aging + Brain Health Innovation
+https://ror.org/01zgm7d48,International Growth Centre
+https://ror.org/01znas443,"Ministry of Education, Science and Technological Development"
+https://ror.org/01zr65j15,Instituto Nacional de Ciência e Tecnologia de Ciência Animal
+https://ror.org/01zt9a375,Chosun University
+https://ror.org/020ast312,Universiti Sains Islam Malaysia
+https://ror.org/020ddnn22,Swiss Federal Office of Energy
+https://ror.org/020er8s15,Vaccine Confidence Fund
+https://ror.org/020w7x032,Sir Halley Stewart Trust
+https://ror.org/020yc1y85,The LEGO Foundation
+https://ror.org/020yyjw05,Fullbright Germany
+https://ror.org/0211vdk93,Belgian Development Agency
+https://ror.org/021adze67,United States Department of Education
+https://ror.org/021jq8741,Alliance for Health Policy and Systems Research
+https://ror.org/021nxhr62,U.S. National Science Foundation
+https://ror.org/021y4b202,Fundação de Apoio à Pesquisa do Estado da Paraíba
+https://ror.org/0220mzb33,King's College London
+https://ror.org/022fs9h90,University of Fribourg
+https://ror.org/022kthw22,University of Rochester
+https://ror.org/022rntb95,Vaccine Impact Modelling Consortium
+https://ror.org/022wnsy59,Krebsforschung Schweiz
+https://ror.org/023907v80,Gill Bergska Foundation
+https://ror.org/023jta124,Norwegian Environment Agency
+https://ror.org/023rhb549,Chongqing University
+https://ror.org/023wsvq95,Department of Foreign Affairs and Trade
+https://ror.org/023xf2a37,Public Health Agency of Canada
+https://ror.org/023z3dm33,State Scholarships Foundation
+https://ror.org/02417p338,Parkinson's UK
+https://ror.org/0243m8266,Mind and Life Institute
+https://ror.org/0248jkv14,British Psychological Society
+https://ror.org/024d6js02,Charles University
+https://ror.org/024fg8t29,Interreg Vlaanderen-Nederland
+https://ror.org/024mrxd33,University of Leeds
+https://ror.org/0250say61,Taiwan Food and Drug Administration
+https://ror.org/025cy1d38,Department of Health Social Services and Public Safety
+https://ror.org/025er3q23,Ministère des Armées
+https://ror.org/025n13r50,Adelphi University
+https://ror.org/025r5qe02,Syracuse University
+https://ror.org/025vmq686,Pontifícia Universidade Católica do Rio Grande do Sul
+https://ror.org/025zmdz23,Imperial College Healthcare Charity
+https://ror.org/02697d919,Gaia Fund
+https://ror.org/026d6ma13,Fundação de Amparo à Pesquisa do Estado do Amazonas
+https://ror.org/026nedj88,Agencja Badań Medycznych
+https://ror.org/026ny0e17,Environment and Climate Change Canada
+https://ror.org/026zht694,Fundação de Amparo à Pesquisa do Estado do Piauí
+https://ror.org/0271asj38,Science Foundation Ireland
+https://ror.org/02747h926,World Cancer Research Fund International
+https://ror.org/027hgk366,Flu Lab
+https://ror.org/027k65916,Jet Propulsion Laboratory
+https://ror.org/027ka1x80,National Aeronautics and Space Administration
+https://ror.org/027m9bs27,University of Manchester
+https://ror.org/027mm1153,Interreg North-West Europe
+https://ror.org/027ras364,IPO Porto
+https://ror.org/027s68j25,Ministry of Science and Technology of the People's Republic of China
+https://ror.org/0281dp749,Helmholtz Association of German Research Centres
+https://ror.org/0284e2q78,American Red Cross
+https://ror.org/0289t9g81,Minderoo Foundation
+https://ror.org/028jc0449,Austrian Research Promotion Agency
+https://ror.org/028ndzd53,Edge Hill University
+https://ror.org/028vg3q27,Maudsley Charity
+https://ror.org/0290a6k23,Region of Southern Denmark
+https://ror.org/029a54f25,Cancer Institute of New South Wales
+https://ror.org/029a84r94,Psi Chi
+https://ror.org/029chgv08,Wellcome Trust
+https://ror.org/029zqs055,College of Wooster
+https://ror.org/02a33b393,Max Planck Institute for Evolutionary Anthropology
+https://ror.org/02a3z0p48,Federal Council
+https://ror.org/02ak8fm03,Friedrich-Ebert-Stiftung e.V.
+https://ror.org/02akpm128,Universidad Católica del Norte
+https://ror.org/02ap3w078,Agencia Nacional de Investigación y Desarrollo
+https://ror.org/02aqsxs83,University of Oklahoma
+https://ror.org/02aqv1x10,Marie Curie
+https://ror.org/02ar66p97,Latvian Council of Science
+https://ror.org/02b5d8509,Natural Environment Research Council
+https://ror.org/02bfwt286,Monash University
+https://ror.org/02bxrrf91,Rufford Foundation
+https://ror.org/02caytj08,Defense Advanced Research Projects Agency
+https://ror.org/02cbq7e25,Knowledge Foundation
+https://ror.org/02d01az19,Caring Futures Institute
+https://ror.org/02d290r06,Swedish Research Council for Health Working Life and Welfare
+https://ror.org/02dddmh90,Fondation de l'Avenir
+https://ror.org/02ddkpn78,Fundação de Amparo à Pesquisa do Estado de São Paulo
+https://ror.org/02dfxg175,EEA and Norway Grants
+https://ror.org/02dgjyy92,University of Miami
+https://ror.org/02dqehb95,Purdue University West Lafayette
+https://ror.org/02e1fjy29,AFA Insurance (Sweden)
+https://ror.org/02e463172,American Cancer Society
+https://ror.org/02en5vm52,Sorbonne Université
+https://ror.org/02eqrsj93,Fonds de Recherche du Québec - Santé
+https://ror.org/02esmmc86,Stiftelsen Dam
+https://ror.org/02f81g417,King Saud University
+https://ror.org/02fa3aq29,McMaster University
+https://ror.org/02fapb125,Majblommans Riksförbund
+https://ror.org/02feahw73,Centre National de la Recherche Scientifique
+https://ror.org/02gfys938,University of Manitoba
+https://ror.org/02grkyz14,Western University
+https://ror.org/02hcmqg97,Fonds Spéciaux de Recherche
+https://ror.org/02he2nc27,National Research Tomsk State University
+https://ror.org/02heb2n75,"Ministry of Innovation, Science and Technology"
+https://ror.org/02hmjzt55,National Research and Innovation Agency
+https://ror.org/02hrqhj53,Rural and Environment Science and Analytical Services
+https://ror.org/02htdjb57,Bial (Portugal)
+https://ror.org/02j46qs45,Masaryk University
+https://ror.org/02jexx044,"Senatsverwaltung für Bildung, Jugend und Wissenschaft"
+https://ror.org/02jf81j23,Narodowa Agencja Wymiany Akademickiej
+https://ror.org/02jkbm893,Stiftelsen Riksbankens Jubileumsfond
+https://ror.org/02jkpm469,Versus Arthritis
+https://ror.org/02jnxpg76,Ministry of Finance of the People's Republic of China
+https://ror.org/02jqj7156,George Mason University
+https://ror.org/02jtq1b51,"Ministry of Business, Innovation and Employment"
+https://ror.org/02jv91m18,Regional Government of Castile-La Mancha
+https://ror.org/02jv93662,Qatar National Library
+https://ror.org/02jx3x895,University College London
+https://ror.org/02jz4aj89,Maastricht University
+https://ror.org/02jzrsm59,National Institute on Alcohol Abuse and Alcoholism
+https://ror.org/02k3smh20,University of Kentucky
+https://ror.org/02k52c211,Marketing Science Institute
+https://ror.org/02k5swt12,Universidade Federal de São Paulo
+https://ror.org/02k7wn190,University of Parma
+https://ror.org/02kcqb193,Colt Foundation
+https://ror.org/02ke2dd77,Foundation for Chiropractic Education
+https://ror.org/02kgj4n82,Foundation for Child Development
+https://ror.org/02ks8qq67,Hungarian Academy of Sciences
+https://ror.org/02kv4zf79,National Science and Technology Council
+https://ror.org/02m62qy71,Örebro University Hospital
+https://ror.org/02m7axw05,Japan Society for the Promotion of Science London
+https://ror.org/02ma4wv74,King Abdulaziz University
+https://ror.org/02mhbdp94,Universidad de Los Andes
+https://ror.org/02n96ep67,East China Normal University
+https://ror.org/02n96xt70,Misophonia Research Fund
+https://ror.org/02nkg1w23,"Consejería de Universidad, Investigación e Innovación"
+https://ror.org/02nrc4737,Stichting A.F. Deutman Oogheelkunde Researchfonds
+https://ror.org/02nt5es71,Alberta Health Services
+https://ror.org/02p0gd045,Universidad Complutense de Madrid
+https://ror.org/02pcb5m77,Guangdong Polytechnic Normal University
+https://ror.org/02pp7px91,Max Planck Institute for Human Development
+https://ror.org/02q3m6z23,Region Värmland Kommunalförbund
+https://ror.org/02q53mk25,Templeton Religion Trust
+https://ror.org/02qenvm24,Chan Zuckerberg Initiative (United States)
+https://ror.org/02qhjtc16,Pelita Harapan University
+https://ror.org/02qx2s478,Southern and Eastern Norway Regional Health Authority
+https://ror.org/02qztda51,Pontificia Universidad Católica del Ecuador
+https://ror.org/02r109517,Weill Cornell Medicine
+https://ror.org/02r1zra39,Workplace Safety & Insurance Board
+https://ror.org/02r531a15,Science Fund of the Republic of Serbia
+https://ror.org/02r7nkw81,Fundação Araucária
+https://ror.org/02rx3b187,Université Grenoble Alpes
+https://ror.org/02rxc7m23,Universidad de Navarra
+https://ror.org/02sqgkj21,Universidad de La Sabana
+https://ror.org/02swcnz29,Department of Health and Aged Care
+https://ror.org/02t1yaf39,Fetzer Institute
+https://ror.org/02t6f2351,"Instituto Federal de Educação, Ciência e Tecnologia de Mato Grosso"
+https://ror.org/02t7gyd38,Paragon Testing Enterprises (Canada)
+https://ror.org/02trn6p95,Comisión Sectorial de Investigación Científica
+https://ror.org/02ttsq026,University of Colorado Boulder
+https://ror.org/02tvrwm90,Canada Excellence Research Chairs
+https://ror.org/02vdm1p28,National Endowment for the Humanities
+https://ror.org/02vgg2808,Bundesministerium für Wirtschaft und Energie
+https://ror.org/02vjkv261,Inserm
+https://ror.org/02vtmh618,Foreign and Commonwealth Office
+https://ror.org/02vtq1a86,Strategisen Tutkimuksen Neuvosto
+https://ror.org/02w0kg036,National Centre for the Replacement Refinement and Reduction of Animals in Research
+https://ror.org/02wn33c27,Fundação de Apoio à Universidade de São Paulo
+https://ror.org/02wn5qz54,University of St Andrews
+https://ror.org/02ws1xc11,Universitat Jaume I
+https://ror.org/02wxr8x18,Research England
+https://ror.org/02x3xhs38,William Demant Fonden
+https://ror.org/02xankh89,Universidade Nova de Lisboa
+https://ror.org/02xey9a22,Fogarty International Center
+https://ror.org/02xfp8v59,Universidade de Brasília
+https://ror.org/02y3ad647,University of Florida
+https://ror.org/02y72wh86,Queen's University
+https://ror.org/02y7nf053,Swedish Environmental Protection Agency
+https://ror.org/02y7p0749,Ministério da Saúde
+https://ror.org/02yc19841,UCD Foundation
+https://ror.org/02yh9se80,Russell Sage Foundation
+https://ror.org/02yjqwr70,Triangle Center for Evolutionary Medicine
+https://ror.org/02ymmdj85,Robert Wood Johnson Foundation
+https://ror.org/02ynbzc81,Universidade de Fortaleza
+https://ror.org/02z0cah89,Universidad Publica de Navarra
+https://ror.org/02z384071,American Political Science Association
+https://ror.org/02z54mf22,Research Network for the Study of Esoteric Practices
+https://ror.org/02zhqgq86,University of Hong Kong
+https://ror.org/02zkxjz73,Fondation de France
+https://ror.org/02znd6t60,Canadian Psychological Association
+https://ror.org/02zsyt821,Jouf University
+https://ror.org/02zt1gg83,International Atomic Energy Agency
+https://ror.org/02zx40v98,Central European University
+https://ror.org/03019wv17,National Multiple Sclerosis Society
+https://ror.org/0302b4677,British Academy
+https://ror.org/0304hq317,Leibniz University Hannover
+https://ror.org/03063wv95,Autism Science Foundation
+https://ror.org/030bbe882,Universidad de la República de Uruguay
+https://ror.org/030c92375,"Department of Agriculture, Water and the Environment"
+https://ror.org/030prv062,Institute of Museum and Library Services
+https://ror.org/030w99567,Financiadora de Estudos e Projetos
+https://ror.org/0314h5y94,Australian Government
+https://ror.org/0318hx909,Northern Ireland Chest Heart and Stroke
+https://ror.org/031h5fa94,Baden-Württemberg Stiftung
+https://ror.org/031jv9v19,European & Developing Countries Clinical Trials Partnership
+https://ror.org/031s4pb13,Office of Special Education and Rehabilitative Services
+https://ror.org/031zfq432,Ferring Pharmaceuticals (Switzerland)
+https://ror.org/03265fv13,University College Cork
+https://ror.org/032eckg27,Disney Conservation Fund
+https://ror.org/032jvkt14,Office on Violence Against Women
+https://ror.org/032v46217,Self Family Foundation
+https://ror.org/032v9er22,Norwegian Armed Forces
+https://ror.org/0333xzh65,Wolfson Foundation
+https://ror.org/033eqas34,Justus-Liebig-Universität Gießen
+https://ror.org/033jmdj81,Solar Energy Technologies Office
+https://ror.org/033jnv181,United States Department of Health and Human Services
+https://ror.org/033sn5p83,Gates Cambridge Trust
+https://ror.org/034179816,Government of Hong Kong
+https://ror.org/03428zt70,Bangladesh Medical Research Council
+https://ror.org/0345bxe71,Society of Critical Care Medicine
+https://ror.org/0349bsm71,Hong Kong Metropolitan University
+https://ror.org/034wa7719,The National Lottery Community Fund
+https://ror.org/034xvzb47,United States Food and Drug Administration
+https://ror.org/034zgem50,Agenzia Spaziale Italiana
+https://ror.org/03577hm03,Ministry of Agriculture of the Republic of Kazakhstan
+https://ror.org/035a68863,United States Geological Survey
+https://ror.org/035qsg823,Udayana University
+https://ror.org/035rzkx15,Jena University Hospital
+https://ror.org/035tnyy05,John Templeton Foundation
+https://ror.org/035xkbk20,Aix-Marseille Université
+https://ror.org/0368jnd28,Dutch Cancer Society
+https://ror.org/036b2ww28,Universidad de Málaga
+https://ror.org/036e5c451,Federal Ministry of Labour and Social Affairs
+https://ror.org/036grjg58,Ministry of the Interior
+https://ror.org/036jhs482,Fundación Alicia Koplowitz
+https://ror.org/036nq5137,Ministry of Education
+https://ror.org/036rp1748,Universidade de São Paulo
+https://ror.org/0375f4d26,Alzheimer's Association
+https://ror.org/0375vv569,Hjerteforeningen
+https://ror.org/037b5pv06,University of Pecs
+https://ror.org/037n8p820,Ministry of Education Youth and Sports
+https://ror.org/037nx0e70,Slovak Research and Development Agency
+https://ror.org/037vpsd04,Berlin University Alliance
+https://ror.org/037wpkx04,University of Minho
+https://ror.org/0382k6j58,Nambu University
+https://ror.org/03844ds60,Irish Cancer Society
+https://ror.org/0384j8v12,The University of Sydney
+https://ror.org/0388pet74,Office of Emerging Frontiers and Multidisciplinary Activities
+https://ror.org/038mte443,Rebecca L. Cooper Medical Research Foundation
+https://ror.org/038sjwq14,Australian Research Data Commons
+https://ror.org/038t36y30,Heidelberg University
+https://ror.org/038tahs86,"Consejería de Educación, Universidades, Ciencia y Portavocía"
+https://ror.org/039bjqg32,University of Warsaw
+https://ror.org/039bp8j42,University of Verona
+https://ror.org/039d9wr27,National Heart Foundation of Australia
+https://ror.org/039djdh30,German Academic Exchange Service
+https://ror.org/039z13y21,National Research Fund Luxembourg
+https://ror.org/03a1kt624,Universidad de Huelva
+https://ror.org/03a1kwz48,University of Tübingen
+https://ror.org/03a63f080,Brain & Behavior Research Foundation
+https://ror.org/03a6wcb68,"Bundesministerium für Wohnen, Kunst, Kultur, Medien und Sport"
+https://ror.org/03aewyp97,Association of Danish Physiotherapists
+https://ror.org/03ak9vt35,Hertie Foundation
+https://ror.org/03anc3s24,Austrian Academy of Sciences
+https://ror.org/03angcq70,University of Birmingham
+https://ror.org/03anrkt33,Muhammadiyah University of Yogyakarta
+https://ror.org/03at7w331,Shanghai Municipal Commission of Health and Family Planning
+https://ror.org/03b94tp07,University of Auckland
+https://ror.org/03bf4az94,American Society for the Prevention of Cruelty to Animals
+https://ror.org/03bhd6288,Education Endowment Foundation
+https://ror.org/03bnmw459,University of Potsdam
+https://ror.org/03bp5hc83,Universidad de Antioquia
+https://ror.org/03bqmcz70,Jagiellonian University
+https://ror.org/03bsmfz84,Volkswagen Foundation
+https://ror.org/03c4mmv16,University of Ottawa
+https://ror.org/03c62dg59,Ottawa Hospital
+https://ror.org/03cpyc314,National Research Foundation
+https://ror.org/03cqe8w59,Consejo Nacional de Investigaciones Científicas y Técnicas
+https://ror.org/03dbr7087,University of Toronto
+https://ror.org/03dqcb840,Luther College
+https://ror.org/03dy4aq19,James S. McDonnell Foundation
+https://ror.org/03e10x626,Universitat de les Illes Balears
+https://ror.org/03ef4a036,Universität für Weiterbildung Krems
+https://ror.org/03embeq77,Mohawk College
+https://ror.org/03etyjw28,Pontificia Universidad Javeriana
+https://ror.org/03f0f6041,University of Technology Sydney
+https://ror.org/03fafnr39,Transport Accident Commission
+https://ror.org/03fd5ne08,"Ministerio de Ciencia, Tecnología e Innovación"
+https://ror.org/03fteab26,"Conselleria de Innovación, Universidades, Ciencia y Sociedad Digital"
+https://ror.org/03fxf3w65,Ministry of AYUSH
+https://ror.org/03g2am276,"National Research, Development and Innovation Office"
+https://ror.org/03gat5t60,"Secretaría Nacional de Ciencia, Tecnología e Innovación"
+https://ror.org/03gf7z214,Institut universitaire de cardiologie et de pneumologie de Québec
+https://ror.org/03gng8t46,"Federal Ministry of Education, Science and Research"
+https://ror.org/03gq5rs15,"Consellería de Cultura, Educación, Formación Profesional e Universidades"
+https://ror.org/03h7mcc28,"Directorate for Social, Behavioral & Economic Sciences"
+https://ror.org/03ha2q922,National Science Centre
+https://ror.org/03htnqd27,Åke Wibergs Stiftelse
+https://ror.org/03hygqf77,American Beverage Association
+https://ror.org/03hz8wd80,Lundbeck Foundation
+https://ror.org/03jdskm89,Walmart Foundation
+https://ror.org/03jjt8440,Government of Shandong Province
+https://ror.org/03jmfdf59,Agency for Healthcare Research and Quality
+https://ror.org/03jzgvn02,Wellcome Leap
+https://ror.org/03kk0s825,Fundação Carlos Chagas Filho de Amparo à Pesquisa do Estado do Rio de Janeiro
+https://ror.org/03kk7td41,Cardiff University
+https://ror.org/03kx2pj14,Royal Society of Edinburgh
+https://ror.org/03m2x1q45,University of Arizona
+https://ror.org/03m8vkq32,Institut National du Cancer
+https://ror.org/03mam0k06,National Collaborative on Gun Violence Research
+https://ror.org/03mnm0t94,University of Wisconsin–Eau Claire
+https://ror.org/03mnxvp33,Dirección General de Universidades e Investigación
+https://ror.org/03myqtf56,Programa Iberoamericano de Ciencia y Tecnología para el Desarrollo
+https://ror.org/03n0ht308,Economic and Social Research Council
+https://ror.org/03n2a3p06,New York Stem Cell Foundation
+https://ror.org/03n51vw80,Croatian Science Foundation
+https://ror.org/03n6nwv02,Universidad Politécnica de Madrid
+https://ror.org/03nadks56,Riga Stradiņš University
+https://ror.org/03nf36p02,University of Beira Interior
+https://ror.org/03ng4kg22,Carl Zeiss Foundation
+https://ror.org/03nqkz164,ETH Zürich Foundation
+https://ror.org/03p3aeb86,Universidad de Murcia
+https://ror.org/03p4pbx79,Centro de Estudios de Conflicto y Cohesión Social
+https://ror.org/03p8jwd38,Tertiary Education Trust Fund
+https://ror.org/03pj6ge82,Ministry of Education and Science of the Republic of Kazakhstan
+https://ror.org/03pjs1y45,Swedish Research Council for Environment Agricultural Sciences and Spatial Planning
+https://ror.org/03pnv4752,Queensland University of Technology
+https://ror.org/03pr08s76,Consejo Nacional de Ciencia y Tecnología
+https://ror.org/03px4ez74,Zoological Society of London
+https://ror.org/03q36qm19,Centro de Estudos Ambientais e Marinhos
+https://ror.org/03q68pf65,Fundación Séneca - Agencia de Ciencia y Tecnología de la Región de Murcia
+https://ror.org/03q83t159,Fund for Scientific Research
+https://ror.org/03qb1q739,Kamprad Family Foundation
+https://ror.org/03qqnc658,"Czech Academy of Sciences, Institute of Botany"
+https://ror.org/03qtxy027,Research Foundation - Flanders
+https://ror.org/03r0ha626,University of Utah
+https://ror.org/03r5zec51,HES-SO Valais-Wallis
+https://ror.org/03r6vqn56,Taskforce for Applied Research
+https://ror.org/03r8z3t63,UNSW Sydney
+https://ror.org/03rc91c03,Froebel Trust
+https://ror.org/03rp50x72,University of the Witwatersrand
+https://ror.org/03s0fv852,Einstein Foundation
+https://ror.org/03sjk9a61,Ministère de l’Enseignement Supérieur et de la Recherche
+https://ror.org/03stxzb56,"Agencia Nacional de Promoción de la Investigación, el Desarrollo Tecnológico y la Innovación"
+https://ror.org/03sv46s19,Ministerio de Asuntos Económicos y Transformación Digital
+https://ror.org/03swz6y49,National Council for Scientific and Technological Development
+https://ror.org/03sxt1c89,Ministry of Education and Culture
+https://ror.org/03t3qg659,Substance Abuse and Mental Health Services Administration
+https://ror.org/03t52dk35,Western Sydney University
+https://ror.org/03tb4gf50,New South Wales Department of Health
+https://ror.org/03tfy8747,Critical Ecosystem Partnership Fund
+https://ror.org/03tj32a09,Jacobs Foundation
+https://ror.org/03v4gjf40,Technische Universität Berlin
+https://ror.org/03vaqfv64,GNS Science
+https://ror.org/03ve4rt72,RACP Foundation
+https://ror.org/03vgk1715,Landes Tirols
+https://ror.org/03vhx9d88,Fundación Canaria de Investigación Sanitaria
+https://ror.org/03vpfss84,Institute of Musculoskeletal Health and Arthritis
+https://ror.org/03vv3x922,Foundation for Opioid Response Efforts
+https://ror.org/03vvynj75,United States Department of State
+https://ror.org/03w04rv71,Iran University of Medical Sciences
+https://ror.org/03wd9za21,European Space Agency
+https://ror.org/03wkg3b53,National Eye Institute
+https://ror.org/03wz10q85,NIHR School for Primary Care Research
+https://ror.org/03x94j517,Medical Research Council
+https://ror.org/03xcfma33,National Council for Air and Stream Improvement
+https://ror.org/03xeqqt61,International Center for Responsible Gaming
+https://ror.org/03xqpdg50,Gigtforeningen
+https://ror.org/03xxypa75,European Health and Digital Executive Agency
+https://ror.org/03xzxnc47,Ministerio de Educación y Formación Profesional
+https://ror.org/03y00b460,Fundación Universitaria Antonio Gargallo
+https://ror.org/03y2gwe85,Russian Science Foundation
+https://ror.org/03y9v4j03,The National Lottery Heritage Fund
+https://ror.org/03ydjzz16,Office of Rural Health
+https://ror.org/03yghzc09,University of Exeter
+https://ror.org/03yjb2x39,University of Calgary
+https://ror.org/03yrrjy16,University of Southern Denmark
+https://ror.org/03yt1ez60,Cisco Systems (United States)
+https://ror.org/03yvabt26,Instituto de Ecología
+https://ror.org/03yxnpp24,Universidad de Sevilla
+https://ror.org/03z942k20,Department of Education
+https://ror.org/03zcny908,Ministerio de Universidades
+https://ror.org/03zcxha54,Else Kröner-Fresenius-Stiftung
+https://ror.org/03zhx9h04,CaixaBank
+https://ror.org/03zj57g67,Petroleum Technology Development Fund
+https://ror.org/03zjqec80,Hospital for Special Surgery
+https://ror.org/03ztsbk67,Universidade do Estado de Santa Catarina
+https://ror.org/03zttf063,Swedish Research Council
+https://ror.org/0405n5e57,National Institute of Mental Health and Neurosciences
+https://ror.org/04088fk89,Staedtler (Germany)
+https://ror.org/0409dgb37,Universidade Federal de Viçosa
+https://ror.org/040af2s02,University of Helsinki
+https://ror.org/040eybd64,Movember Foundation
+https://ror.org/040gcmg81,National Cancer Institute
+https://ror.org/040scgh75,Comunidad de Madrid
+https://ror.org/040t43x18,University of West Bohemia
+https://ror.org/040vwpm13,University of Houston System
+https://ror.org/040y74d88,Associação Fundo de Incentivo à Pesquisa
+https://ror.org/0413bc824,Centre Azrieli de recherche sur l'autisme
+https://ror.org/041akq887,Universidade Federal de Santa Catarina
+https://ror.org/041f67531,American Psychoanalytic Association
+https://ror.org/041kmwe10,Imperial College London
+https://ror.org/041nas322,University of Bonn
+https://ror.org/041nggf72,Tree Research and Education Endowment Fund
+https://ror.org/041s47w50,Shanghai Pudong New Area Health Commission
+https://ror.org/041yk2d64,Universidade Federal do Rio Grande do Sul
+https://ror.org/042335e16,University of the Llanos
+https://ror.org/0425pg203,Gobierno de Aragón
+https://ror.org/0427vvt16,Global Affairs Canada
+https://ror.org/042hqe202,Breakthrough T1D UK
+https://ror.org/042twtr12,Centers for Disease Control and Prevention
+https://ror.org/04323m874,Science and Technology Department of Sichuan Province
+https://ror.org/0439y7842,Engineering and Physical Sciences Research Council
+https://ror.org/043ae3f44,Hospital Research Foundation
+https://ror.org/043c0p156,Royal Netherlands Academy of Arts and Sciences
+https://ror.org/043mk2594,Trygg Hansas Forskningsstiftelse
+https://ror.org/043z4tv69,National Institute of Allergy and Infectious Diseases
+https://ror.org/043zam433,Wings for Life
+https://ror.org/04437j066,Solar System Exploration Research Virtual Institute
+https://ror.org/0444fnd49,University of Southern California Sea Grant
+https://ror.org/0445x0472,International Development Research Centre
+https://ror.org/0447fe631,United States Department of Defense
+https://ror.org/04489at23,"City, University of London"
+https://ror.org/044bb5p62,Hangzhou Municipal Health Commission
+https://ror.org/044q2b203,Fondation Institut de Cardiologie de Montréal
+https://ror.org/044weyr28,Saudi Arabian Cultural Bureau
+https://ror.org/044ym4p17,Climate and Energy Fund
+https://ror.org/044zqqy65,National Park Service
+https://ror.org/0451qtk15,Royal College of Physicians of Edinburgh
+https://ror.org/0456r8d26,Gates Foundation
+https://ror.org/045k2ma45,Food Safety and Inspection Service
+https://ror.org/045ntgf29,Oklahoma State University System
+https://ror.org/0460p7240,Species Conservation Foundation
+https://ror.org/046ak2485,Freie Universität Berlin
+https://ror.org/046cr9566,Nottingham Biomedical Research Centre
+https://ror.org/047272k79,The University of Western Australia
+https://ror.org/0472cxd90,European Research Council
+https://ror.org/0472gwq90,Alzheimer's Society
+https://ror.org/0473khm44,Fundação de Amparo à Pesquisa do Estado da Bahia
+https://ror.org/047885v26,Fulbright Ireland
+https://ror.org/047gc3g35,University of Chile
+https://ror.org/047nxs434,Office of Population Affairs
+https://ror.org/0482b5b22,Brazilian Agricultural Research Corporation
+https://ror.org/0485axj58,University Hospital Southampton NHS Foundation Trust
+https://ror.org/04861m839,Associação Brasileira de Saúde Coletiva
+https://ror.org/0489rf374,Psoriasis Association
+https://ror.org/048a87296,Uppsala University
+https://ror.org/048jthh02,Colciencias
+https://ror.org/048zd9m77,Foundation for Polish Science
+https://ror.org/0492gsr48,Brain Research Foundation
+https://ror.org/0492wrx28,Indian Council of Medical Research
+https://ror.org/0493hgw16,National Institute on Minority Health and Health Disparities
+https://ror.org/04944pj78,Easterseals of Greater Waterbury
+https://ror.org/0499qpt59,Joyce Foundation
+https://ror.org/049v75w11,National Institute on Aging
+https://ror.org/04a5b0p13,Al-Zaytoonah University of Jordan
+https://ror.org/04a80wt33,Canadian Frailty Network
+https://ror.org/04afqts81,Innovative Health Initiative
+https://ror.org/04aqg9s78,Beiersdorf (Germany)
+https://ror.org/04atp4p48,China Scholarship Council
+https://ror.org/04avfj734,Cabildo de Tenerife
+https://ror.org/04avkmd49,Williams College
+https://ror.org/04b8v1s79,Tilburg University
+https://ror.org/04baade76,Massachusetts Gaming Commission
+https://ror.org/04bkad313,Autism Speaks
+https://ror.org/04bqh5m06,National Geographic Society
+https://ror.org/04bqqa360,Universidade Estadual de Maringá
+https://ror.org/04bxcqt73,United Nations Global Compact
+https://ror.org/04byxyr05,Eunice Kennedy Shriver National Institute of Child Health and Human Development
+https://ror.org/04c4bm785,CGIAR
+https://ror.org/04c8bjx39,Oxford Health NHS Foundation Trust
+https://ror.org/04cdgtt98,German Cancer Research Center
+https://ror.org/04cexk154,Workers Compensation Board of Manitoba
+https://ror.org/04cr1bk24,NASA Planetary Science
+https://ror.org/04cxm4j25,Australian Catholic University
+https://ror.org/04d5vba33,The University of Texas at El Paso
+https://ror.org/04d8ywj90,Multiple Sclerosis Society of Canada
+https://ror.org/04djvx395,Foundation for Research Support of the Federal District
+https://ror.org/04dkzbv90,Society for Personality and Social Psychology
+https://ror.org/04dtjxm91,Crown Family Philanthropies
+https://ror.org/04dwpyh46,Centro Hospitalar do Porto
+https://ror.org/04e4jbv10,Institut de Recherche Robert-Sauvé en Santé et en Sécurité du Travail
+https://ror.org/04eb9e087,Finnish Foundation for Alcohol Studies
+https://ror.org/04esata81,European Science Foundation
+https://ror.org/04et59085,Institute of Education Sciences
+https://ror.org/04f6s9e70,The National Center for Special Education Research
+https://ror.org/04fpkc108,Toyota Research Institute
+https://ror.org/04g6bbq64,Adam Mickiewicz University in Poznań
+https://ror.org/04gbpnx96,University of Opole
+https://ror.org/04gffpy86,Stichting ALS Nederland
+https://ror.org/04gqg1a07,Université Savoie Mont Blanc
+https://ror.org/04gvszq17,CETYS Universidad
+https://ror.org/04gyf1771,"University of California, Irvine"
+https://ror.org/04h7fev25,Fondation Bertarelli
+https://ror.org/04hd1y677,Hewlett Foundation
+https://ror.org/04hm9pd03,Association of Anaesthetists of Great Britain and Ireland
+https://ror.org/04hmn8g73,Bayer (Germany)
+https://ror.org/04hqxh742,Arnold Ventures
+https://ror.org/04hs54263,Clinical and Translational Science Institute
+https://ror.org/04hsw8w46,Unfunded List
+https://ror.org/04j198w64,Western Michigan University
+https://ror.org/04j5jqy92,Social Sciences and Humanities Research Council
+https://ror.org/04jhswv08,Fundação Oswaldo Cruz
+https://ror.org/04jsz6e67,Dutch Research Council
+https://ror.org/04jw21793,Federal Ministry of Food and Agriculture
+https://ror.org/04k620071,American Society for Quality
+https://ror.org/04krc7206,Lemann Center for Brazilian Studies
+https://ror.org/04kxx2q73,Luzhou Science and Technology Bureau
+https://ror.org/04m01e293,University of York
+https://ror.org/04m0ms912,National Office of Philosophy and Social Sciences
+https://ror.org/04m3t9183,Hasler Foundation
+https://ror.org/04marky29,"Bundesministerium für Klimaschutz, Umwelt, Energie, Mobilität, Innovation und Technologie"
+https://ror.org/04mb62065,Direktorat Riset Dan Pengabdian Kepada Masyarakat
+https://ror.org/04mhx6838,National Institute on Deafness and Other Communication Disorders
+https://ror.org/04mv4n011,Amazon (United States)
+https://ror.org/04mz5ra38,University of Duisburg-Essen
+https://ror.org/04n00c532,Ministerium für Kultur und Wissenschaft des Landes Nordrhein-Westfalen
+https://ror.org/04n0vf235,Canadian Breast Cancer Foundation
+https://ror.org/04nh1dc89,Division of Advanced Cyberinfrastructure
+https://ror.org/04njjy449,Universidad de Granada
+https://ror.org/04nm1xm49,Hainan Provincial Health Commission
+https://ror.org/04nqfdt43,Stiftelsen Sunnerdahls Handikappfond
+https://ror.org/04p491231,Pennsylvania State University
+https://ror.org/04p800546,University Grants Commission
+https://ror.org/04pp8hn57,Utrecht University
+https://ror.org/04pqetg36,Ministry of Health and Family Welfare
+https://ror.org/04pw6fb54,National Center for Advancing Translational Sciences
+https://ror.org/04pz7b180,"Bundesministerium für Forschung, Technologie und Raumfahrt"
+https://ror.org/04pznsd21,American University of Beirut
+https://ror.org/04q48ey07,National Institute of General Medical Sciences
+https://ror.org/04q4ck618,Brain Research UK
+https://ror.org/04qn5a624,Swedish Armed Forces
+https://ror.org/04qtw4d33,Canadian Foundation for Dietetic Research
+https://ror.org/04qvvhf62,Wenner-Gren Foundation
+https://ror.org/04qxnmv42,Palacký University Olomouc
+https://ror.org/04qy50a03,Friedrich Naumann Foundation
+https://ror.org/04qzfn040,University of KwaZulu-Natal
+https://ror.org/04rbpat47,Mercator Research Center Ruhr
+https://ror.org/04reqzt68,Wellcome Trust/DBT India Alliance
+https://ror.org/04rhqkc66,"Ministerium für Landwirtschaft, Umwelt und Klimaschutz des Landes Brandenburg"
+https://ror.org/04rq5mt64,"University of Maryland, Baltimore"
+https://ror.org/04rswrd78,Iowa State University
+https://ror.org/04rx3tw33,GeoBioTec
+https://ror.org/04sazxf24,Israel Science Foundation
+https://ror.org/04sed8n13,"Ministerium für Wirtschaft, Arbeit und Wohnungsbau Baden-Württemberg"
+https://ror.org/04sjchr03,Université Laval
+https://ror.org/04sn78z72,Chartered Society of Physiotherapy
+https://ror.org/04t269f15,National Endowment for the Arts
+https://ror.org/04t3en479,Karlsruhe Institute of Technology
+https://ror.org/04tajb587,Royal Society Te Apārangi
+https://ror.org/04td15k45,Universidad Cooperativa de Colombia
+https://ror.org/04tsk2644,Ruhr University Bochum
+https://ror.org/04txyc737,Novo Nordisk Foundation
+https://ror.org/04v0fk911,Technology Agency of the Czech Republic
+https://ror.org/04v2xmd71,Scottish Government
+https://ror.org/04vfsmv21,National Institutes of Health Clinical Center
+https://ror.org/04vvzp265,Mava Foundation
+https://ror.org/04w1c8b31,Academy for Eating Disorders
+https://ror.org/04w6kn183,Fondation pour la Recherche Médicale
+https://ror.org/04w7skc03,University of Denver
+https://ror.org/04w9kkr77,Scientific and Technological Research Council of Turkey
+https://ror.org/04wex6338,Sickkids Research Institute
+https://ror.org/04wynx969,Paul Ramsay Foundation
+https://ror.org/04x1xkh65,State of Florida
+https://ror.org/04x9ra670,Digital Communication Methods Lab
+https://ror.org/04xeg9z08,National Institute of Mental Health
+https://ror.org/04xfq0f34,RWTH Aachen University
+https://ror.org/04xsxqp89,Alliance Bioversity International - CIAT
+https://ror.org/04y8met08,Hersenstichting
+https://ror.org/04ypb4059,National Forest Foundation
+https://ror.org/04z45pv75,Institut du Savoir Montfort
+https://ror.org/04zke5364,Health Service Executive
+https://ror.org/04zp6eb52,Foundation for Chemistry Research and Initiatives
+https://ror.org/050103r16,CDC Foundation
+https://ror.org/0502a2655,National Institute for Occupational Safety and Health
+https://ror.org/0503xdx77,Fundação de Amparo à Pesquisa e Inovação do Estado de Santa Catarina
+https://ror.org/0505m1554,Arts and Humanities Research Council
+https://ror.org/050bg0846,University of Nariño
+https://ror.org/050kcr883,Illinois State University
+https://ror.org/0511nn663,Medavie Blue Cross
+https://ror.org/0512bh102,Ministry of Higher Education
+https://ror.org/0513pp416,Barts Charity
+https://ror.org/0515k5w36,Rita Allen Foundation
+https://ror.org/0517h6h17,Canada Research Chairs
+https://ror.org/051aqjh92,Ministry of Education and Research
+https://ror.org/051ev5v05,American Institute of Certified Public Accountants
+https://ror.org/051x4wh35,Commonwealth Scholarship Commission
+https://ror.org/051xex213,Irish Research Council
+https://ror.org/051zva233,National Library Board
+https://ror.org/052261q33,Swedish Heart-Lung Foundation
+https://ror.org/0524sp257,University of Bristol
+https://ror.org/0526snb40,Royal Academy of Engineering
+https://ror.org/0527jb766,Swedish Cancer Society
+https://ror.org/052csg198,Alfred P. Sloan Foundation
+https://ror.org/052gg0110,University of Oxford
+https://ror.org/052nwcv16,Knobloch Family Foundation
+https://ror.org/0530pts50,South China University of Technology
+https://ror.org/053528t47,The Foundation for Science and Technology
+https://ror.org/053mfxd72,ARC Centre of Excellence for Children and Families over the Life Course
+https://ror.org/054225q67,Cancer Research UK
+https://ror.org/054b4h407,Gesellschaft für Forschungsförderung Niederösterreich
+https://ror.org/0558j5q12,Universitatea Națională de Știință și Tehnologie Politehnica București
+https://ror.org/05591te55,Ludwig-Maximilians-Universität München
+https://ror.org/055f7t516,National Research University Higher School of Economics
+https://ror.org/055khg266,Institut Universitaire de France
+https://ror.org/055mf0v62,King Mongkut's Institute of Technology Ladkrabang
+https://ror.org/055mhsv54,Jazz Pharmaceuticals (Ireland)
+https://ror.org/055y1ne20,Helmholtz-Fonds e.V.
+https://ror.org/055zd7d59,Korea Brain Research Institute
+https://ror.org/0561a3s31,University of St.Gallen
+https://ror.org/056546b03,Gilead Sciences (United States)
+https://ror.org/056am2717,Brock University
+https://ror.org/056bjta22,Diponegoro University
+https://ror.org/056cbez68,Henan Zhongyuan Medical Science and Technology Innovation and Development Foundation
+https://ror.org/056cwr036,Health Holland
+https://ror.org/056d84691,Karolinska Institutet
+https://ror.org/056naxb15,"Department of Industry, Science, Energy and Resources"
+https://ror.org/0575ycz84,Prince of Songkla University
+https://ror.org/057g0br29,Brazilian Institute of Environment and Renewable Natural Resources
+https://ror.org/057w15z03,Erasmus University Rotterdam
+https://ror.org/057zq8s17,American Academy of Sleep Medicine Foundation
+https://ror.org/0592vaq06,Channel 7 Children's Research Foundation
+https://ror.org/0595gz585,University of Gondar
+https://ror.org/059dqb057,American Chemical Society
+https://ror.org/059ex5q34,"Secretaría de Ciencia, Humanidades, Tecnología e Innovación"
+https://ror.org/059gcgy73,Nanjing Medical University
+https://ror.org/059md9404,Jiangsu Education Department
+https://ror.org/059v3b755,Ministry of Health
+https://ror.org/059yx9a68,Universidad Nacional de Colombia
+https://ror.org/05a2bhn71,Innosuisse – Swiss Innovation Agency
+https://ror.org/05ac26z88,Oberlin College
+https://ror.org/05ac42c11,Soroptimist Foundation of Canada
+https://ror.org/05ag50972,Dowager Countess Eleanor Peel Trust
+https://ror.org/05am9gt90,Deutsche Rentenversicherung Bund
+https://ror.org/05ar5fy68,Innovate UK
+https://ror.org/05ayqqv15,Vivensa Foundation
+https://ror.org/05b1nw684,Burdett Trust for Nursing
+https://ror.org/05bakh610,Healthway
+https://ror.org/05bgf9v38,Business Finland
+https://ror.org/05bk57929,Stellenbosch University
+https://ror.org/05bnce492,Fundación Humanismo y Ciencia
+https://ror.org/05bnh6r87,Cornell University
+https://ror.org/05bqzfg94,NordForsk
+https://ror.org/05c4jxb21,Workers Compensation Board of British Columbia
+https://ror.org/05c7j7r25,"Consejo Nacional de Ciencia, Tecnología e Innovación Tecnológica"
+https://ror.org/05c9p6d02,NIHR School for Public Health Research
+https://ror.org/05ccjmp23,NIHR Birmingham Biomedical Research Centre
+https://ror.org/05cszw148,Kempe Foundation
+https://ror.org/05cx8cy07,European Innovation Council
+https://ror.org/05d5mza29,Center for Open Science
+https://ror.org/05ddrvt52,Defence Science and Technology Group
+https://ror.org/05dk0ce17,Washington State University
+https://ror.org/05dsmqn98,Medtronic (Canada)
+https://ror.org/05dwvd537,Ministry of Science and Higher Education
+https://ror.org/05ebnp485,Fondation Fyssen
+https://ror.org/05eer8g02,Jimma University
+https://ror.org/05eg49r29,Bulgarian Science Fund
+https://ror.org/05epdh915,United States Army Research Office
+https://ror.org/05et9cg77,Sexual Violence Research Initiative
+https://ror.org/05f950310,KU Leuven
+https://ror.org/05fd9ct06,NIHR Maudsley Biomedical Research Centre
+https://ror.org/05fsa3j22,Kom op tegen Kanker
+https://ror.org/05fw72335,GIS-Institut pour la Recherche en Santé Publique
+https://ror.org/05fw97k56,Siberian Federal University
+https://ror.org/05g3dte14,Florida State University
+https://ror.org/05g7knd32,"Czech Academy of Sciences, Institute of Analytical Chemistry"
+https://ror.org/05gepz749,Institute for the Advancement of Food and Nutrition Sciences
+https://ror.org/05ghs6f64,Montreal Neurological Institute and Hospital
+https://ror.org/05h37g806,Alberta Student Aid
+https://ror.org/05hag2y10,Universidade Federal do Acre
+https://ror.org/05hhm9a98,Savannah River Operations Office
+https://ror.org/05hkkdn48,Fraunhofer-Gesellschaft
+https://ror.org/05hs6h993,Michigan State University
+https://ror.org/05j0ve876,Aston University
+https://ror.org/05j8qnr48,Federal Agency for Nature Conservation
+https://ror.org/05jfp8s87,Pediatric Dermatology Research Alliance
+https://ror.org/05jhnwe22,Edith Cowan University
+https://ror.org/05jnma812,"Office of Planning, Research and Evaluation"
+https://ror.org/05jscf583,Harbin Medical University
+https://ror.org/05jtrt935,"Fundação de Apoio ao Desenvolvimento do Ensino, Ciência e Tecnologia do Estado de Mato Grosso do Sul"
+https://ror.org/05k49za97,Fundação de Amparo à Pesquisa do Estado do Rio Grande do Sul
+https://ror.org/05k73zm37,Research Council of Finland
+https://ror.org/05kdz4d87,NHS Greater Glasgow and Clyde
+https://ror.org/05keh7220,Olivia Fund
+https://ror.org/05krs5044,University of Sheffield
+https://ror.org/05m2fqn25,Chiang Mai University
+https://ror.org/05m7pjf47,University College Dublin
+https://ror.org/05m8t8e28,Agentura Pro Zdravotnický Výzkum České Republiky
+https://ror.org/05maa9n89,Virbac (France)
+https://ror.org/05mb6z682,Helsefonden
+https://ror.org/05mbkbj54,United States Department of Labor
+https://ror.org/05mcs2t73,Ministry of Higher Education
+https://ror.org/05mgfq941,Stroke Association
+https://ror.org/05mkt9r11,European Research Executive Agency
+https://ror.org/05mmh0f86,Australian Research Council
+https://ror.org/05mzwwx48,La Région Occitanie Pyrénées-Méditerranée
+https://ror.org/05n0tzs53,Sunnybrook Research Institute
+https://ror.org/05n28ff84,Fundação de Apoio à Pesquisa e à Inovação Tecnológica do Estado de Sergipe
+https://ror.org/05ne20t07,Universidade Estadual do Oeste do Paraná
+https://ror.org/05njkjr15,NIHR Manchester Biomedical Research Centre
+https://ror.org/05nne8c43,NSW Department of Education
+https://ror.org/05nqkay65,Villum Fonden
+https://ror.org/05nry7t92,Association of Public and Land-grant Universities
+https://ror.org/05nvqhd79,Art Fund
+https://ror.org/05nwjp114,Office of Polar Programs
+https://ror.org/05p2xef58,Lembaga Pengelola Dana Pendidikan
+https://ror.org/05p7z7s64,Centro Interdisciplinar de Investigação Marinha e Ambiental
+https://ror.org/05p8nb362,Health Canada
+https://ror.org/05pg13f04,Morris Animal Foundation
+https://ror.org/05phns765,Western Norway University of Applied Sciences
+https://ror.org/05psqqq26,Equity Trustees
+https://ror.org/05q2q3076,Medical Research Foundation
+https://ror.org/05q60vz69,South African Medical Research Council
+https://ror.org/05q650k44,Heinz Endowments
+https://ror.org/05qbqeh37,Environmental Protection Agency
+https://ror.org/05qn5hd16,Hass Avocado Board
+https://ror.org/05qwgg493,Boston University
+https://ror.org/05qx3fv49,National Institute of Food and Agriculture
+https://ror.org/05qx80v97,Scope Australia
+https://ror.org/05r0vyz12,"Ministerio de Ciencia, Innovación y Universidades"
+https://ror.org/05r78ng12,University of Castilla-La Mancha
+https://ror.org/05rd1nw76,Canadian Open Neuroscience Platform
+https://ror.org/05rdf8595,Universidade de Vigo
+https://ror.org/05rsv9s98,United States Department of Veterans Affairs
+https://ror.org/05s0g1g46,National Research Foundation
+https://ror.org/05s754026,Karlstad University
+https://ror.org/05sprqy15,Cambridge Commonwealth European and International Trust
+https://ror.org/05svhj534,Danmarks Frie Forskningsfond
+https://ror.org/05syd6y78,Universidade Federal do Paraná
+https://ror.org/05t8bcz72,University of Alicante
+https://ror.org/05tgxx705,Department of Science and Technology
+https://ror.org/05trey949,Scottish Graduate School of Social Science
+https://ror.org/05v01mk25,Division of Earth Sciences
+https://ror.org/05v75r592,Hellenic Foundation for Research and Innovation
+https://ror.org/05vbfxw79,Software AG – Stiftung
+https://ror.org/05vdh4r44,North Carolina General Assembly
+https://ror.org/05vhwqa91,Independent Sector
+https://ror.org/05vp4ka74,Federal Ministry of Health
+https://ror.org/05w6qh410,Royal National Institute for Deaf People
+https://ror.org/05wgkzg12,Division of Behavioral and Cognitive Sciences
+https://ror.org/05wn7r715,Western Washington University
+https://ror.org/05wnef833,Saxon State Ministry for Science and the Arts
+https://ror.org/05wvpxv85,Tufts University
+https://ror.org/05x7bg352,Sistema General de Regalías de Colombia
+https://ror.org/05xg72x27,Norwegian University of Science and Technology
+https://ror.org/05xwcq167,Universidad Autónoma de Baja California
+https://ror.org/05xwwfy96,German National Academic Foundation
+https://ror.org/05y9csv14,Austrian Agency for International Cooperation in Education and Research
+https://ror.org/05yaa9j15,Hubei Provincial Department of Education
+https://ror.org/05yh4rh25,Walton Family Foundation
+https://ror.org/05ykzvv97,Jascha Fonden
+https://ror.org/05ymr3m21,Vector Stiftung

--- a/osf/management/commands/migrate_funder_names_to_ror.py
+++ b/osf/management/commands/migrate_funder_names_to_ror.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--csv-file',
             type=str,
-            required=True,
+            required=False,
             help='Path to the CSV file containing the Crossref to ROR mapping.',
         )
         parser.add_argument(
@@ -74,234 +74,220 @@ class Command(BaseCommand):
         reindex = not options['skip_reindex']
 
         if dry_run:
-            self.stdout.write(self.style.WARNING('[DRY RUN] No changes will be made to the database.'))
+            logger.warning('[DRY RUN] No changes will be made to the database.')
 
         if not reindex:
-            self.stdout.write(self.style.WARNING('Re-indexing is disabled. Run recatalog_metadata after migration.'))
+            logger.warning('Re-indexing is disabled. Run recatalog_metadata after migration.')
 
-        # Load the mapping
-        mapping = self.load_mapping(csv_file)
-        if not mapping:
-            self.stdout.write(self.style.ERROR('No valid mappings found in CSV file.'))
-            return
+        migrate_funder_names_to_ror(csv_file=csv_file, dry_run=dry_run, batch_size=batch_size,
+                                    reindex=reindex, stdout=self.stdout)
 
-        self.stdout.write(f'Loaded {len(mapping)} ROR id to name mappings.')
+def migrate_funder_names_to_ror(csv_file=None, dry_run=False, batch_size=1000, reindex=True,
+                                stdout=None):
 
-        # Find and update records
-        stats = self.migrate_records(mapping, dry_run, batch_size, reindex)
+    if csv_file is None:
+        csv_file = 'osf/management/commands/funder_mapping.csv'
 
-        # Print summary
-        self.stdout.write('\n' + '=' * 60)
-        self.stdout.write(self.style.SUCCESS('Migration Summary:'))
-        self.stdout.write(f"  Records scanned: {stats['scanned']}")
-        self.stdout.write(f"  Records updated: {stats['updated']}")
-        self.stdout.write(f"  Records re-indexed: {stats['reindexed']}")
-        self.stdout.write(f"  Funder names updated: {stats['funders_migrated']}")
-        self.stdout.write(f"  Unmapped funders removed: {stats['not_in_mapping']}")
-        self.stdout.write(f"  Unique funders not in mapping: {len(stats['unmapped_ids'])}")
-        if stats['errors']:
-            self.stdout.write(self.style.ERROR(f"  Errors: {stats['errors']}"))
+    # Load the mapping
+    mapping = load_mapping(csv_file)
+    if not mapping:
+        stdout.write('No valid mappings found in CSV file.')
+        return
 
-        if stats['unmapped_ids']:
-            self.stdout.write('\nUnmapped ROR Funder IDs (not in CSV):')
-            for funder_id in sorted(stats['unmapped_ids'])[:50]:  # Show first 50
-                self.stdout.write(f'  - {funder_id}')
-            if len(stats['unmapped_ids']) > 50:
-                self.stdout.write(f'  ... and {len(stats["unmapped_ids"]) - 50} more')
+    stdout.write(f'Loaded {len(mapping)} ROR id to name mappings.')
 
-    def load_mapping(self, csv_file):
-        """Load the ROR ID to ROR info mapping from CSV file.
+    # Find and update records
+    stats = migrate_records(mapping, dry_run, batch_size, reindex, stdout=stdout)
 
-        Returns a dict mapping ROR IDs to ROR info:
-        {
-            'https://ror.org/021nxhr62': {
-                'ror_id': 'https://ror.org/021nxhr62',
-                'ror_name': 'National Science Foundation'
-            },
-            ...
-        }
-        """
-        mapping = {}
+    # Print summary
+    stdout.write('\n' + '=' * 60)
+    stdout.write('Migration Summary:')
+    stdout.write(f"  Records scanned: {stats['scanned']}")
+    stdout.write(f"  Records updated: {stats['updated']}")
+    stdout.write(f"  Records re-indexed: {stats['reindexed']}")
+    stdout.write(f"  Funder names updated: {stats['funders_migrated']}")
+    stdout.write(f"  Unmapped funders removed: {stats['not_in_mapping']}")
+    stdout.write(f"  Unique funders not in mapping: {len(stats['unmapped_ids'])}")
+    if stats['errors']:
+        stdout.write(f"  Errors: {stats['errors']}")
+
+    if stats['unmapped_ids']:
+        stdout.write('Unmapped ROR Funder IDs (not in CSV):')
+        for funder_id in sorted(stats['unmapped_ids'])[:50]:  # Show first 50
+            stdout.write(f'  - {funder_id}')
+        if len(stats['unmapped_ids']) > 50:
+            stdout.write(f'  ... and {len(stats["unmapped_ids"]) - 50} more')
+
+def load_mapping(csv_file):
+    """Load the ROR ID to ROR info mapping from CSV file.
+
+    Returns a dict mapping ROR IDs to ROR info:
+    {
+        'https://ror.org/021nxhr62': {
+            'ror_id': 'https://ror.org/021nxhr62',
+            'ror_name': 'National Science Foundation'
+        },
+        ...
+    }
+    """
+    funder_map = {}
+
+    try:
+        with open(csv_file, 'r', encoding='utf-8') as f:
+            # Try to detect delimiter
+            sample = f.read(2048)
+            delimiter = '\t' if '\t' in sample else ','
+
+            # reset fp and read
+            f.seek(0)
+            reader = csv.reader(f, delimiter=delimiter, quotechar='"')
+
+            for row in reader:
+                funder_map[row[0]] = {
+                    'ror_id': row[0],
+                    'ror_name': row[1],
+                }
+
+    except FileNotFoundError:
+        logger.error(f'CSV file not found: {csv_file}')
+        return None
+    except Exception as e:
+        logger.error(f'Error reading CSV file: {type(e)}')
+        return None
+
+    return funder_map
+
+def migrate_records(mapping, dry_run, batch_size, reindex, stdout=None):
+    """Find and migrate all GuidMetadataRecord entries with Crossref Funder IDs."""
+    stats = {
+        'scanned': 0,
+        'updated': 0,
+        'reindexed': 0,
+        'funders_migrated': 0,
+        'not_in_mapping': 0,
+        'errors': 0,
+        'unmapped_ids': set(),
+    }
+
+    # Query records that have non-empty funding_info
+    # We need to check if any funder has 'Crossref Funder ID' type
+    queryset = GuidMetadataRecord.objects.exclude(funding_info=[]).exclude(funding_info__isnull=True)
+
+    total_count = queryset.count()
+    stdout.write(f'Found {total_count} records with funding_info to scan.')
+
+    processed = 0
+    for record in queryset.iterator(chunk_size=batch_size):
+        stats['scanned'] += 1
+        processed += 1
+
+        if processed % 500 == 0:
+            stdout.write(f'  Processed {processed}/{total_count} records...')
 
         try:
-            with open(csv_file, 'r', encoding='utf-8-sig') as f:
-                # Try to detect delimiter
-                sample = f.read(2048)
-                f.seek(0)
-                if '\t' in sample:
-                    delimiter = '\t'
-                else:
-                    delimiter = ','
-
-                reader = csv.DictReader(f, delimiter=delimiter)
-
-                # Normalize column names (handle various formats)
-                for row in reader:
-                    # Try to find the relevant columns
-                    ror_id = None
-                    ror_name = None
-
-                    for key, value in row.items():
-                        if not key:
-                            continue
-                        key_lower = key.lower().strip()
-
-                        if 'ror' in key_lower and 'id' in key_lower and 'ror_name' not in key_lower:
-                            ror_id = value.strip() if value else None
-                        elif 'ror' in key_lower and 'name' in key_lower:
-                            ror_name = value.strip() if value else None
-
-                    if not ror_id:
-                        continue
-
-                    ror_info = {
-                        'ror_id': ror_id,
-                        'ror_name': ror_name,
-                    }
-
-                    # Add mappings for various ID formats
-                    mapping[ror_id] = ror_info
-
-        except FileNotFoundError:
-            self.stdout.write(self.style.ERROR(f'CSV file not found: {csv_file}'))
-            return None
+            updated, funder_stats = migrate_record(record, mapping, dry_run, stdout)
+            if updated:
+                stats['updated'] += 1
+                if reindex and not dry_run:
+                    try:
+                        reindex_record(record)
+                        stats['reindexed'] += 1
+                    except Exception as e:
+                        stdout.write(f'Error re-indexing record {record.guid._id}: {e}')
+            stats['funders_migrated'] += funder_stats['migrated']
+            stats['not_in_mapping'] += funder_stats['not_found']
+            stats['unmapped_ids'].update(funder_stats['unmapped_ids'])
         except Exception as e:
-            self.stdout.write(self.style.ERROR(f'Error reading CSV file: {e}'))
-            return None
+            stats['errors'] += 1
+            stdout.write(f'Error migrating record {record.guid._id}: {e}')
 
-        return mapping
+    return stats
 
-    def migrate_records(self, mapping, dry_run, batch_size, reindex):
-        """Find and migrate all GuidMetadataRecord entries with Crossref Funder IDs."""
-        stats = {
-            'scanned': 0,
-            'updated': 0,
-            'reindexed': 0,
-            'funders_migrated': 0,
-            'not_in_mapping': 0,
-            'errors': 0,
-            'unmapped_ids': set(),
-        }
+def migrate_record(record, mapping, dry_run, stdout=None):
+    """Migrate a single GuidMetadataRecord's funding_info.
 
-        # Query records that have non-empty funding_info
-        # We need to check if any funder has 'Crossref Funder ID' type
-        queryset = GuidMetadataRecord.objects.exclude(funding_info=[]).exclude(funding_info__isnull=True)
+    Returns (was_updated, funder_stats)
+    """
+    funder_stats = {
+        'migrated': 0,
+        'not_found': 0,
+        'unmapped_ids': set(),
+    }
 
-        total_count = queryset.count()
-        self.stdout.write(f'Found {total_count} records with funding_info to scan.')
+    if not record.funding_info:
+        return False, funder_stats
 
-        processed = 0
-        for record in queryset.iterator(chunk_size=batch_size):
-            stats['scanned'] += 1
-            processed += 1
+    updated_funding_info = []
+    record_modified = False
 
-            if processed % 500 == 0:
-                self.stdout.write(f'  Processed {processed}/{total_count} records...')
+    for funder in record.funding_info:
+        funder_type = funder.get('funder_identifier_type', '')
+        funder_identifier = funder.get('funder_identifier', '')
 
-            try:
-                updated, funder_stats = self.migrate_record(record, mapping, dry_run)
-                if updated:
-                    stats['updated'] += 1
-                    if reindex and not dry_run:
-                        try:
-                            self.reindex_record(record)
-                            stats['reindexed'] += 1
-                        except Exception as e:
-                            logger.error(f'Error re-indexing record {record.guid._id}: {e}')
-                stats['funders_migrated'] += funder_stats['migrated']
-                stats['not_in_mapping'] += funder_stats['not_found']
-                stats['unmapped_ids'].update(funder_stats['unmapped_ids'])
-            except Exception as e:
-                stats['errors'] += 1
-                logger.error(f'Error migrating record {record.guid._id}: {e}')
+        # Only update ROR funder records
+        if funder_type != 'ROR':
+            updated_funding_info.append(funder)
+            continue
 
-        return stats
-
-    def migrate_record(self, record, mapping, dry_run):
-        """Migrate a single GuidMetadataRecord's funding_info.
-
-        Returns (was_updated, funder_stats)
-        """
-        funder_stats = {
-            'migrated': 0,
-            'not_found': 0,
-            'unmapped_ids': set(),
-        }
-
-        if not record.funding_info:
-            return False, funder_stats
-
-        updated_funding_info = []
-        record_modified = False
-
-        for funder in record.funding_info:
-            funder_type = funder.get('funder_identifier_type', '')
-            funder_identifier = funder.get('funder_identifier', '')
-
-            # Only update ROR funder records
-            if funder_type != 'ROR':
-                updated_funding_info.append(funder)
-                continue
-
-            # Try to find in mapping
-            ror_info = mapping.get(funder_identifier, None)
-            if ror_info is None:
-                logger.info(
-                    f'{"[DRY RUN] " if dry_run else ""}'
-                    f'Unrecognized ror id for {record.guid._id}: '
-                    f'{funder_identifier}'
-                )
-                updated_funding_info.append(funder)
-                continue
-
-            # Has name changed?
-            if funder.get('funder_name') == ror_info['ror_name']:
-                logger.info(
-                    f'{"[DRY RUN] " if dry_run else ""}'
-                    f'ROR name unchanged for {record.guid._id}: '
-                    f'{funder_identifier} -> {funder.get("funder_name")}'
-                )
-                updated_funding_info.append(funder)
-                continue
-
-            # Create updated funder entry
-            logger.info(
+        # Try to find in mapping
+        ror_info = mapping.get(funder_identifier, None)
+        if ror_info is None:
+            stdout.write(
                 f'{"[DRY RUN] " if dry_run else ""}'
-                f'Updating name for {record.guid._id}: '
-                f'id {funder_identifier} from {funder["funder_name"]} to {ror_info["ror_name"]}'
+                f'Unrecognized ror id for {record.guid._id}: '
+                f'{funder_identifier}'
             )
-            updated_funder = funder.copy()
-            updated_funder['funder_name'] = ror_info['ror_name']
-            updated_funding_info.append(updated_funder)
-            record_modified = True
-            funder_stats['migrated'] += 1
+            updated_funding_info.append(funder)
+            continue
 
-        # Warn about duplicate ROR IDs that would result from migration
-        # THIS SHOULDN'T HAPPEN
-        if record_modified:
-            ror_identifiers = [
-                f['funder_identifier']
-                for f in updated_funding_info
-                if f.get('funder_identifier_type') == 'ROR'
-            ]
-            seen = set()
-            duplicates = {rid for rid in ror_identifiers if rid in seen or seen.add(rid)}
-            if duplicates:
-                logger.warning(
-                    f'Record {record.guid._id} has duplicate ROR IDs after migration: {duplicates}'
-                )
+        # Has name changed?
+        if funder.get('funder_name') == ror_info['ror_name']:
+            logger.debug(
+                f'{"[DRY RUN] " if dry_run else ""}'
+                f'ROR name unchanged for {record.guid._id}: '
+                f'{funder_identifier} -> {funder.get("funder_name")}'
+            )
+            updated_funding_info.append(funder)
+            continue
 
-        if record_modified and not dry_run:
-            with transaction.atomic():
-                record.funding_info = updated_funding_info
-                record.save(update_fields=['funding_info'])
+        # Create updated funder entry
+        stdout.write(
+            f'{"[DRY RUN] " if dry_run else ""}'
+            f'Updating name for {record.guid._id}: '
+            f'id {funder_identifier} from {funder["funder_name"]} to {ror_info["ror_name"]}'
+        )
+        updated_funder = funder.copy()
+        updated_funder['funder_name'] = ror_info['ror_name']
+        updated_funding_info.append(updated_funder)
+        record_modified = True
+        funder_stats['migrated'] += 1
 
-        return record_modified, funder_stats
+    # Warn about duplicate ROR IDs that would result from migration
+    # THIS SHOULDN'T HAPPEN
+    if record_modified:
+        ror_identifiers = [
+            f['funder_identifier']
+            for f in updated_funding_info
+            if f.get('funder_identifier_type') == 'ROR'
+        ]
+        seen = set()
+        duplicates = {rid for rid in ror_identifiers if rid in seen or seen.add(rid)}
+        if duplicates:
+            logger.debug(
+                f'Record {record.guid._id} has multiple ROR IDs after migration: {duplicates}'
+            )
 
-    def reindex_record(self, record):
-        """Trigger SHARE/ElasticSearch and DataCite re-indexing for the record's referent."""
-        referent = record.guid.referent
-        if hasattr(referent, 'update_search'):
-            referent.update_search()
-        if hasattr(referent, 'request_identifier_update'):
-            referent.request_identifier_update('doi')
+    if record_modified and not dry_run:
+        with transaction.atomic():
+            record.funding_info = updated_funding_info
+            record.save(update_fields=['funding_info'])
+
+    return record_modified, funder_stats
+
+def reindex_record(record):
+    """Trigger SHARE/ElasticSearch and DataCite re-indexing for the record's referent."""
+    referent = record.guid.referent
+    if hasattr(referent, 'update_search'):
+        referent.update_search()
+    if hasattr(referent, 'request_identifier_update'):
+        referent.request_identifier_update('doi')


### PR DESCRIPTION



## Ticket

* [ENG-1171](https://openscience.atlassian.net/browse/ENG-11171)

## Purpose

ROR funder names get out of sync sometimes. Allow admins to update the names when needed.

## Changes

* Add a button to admin to resync them with an in-repo master list of names.
* simplify ror funder name command code
* update migrate to accept a stdout

## Side Effects

None expected.

## QE Notes

dev QA'd on staging4

## CE Notes

No CE changes needed.

## Documentation

None.


[ENG-1171]: https://openscience.atlassian.net/browse/ENG-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ