### PR TITLE
[ENG-11588] fix(osf): execute archive chain via self.replace so registr…

### DIFF
--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -542,8 +542,9 @@ class TestArchiverTasks(ArchiverTestCase):
         )
         mock_log_exception.assert_called_once()
 
+    @mock.patch.object(archive_node, 'replace')
     @mock.patch('website.archiver.tasks.archive_addon.si')
-    def test_archive_node_pass(self, mock_archive_addon):
+    def test_archive_node_pass(self, mock_archive_addon, mock_replace):
         settings.MAX_ARCHIVE_SIZE = 1024 ** 3
         with mock.patch.object(BaseStorageAddon, '_get_file_tree') as mock_file_tree:
             mock_file_tree.return_value = FILE_TREE
@@ -561,9 +562,10 @@ class TestArchiverTasks(ArchiverTestCase):
         with pytest.raises(ArchiverSizeExceeded):  # Note: Requires task_eager_propagates = True in celery
             archive_node.apply(args=(results, self.archive_job._id))
 
+    @mock.patch.object(archive_node, 'replace')
     @mock.patch('website.archiver.tasks.archive_callback.si')
     @mock.patch('website.archiver.tasks.archive_addon.si')
-    def test_archive_node_does_not_archive_empty_addons(self, mock_archive_addon, mock_send):
+    def test_archive_node_does_not_archive_empty_addons(self, mock_archive_addon, mock_send, mock_replace):
         with mock.patch('osf.models.mixins.AddonModelMixin.get_addon') as mock_get_addon:
             mock_addon = MockAddon()
 
@@ -582,8 +584,9 @@ class TestArchiverTasks(ArchiverTestCase):
         assert mock_send.called
 
     @use_fake_addons
+    @mock.patch.object(archive_node, 'replace')
     @mock.patch('website.archiver.tasks.archive_addon.si')
-    def test_archive_node_no_archive_size_limit(self, mock_archive_addon):
+    def test_archive_node_no_archive_size_limit(self, mock_archive_addon, mock_replace):
         settings.MAX_ARCHIVE_SIZE = 100
         self.archive_job.initiator.add_system_tag(NO_ARCHIVE_LIMIT)
         self.archive_job.initiator.save()
@@ -617,6 +620,7 @@ class TestArchiverTasks(ArchiverTestCase):
 
         mock_archive_callback.assert_not_called()
 
+    @mock.patch.object(archive_node, 'replace')
     @mock.patch('website.archiver.tasks.archive_callback.si')
     @mock.patch('website.archiver.tasks.make_copy_request.s')
     @mock.patch('website.archiver.tasks.celery.chain')
@@ -629,6 +633,7 @@ class TestArchiverTasks(ArchiverTestCase):
         mock_chain,
         mock_make_copy_request_s,
         mock_archive_callback,
+        mock_replace,
     ):
         settings.MAX_ARCHIVE_SIZE = 1024 ** 3
         with mock.patch.object(BaseStorageAddon, '_get_file_tree') as mock_file_tree:
@@ -651,6 +656,9 @@ class TestArchiverTasks(ArchiverTestCase):
             mock_group.return_value,
             mock_archive_callback.return_value,
         ])
+        # The built chain must be handed to self.replace() so Celery actually
+        # executes it; a bare `return chain` would silently never run.
+        mock_replace.assert_called_once_with(mock_chain.return_value)
 
     @pytest.mark.usefixtures('mock_gravy_valet_get_verified_links')
     def test_archive_success(self):

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -274,10 +274,17 @@ def make_copy_request(self, params, job_pk):
             timeout=settings.EXTERNAL_REQUEST_TIMEOUT,
         )
     except requests.RequestException as exc:
+        # A failed copy request marks the target as failed, which fails the whole
+        # archive and deletes the registration. Retry transient network errors first.
+        if self.request.retries < self.max_retries:
+            raise self.retry(exc=exc)
         job.update_target(addon_short_name, ARCHIVER_FAILURE, errors=[str(exc)])
         raise
 
     if res.status_code not in (http_status.HTTP_200_OK, http_status.HTTP_201_CREATED, http_status.HTTP_202_ACCEPTED):
+        # Retry server-side WaterButler errors before failing (and deleting) the archive.
+        if res.status_code >= 500 and self.request.retries < self.max_retries:
+            raise self.retry(exc=HTTPError(res.status_code))
         job.update_target(addon_short_name, ARCHIVER_FAILURE, errors=[res.text or f'WaterButler request failed with status {res.status_code}'])
         raise HTTPError(res.status_code)
 
@@ -394,17 +401,21 @@ def archive_node(self, stat_results, job_pk):
                     )
                 )
 
+        # NOTE: use self.replace() rather than `return celery.chain(...)`. A Celery
+        # task that merely *returns* a signature does NOT execute it, so the copy
+        # requests and archive_callback would never run -- the archive would stall
+        # and the registration would be torn down (deleted) after submission.
         if not addon_tasks:
-            return celery.chain([
+            return self.replace(celery.chain([
                 archive_callback.si(dst_id=dst._id)
-            ])
+            ]))
 
-        return celery.chain(
+        return self.replace(celery.chain(
             [
                 celery.group(addon_tasks),
                 archive_callback.si(dst_id=dst._id),
             ]
-        )
+        ))
 
 
 def archive(job_pk):


### PR DESCRIPTION
…ations aren't deleted after submission

[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* [ENG-*****]()

## Purpose

[//]: # (Briefly describe the purpose of this PR.)

## Changes

[//]: # (Briefly describe or list your changes.)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
