### PR TITLE
[ENG-10341] Recast to OsfStorageFileNode after restore does not clear delete_* fields

### DIFF
--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -276,9 +276,9 @@ class TestOsfstorageFileNode(StorageTestCase):
         restored_file = trashed_file.restore()
 
         assert restored_file.deleted is None
+        assert restored_file.deleted_on is None
         # None because we do not set deleted_by when delete the child
         assert restored_file.deleted_by is None
-        assert restored_file.deleted_on is not None
 
         assert models.TrashedFileNode.objects.exists() is False
 

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -266,6 +266,21 @@ class TestOsfstorageFileNode(StorageTestCase):
         assert BaseFileNode.objects.get(_id=folder._id).type == 'osf.trashedfolder'
         assert BaseFileNode.objects.get(_id=file._id).type == 'osf.trashedfile'
 
+    def test_restore_deleted_file_without_deleted_fields(self):
+        assert models.TrashedFileNode.objects.exists() is False
+
+        child = self.node_settings.get_root().append_file('Test')
+        child.delete()
+
+        trashed_file = models.TrashedFileNode.objects.first()
+        restored_file = trashed_file.restore()
+
+        assert restored_file.deleted is None
+        assert restored_file.deleted_by is None
+        assert restored_file.deleted_on is None
+
+        assert models.TrashedFileNode.objects.exists() is False
+
     def test_delete_file(self):
         child = self.node_settings.get_root().append_file('Test')
         field_names = [f.name for f in child._meta.get_fields() if not f.is_relation and f.name not in ['id', 'content_type_pk']]

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -266,7 +266,7 @@ class TestOsfstorageFileNode(StorageTestCase):
         assert BaseFileNode.objects.get(_id=folder._id).type == 'osf.trashedfolder'
         assert BaseFileNode.objects.get(_id=file._id).type == 'osf.trashedfile'
 
-    def test_restore_deleted_file_without_deleted_fields(self):
+    def test_restore_deleted_file_without_deleted_field(self):
         assert models.TrashedFileNode.objects.exists() is False
 
         child = self.node_settings.get_root().append_file('Test')
@@ -276,8 +276,9 @@ class TestOsfstorageFileNode(StorageTestCase):
         restored_file = trashed_file.restore()
 
         assert restored_file.deleted is None
+        # None because we do not set deleted_by when delete the child
         assert restored_file.deleted_by is None
-        assert restored_file.deleted_on is None
+        assert restored_file.deleted_on is not None
 
         assert models.TrashedFileNode.objects.exists() is False
 

--- a/admin/management/urls.py
+++ b/admin/management/urls.py
@@ -24,4 +24,6 @@ urlpatterns = [
             name='remove_orcid_from_user_social'),
     re_path(r'^migrate_funder_names_to_ror', views.MigrateFunderNamesToRor.as_view(),
             name='migrate_funder_names_to_ror'),
+    re_path(r'^fix_restored_trashed_files', views.FixRestoredTrashedFiles.as_view(),
+            name='fix_restored_trashed_files'),
 ]

--- a/admin/management/views.py
+++ b/admin/management/views.py
@@ -228,3 +228,11 @@ class MigrateFunderNamesToRor(ManagementCommandPermissionView):
         for _line in _out_io.getvalue().split('\n'):
             messages.info(request, _line)
         return redirect(reverse('management:commands'))
+
+
+class FixRestoredTrashedFiles(ManagementCommandPermissionView):
+
+    def post(self, request):
+        call_command('fix_restored_trashed_files')
+        messages.success(request, 'Restored trashed files have been successfully fixed.')
+        return redirect(reverse('management:commands'))

--- a/admin/templates/management/commands.html
+++ b/admin/templates/management/commands.html
@@ -226,6 +226,19 @@
                     </nav>
                 </form>
             </section>
+            <section>
+                <h4><u>Fix restored files</u></h4>
+                <p>
+                    Use this management command to fix restored files that were previously trashed.
+                </p>
+                <form method="post"
+                      action="{% url 'management:fix_restored_trashed_files'%}">
+                    {% csrf_token %}
+                    <nav>
+                        <input class="btn btn-success" type="submit" value="Run" />
+                    </nav>
+                </form>
+            </section>
         </div>
     </section>
 {% endblock %}

--- a/osf/management/commands/fix_restored_trashed_files.py
+++ b/osf/management/commands/fix_restored_trashed_files.py
@@ -14,10 +14,28 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Run without making changes',
+        )
+
     def handle(self, *args, **options):
+        files_to_fix = OsfStorageFileNode.objects.filter(deleted__isnull=False)
+        file_ids = list(files_to_fix.values_list('_id', flat=True))
+        dry_run = options.get('dry_run', False)
+
+        if dry_run:
+            logger.info(f'Running in dry-run mode, the following files would be fixed: {file_ids}')
+            self.stdout.write(f'Running in dry-run mode, the following files would be fixed: {file_ids}')
+            return
+
         with transaction.atomic():
