### PR TITLE
added MonthlyPublicItemUsageReport to _/metrics/reports

### DIFF
--- a/api/metrics/views.py
+++ b/api/metrics/views.py
@@ -59,6 +59,7 @@ from osf.metrics.daily_reports import (
 )
 from osf.metrics.monthly_reports import (
     BaseMonthlyReport,
+    MonthlyPublicItemUsageReport,
     MonthlySpamSummaryReport,
 )
 from osf.metrics.openapi import get_metrics_openapi_json_dict
@@ -79,6 +80,7 @@ VIEWABLE_REPORTS = {
     'user_summary': DailyUserSummaryReport,
     'spam_summary': MonthlySpamSummaryReport,
     'new_user_domains': DailyNewUserDomainReport,
+    'items_usage': MonthlyPublicItemUsageReport,
 }
 
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-11862

**NOTE FOR A REVIEWER**
Per Abarm's words:

> but to create the index templates in elasticsearch, need to run manage.py djelme_backend_setup (see https://github.com/CenterForOpenScience/django-elasticsearch-metrics#quickstart )
