### PR TITLE
[ENG-10829] Embargoed Registration — End Embargo Early Button Missing | Fix wrong moderation_state after terminate_embargo()

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -605,6 +605,9 @@ class Registration(AbstractNode):
         self.refresh_from_db()
         if self.is_pending_embargo_termination:
             self.embargo_termination_approval.accept()
+            # accept() above updates moderation_state through a different in-memory
+            # Registration; refresh again or set_privacy() below will overwrite it
+            self.refresh_from_db()
 
         for node in self.node_and_primary_descendants():
             node.set_privacy(

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -6,7 +6,7 @@ import datetime
 from django.utils import timezone
 from transitions import MachineError
 
-from osf.models import NodeLog
+from osf.models import NodeLog, Registration
 from osf.exceptions import NodeStateError
 from osf_tests import factories
 from osf_tests.utils import mock_archive
@@ -73,6 +73,16 @@ class TestNodeEmbargoTerminations:
         last_log = node.logs.first()
         assert last_log.action == NodeLog.EMBARGO_TERMINATED
         assert last_log.user is None
+
+    def test_terminate_embargo_on_fresh_object_with_pending_termination_sets_correct_state(self, registration, user):
+        with capture_notifications():
+            registration.request_embargo_termination(user)
+        assert registration.is_pending_embargo_termination is True
+        fresh_registration = Registration.objects.get(pk=registration.pk)
+        fresh_registration.terminate_embargo()
+        assert fresh_registration.is_public is True
+        assert fresh_registration.is_embargoed is False
+        assert fresh_registration.moderation_state == 'accepted'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* https://openscience.atlassian.net/browse/ENG-10829

## Purpose

There are a bunch of registrations on prod that has this particular problem: is_public=True, is_embargoed=False but the moderation state is still in pending_embargo_termination. Examples are 726kt, fgbp4, hmwdp, 6vhm4 mt7h8, hceu7, 45fbh, ktgu7, f69mh, and etc. They seem to fit a certain criteria:

The registration was previously embargoed

Embargo expires and the nightly run script embargo_registrations.py terminates their embargo by calling terminate_embargo()

It is suspected that somewhere within terminate_embargo() things go wrong. Here is a possible explanation:

[osf.io/osf/models/registrations.py at develop · CenterForOpenScience/osf.io](https://github.com/CenterForOpenScience/osf.io/blob/develop/osf/models/registrations.py#L607)  Here we do self.embargo_termination_approval.accept(), which eventually would lead to self.target_registration.update_moderation_state(initiated_by=user, comment=comment) at[osf.io/osf/models/sanctions.py at develop · CenterForOpenScience/osf.io](https://github.com/CenterForOpenScience/osf.io/blob/develop/osf/models/sanctions.py#L196) , this should set the moderation_state of the registration to accepted.

However, further down the line at [osf.io/osf/models/registrations.py at develop · CenterForOpenScience/osf.io](https://github.com/CenterForOpenScience/osf.io/blob/develop/osf/models/registrations.py#L610) , we call set_privacy on the registration, which would lead to a full save on the registration model that still has the stale moderation state of pending_embargo_termination because the registration referenced here may be a different object (in memory) than the registration referenced within _save_transtion in sanctions.py, resulting in it clobbering the state back to pending_embargo_termination, even though two registration objects refer to the same row in the db.

(

https://openscience.atlassian.net/browse/ENG-10829?focusedCommentId=122430

)

## Changes

Fix wrong moderation_state after terminate_embargo()


(

I have done SPIKE ticket research for End Embargo Early Button Missing | Fix wrong moderation_state after terminate_embargo()

https://openscience.atlassian.net/browse/ENG-10828?focusedCommentId=122422

maybe something from the research is possible to apply for code changings too
)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
