### PR TITLE
[ENG-11802] fix preprint metrics with future reports

### DIFF
--- a/api/base/metrics.py
+++ b/api/base/metrics.py
@@ -5,6 +5,10 @@ from api.base.exceptions import InvalidQueryStringError
 from osf import features
 from osf.metrics.events import OsfCountedUsageEvent
 from osf.metrics.monthly_reports import MonthlyPublicItemUsageReport
+from osf.metrics.utils import (
+    YearMonth,
+    cycle_coverage_yearmonth,
+)
 from osf.models.base import osfid_iri
 
 
@@ -103,6 +107,12 @@ class UsageMetricsViewMixin(abc.ABC):
         _search = (
             MonthlyPublicItemUsageReport.search()
             .filter('term', item_iri=item_iri)
+            .filter(
+                'range', cycle_coverage={
+                    # only past months (sometimes the current month's report is created early)
+                    'lt': cycle_coverage_yearmonth(YearMonth.from_today()),
+                },
+            )
             .sort('-cycle_coverage')
         )
         _response = _search[0].execute()

--- a/api_tests/preprints/views/test_preprint_detail_metrics.py
+++ b/api_tests/preprints/views/test_preprint_detail_metrics.py
@@ -1,10 +1,16 @@
-
+import functools
 from unittest import mock
-import pytest
+import uuid
 
+import pytest
 from waffle.testutils import override_switch
 
 from osf import features
+from osf.models.base import osfid_iri
+from osf.metrics.events import OsfCountedUsageEvent
+from osf.metrics.monthly_reports import MonthlyPublicItemUsageReport
+from osf.metrics.reporters.public_item_usage import PublicItemUsageReporter
+from osf.metrics.utils import YearMonth
 from api.base.settings.defaults import API_BASE
 from osf_tests.factories import PreprintFactory
 
@@ -31,3 +37,113 @@ class TestPreprintDetailWithMetrics:
         assert 'metrics' in data['meta']
         assert metric_name in data['meta']['metrics']
         assert data['meta']['metrics'][metric_name] == 42
+
+
+@pytest.mark.django_db
+@pytest.mark.osfmetrics_elastic_backends
+class TestPreprintDetailWithElasticMetrics:
+
+    @functools.cached_property
+    def _preprint(self):
+        return PreprintFactory()
+
+    @functools.cached_property
+    def _preprint_detail_url(self):
+        return f'/{API_BASE}preprints/{self._preprint._id}/?metrics[views]=total&metrics[downloads]=total'
+
+    @functools.cached_property
+    def _this_month(self):
+        return YearMonth.from_today()
+
+    @functools.cached_property
+    def _last_month(self):
+        return self._this_month.prior()
+
+    @functools.cached_property
+    def _last_month_usage_events(self):
+        # 2 views, 1 download
+        _events = [
+            self._save_view(self._last_month.month_start()),
+            self._save_view(self._last_month.month_start()),
+            self._save_download(self._last_month.month_start()),
+        ]
+        OsfCountedUsageEvent.refresh()
+        return _events
+
+    @functools.cached_property
+    def _this_month_usage_events(self):
+        # 3 views, 2 downloads
+        _events = [
+            self._save_view(self._this_month.month_start()),
+            self._save_view(self._this_month.month_start()),
+            self._save_view(self._this_month.month_start()),
+            self._save_download(self._this_month.month_start()),
+            self._save_download(self._this_month.month_start()),
+        ]
+        OsfCountedUsageEvent.refresh()
+        return _events
+
+    def _save_view(self, timestamp):
+        return OsfCountedUsageEvent.record(
+            timestamp=timestamp,
+            item_osfid=self._preprint._id,
+            action_labels=['view', 'web'],
+            client_session_id=str(uuid.uuid4()),
+        )
+
+    def _save_download(self, timestamp):
+        return OsfCountedUsageEvent.record(
+            timestamp=timestamp,
+            item_osfid=self._preprint._id,
+            action_labels=['download'],
+            client_session_id=str(uuid.uuid4()),
+        )
+
+    def _save_usage_report(self, yearmonth, **attr_overrides):
+        _item_iri = osfid_iri(self._preprint._id)
+        _reports = list(PublicItemUsageReporter(yearmonth).report(item_iri=_item_iri))
+        for _report in _reports:
+            for _attr_name, _attr_value in attr_overrides.items():
+                setattr(_report, _attr_name, _attr_value)
+            _report.save()
+        return _reports
+
+    def test_no_views_and_downloads(self, app):
+        _res = app.get(self._preprint_detail_url)
+        assert _res.status_code == 200
+        _resp_metrics = _res.json['meta']['metrics']
+        assert _resp_metrics['views'] == 0
+        assert _resp_metrics['downloads'] == 0
+
+    def test_with_usage_events_no_reports(self, app):
+        self._this_month_usage_events
+        self._last_month_usage_events
+        _res = app.get(self._preprint_detail_url)
+        assert _res.status_code == 200
+        _resp_metrics = _res.json['meta']['metrics']
+        assert _resp_metrics['views'] == 5
+        assert _resp_metrics['downloads'] == 3
+
+    def test_with_usage_events_and_reports(self, app):
+        self._last_month_usage_events
+        self._this_month_usage_events
+        # last month's cumulative count should be used instead of querying all past events
+        self._save_usage_report(
+            self._last_month,
+            cumulative_view_count=17,
+            cumulative_download_count=13,
+        )
+        # this month's (premature) cumulative count should be ignored
+        self._save_usage_report(
+            self._this_month,
+            cumulative_view_count=111,
+            cumulative_download_count=333,
+        )
+        MonthlyPublicItemUsageReport.refresh()
+        _res = app.get(self._preprint_detail_url)
+        assert _res.status_code == 200
+        _resp_metrics = _res.json['meta']['metrics']
+        # 17 from last-month report, 3 from this-month events
+        assert _resp_metrics['views'] == 17 + 3
+        # 13 from last-month report, 2 from this-month events
+        assert _resp_metrics['downloads'] == 13 + 2


### PR DESCRIPTION
[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* [ENG-11802]

## Purpose

[//]: # (Briefly describe the purpose of this PR.)

fix preprint view/download counts when future monthly usage reports have been generated early

## Changes

- add failing test
- fix by filtering to only past monthly usage reports when fetching latest

[//]: # (Briefly describe or list your changes.)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

- this bug occurs for preprints that were previously viewed or downloaded in ~early july 2026 (because they got july's monthly usage report generated early)
- after viewing or downloading a preprint, the corresponding count should increment (except when repeated within 30 seconds by the same user/session)

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)


[ENG-11802]: https://openscience.atlassian.net/browse/ENG-11802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