### PR TITLE
[draft][ENG-12182] fix: more consistent naming of celery tasks

### DIFF
--- a/osf/management/commands/addon_deleted_date.py
+++ b/osf/management/commands/addon_deleted_date.py
@@ -44,7 +44,7 @@ TABLES_TO_POPULATE_WITH_MODIFIED = [
 UPDATE_DELETED_WITH_MODIFIED = """UPDATE {} SET deleted=modified
     WHERE id IN (SELECT id FROM {} WHERE is_deleted AND deleted IS NULL LIMIT {}) RETURNING id;"""
 
-@celery_app.task(name='management.commands.addon_deleted_date')
+@celery_app.task(name='osf.management.commands.addon_deleted_date')
 def populate_deleted(dry_run=False, page_size=1000):
     with transaction.atomic():
         for table in TABLES_TO_POPULATE_WITH_MODIFIED:

--- a/osf/management/commands/correct_registration_moderation_states.py
+++ b/osf/management/commands/correct_registration_moderation_states.py
@@ -9,7 +9,7 @@ from osf.utils.workflows import RegistrationModerationStates
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task(name='management.commands.correct_registration_moderation_states')
+@celery_app.task(name='osf.management.commands.correct_registration_moderation_states')
 def correct_registration_moderation_states(page_size=None):
     '''Backfill the moderation_state field of all registrations based on its current Sanction.'''
 

--- a/osf/management/commands/daily_reporters_go.py
+++ b/osf/management/commands/daily_reporters_go.py
@@ -12,7 +12,7 @@ from osf.metrics.reporters import AllDailyReporters
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task(name='management.commands.daily_reporters_go')
+@celery_app.task(name='osf.management.commands.daily_reporters_go')
 def daily_reporters_go(report_date=None, reporter_key=None, **kwargs):
     if not report_date:  # default to yesterday
         report_date = (timezone.now() - datetime.timedelta(days=1)).date()
@@ -29,7 +29,6 @@ def daily_reporters_go(report_date=None, reporter_key=None, **kwargs):
 
 
 @celery_app.task(
-    name='management.commands.daily_reporter_go',
     autoretry_for=(OperationalError,),
     max_retries=5,
     retry_backoff=True,

--- a/osf/management/commands/data_storage_usage.py
+++ b/osf/management/commands/data_storage_usage.py
@@ -450,7 +450,7 @@ def upload_to_storage(file_path, upload_url, params):
         )
 
 
-@celery_app.task(name='management.commands.data_storage_usage')
+@celery_app.task(name='osf.management.commands.data_storage_usage')
 def process_usages(
         dry_run=False,
         page_size=10000,

--- a/osf/management/commands/deactivate_requested_accounts.py
+++ b/osf/management/commands/deactivate_requested_accounts.py
@@ -51,7 +51,7 @@ def deactivate_requested_accounts(dry_run=True):
         logger.info('Dry run complete')
 
 
-@celery_app.task(name='management.commands.deactivate_requested_accounts')
+@celery_app.task(name='osf.management.commands.deactivate_requested_accounts')
 def main(dry_run=False):
     """
     This task runs nightly and emails users who want to delete there account with info on how to do so. Users who don't

--- a/osf/management/commands/delete_withdrawn_or_failed_registration_files.py
+++ b/osf/management/commands/delete_withdrawn_or_failed_registration_files.py
@@ -42,7 +42,7 @@ def mark_failed_registration_files_as_deleted(batch_size, dry_run=False):
                 file.delete()
 
 
-@celery_app.task(name='management.commands.delete_withdrawn_or_failed_registration_files')
+@celery_app.task(name='osf.management.commands.delete_withdrawn_or_failed_registration_files')
 def main(batch_size_withdrawn, batch_size_stuck, dry_run=False):
     """
     This script purges files that are deleted after being withdrawn 30 days.

--- a/osf/management/commands/fetch_cedar_metadata_templates.py
+++ b/osf/management/commands/fetch_cedar_metadata_templates.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         ingest_cedar_metadata_templates()
 
-@celery_app.task(name='management.commands.ingest_cedar_metadata_templates')
+@celery_app.task(name='osf.management.commands.ingest_cedar_metadata_templates')
 def ingest_cedar_metadata_templates():
     try:
         ids = CedarClient().retrieve_all_template_ids()

--- a/osf/management/commands/migrate_deleted_date.py
+++ b/osf/management/commands/migrate_deleted_date.py
@@ -44,7 +44,7 @@ REVERSE_COMMENT = 'UPDATE osf_comment SET deleted = null'
 REVERSE_INSTITUTION = 'UPDATE osf_institution SET deleted = null'
 REVERSE_PRIVATE_LINK = 'UPDATE osf_privatelink SET deleted = null'
 
-@celery_app.task(name='management.commands.migrate_deleted_date')
+@celery_app.task(name='osf.management.commands.migrate_deleted_date')
 def populate_deleted(dry_run=False, page_size=1000):
     with transaction.atomic():
         for table in TABLES_TO_POPULATE_WITH_MODIFIED:

--- a/osf/management/commands/migrate_pagecounter_data.py
+++ b/osf/management/commands/migrate_pagecounter_data.py
@@ -56,7 +56,7 @@ SELECT count(PC.id)
 where (PC.resource_id IS NULL or PC.file_id IS NULL);
 '''
 
-@celery_app.task(name='management.commands.migrate_pagecounter_data')
+@celery_app.task(name='osf.management.commands.migrate_pagecounter_data')
 def migrate_page_counters(dry_run=False, rows=10000, reverse=False):
     script_start_time = datetime.datetime.now()
     logger.info(f'Script started time: {script_start_time}')

--- a/osf/management/commands/migrate_registration_responses.py
+++ b/osf/management/commands/migrate_registration_responses.py
@@ -123,7 +123,7 @@ def migrate_responses(model, resources, resource_name, dry_run=False, rows='all'
     return total_count
 
 
-@celery_app.task(name='management.commands.migrate_registration_responses')
+@celery_app.task(name='osf.management.commands.migrate_registration_responses')
 def migrate_registration_responses(dry_run=False, rows=5000):
     script_start_time = datetime.datetime.now()
     logger.info(f'Script started time: {script_start_time}')

--- a/osf/management/commands/monthly_reporters_go.py
+++ b/osf/management/commands/monthly_reporters_go.py
@@ -21,7 +21,7 @@ _CONTINUE_AFTER_ERRORS = (
     PostgresOperationalError,
 )
 
-@celery_app.task(name='management.commands.monthly_reporters_go')
+@celery_app.task(name='osf.management.commands.monthly_reporters_go')
 def monthly_reporters_go(yearmonth: str = '', reporter_key: str = ''):
     _yearmonth = (
         YearMonth.from_str(yearmonth)
@@ -40,7 +40,7 @@ def monthly_reporters_go(yearmonth: str = '', reporter_key: str = ''):
         })
 
 
-@celery_app.task(name='management.commands.schedule_monthly_reporter')
+@celery_app.task
 def schedule_monthly_reporter(
     yearmonth: str,
     reporter_key: str,
@@ -69,7 +69,6 @@ def schedule_monthly_reporter(
 
 
 @celery_app.task(
-    name='management.commands.monthly_reporter_do',
     autoretry_for=_CONTINUE_AFTER_ERRORS,
     max_retries=15,
     retry_backoff=True,

--- a/osf/management/commands/populate_branched_from_node.py
+++ b/osf/management/commands/populate_branched_from_node.py
@@ -23,7 +23,7 @@ FROM cte
 WHERE cte.id = a.id
 """
 
-@celery_app.task(name='management.commands.populate_branched_from')
+@celery_app.task(name='osf.management.commands.populate_branched_from')
 def populate_branched_from(page_size=10000, dry_run=False):
     with transaction.atomic():
         with connection.cursor() as cursor:

--- a/osf/management/commands/populate_initial_schema_responses.py
+++ b/osf/management/commands/populate_initial_schema_responses.py
@@ -29,7 +29,7 @@ def _update_schema_response_state(schema_response):
     schema_response.save()
 
 
-@celery_app.task(name='management.commands.populate_initial_schema_responses')
+@celery_app.task(name='osf.management.commands.populate_initial_schema_responses')
 @transaction.atomic
 def populate_initial_schema_responses(dry_run=False, batch_size=None):
     '''Migrate registration_responses into a SchemaResponse for historical registrations.'''

--- a/osf/management/commands/registration_schema_metrics.py
+++ b/osf/management/commands/registration_schema_metrics.py
@@ -125,7 +125,7 @@ def write_raw_data(cursor, filename):
     upload_to_storage(file_path=file_path, upload_url=REG_METRICS_BASE_FOLDER, params=params)
 
 
-@celery_app.task(name='management.commands.registration_schema_metrics')
+@celery_app.task(name='osf.management.commands.registration_schema_metrics')
 def gather_metrics(dry_run=False):
     today = datetime.date.today()
     first = today.replace(day=1)

--- a/osf/management/commands/update_storage_usage.py
+++ b/osf/management/commands/update_storage_usage.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 DAYS = 1
 
-@celery_app.task(name='management.commands.update_storage_usage')
+@celery_app.task(name='osf.management.commands.update_storage_usage')
 def update_storage_usage(dry_run=False, days=DAYS):
     with transaction.atomic():
         modified_limit = timezone.now() - timezone.timedelta(days=days)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -720,16 +720,16 @@ class CeleryConfig:
             'kwargs': {'dry_run': False},
         },
         'registration_schema_metrics': {
-            'task': 'management.commands.registration_schema_metrics',
+            'task': 'osf.management.commands.registration_schema_metrics',
             'schedule': crontab(minute=45, hour=7, day_of_month=3),  # Third day of month 2:45 a.m.
             'kwargs': {'dry_run': False}
         },
         'daily_reporters_go': {
-            'task': 'management.commands.daily_reporters_go',
+            'task': 'osf.management.commands.daily_reporters_go',
             'schedule': crontab(minute=0, hour=6),  # Daily 1:00 a.m.
         },
         'monthly_reporters_go': {
-            'task': 'management.commands.monthly_reporters_go',
+            'task': 'osf.management.commands.monthly_reporters_go',
             'schedule': crontab(minute=30, hour=6, day_of_month=2),     # Second day of month 1:30 a.m.
         },
         'generate_sitemap': {
@@ -737,11 +737,11 @@ class CeleryConfig:
             'schedule': crontab(minute=0, hour=5),  # Daily 12:00 a.m.
         },
         'deactivate_requested_accounts': {
-            'task': 'management.commands.deactivate_requested_accounts',
+            'task': 'osf.management.commands.deactivate_requested_accounts',
             'schedule': crontab(minute=0, hour=5),  # Daily 12:00 a.m.
         },
         'delete_withdrawn_or_failed_registration_files': {
-            'task': 'management.commands.delete_withdrawn_or_failed_registration_files',
+            'task': 'osf.management.commands.delete_withdrawn_or_failed_registration_files',
             'schedule': crontab(minute=0, hour=5),  # Daily 12 a.m
             'kwargs': {
                 'dry_run': False,


### PR DESCRIPTION

[//]: # (
    * Before submitting your Pull Request, make sure you've picked the right branch and your code is up-to-date with it.
        * For critical hotfixes, select "master" as the target branch.
        * For bugfixes, improvements and new features, select "develop" as the target branch.
        * If your PR is part of a project/team, select project/team's dedicated feature branch as the target.
    * If you have a JIRA ticket, prefix the ticket number [ENG-*****] to the PR title.
)

## Ticket

[//]: # (Link to a JIRA ticket if available.)

* [ENG-*****]()

## Purpose
for celery tasks defined under `osf/management/commands/`, use task names that begin with the full python module path (use celery's default task name in most cases)

specifically, this fixes a problem where tasks were expected to be "low priority" based on matching `CeleryConfig.low_pri_modules`, but would instead go in the default queue


[//]: # (Briefly describe the purpose of this PR.)

## Changes
`low_pri_modules` entries with mismatched task names that went to the default queue instead:
- osf.management.commands.daily_reporters_go
- osf.management.commands.delete_withdrawn_or_failed_registration_files
- osf.management.commands.ingest_cedar_metadata_templates (note: not an actual module, just a task name)
- osf.management.commands.migrate_deleted_date
- osf.management.commands.migrate_pagecounter_data
- osf.management.commands.monthly_reporters_go
- osf.management.commands.populate_branched_from (note: not an actual module, just a task name)

[//]: # (Briefly describe or list your changes.)

## Side Effects

[//]: # (Any possible side effects?)

## QE Notes

[//]: # (
    * Any QA testing notes for QE?
        * Make verification statements inspired by your code and what your code touches.
        * What are the areas of risk?
        * Any concerns/considerations/questions that development raised?
    * If you have a JIRA ticket, make sure the ticket also contains the QE notes.
)

## CE Notes
changes celery task names -- if deployed while any of these tasks are already enqueued, those tasks will fail to run (which may or may not be a problem, depending on the task)

[//]: # (
    * Any server configuration and deployment notes for CE?
        * Is model migration required? Is data migration/backfill/population required?
            * If so, is it reversible? Is there a roll-back plan?
        * Does server settings needs to be updated?
            * If so, have you checked with CE on existing settings for affected servers?
        * Are there any deployment dependencies to other services?
    * If you have a JIRA ticket, make sure the ticket also contains the CE notes.
)

## Documentation

[//]: # (
    * Does any internal or external documentation need to be updated?
        * If the API was versioned, update the developer.osf.io changelog.
        * If changes were made to the API, link the developer.osf.io PR here.
)
