### PR TITLE
[ENG-10365] Fixed tasks enqueue

### DIFF
--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -617,7 +617,6 @@ class TestArchiverTasks(ArchiverTestCase):
 
         mock_archive_callback.assert_not_called()
 
-    @mock.patch('website.archiver.tasks.handlers.enqueue_task')
     @mock.patch('website.archiver.tasks.archive_callback.si')
     @mock.patch('website.archiver.tasks.make_copy_request.s')
     @mock.patch('website.archiver.tasks.celery.chain')
@@ -630,7 +629,6 @@ class TestArchiverTasks(ArchiverTestCase):
         mock_chain,
         mock_make_copy_request_s,
         mock_archive_callback,
-        mock_enqueue_task,
     ):
         settings.MAX_ARCHIVE_SIZE = 1024 ** 3
         with mock.patch.object(BaseStorageAddon, '_get_file_tree') as mock_file_tree:
@@ -653,7 +651,6 @@ class TestArchiverTasks(ArchiverTestCase):
             mock_group.return_value,
             mock_archive_callback.return_value,
         ])
-        mock_enqueue_task.assert_called_once_with(mock_chain.return_value)
 
     @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success(self):

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -7,7 +7,7 @@ from rest_framework import status as http_status
 import celery
 from celery.utils.log import get_task_logger
 
-from framework.celery_tasks import app as celery_app, handlers
+from framework.celery_tasks import app as celery_app
 from framework.celery_tasks.utils import logged
 from framework.exceptions import HTTPError
 from framework import sentry
@@ -395,16 +395,15 @@ def archive_node(self, stat_results, job_pk):
                 )
 
         if not addon_tasks:
-            handlers.enqueue_task(archive_callback.si(dst_id=dst._id))
-            return
+            return celery.chain([
+                archive_callback.si(dst_id=dst._id)
+            ])
 
-        handlers.enqueue_task(
-            celery.chain(
-                [
-                    celery.group(addon_tasks),
-                    archive_callback.si(dst_id=dst._id),
-                ]
-            )
+        return celery.chain(
+            [
+                celery.group(addon_tasks),
+                archive_callback.si(dst_id=dst._id),
+            ]
         )
 
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-10365

## Purpose

`after_register` signal calls `handlers.enqueue_task` on a list of `archive` tasks that call `archive_node` which archives a node and calls waterbutler callback synchronously within asynchronous context. Instead of calling archiving addons and waterbutler callback, return chain of tasks that will be called by `after_register`