-            files_to_fix = OsfStorageFileNode.objects.filter(deleted__isnull=False)
             for file in files_to_fix:
                 file.deleted = None
 
             OsfStorageFileNode.objects.bulk_update(files_to_fix, ['deleted'], batch_size=1000)
+
+        logger.info(f'The following files have been fixed: {file_ids}')
+        self.stdout.write(f'The following files have been fixed: {file_ids}')

--- a/osf/management/commands/fix_restored_trashed_files.py
+++ b/osf/management/commands/fix_restored_trashed_files.py
@@ -1,11 +1,10 @@
 """
-Clears deleted, deleted_on, deleted_by values for all restored OsfStorageFileNode objects
-as restore() method did not remove them and such files after restore from TrashedFileNode are not shown on UI
+Clears deleted field value for all restored OsfStorageFileNode objects
+as restore() method did not remove it and such files after restore from TrashedFileNode are not shown on UI
 """
 import logging
 
 from django.db import transaction
-from django.db.models import Q
 from django.core.management.base import BaseCommand
 
 from addons.osfstorage.models import OsfStorageFileNode
@@ -17,12 +16,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         with transaction.atomic():
-            files_to_fix = OsfStorageFileNode.objects.filter(
-                Q(deleted__isnull=False) | Q(deleted_by__isnull=False) | Q(deleted_on__isnull=False),
-            )
+            files_to_fix = OsfStorageFileNode.objects.filter(deleted__isnull=False)
             for file in files_to_fix:
                 file.deleted = None
-                file.deleted_by = None
-                file.deleted_on = None
 
-            OsfStorageFileNode.objects.bulk_update(files_to_fix, ['deleted', 'deleted_by', 'deleted_on'], batch_size=1000)
+            OsfStorageFileNode.objects.bulk_update(files_to_fix, ['deleted'], batch_size=1000)

--- a/osf/management/commands/fix_restored_trashed_files.py
+++ b/osf/management/commands/fix_restored_trashed_files.py
@@ -1,0 +1,28 @@
+"""
+Clears deleted, deleted_on, deleted_by values for all restored OsfStorageFileNode objects
+as restore() method did not remove them and such files after restore from TrashedFileNode are not shown on UI
+"""
+import logging
+
+from django.db import transaction
+from django.db.models import Q
+from django.core.management.base import BaseCommand
+
+from addons.osfstorage.models import OsfStorageFileNode
+
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            files_to_fix = OsfStorageFileNode.objects.filter(
+                Q(deleted__isnull=False) | Q(deleted_by__isnull=False) | Q(deleted_on__isnull=False),
+            )
+            for file in files_to_fix:
+                file.deleted = None
+                file.deleted_by = None
+                file.deleted_on = None
+
+            OsfStorageFileNode.objects.bulk_update(files_to_fix, ['deleted', 'deleted_by', 'deleted_on'], batch_size=1000)

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -672,8 +672,6 @@ class TrashedFileNode(BaseFileNode):
         type_cls = File if self.is_file else Folder
 
         self.deleted = None
-        self.deleted_by = None
-        self.deleted_on = None
 
         self.recast(self._resolve_class(type_cls)._typedmodels_type)
 

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -672,6 +672,7 @@ class TrashedFileNode(BaseFileNode):
         type_cls = File if self.is_file else Folder
 
         self.deleted = None
+        self.deleted_on = None
 
         self.recast(self._resolve_class(type_cls)._typedmodels_type)
 
@@ -759,10 +760,10 @@ class TrashedFolder(TrashedFileNode):
         :param deleted_on:
         :return:
         """
+        deleted_on = deleted_on or self.deleted_on
         tf = super().restore(recursive=True, parent=None, save=True, deleted_on=None)
 
         if not self.is_file and recursive:
-            deleted_on = deleted_on or self.deleted_on
             for child in TrashedFileNode.objects.filter(parent=self.id, deleted_on=deleted_on):
                 child.restore(recursive=True, save=save, deleted_on=deleted_on)
         return tf

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -671,6 +671,10 @@ class TrashedFileNode(BaseFileNode):
 
         type_cls = File if self.is_file else Folder
 
+        self.deleted = None
+        self.deleted_by = None
+        self.deleted_on = None
+
         self.recast(self._resolve_class(type_cls)._typedmodels_type)
 
         if save:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/ENG-10341

## Purpose

Restored files are considered as deleted and not shown on UI

## Changes

In fact, when user restores `TrashedFileNode`, we recast this object to `OsfStorageFileNode` but this object still contains `deleted`, `deleted_on`, `deleted_by` field values that make this file unreachable

- Now `restore()` method for `TrashedFileNode` objects clears values for the `deleted` field before recasting to `OsfStorageFileNode`
- Management command fixes all `OsfStorageFileNode` objects that were restored via `restore()` and have values in `deleted` field
- `deleted_on` field is not cleared because when we restore a folder, it restores **ONLY** children within the same `deleted_on` datetime. Therefore, we preserve `deleted_by` to know who triggered deletion
Code reference:
https://github.com/CenterForOpenScience/osf.io/blob/e2f47e984b5f0c42cf2f1668f44c2d7b14e96054/osf/models/files.py#L751-L766